### PR TITLE
fix: ライブターンの全メッセージ除外と中間フレーム削除で重複出力を解消 (#1)

### DIFF
--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -61,7 +61,8 @@ impl App {
                 StateTransition::StartThinking
             };
             let _ = self.transition_with_context(thinking, transition)?;
-            frames.push(self.render_console(tui)?);
+            // Skip intermediate Thinking frames — the user already sees
+            // live streaming output on stderr (Issue #1).
 
             // Execute tool calls and record results WITH payload
             let results = self.execute_structured_tool_calls(&current)?;
@@ -81,7 +82,8 @@ impl App {
                 .with_tool_logs(tool_log_views)
                 .with_elapsed_ms(elapsed_ms);
             let _ = self.transition_with_context(working, StateTransition::StartWorking)?;
-            frames.push(self.render_console(tui)?);
+            // Skip intermediate Working frames — tool execution output
+            // is already shown on stderr (Issue #1).
 
             // Send tool results back to LLM for the next turn
             let spinner = Spinner::start(format!(

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -663,8 +663,9 @@ impl App {
     }
 
     fn build_console_render_context(&self) -> ConsoleRenderContext {
-        // Exclude assistant messages from frame rendering because they were
-        // already streamed to stderr in real-time (Issue #1).
+        // Exclude all messages from frame rendering because they were
+        // already shown during the live turn — streaming to stderr and
+        // tool execution output (Issue #1).
         self.session.console_render_context(
             self.state_machine.snapshot(),
             &self.config.runtime.model,

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -160,20 +160,21 @@ impl SessionRecord {
     pub fn recent_message_views(
         &self,
         limit: usize,
-        exclude_assistant: bool,
+        exclude_messages: bool,
     ) -> Vec<ConsoleMessageView> {
+        // When exclude_messages is true, skip ALL messages because they
+        // were already shown during the live turn (streaming to stderr,
+        // tool execution output, etc.).  Rendering them again in the
+        // console frame would cause duplicate output (Issue #1).
+        if exclude_messages {
+            return Vec::new();
+        }
+
         let len = self.messages.len();
         let start = len.saturating_sub(limit);
 
         self.messages[start..]
             .iter()
-            .filter(|message| {
-                // When exclude_assistant is true, skip Assistant messages
-                // because they were already streamed to stderr in real-time.
-                // Rendering them again in the console frame would cause
-                // duplicate output (Issue #1).
-                !exclude_assistant || message.role != MessageRole::Assistant
-            })
             .map(|message| ConsoleMessageView {
                 role: match message.role {
                     MessageRole::User => ConsoleMessageRole::User,
@@ -233,10 +234,14 @@ impl SessionRecord {
         snapshot: &AppStateSnapshot,
         model_name: &str,
         visible_message_limit: usize,
-        exclude_assistant: bool,
+        exclude_messages: bool,
     ) -> ConsoleRenderContext {
-        let messages = self.recent_message_views(visible_message_limit, exclude_assistant);
-        let history_summary = self.recent_history_summary(messages.len());
+        let messages = self.recent_message_views(visible_message_limit, exclude_messages);
+        let history_summary = if exclude_messages {
+            None
+        } else {
+            self.recent_history_summary(messages.len())
+        };
 
         ConsoleRenderContext {
             snapshot: snapshot.clone(),

--- a/tests/provider_integration.rs
+++ b/tests/provider_integration.rs
@@ -199,24 +199,21 @@ fn live_turn_executes_structured_file_write_response_without_approval() {
     let written = fs::read_to_string(root.join("sandbox/test1_001/index.html"))
         .expect("file.write should materialize output");
     assert!(written.contains("invaders"));
+    // Intermediate Thinking/Working frames are no longer emitted to avoid
+    // duplicate output (Issue #1).  Only the final Done frame is returned,
+    // which contains tool_logs and completion_summary.
     assert!(
         frames
             .iter()
-            .any(|frame| frame.contains("[T] tool  > file.write"))
+            .any(|frame| frame.contains("[T] tool  > file.write")),
+        "done frame should contain tool log for file.write"
     );
-    assert!(
-        frames
-            .iter()
-            .any(|frame| frame.contains("[A] anvil > plan"))
-    );
-    assert!(frames.iter().any(|frame| frame.contains("working on 1/")));
-    // The agentic loop feeds tool results back to the LLM.  The final
-    // answer comes from the follow-up turn (not the original ANVIL_FINAL).
     assert!(
         frames
             .last()
             .expect("done frame should exist")
-            .contains("Executed")
+            .contains("Executed"),
+        "done frame should contain execution summary"
     );
 }
 

--- a/tests/tui_console.rs
+++ b/tests/tui_console.rs
@@ -169,16 +169,20 @@ fn tui_renders_working_and_done_views_with_tool_logs() {
         .render_console(&tui)
         .expect("done render should succeed");
 
-    assert!(working.contains("[U] you > inspect state handling"));
+    // All messages (user, tool, assistant) are excluded from live-turn
+    // frames because they were already shown during the turn via stderr
+    // streaming and tool execution output (Issue #1).
+    assert!(
+        !working.contains("[U] you > inspect state handling"),
+        "user message should not appear in working frame (already shown)"
+    );
     assert!(working.contains("[T] tool  > progress"));
     assert!(working.contains("completed:2"));
     assert!(working.contains("[T] tool  > Read"));
     assert!(working.contains("tools active"));
-    // Assistant message is excluded from frame rendering because it was
-    // already streamed to stderr (Issue #1). It should still be in the session.
     assert!(
         !done.contains("[A] anvil > 調査結果を整理しました。"),
-        "assistant message should not appear in done frame (streamed to stderr)"
+        "assistant message should not appear in done frame"
     );
     assert!(
         app.session()
@@ -207,7 +211,11 @@ fn app_can_render_console_from_runtime_state_without_manual_message_plumbing() {
         .render_console(&tui)
         .expect("console render should succeed");
 
-    assert!(rendered.contains("[U] you > trace runtime-driven rendering"));
+    // Messages are excluded from live-turn frames (Issue #1).
+    assert!(
+        !rendered.contains("[U] you > trace runtime-driven rendering"),
+        "user message should not appear in live-turn frame"
+    );
     assert!(rendered.contains("[A] anvil > Thinking."));
     assert!(rendered.contains("typeahead enabled"));
 }
@@ -225,13 +233,15 @@ fn tui_limits_rendered_history_to_recent_messages() {
         .mock_thinking_snapshot()
         .expect("thinking snapshot should build");
 
-    let rendered = app
-        .render_console(&tui)
-        .expect("console render should succeed");
+    // Live-turn frames exclude all messages (Issue #1), so verify via
+    // startup rendering where history is displayed.
+    let startup = app
+        .startup_console(&tui)
+        .expect("startup render should succeed");
 
-    assert!(!rendered.contains("[U] you > message 0"));
-    assert!(rendered.contains("[U] you > message 7"));
-    assert!(rendered.contains("history: recent 5 messages"));
+    assert!(!startup.contains("[U] you > message 0"));
+    assert!(startup.contains("[U] you > message 7"));
+    assert!(startup.contains("history: recent 5 messages"));
 }
 
 #[test]
@@ -269,13 +279,15 @@ fn done_frame_excludes_streamed_assistant_messages() {
         .render_console(&tui)
         .expect("done render should succeed");
 
-    // The assistant message was already streamed to stderr during the turn,
-    // so the frame should NOT render it again in the message list.
-    // User messages should still appear.
-    assert!(rendered.contains("[U] you > ask a question"));
+    // All messages are excluded from live-turn frames because they were
+    // already shown via stderr streaming and tool output (Issue #1).
+    assert!(
+        !rendered.contains("[U] you > ask a question"),
+        "user message should not appear in done frame (already shown)"
+    );
     assert!(
         !rendered.contains("[A] anvil > 調査結果を整理しました。"),
-        "assistant message should be excluded from done frame to avoid duplicate output"
+        "assistant message should be excluded from done frame"
     );
     // The frame should still contain the status/result sections
     assert!(rendered.contains("[A] anvil > result"));


### PR DESCRIPTION
## Summary

- PR #3 の修正（Assistant メッセージのみ除外）では不十分だった重複出力問題を完全に解消
- 中間フレーム（Thinking/Working）の生成を停止し、Done フレームのみ返却するよう変更
- `exclude_assistant` を `exclude_messages` に拡張し、ライブターン中は全メッセージ（User/Tool/Assistant）をフレームから除外
- セッション再開時の履歴表示は引き続き正常動作

## Test plan

- [x] `cargo build` エラー0件
- [x] `cargo clippy --all-targets` 警告0件
- [x] `cargo test` 全109テストパス
- [x] `cargo fmt --check` 差分なし
- [ ] 手動確認: `cargo run` でレスポンスが1回のみ表示されること

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)