### PR TITLE
feat: Web検索ツール追加とGitHub Insights対応 (#6)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,9 +3,19 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anvil"
 version = "0.0.1"
 dependencies = [
+ "regex",
  "rustyline",
  "serde",
  "serde_json",
@@ -158,6 +168,35 @@ dependencies = [
  "endian-type",
  "nibble_vec",
 ]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rustix"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2024"
 rustyline = "15"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+regex = { version = "1", default-features = false, features = ["std"] }

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -142,15 +142,7 @@ impl BasicAgentLoop {
             model.into(),
             session.messages[start..]
                 .iter()
-                .map(|message| {
-                    let role = match message.role {
-                        MessageRole::System => ProviderMessageRole::System,
-                        MessageRole::User => ProviderMessageRole::User,
-                        MessageRole::Assistant => ProviderMessageRole::Assistant,
-                        MessageRole::Tool => ProviderMessageRole::Tool,
-                    };
-                    ProviderMessage::new(role, message.content.clone())
-                })
+                .map(to_provider_message)
                 .collect(),
             stream,
         )
@@ -182,15 +174,7 @@ impl BasicAgentLoop {
                 ProviderMessageRole::System,
                 tool_protocol_system_prompt(),
             ))
-            .chain(selected.into_iter().map(|message| {
-                let role = match message.role {
-                    MessageRole::System => ProviderMessageRole::System,
-                    MessageRole::User => ProviderMessageRole::User,
-                    MessageRole::Assistant => ProviderMessageRole::Assistant,
-                    MessageRole::Tool => ProviderMessageRole::Tool,
-                };
-                ProviderMessage::new(role, message.content.clone())
-            }))
+            .chain(selected.into_iter().map(to_provider_message))
             .collect(),
             stream,
         )
@@ -249,57 +233,7 @@ fn parse_tool_call_value(value: &Value) -> Result<ToolCallRequest, String> {
         .get("id")
         .and_then(Value::as_str)
         .unwrap_or("call_generated_001");
-    let input = match tool_name {
-        "file.write" => ToolInput::FileWrite {
-            path: value
-                .get("path")
-                .and_then(Value::as_str)
-                .ok_or_else(|| "missing path in file.write tool block".to_string())?
-                .to_string(),
-            content: value
-                .get("content")
-                .and_then(Value::as_str)
-                .ok_or_else(|| "missing content in file.write tool block".to_string())?
-                .to_string(),
-        },
-        "file.read" => ToolInput::FileRead {
-            path: value
-                .get("path")
-                .and_then(Value::as_str)
-                .ok_or_else(|| "missing path in file.read tool block".to_string())?
-                .to_string(),
-        },
-        "file.search" => ToolInput::FileSearch {
-            root: value
-                .get("root")
-                .or_else(|| value.get("path"))
-                .and_then(Value::as_str)
-                .ok_or_else(|| "missing root in file.search tool block".to_string())?
-                .to_string(),
-            pattern: value
-                .get("pattern")
-                .or_else(|| value.get("content"))
-                .or_else(|| value.get("query"))
-                .and_then(Value::as_str)
-                .ok_or_else(|| "missing pattern in file.search tool block".to_string())?
-                .to_string(),
-        },
-        "shell.exec" | "shell" => ToolInput::ShellExec {
-            command: value
-                .get("command")
-                .and_then(Value::as_str)
-                .ok_or_else(|| "missing command in shell.exec tool block".to_string())?
-                .to_string(),
-        },
-        "web.fetch" => ToolInput::WebFetch {
-            url: value
-                .get("url")
-                .and_then(Value::as_str)
-                .ok_or_else(|| "missing url in web.fetch tool block".to_string())?
-                .to_string(),
-        },
-        other => return Err(format!("unsupported tool in ANVIL_TOOL block: {other}")),
-    };
+    let input = ToolInput::from_json(tool_name, value)?;
 
     Ok(ToolCallRequest::new(
         tool_call_id.to_string(),
@@ -313,29 +247,12 @@ fn repair_tool_call_block(block: &str) -> Option<ToolCallRequest> {
     let tool_call_id = extract_simple_string_field(block, "id")
         .unwrap_or_else(|| "call_generated_001".to_string());
 
-    let input = match tool_name.as_str() {
-        "file.write" => ToolInput::FileWrite {
-            path: extract_simple_string_field(block, "path")?,
-            content: extract_trailing_string_field(block, "content")?,
-        },
-        "file.read" => ToolInput::FileRead {
-            path: extract_simple_string_field(block, "path")?,
-        },
-        "file.search" => ToolInput::FileSearch {
-            root: extract_simple_string_field(block, "root")
-                .or_else(|| extract_simple_string_field(block, "path"))?,
-            pattern: extract_simple_string_field(block, "pattern")
-                .or_else(|| extract_simple_string_field(block, "content"))
-                .or_else(|| extract_simple_string_field(block, "query"))?,
-        },
-        "shell.exec" | "shell" => ToolInput::ShellExec {
-            command: extract_simple_string_field(block, "command")?,
-        },
-        "web.fetch" => ToolInput::WebFetch {
-            url: extract_simple_string_field(block, "url")?,
-        },
-        _ => return None,
-    };
+    let input = ToolInput::repair_from_block(
+        &tool_name,
+        block,
+        extract_simple_string_field,
+        extract_trailing_string_field,
+    )?;
 
     Some(ToolCallRequest::new(tool_call_id, tool_name, input))
 }
@@ -387,6 +304,16 @@ fn loose_unescape(value: &str) -> String {
         .replace("\\t", "\t")
         .replace("\\\"", "\"")
         .replace("\\\\", "\\")
+}
+
+fn to_provider_message(message: &crate::session::SessionMessage) -> ProviderMessage {
+    let role = match message.role {
+        MessageRole::System => ProviderMessageRole::System,
+        MessageRole::User => ProviderMessageRole::User,
+        MessageRole::Assistant => ProviderMessageRole::Assistant,
+        MessageRole::Tool => ProviderMessageRole::Tool,
+    };
+    ProviderMessage::new(role, message.content.clone())
 }
 
 fn derive_context_budget(context_window: u32) -> usize {
@@ -447,6 +374,12 @@ fn tool_protocol_system_prompt() -> &'static str {
         "{\"id\":\"call_005\",\"tool\":\"web.fetch\",\"url\":\"https://example.com\"}\n",
         "```\n",
         "\n",
+        "6. web.search — search the web by keyword:\n",
+        "```ANVIL_TOOL\n",
+        "{\"id\":\"call_006\",\"tool\":\"web.search\",\"query\":\"search keywords here\"}\n",
+        "```\n",
+        "Use web.search when you need to look up error messages, library usage, or any information not available locally.\n",
+        "\n",
         "After ALL tool blocks, include exactly one final block with your summary:\n",
         "```ANVIL_FINAL\n",
         "User-facing summary and code review notes.\n",
@@ -460,7 +393,15 @@ fn tool_protocol_system_prompt() -> &'static str {
         "- Start exploration with file.read on \".\" to list the project root before reading specific files.\n",
         "- Do not assume files like README.md exist — verify first.\n",
         "- For dev servers and watch processes (npm run dev, cargo watch, etc.), use background execution with '&' so the command returns immediately.\n",
-        "- shell.exec output is streamed to the terminal in real-time. The user can press Ctrl+C to cancel."
+        "- shell.exec output is streamed to the terminal in real-time. The user can press Ctrl+C to cancel.\n",
+        "\n",
+        "## GitHub Insights\n",
+        "When asked about repository statistics, use shell.exec with gh api:\n",
+        "- Contributors: gh api repos/{owner}/{repo}/stats/contributors\n",
+        "- Commit activity: gh api repos/{owner}/{repo}/stats/commit_activity\n",
+        "- Code frequency: gh api repos/{owner}/{repo}/stats/code_frequency\n",
+        "- Detect repo: gh repo view --json owner,name\n",
+        "- GitHub stats endpoints (contributors, commit_activity) may return {} on first request. If you get an empty response, wait 3 seconds with shell.exec sleep 3 and retry the same API call."
     )
 }
 

--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -188,73 +188,28 @@ impl App {
         &mut self,
         structured: &StructuredAssistantResponse,
     ) -> Result<Vec<ToolExecutionResult>, AppError> {
-        let executor = LocalToolExecutor::new(self.config.paths.cwd.clone());
+        let mut executor =
+            LocalToolExecutor::new(self.config.paths.cwd.clone(), &self.config.runtime);
         let mut results = Vec::new();
         for call in &structured.tool_calls {
             let validated = match self.tools.validate(call.clone()) {
                 Ok(v) => v,
                 Err(err) => {
-                    let error_result = ToolExecutionResult {
-                        tool_call_id: call.tool_call_id.clone(),
-                        tool_name: call.tool_name.clone(),
-                        status: crate::tooling::ToolExecutionStatus::Failed,
-                        summary: format!("validation failed: {err:?}"),
-                        payload: crate::tooling::ToolExecutionPayload::None,
-                        artifacts: Vec::new(),
-                        elapsed_ms: 0,
-                    };
-                    self.session.push_message(
-                        SessionMessage::new(
-                            MessageRole::Tool,
-                            "tool",
-                            format_tool_result_message(
-                                &error_result,
-                                self.config.runtime.tool_result_max_chars,
-                            ),
-                        )
-                        .with_id(self.next_message_id("tool")),
-                    );
+                    let error_result =
+                        build_failed_result(call, format!("validation failed: {err:?}"));
+                    self.record_tool_result(&error_result);
                     results.push(error_result);
                     continue;
                 }
             };
             // Check if this tool needs approval in the current mode
             if self.config.mode.approval_required && validated.approval_required(true).is_some() {
-                let summary = match &call.input {
-                    crate::tooling::ToolInput::ShellExec { command } => {
-                        format!("{}: {command}", call.tool_name)
-                    }
-                    crate::tooling::ToolInput::FileWrite { path, .. } => {
-                        format!("{}: {path}", call.tool_name)
-                    }
-                    crate::tooling::ToolInput::WebFetch { url } => {
-                        format!("{}: {url}", call.tool_name)
-                    }
-                    _ => call.tool_name.clone(),
-                };
+                let summary = tool_call_approval_summary(call);
                 // Ask user inline via stderr/stdin
                 let approved = prompt_inline_approval(&summary);
                 if !approved {
-                    let denied_result = ToolExecutionResult {
-                        tool_call_id: call.tool_call_id.clone(),
-                        tool_name: call.tool_name.clone(),
-                        status: crate::tooling::ToolExecutionStatus::Failed,
-                        summary: "denied by user".to_string(),
-                        payload: crate::tooling::ToolExecutionPayload::None,
-                        artifacts: Vec::new(),
-                        elapsed_ms: 0,
-                    };
-                    self.session.push_message(
-                        SessionMessage::new(
-                            MessageRole::Tool,
-                            "tool",
-                            format_tool_result_message(
-                                &denied_result,
-                                self.config.runtime.tool_result_max_chars,
-                            ),
-                        )
-                        .with_id(self.next_message_id("tool")),
-                    );
+                    let denied_result = build_failed_result(call, "denied by user".to_string());
+                    self.record_tool_result(&denied_result);
                     results.push(denied_result);
                     continue;
                 }
@@ -269,26 +224,8 @@ impl App {
                 }) {
                 Ok(r) => r,
                 Err(err) => {
-                    let error_result = ToolExecutionResult {
-                        tool_call_id: call.tool_call_id.clone(),
-                        tool_name: call.tool_name.clone(),
-                        status: crate::tooling::ToolExecutionStatus::Failed,
-                        summary: format!("{err:?}"),
-                        payload: crate::tooling::ToolExecutionPayload::None,
-                        artifacts: Vec::new(),
-                        elapsed_ms: 0,
-                    };
-                    self.session.push_message(
-                        SessionMessage::new(
-                            MessageRole::Tool,
-                            "tool",
-                            format_tool_result_message(
-                                &error_result,
-                                self.config.runtime.tool_result_max_chars,
-                            ),
-                        )
-                        .with_id(self.next_message_id("tool")),
-                    );
+                    let error_result = build_failed_result(call, format!("{err:?}"));
+                    self.record_tool_result(&error_result);
                     results.push(error_result);
                     continue;
                 }
@@ -306,18 +243,23 @@ impl App {
                 },
             };
             // Record tool result WITH actual payload so the LLM can see it
-            self.session.push_message(
-                SessionMessage::new(
-                    MessageRole::Tool,
-                    "tool",
-                    format_tool_result_message(&result, self.config.runtime.tool_result_max_chars),
-                )
-                .with_id(self.next_message_id("tool")),
-            );
+            self.record_tool_result(&result);
             results.push(result);
         }
         self.persist_session(crate::contracts::AppEvent::SessionSaved)?;
         Ok(results)
+    }
+
+    /// Push a tool execution result into the session as a tool message.
+    fn record_tool_result(&mut self, result: &ToolExecutionResult) {
+        self.session.push_message(
+            SessionMessage::new(
+                MessageRole::Tool,
+                "tool",
+                format_tool_result_message(result, self.config.runtime.tool_result_max_chars),
+            )
+            .with_id(self.next_message_id("tool")),
+        );
     }
 
     pub(crate) fn handle_structured_done<C: ProviderClient>(
@@ -370,6 +312,9 @@ pub(crate) fn infer_plan_from_structured_response(
                 format!("run shell command: {command}")
             }
             crate::tooling::ToolInput::WebFetch { url } => format!("fetch {url}"),
+            crate::tooling::ToolInput::WebSearch { query } => {
+                format!("web search: {query}")
+            }
         };
         plan.push(item);
     }
@@ -411,6 +356,41 @@ pub(crate) fn format_tool_result_message(result: &ToolExecutionResult, max_chars
                 listing
             )
         }
+    }
+}
+
+/// Build a failed [`ToolExecutionResult`] with no payload.
+fn build_failed_result(
+    call: &crate::tooling::ToolCallRequest,
+    summary: String,
+) -> ToolExecutionResult {
+    ToolExecutionResult {
+        tool_call_id: call.tool_call_id.clone(),
+        tool_name: call.tool_name.clone(),
+        status: crate::tooling::ToolExecutionStatus::Failed,
+        summary,
+        payload: crate::tooling::ToolExecutionPayload::None,
+        artifacts: Vec::new(),
+        elapsed_ms: 0,
+    }
+}
+
+/// Produce a human-readable summary of a tool call for the approval prompt.
+fn tool_call_approval_summary(call: &crate::tooling::ToolCallRequest) -> String {
+    match &call.input {
+        crate::tooling::ToolInput::ShellExec { command } => {
+            format!("{}: {command}", call.tool_name)
+        }
+        crate::tooling::ToolInput::FileWrite { path, .. } => {
+            format!("{}: {path}", call.tool_name)
+        }
+        crate::tooling::ToolInput::WebFetch { url } => {
+            format!("{}: {url}", call.tool_name)
+        }
+        crate::tooling::ToolInput::WebSearch { query } => {
+            format!("Web search: {query}")
+        }
+        _ => call.tool_name.clone(),
     }
 }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -13,6 +13,13 @@ use std::{
     fmt::{Display, Formatter},
 };
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum WebSearchProvider {
+    #[default]
+    DuckDuckGo,
+    SerperApi,
+}
+
 #[derive(Debug, Clone)]
 /// Provider, model, and transport settings.
 pub struct RuntimeConfig {
@@ -28,6 +35,8 @@ pub struct RuntimeConfig {
     pub auto_compact_threshold: usize,
     pub tool_result_max_chars: usize,
     pub stream: bool,
+    pub web_search_provider: WebSearchProvider,
+    pub serper_api_key: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -69,6 +78,7 @@ pub enum ConfigError {
     InvalidConfigLine(String),
     InvalidNumericValue(String),
     InvalidReasoningVisibility(String),
+    InvalidWebSearchProvider(String),
 }
 
 impl Display for ConfigError {
@@ -82,6 +92,9 @@ impl Display for ConfigError {
             Self::InvalidNumericValue(value) => write!(f, "invalid numeric config value: {value}"),
             Self::InvalidReasoningVisibility(value) => {
                 write!(f, "invalid reasoning visibility: {value}")
+            }
+            Self::InvalidWebSearchProvider(value) => {
+                write!(f, "invalid web search provider: {value}")
             }
         }
     }
@@ -117,6 +130,8 @@ impl EffectiveConfig {
                 auto_compact_threshold: 64,
                 tool_result_max_chars: 8000,
                 stream: true,
+                web_search_provider: WebSearchProvider::default(),
+                serper_api_key: None,
             },
             mode: ModeConfig {
                 interactive: true,
@@ -187,6 +202,8 @@ impl EffectiveConfig {
             "ANVIL_FRESH_SESSION",
             "ANVIL_REASONING_VISIBILITY",
             "ANVIL_DEBUG",
+            "ANVIL_WEB_SEARCH_PROVIDER",
+            "SERPER_API_KEY",
         ] {
             if let Ok(value) = std::env::var(key) {
                 map.insert(key.to_string(), value);
@@ -337,6 +354,16 @@ impl EffectiveConfig {
                 "reasoning_visibility" | "ANVIL_REASONING_VISIBILITY" => {
                     self.mode.reasoning_visibility = parse_reasoning_visibility(value)?;
                 }
+                "web_search_provider" | "ANVIL_WEB_SEARCH_PROVIDER" => {
+                    self.runtime.web_search_provider = parse_web_search_provider(value)?;
+                }
+                "serper_api_key" | "SERPER_API_KEY" => {
+                    self.runtime.serper_api_key = if value.is_empty() {
+                        None
+                    } else {
+                        Some(value.clone())
+                    };
+                }
                 _ => {}
             }
         }
@@ -383,5 +410,13 @@ fn parse_reasoning_visibility(value: &str) -> Result<ReasoningVisibility, Config
         "hidden" => Ok(ReasoningVisibility::Hidden),
         "summary" => Ok(ReasoningVisibility::Summary),
         other => Err(ConfigError::InvalidReasoningVisibility(other.to_string())),
+    }
+}
+
+fn parse_web_search_provider(value: &str) -> Result<WebSearchProvider, ConfigError> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "duckduckgo" => Ok(WebSearchProvider::DuckDuckGo),
+        "serper_api" | "serperapi" | "serper" => Ok(WebSearchProvider::SerperApi),
+        other => Err(ConfigError::InvalidWebSearchProvider(other.to_string())),
     }
 }

--- a/src/tooling/mod.rs
+++ b/src/tooling/mod.rs
@@ -4,13 +4,14 @@
 //! through a permission and plan-mode pipeline, and executed by
 //! [`LocalToolExecutor`] within a sandboxed workspace root.
 
+use crate::config::{RuntimeConfig, WebSearchProvider};
 use crate::contracts::ToolLogView;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fmt::{Display, Formatter};
 use std::fs;
 use std::path::{Component, Path, PathBuf};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PermissionClass {
@@ -53,6 +54,7 @@ pub enum ToolKind {
     FileSearch,
     ShellExec,
     WebFetch,
+    WebSearch,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -62,6 +64,7 @@ pub enum ToolInput {
     FileSearch { root: String, pattern: String },
     ShellExec { command: String },
     WebFetch { url: String },
+    WebSearch { query: String },
 }
 
 impl ToolInput {
@@ -72,6 +75,108 @@ impl ToolInput {
             Self::FileSearch { .. } => ToolKind::FileSearch,
             Self::ShellExec { .. } => ToolKind::ShellExec,
             Self::WebFetch { .. } => ToolKind::WebFetch,
+            Self::WebSearch { .. } => ToolKind::WebSearch,
+        }
+    }
+
+    /// Parse a JSON value into a `ToolInput` given a tool name.
+    ///
+    /// This centralises all field-name knowledge in the `ToolInput` enum
+    /// definition, keeping the agent parser thin.
+    pub fn from_json(tool_name: &str, value: &serde_json::Value) -> Result<ToolInput, String> {
+        match tool_name {
+            "file.write" => Ok(ToolInput::FileWrite {
+                path: value
+                    .get("path")
+                    .and_then(serde_json::Value::as_str)
+                    .ok_or_else(|| "missing path in file.write tool block".to_string())?
+                    .to_string(),
+                content: value
+                    .get("content")
+                    .and_then(serde_json::Value::as_str)
+                    .ok_or_else(|| "missing content in file.write tool block".to_string())?
+                    .to_string(),
+            }),
+            "file.read" => Ok(ToolInput::FileRead {
+                path: value
+                    .get("path")
+                    .and_then(serde_json::Value::as_str)
+                    .ok_or_else(|| "missing path in file.read tool block".to_string())?
+                    .to_string(),
+            }),
+            "file.search" => Ok(ToolInput::FileSearch {
+                root: value
+                    .get("root")
+                    .or_else(|| value.get("path"))
+                    .and_then(serde_json::Value::as_str)
+                    .ok_or_else(|| "missing root in file.search tool block".to_string())?
+                    .to_string(),
+                pattern: value
+                    .get("pattern")
+                    .or_else(|| value.get("content"))
+                    .or_else(|| value.get("query"))
+                    .and_then(serde_json::Value::as_str)
+                    .ok_or_else(|| "missing pattern in file.search tool block".to_string())?
+                    .to_string(),
+            }),
+            "shell.exec" | "shell" => Ok(ToolInput::ShellExec {
+                command: value
+                    .get("command")
+                    .and_then(serde_json::Value::as_str)
+                    .ok_or_else(|| "missing command in shell.exec tool block".to_string())?
+                    .to_string(),
+            }),
+            "web.fetch" => Ok(ToolInput::WebFetch {
+                url: value
+                    .get("url")
+                    .and_then(serde_json::Value::as_str)
+                    .ok_or_else(|| "missing url in web.fetch tool block".to_string())?
+                    .to_string(),
+            }),
+            "web.search" => Ok(ToolInput::WebSearch {
+                query: value
+                    .get("query")
+                    .and_then(serde_json::Value::as_str)
+                    .ok_or_else(|| "missing query in web.search tool block".to_string())?
+                    .to_string(),
+            }),
+            other => Err(format!("unsupported tool in ANVIL_TOOL block: {other}")),
+        }
+    }
+
+    /// Attempt to repair a malformed JSON block into a `ToolInput`.
+    ///
+    /// Uses simple string extraction as a fallback when JSON parsing fails.
+    pub fn repair_from_block(
+        tool_name: &str,
+        block: &str,
+        extract_simple: fn(&str, &str) -> Option<String>,
+        extract_trailing: fn(&str, &str) -> Option<String>,
+    ) -> Option<ToolInput> {
+        match tool_name {
+            "file.write" => Some(ToolInput::FileWrite {
+                path: extract_simple(block, "path")?,
+                content: extract_trailing(block, "content")?,
+            }),
+            "file.read" => Some(ToolInput::FileRead {
+                path: extract_simple(block, "path")?,
+            }),
+            "file.search" => Some(ToolInput::FileSearch {
+                root: extract_simple(block, "root").or_else(|| extract_simple(block, "path"))?,
+                pattern: extract_simple(block, "pattern")
+                    .or_else(|| extract_simple(block, "content"))
+                    .or_else(|| extract_simple(block, "query"))?,
+            }),
+            "shell.exec" | "shell" => Some(ToolInput::ShellExec {
+                command: extract_simple(block, "command")?,
+            }),
+            "web.fetch" => Some(ToolInput::WebFetch {
+                url: extract_simple(block, "url")?,
+            }),
+            "web.search" => Some(ToolInput::WebSearch {
+                query: extract_simple(block, "query")?,
+            }),
+            _ => None,
         }
     }
 }
@@ -147,13 +252,15 @@ impl ValidatedToolCall {
             return None;
         }
 
-        match self.spec.permission_class {
-            PermissionClass::Safe => None,
-            PermissionClass::Confirm | PermissionClass::Restricted => Some(ApprovalRequest {
-                tool_call_id: self.request.tool_call_id.clone(),
-                tool_name: self.spec.name.clone(),
-            }),
+        let effective = effective_permission_class(&self.request.input, &self.spec);
+        if effective == PermissionClass::Safe {
+            return None;
         }
+
+        Some(ApprovalRequest {
+            tool_call_id: self.request.tool_call_id.clone(),
+            tool_name: self.spec.name.clone(),
+        })
     }
 
     pub fn approve(mut self) -> Self {
@@ -348,12 +455,26 @@ impl ToolRegistry {
         });
     }
 
+    pub fn register_web_search(&mut self) {
+        self.register(ToolSpec {
+            version: 1,
+            name: "web.search".to_string(),
+            kind: ToolKind::WebSearch,
+            execution_class: ExecutionClass::Network,
+            permission_class: PermissionClass::Confirm,
+            execution_mode: ExecutionMode::SequentialOnly,
+            plan_mode: PlanModePolicy::Allowed,
+            rollback_policy: RollbackPolicy::None,
+        });
+    }
+
     pub fn register_standard_tools(&mut self) {
         self.register_file_read();
         self.register_file_write();
         self.register_file_search();
         self.register_shell_exec();
         self.register_web_fetch();
+        self.register_web_search();
     }
 
     pub fn validate(
@@ -380,8 +501,16 @@ impl ToolRegistry {
     }
 }
 
+// Rate limit intervals per provider.
+const RATE_LIMIT_DUCKDUCKGO: Duration = Duration::from_secs(2);
+const RATE_LIMIT_SERPER_API: Duration = Duration::from_secs(1);
+
 pub struct LocalToolExecutor {
     root: PathBuf,
+    last_web_search: Option<Instant>,
+    web_search_min_interval: Duration,
+    web_search_provider: WebSearchProvider,
+    serper_api_key: Option<String>,
 }
 
 #[derive(Debug)]
@@ -402,201 +531,426 @@ impl Display for ToolRuntimeError {
 impl std::error::Error for ToolRuntimeError {}
 
 impl LocalToolExecutor {
-    pub fn new(root: impl Into<PathBuf>) -> Self {
-        Self { root: root.into() }
+    pub fn new(root: impl Into<PathBuf>, config: &RuntimeConfig) -> Self {
+        let interval = match config.web_search_provider {
+            WebSearchProvider::DuckDuckGo => RATE_LIMIT_DUCKDUCKGO,
+            WebSearchProvider::SerperApi => RATE_LIMIT_SERPER_API,
+        };
+        Self {
+            root: root.into(),
+            last_web_search: None,
+            web_search_min_interval: interval,
+            web_search_provider: config.web_search_provider,
+            serper_api_key: config.serper_api_key.clone(),
+        }
+    }
+
+    /// Create an executor without rate limiting (for tests).
+    pub fn new_without_rate_limit(root: impl Into<PathBuf>) -> Self {
+        Self {
+            root: root.into(),
+            last_web_search: None,
+            web_search_min_interval: Duration::ZERO,
+            web_search_provider: WebSearchProvider::DuckDuckGo,
+            serper_api_key: None,
+        }
     }
 
     pub fn execute(
-        &self,
+        &mut self,
         request: ToolExecutionRequest,
     ) -> Result<ToolExecutionResult, ToolRuntimeError> {
         let started = Instant::now();
         match request.input {
-            ToolInput::FileRead { path } => {
-                let resolved = self.resolve_path(&path)?;
-                let content = if resolved.is_dir() {
-                    render_directory_listing(&resolved)?
-                } else {
-                    fs::read_to_string(&resolved).map_err(|err| {
-                        ToolRuntimeError::Io(format!(
-                            "file.read failed for {}: {err}",
-                            resolved.display()
-                        ))
-                    })?
-                };
-                Ok(ToolExecutionResult {
-                    tool_call_id: request.tool_call_id,
-                    tool_name: request.spec.name,
-                    status: ToolExecutionStatus::Completed,
-                    summary: path,
-                    payload: ToolExecutionPayload::Text(content),
-                    artifacts: vec![resolved.display().to_string()],
-                    elapsed_ms: started.elapsed().as_millis(),
-                })
+            ToolInput::FileRead { ref path } => self.execute_file_read(&request, path, started),
+            ToolInput::FileWrite {
+                ref path,
+                ref content,
+            } => self.execute_file_write(&request, path, content, started),
+            ToolInput::FileSearch {
+                ref root,
+                ref pattern,
+            } => self.execute_file_search(&request, root, pattern, started),
+            ToolInput::WebFetch { ref url } => self.execute_web_fetch(&request, url, started),
+            ToolInput::ShellExec { ref command } => {
+                self.execute_shell_exec(&request, command, started)
             }
-            ToolInput::FileWrite { path, content } => {
-                let resolved = self.resolve_path(&path)?;
-                if let Some(parent) = resolved.parent() {
-                    fs::create_dir_all(parent).map_err(|err| {
-                        ToolRuntimeError::Io(format!(
-                            "file.write failed to create parent {}: {err}",
-                            parent.display()
-                        ))
-                    })?;
+            ToolInput::WebSearch { ref query } => self.execute_web_search(&request, query, started),
+        }
+    }
+
+    fn execute_file_read(
+        &self,
+        request: &ToolExecutionRequest,
+        path: &str,
+        started: Instant,
+    ) -> Result<ToolExecutionResult, ToolRuntimeError> {
+        let resolved = self.resolve_path(path)?;
+        let content = if resolved.is_dir() {
+            render_directory_listing(&resolved)?
+        } else {
+            fs::read_to_string(&resolved).map_err(|err| {
+                ToolRuntimeError::Io(format!(
+                    "file.read failed for {}: {err}",
+                    resolved.display()
+                ))
+            })?
+        };
+        Ok(build_completed_result(
+            request,
+            path.to_string(),
+            ToolExecutionPayload::Text(content),
+            vec![resolved.display().to_string()],
+            started,
+        ))
+    }
+
+    fn execute_file_write(
+        &self,
+        request: &ToolExecutionRequest,
+        path: &str,
+        content: &str,
+        started: Instant,
+    ) -> Result<ToolExecutionResult, ToolRuntimeError> {
+        let resolved = self.resolve_path(path)?;
+        if let Some(parent) = resolved.parent() {
+            fs::create_dir_all(parent).map_err(|err| {
+                ToolRuntimeError::Io(format!(
+                    "file.write failed to create parent {}: {err}",
+                    parent.display()
+                ))
+            })?;
+        }
+        fs::write(&resolved, content).map_err(|err| {
+            ToolRuntimeError::Io(format!(
+                "file.write failed for {}: {err}",
+                resolved.display()
+            ))
+        })?;
+        Ok(build_completed_result(
+            request,
+            path.to_string(),
+            ToolExecutionPayload::None,
+            vec![resolved.display().to_string()],
+            started,
+        ))
+    }
+
+    fn execute_file_search(
+        &self,
+        request: &ToolExecutionRequest,
+        root: &str,
+        pattern: &str,
+        started: Instant,
+    ) -> Result<ToolExecutionResult, ToolRuntimeError> {
+        let resolved_root = self.resolve_path(root)?;
+        let mut matches = Vec::new();
+        collect_search_matches(&resolved_root, pattern, &mut matches)?;
+        Ok(build_completed_result(
+            request,
+            format!("{root} :: {pattern}"),
+            ToolExecutionPayload::Paths(matches.clone()),
+            matches,
+            started,
+        ))
+    }
+
+    fn execute_web_fetch(
+        &self,
+        request: &ToolExecutionRequest,
+        url: &str,
+        started: Instant,
+    ) -> Result<ToolExecutionResult, ToolRuntimeError> {
+        let output = std::process::Command::new("curl")
+            .args([
+                "-s",
+                "-L",
+                "--fail",
+                "--max-time",
+                "30",
+                "--max-filesize",
+                "1048576",
+                "--max-redirs",
+                "5",
+                "--",
+                url,
+            ])
+            .output()
+            .map_err(|err| {
+                ToolRuntimeError::Io(format!("web.fetch failed to spawn curl: {err}"))
+            })?;
+
+        if output.status.success() {
+            let body = String::from_utf8_lossy(&output.stdout).to_string();
+            Ok(build_completed_result(
+                request,
+                url.to_string(),
+                ToolExecutionPayload::Text(body),
+                Vec::new(),
+                started,
+            ))
+        } else {
+            let stderr_msg = String::from_utf8_lossy(&output.stderr).to_string();
+            Err(ToolRuntimeError::Io(format!(
+                "web.fetch failed for {url}: {stderr_msg}"
+            )))
+        }
+    }
+
+    fn execute_shell_exec(
+        &self,
+        request: &ToolExecutionRequest,
+        command: &str,
+        started: Instant,
+    ) -> Result<ToolExecutionResult, ToolRuntimeError> {
+        use std::io::{BufRead, Write as _};
+
+        let _ = writeln!(std::io::stderr(), "\n  $ {command}");
+
+        let mut child = std::process::Command::new("sh")
+            .arg("-c")
+            .arg(command)
+            .current_dir(&self.root)
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .map_err(|err| ToolRuntimeError::Io(format!("shell.exec failed to spawn: {err}")))?;
+
+        let stdout_handle = child.stdout.take();
+        let stderr_handle = child.stderr.take();
+
+        let stdout_thread = std::thread::spawn(move || {
+            let mut captured = String::new();
+            if let Some(out) = stdout_handle {
+                let reader = std::io::BufReader::new(out);
+                for line in reader.lines() {
+                    let Ok(line) = line else { break };
+                    let _ = writeln!(std::io::stderr(), "  {line}");
+                    captured.push_str(&line);
+                    captured.push('\n');
                 }
-                fs::write(&resolved, &content).map_err(|err| {
-                    ToolRuntimeError::Io(format!(
-                        "file.write failed for {}: {err}",
-                        resolved.display()
-                    ))
-                })?;
-                Ok(ToolExecutionResult {
-                    tool_call_id: request.tool_call_id,
-                    tool_name: request.spec.name,
-                    status: ToolExecutionStatus::Completed,
-                    summary: path,
-                    payload: ToolExecutionPayload::None,
-                    artifacts: vec![resolved.display().to_string()],
-                    elapsed_ms: started.elapsed().as_millis(),
-                })
             }
-            ToolInput::FileSearch { root, pattern } => {
-                let resolved_root = self.resolve_path(&root)?;
-                let mut matches = Vec::new();
-                collect_search_matches(&resolved_root, &pattern, &mut matches)?;
-                Ok(ToolExecutionResult {
-                    tool_call_id: request.tool_call_id,
-                    tool_name: request.spec.name,
-                    status: ToolExecutionStatus::Completed,
-                    summary: format!("{root} :: {pattern}"),
-                    payload: ToolExecutionPayload::Paths(matches.clone()),
-                    artifacts: matches,
-                    elapsed_ms: started.elapsed().as_millis(),
-                })
-            }
-            ToolInput::WebFetch { url } => {
-                let output = std::process::Command::new("curl")
-                    .args([
-                        "-s",
-                        "-L",
-                        "--fail",
-                        "--max-time",
-                        "30",
-                        "--max-filesize",
-                        "1048576",
-                        "--max-redirs",
-                        "5",
-                        &url,
-                    ])
-                    .output()
-                    .map_err(|err| {
-                        ToolRuntimeError::Io(format!("web.fetch failed to spawn curl: {err}"))
-                    })?;
+            captured
+        });
 
-                if output.status.success() {
-                    let body = String::from_utf8_lossy(&output.stdout).to_string();
-                    Ok(ToolExecutionResult {
-                        tool_call_id: request.tool_call_id,
-                        tool_name: request.spec.name,
-                        status: ToolExecutionStatus::Completed,
-                        summary: url,
-                        payload: ToolExecutionPayload::Text(body),
-                        artifacts: Vec::new(),
-                        elapsed_ms: started.elapsed().as_millis(),
-                    })
-                } else {
-                    let stderr_msg = String::from_utf8_lossy(&output.stderr).to_string();
-                    Err(ToolRuntimeError::Io(format!(
-                        "web.fetch failed for {url}: {stderr_msg}"
-                    )))
+        let stderr_thread = std::thread::spawn(move || {
+            let mut captured = String::new();
+            if let Some(err) = stderr_handle {
+                let reader = std::io::BufReader::new(err);
+                for line in reader.lines() {
+                    let Ok(line) = line else { break };
+                    let _ = writeln!(std::io::stderr(), "  {line}");
+                    captured.push_str(&line);
+                    captured.push('\n');
                 }
             }
-            ToolInput::ShellExec { command } => {
-                use std::io::{BufRead, Write as _};
+            captured
+        });
 
-                let _ = writeln!(std::io::stderr(), "\n  $ {command}");
+        let exit_status = child.wait().ok();
+        let stdout_buf = stdout_thread.join().unwrap_or_default();
+        let stderr_buf = stderr_thread.join().unwrap_or_default();
 
-                let mut child = std::process::Command::new("sh")
-                    .arg("-c")
-                    .arg(&command)
-                    .current_dir(&self.root)
-                    .stdout(std::process::Stdio::piped())
-                    .stderr(std::process::Stdio::piped())
-                    .spawn()
-                    .map_err(|err| {
-                        ToolRuntimeError::Io(format!("shell.exec failed to spawn: {err}"))
-                    })?;
+        let combined = if stderr_buf.trim().is_empty() {
+            stdout_buf
+        } else if stdout_buf.trim().is_empty() {
+            stderr_buf
+        } else {
+            format!("{stdout_buf}--- stderr ---\n{stderr_buf}")
+        };
 
-                // Stream stdout to stderr in real-time so the user can
-                // see progress and Ctrl+C if needed.
-                let stdout_handle = child.stdout.take();
-                let stderr_handle = child.stderr.take();
+        let success = exit_status.is_some_and(|s| s.success());
+        let status = if success {
+            ToolExecutionStatus::Completed
+        } else {
+            ToolExecutionStatus::Failed
+        };
+        let summary = if success {
+            format!("shell.exec completed: {command}")
+        } else {
+            format!(
+                "shell.exec failed (exit {}): {command}",
+                exit_status.and_then(|s| s.code()).unwrap_or(-1)
+            )
+        };
+        Ok(ToolExecutionResult {
+            tool_call_id: request.tool_call_id.clone(),
+            tool_name: request.spec.name.clone(),
+            status,
+            summary,
+            payload: ToolExecutionPayload::Text(combined),
+            artifacts: Vec::new(),
+            elapsed_ms: started.elapsed().as_millis(),
+        })
+    }
 
-                let stdout_thread = std::thread::spawn(move || {
-                    let mut captured = String::new();
-                    if let Some(out) = stdout_handle {
-                        let reader = std::io::BufReader::new(out);
-                        for line in reader.lines() {
-                            let Ok(line) = line else { break };
-                            let _ = writeln!(std::io::stderr(), "  {line}");
-                            captured.push_str(&line);
-                            captured.push('\n');
-                        }
-                    }
-                    captured
-                });
+    fn execute_web_search(
+        &mut self,
+        request: &ToolExecutionRequest,
+        query: &str,
+        started: Instant,
+    ) -> Result<ToolExecutionResult, ToolRuntimeError> {
+        self.enforce_rate_limit();
 
-                let stderr_thread = std::thread::spawn(move || {
-                    let mut captured = String::new();
-                    if let Some(err) = stderr_handle {
-                        let reader = std::io::BufReader::new(err);
-                        for line in reader.lines() {
-                            let Ok(line) = line else { break };
-                            let _ = writeln!(std::io::stderr(), "  {line}");
-                            captured.push_str(&line);
-                            captured.push('\n');
-                        }
-                    }
-                    captured
-                });
+        match self.web_search_provider {
+            WebSearchProvider::DuckDuckGo => {
+                self.execute_web_search_duckduckgo(request, query, started)
+            }
+            WebSearchProvider::SerperApi => self.execute_web_search_serper(request, query, started),
+        }
+    }
 
-                let exit_status = child.wait().ok();
-                let stdout_buf = stdout_thread.join().unwrap_or_default();
-                let stderr_buf = stderr_thread.join().unwrap_or_default();
+    fn execute_web_search_duckduckgo(
+        &self,
+        request: &ToolExecutionRequest,
+        query: &str,
+        started: Instant,
+    ) -> Result<ToolExecutionResult, ToolRuntimeError> {
+        let encoded_query = percent_encode(query);
+        let url = format!("https://html.duckduckgo.com/html/?q={encoded_query}");
 
-                let combined = if stderr_buf.trim().is_empty() {
-                    stdout_buf
-                } else if stdout_buf.trim().is_empty() {
-                    stderr_buf
-                } else {
-                    format!("{stdout_buf}--- stderr ---\n{stderr_buf}")
-                };
+        let output = std::process::Command::new("curl")
+            .args([
+                "-s",
+                "-L",
+                "--fail",
+                "--max-time",
+                "15",
+                "-H",
+                "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+                "--",
+            ])
+            .arg(&url)
+            .output()
+            .map_err(|err| {
+                ToolRuntimeError::Io(format!("web.search failed to spawn curl: {err}"))
+            })?;
 
-                let success = exit_status.is_some_and(|s| s.success());
-                let status = if success {
-                    ToolExecutionStatus::Completed
-                } else {
-                    ToolExecutionStatus::Failed
-                };
-                let summary = if success {
-                    format!("shell.exec completed: {command}")
-                } else {
-                    format!(
-                        "shell.exec failed (exit {}): {command}",
-                        exit_status.and_then(|s| s.code()).unwrap_or(-1)
-                    )
-                };
-                Ok(ToolExecutionResult {
-                    tool_call_id: request.tool_call_id,
-                    tool_name: request.spec.name,
-                    status,
-                    summary,
-                    payload: ToolExecutionPayload::Text(combined),
-                    artifacts: Vec::new(),
-                    elapsed_ms: started.elapsed().as_millis(),
-                })
+        if !output.status.success() {
+            return Err(ToolRuntimeError::Io(
+                "DuckDuckGo search failed. CAPTCHA/rate limit may be active. Please wait and retry."
+                    .to_string(),
+            ));
+        }
+
+        let body = String::from_utf8_lossy(&output.stdout).to_string();
+
+        // Parse results using regex
+        let results = parse_duckduckgo_results(&body);
+
+        // CAPTCHA / bot detection
+        if results.is_empty() {
+            let lower = body.to_ascii_lowercase();
+            let has_result_elements = lower.contains("result__a");
+            if !has_result_elements && (lower.contains("captcha") || lower.contains("bot")) {
+                return Err(ToolRuntimeError::Io(
+                    "DuckDuckGo search blocked by CAPTCHA/rate limit. Please wait and retry."
+                        .to_string(),
+                ));
             }
         }
+
+        let formatted = format_search_results(&results);
+
+        Ok(build_completed_result(
+            request,
+            format!("web.search: {query}"),
+            ToolExecutionPayload::Text(formatted),
+            Vec::new(),
+            started,
+        ))
+    }
+
+    fn execute_web_search_serper(
+        &self,
+        request: &ToolExecutionRequest,
+        query: &str,
+        started: Instant,
+    ) -> Result<ToolExecutionResult, ToolRuntimeError> {
+        let api_key = self.serper_api_key.as_deref().ok_or_else(|| {
+            ToolRuntimeError::Io("SerperAPI search failed. SERPER_API_KEY is not set.".to_string())
+        })?;
+
+        let body = serde_json::json!({"q": query}).to_string();
+        let header_value = format!("X-API-KEY: {api_key}");
+
+        let output = std::process::Command::new("curl")
+            .args([
+                "-s",
+                "-o",
+                "-",
+                "-w",
+                "\n%{http_code}",
+                "--max-time",
+                "10",
+                "-H",
+                &header_value,
+                "-H",
+                "Content-Type: application/json",
+                "-d",
+                &body,
+                "--",
+                "https://google.serper.dev/search",
+            ])
+            .output()
+            .map_err(|err| {
+                ToolRuntimeError::Io(format!(
+                    "web.search (SerperAPI) failed to spawn curl: {err}"
+                ))
+            })?;
+
+        if !output.status.success() {
+            let stderr_msg = String::from_utf8_lossy(&output.stderr).to_string();
+            return Err(ToolRuntimeError::Io(format!(
+                "Failed to reach SerperAPI. Check your network connection. {stderr_msg}"
+            )));
+        }
+
+        let raw_output = String::from_utf8_lossy(&output.stdout).to_string();
+        // Extract HTTP status code from the last line (appended by -w '\n%{http_code}')
+        let (response_body, http_code) = match raw_output.rsplit_once('\n') {
+            Some((body, code)) => (body.to_string(), code.trim().to_string()),
+            None => (raw_output, String::new()),
+        };
+
+        match http_code.as_str() {
+            "200" => {} // success
+            "401" | "403" => {
+                return Err(ToolRuntimeError::Io(
+                    "Invalid or expired SerperAPI key.".to_string(),
+                ));
+            }
+            "429" => {
+                return Err(ToolRuntimeError::Io(
+                    "SerperAPI rate limit exceeded. Please wait and retry.".to_string(),
+                ));
+            }
+            code => {
+                return Err(ToolRuntimeError::Io(format!(
+                    "SerperAPI request failed with HTTP {code}."
+                )));
+            }
+        }
+        let results = parse_serper_results(&response_body);
+        let formatted = format_search_results(&results);
+
+        Ok(build_completed_result(
+            request,
+            format!("web.search: {query}"),
+            ToolExecutionPayload::Text(formatted),
+            Vec::new(),
+            started,
+        ))
+    }
+
+    fn enforce_rate_limit(&mut self) {
+        if let Some(prev) = self.last_web_search {
+            let elapsed = prev.elapsed();
+            if elapsed < self.web_search_min_interval {
+                std::thread::sleep(self.web_search_min_interval - elapsed);
+            }
+        }
+        self.last_web_search = Some(Instant::now());
     }
 
     fn resolve_path(&self, raw: &str) -> Result<PathBuf, ToolRuntimeError> {
@@ -628,6 +982,27 @@ impl LocalToolExecutor {
             }
         }
         Ok(joined)
+    }
+}
+
+/// Build a [`ToolExecutionResult`] with `Completed` status.
+///
+/// Centralises the boilerplate shared by every successful execution path.
+fn build_completed_result(
+    request: &ToolExecutionRequest,
+    summary: String,
+    payload: ToolExecutionPayload,
+    artifacts: Vec<String>,
+    started: Instant,
+) -> ToolExecutionResult {
+    ToolExecutionResult {
+        tool_call_id: request.tool_call_id.clone(),
+        tool_name: request.spec.name.clone(),
+        status: ToolExecutionStatus::Completed,
+        summary,
+        payload,
+        artifacts,
+        elapsed_ms: started.elapsed().as_millis(),
     }
 }
 
@@ -720,6 +1095,24 @@ fn validate_required_fields(input: &ToolInput) -> Result<(), ToolValidationError
                 });
             }
         }
+        ToolInput::WebSearch { query } => {
+            if query.trim().is_empty() {
+                return Err(ToolValidationError::MissingRequiredField(
+                    "query".to_string(),
+                ));
+            }
+            const MAX_QUERY_LENGTH: usize = 500;
+            if query.len() > MAX_QUERY_LENGTH {
+                return Err(ToolValidationError::InvalidFieldValue {
+                    field: "query".to_string(),
+                    reason: format!(
+                        "query length {} exceeds maximum of {} characters",
+                        query.len(),
+                        MAX_QUERY_LENGTH
+                    ),
+                });
+            }
+        }
     }
 
     Ok(())
@@ -761,32 +1154,328 @@ fn validate_shell_command_safety(command: &str) -> Result<(), ToolValidationErro
     Ok(())
 }
 
+/// Determine whether a shell command is safe enough to auto-approve.
+///
+/// Commands that pass this check are promoted from `Confirm` to `Safe`
+/// by [`effective_permission_class`], skipping the approval prompt.
+pub fn is_safe_shell_command(command: &str) -> bool {
+    let trimmed = command.trim();
+
+    // Reject command chaining / injection vectors
+    if trimmed.contains('|')
+        || trimmed.contains(';')
+        || trimmed.contains('`')
+        || trimmed.contains("$(")
+        || trimmed.contains("${")
+        || trimmed.contains('\n')
+    {
+        return false;
+    }
+
+    // gh api: GET-only is safe (token-split based flag detection)
+    if trimmed.starts_with("gh api ") {
+        let tokens: Vec<&str> = trimmed.split_whitespace().collect();
+        let mutation_flags = [
+            "--method",
+            "-X",
+            "--input",
+            "-f",
+            "--field",
+            "-F",
+            "--raw-field",
+        ];
+        let mutation_combined = [
+            "-XPOST",
+            "-XPUT",
+            "-XPATCH",
+            "-XDELETE",
+            "--method=POST",
+            "--method=PUT",
+            "--method=PATCH",
+            "--method=DELETE",
+            "--input=",
+            "-f=",
+            "--field=",
+            "-F=",
+            "--raw-field=",
+        ];
+
+        for (i, token) in tokens.iter().enumerate() {
+            // Check flag + next-token patterns (e.g. --method POST)
+            if mutation_flags.iter().any(|f| token == f) {
+                if let Some(next) = tokens.get(i + 1) {
+                    let upper = next.to_uppercase();
+                    if ["POST", "PUT", "PATCH", "DELETE"].contains(&upper.as_str()) {
+                        return false;
+                    }
+                }
+                // -f, --field, -F, --raw-field, --input are mutation flags by themselves
+                if ["-f", "--field", "-F", "--raw-field", "--input"].contains(token) {
+                    return false;
+                }
+            }
+            // Check combined forms (e.g. -XPOST, --method=POST, --input=file)
+            if mutation_combined.iter().any(|f| token.starts_with(f)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    const SAFE_PREFIXES: &[&str] = &[
+        "gh repo view",
+        "gh pr list",
+        "gh issue list",
+        "git log",
+        "git status",
+        "git diff",
+    ];
+    if !SAFE_PREFIXES
+        .iter()
+        .any(|prefix| trimmed.starts_with(prefix))
+    {
+        return false;
+    }
+
+    // Block dangerous options that may launch external processes
+    let dangerous_options = ["--web", "--browse"];
+    let tokens: Vec<&str> = trimmed.split_whitespace().collect();
+    for token in &tokens {
+        if dangerous_options.iter().any(|opt| token == opt) {
+            return false;
+        }
+    }
+    true
+}
+
+/// Compute the effective permission class for a tool call.
+///
+/// Safe shell commands (as determined by [`is_safe_shell_command`]) are
+/// promoted from `Confirm` to `Safe`, skipping the approval prompt.
+pub fn effective_permission_class(input: &ToolInput, spec: &ToolSpec) -> PermissionClass {
+    match input {
+        ToolInput::ShellExec { command } if is_safe_shell_command(command) => PermissionClass::Safe,
+        _ => spec.permission_class,
+    }
+}
+
+// --- Search result parsing helpers ---
+
+struct SearchResult {
+    title: String,
+    url: String,
+    snippet: String,
+}
+
+fn parse_duckduckgo_results(html: &str) -> Vec<SearchResult> {
+    use regex::Regex;
+
+    let mut results = Vec::new();
+
+    // Filter out ad results
+    let ad_re = Regex::new(r#"class="[^"]*result--ad[^"]*""#).ok();
+
+    // Match result links: <a ... class="result__a" ... href="URL">TITLE</a>
+    let link_re = Regex::new(r#"<a[^>]+class="result__a"[^>]*href="([^"]*)"[^>]*>(.*?)</a>"#).ok();
+
+    // Match snippets: <a class="result__snippet" ...>SNIPPET</a>
+    // Also try <td class="result__snippet"> for alternative format
+    let snippet_re = Regex::new(r#"class="result__snippet"[^>]*>(.*?)</(?:a|td)>"#).ok();
+
+    let (Some(link_re), Some(snippet_re)) = (link_re, snippet_re) else {
+        return results;
+    };
+
+    // Split the HTML into result blocks (each starts with result__a)
+    let link_captures: Vec<_> = link_re.captures_iter(html).collect();
+    let snippet_captures: Vec<_> = snippet_re.captures_iter(html).collect();
+
+    for (i, link_cap) in link_captures.iter().enumerate() {
+        if results.len() >= 10 {
+            break;
+        }
+
+        // Check if this result is within an ad block
+        let match_start = link_cap.get(0).map(|m| m.start()).unwrap_or(0);
+        if let Some(ref ad_re) = ad_re {
+            // Look backwards for ad class marker
+            let preceding = &html[..match_start];
+            let last_result_start = preceding.rfind("class=\"result ");
+            let last_ad = preceding.rfind("result--ad");
+            if let (Some(result_pos), Some(ad_pos)) = (last_result_start, last_ad)
+                && ad_pos > result_pos
+            {
+                continue;
+            }
+            // Also check forward context for ad markers
+            let end = (match_start + 500).min(html.len());
+            let context = &html[match_start..end];
+            if ad_re.is_match(context) {
+                continue;
+            }
+        }
+
+        let raw_url = link_cap.get(1).map_or("", |m| m.as_str());
+        let raw_title = link_cap.get(2).map_or("", |m| m.as_str());
+
+        // Decode DuckDuckGo redirect URLs
+        let url = decode_duckduckgo_url(raw_url);
+        let title = strip_html_tags(raw_title);
+
+        let snippet = snippet_captures
+            .get(i)
+            .and_then(|cap| cap.get(1))
+            .map(|m| strip_html_tags(m.as_str()))
+            .unwrap_or_default();
+
+        if !title.is_empty() && !url.is_empty() {
+            results.push(SearchResult {
+                title,
+                url,
+                snippet,
+            });
+        }
+    }
+
+    results
+}
+
+fn parse_serper_results(json_str: &str) -> Vec<SearchResult> {
+    let mut results = Vec::new();
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(json_str) else {
+        return results;
+    };
+
+    if let Some(organic) = value.get("organic").and_then(|v| v.as_array()) {
+        for item in organic.iter().take(10) {
+            let title = item
+                .get("title")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let url = item
+                .get("link")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let snippet = item
+                .get("snippet")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            if !title.is_empty() && !url.is_empty() {
+                results.push(SearchResult {
+                    title,
+                    url,
+                    snippet,
+                });
+            }
+        }
+    }
+
+    results
+}
+
+fn format_search_results(results: &[SearchResult]) -> String {
+    if results.is_empty() {
+        return "No search results found.".to_string();
+    }
+    let mut lines = Vec::new();
+    for (i, result) in results.iter().enumerate() {
+        lines.push(format!("[{}] {}", i + 1, result.title));
+        lines.push(format!("    {}", result.url));
+        if !result.snippet.is_empty() {
+            lines.push(format!("    {}", result.snippet));
+        }
+        lines.push(String::new());
+    }
+    lines.join("\n")
+}
+
+/// Percent-encode a query string for use in URLs.
+fn percent_encode(input: &str) -> String {
+    use std::fmt::Write;
+    let mut encoded = String::with_capacity(input.len() * 3);
+    for byte in input.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                encoded.push(byte as char);
+            }
+            b' ' => encoded.push('+'),
+            _ => {
+                let _ = write!(encoded, "%{byte:02X}");
+            }
+        }
+    }
+    encoded
+}
+
+/// Decode a DuckDuckGo redirect URL to extract the actual target URL.
+fn decode_duckduckgo_url(url: &str) -> String {
+    // DuckDuckGo wraps URLs in redirects like //duckduckgo.com/l/?uddg=ENCODED_URL&...
+    if (url.contains("duckduckgo.com/l/") || url.contains("uddg="))
+        && let Some(start) = url.find("uddg=")
+    {
+        let rest = &url[start + 5..];
+        let end = rest.find('&').unwrap_or(rest.len());
+        let encoded = &rest[..end];
+        return percent_decode(encoded);
+    }
+    url.to_string()
+}
+
+/// Simple percent-decode.
+fn percent_decode(input: &str) -> String {
+    let mut result = String::with_capacity(input.len());
+    let mut chars = input.chars();
+    while let Some(ch) = chars.next() {
+        if ch == '%' {
+            let hex: String = chars.by_ref().take(2).collect();
+            if let Ok(byte) = u8::from_str_radix(&hex, 16) {
+                result.push(byte as char);
+            } else {
+                result.push('%');
+                result.push_str(&hex);
+            }
+        } else if ch == '+' {
+            result.push(' ');
+        } else {
+            result.push(ch);
+        }
+    }
+    result
+}
+
+/// Strip HTML tags from a string.
+fn strip_html_tags(input: &str) -> String {
+    let mut result = String::with_capacity(input.len());
+    let mut in_tag = false;
+    for ch in input.chars() {
+        match ch {
+            '<' => in_tag = true,
+            '>' => in_tag = false,
+            _ if !in_tag => result.push(ch),
+            _ => {}
+        }
+    }
+    // Decode common HTML entities
+    result
+        .replace("&amp;", "&")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&quot;", "\"")
+        .replace("&#x27;", "'")
+        .replace("&apos;", "'")
+        .replace("&#39;", "'")
+}
+
 fn collect_search_matches(
     root: &Path,
     pattern: &str,
     matches: &mut Vec<String>,
 ) -> Result<(), ToolRuntimeError> {
-    use std::io::BufRead;
-
     if root.is_file() {
-        let path_str = root.display().to_string();
-        if path_str.contains(pattern) {
-            matches.push(path_str);
-            return Ok(());
-        }
-        if !is_searchable_file(root) {
-            return Ok(());
-        }
-        if let Ok(file) = fs::File::open(root) {
-            let reader = std::io::BufReader::new(file);
-            for line in reader.lines() {
-                let Ok(line) = line else { break };
-                if line.contains(pattern) {
-                    matches.push(path_str);
-                    break;
-                }
-            }
-        }
+        check_file_match(root, pattern, matches);
         return Ok(());
     }
 
@@ -814,28 +1503,35 @@ fn collect_search_matches(
             }
             collect_search_matches(&path, pattern, matches)?;
         } else {
-            let path_str = path.display().to_string();
-            if path_str.contains(pattern) {
-                matches.push(path_str);
-                continue;
-            }
-            if !is_searchable_file(&path) {
-                continue;
-            }
-            if let Ok(file) = fs::File::open(&path) {
-                let reader = std::io::BufReader::new(file);
-                for line in reader.lines() {
-                    let Ok(line) = line else { break };
-                    if line.contains(pattern) {
-                        matches.push(path_str);
-                        break;
-                    }
-                }
-            }
+            check_file_match(&path, pattern, matches);
         }
     }
 
     Ok(())
+}
+
+/// Check whether a single file matches `pattern` by path name or content.
+fn check_file_match(path: &Path, pattern: &str, matches: &mut Vec<String>) {
+    use std::io::BufRead;
+
+    let path_str = path.display().to_string();
+    if path_str.contains(pattern) {
+        matches.push(path_str);
+        return;
+    }
+    if !is_searchable_file(path) {
+        return;
+    }
+    if let Ok(file) = fs::File::open(path) {
+        let reader = std::io::BufReader::new(file);
+        for line in reader.lines() {
+            let Ok(line) = line else { break };
+            if line.contains(pattern) {
+                matches.push(path_str);
+                break;
+            }
+        }
+    }
 }
 
 /// Check if a file is likely to be text and worth searching.

--- a/tests/provider_integration.rs
+++ b/tests/provider_integration.rs
@@ -1299,3 +1299,94 @@ fn system_prompt_includes_web_fetch_tool() {
         "system prompt should mention web.fetch"
     );
 }
+
+// --- web.search agent protocol tests ---
+
+#[test]
+fn structured_response_parser_handles_web_search_tool_block() {
+    let response = anvil::agent::BasicAgentLoop::parse_structured_response(concat!(
+        "```ANVIL_TOOL\n",
+        "{\"id\":\"call_search_001\",\"tool\":\"web.search\",\"query\":\"rust error handling\"}\n",
+        "```\n",
+        "```ANVIL_FINAL\n",
+        "Searched for rust error handling.\n",
+        "```\n"
+    ))
+    .expect("parser should handle web.search block");
+
+    assert_eq!(response.tool_calls.len(), 1);
+    assert_eq!(response.tool_calls[0].tool_name, "web.search");
+    match &response.tool_calls[0].input {
+        anvil::tooling::ToolInput::WebSearch { query } => {
+            assert_eq!(query, "rust error handling");
+        }
+        other => panic!("unexpected tool input: {other:?}"),
+    }
+}
+
+#[test]
+fn structured_response_parser_rejects_web_search_missing_query() {
+    let result = anvil::agent::BasicAgentLoop::parse_structured_response(concat!(
+        "```ANVIL_TOOL\n",
+        "{\"id\":\"call_search_002\",\"tool\":\"web.search\"}\n",
+        "```\n",
+        "```ANVIL_FINAL\n",
+        "Done.\n",
+        "```\n"
+    ));
+
+    assert!(result.is_err(), "missing query should fail");
+    let err = result.unwrap_err();
+    assert!(
+        err.contains("missing query"),
+        "error should mention missing query, got: {err}"
+    );
+}
+
+#[test]
+fn structured_response_parser_repairs_web_search_block() {
+    // Simulate malformed JSON that the repair path should handle
+    let response = anvil::agent::BasicAgentLoop::parse_structured_response(concat!(
+        "```ANVIL_TOOL\n",
+        "{\"id\":\"call_search_003\",\"tool\":\"web.search\",\"query\":\"serde derive\"\n",
+        "```\n",
+        "```ANVIL_FINAL\n",
+        "Searched.\n",
+        "```\n"
+    ))
+    .expect("parser should repair web.search block");
+
+    assert_eq!(response.tool_calls.len(), 1);
+    match &response.tool_calls[0].input {
+        anvil::tooling::ToolInput::WebSearch { query } => {
+            assert_eq!(query, "serde derive");
+        }
+        other => panic!("unexpected tool input: {other:?}"),
+    }
+}
+
+#[test]
+fn system_prompt_includes_web_search_tool() {
+    let session = anvil::session::SessionRecord::new(std::path::PathBuf::from("/tmp"));
+    let request =
+        anvil::agent::BasicAgentLoop::build_turn_request("test-model", &session, false, 4096);
+    assert!(
+        request.messages[0].content.contains("web.search"),
+        "system prompt should mention web.search"
+    );
+}
+
+#[test]
+fn system_prompt_includes_github_insights() {
+    let session = anvil::session::SessionRecord::new(std::path::PathBuf::from("/tmp"));
+    let request =
+        anvil::agent::BasicAgentLoop::build_turn_request("test-model", &session, false, 4096);
+    assert!(
+        request.messages[0].content.contains("GitHub Insights"),
+        "system prompt should mention GitHub Insights"
+    );
+    assert!(
+        request.messages[0].content.contains("gh api"),
+        "system prompt should mention gh api"
+    );
+}

--- a/tests/state_session.rs
+++ b/tests/state_session.rs
@@ -413,3 +413,34 @@ fn session_interrupt_persists_and_resumes_correctly() {
     resumed.push_message(new_user_message("msg_003", "continue"));
     assert_eq!(resumed.message_count(), 3); // original 2 (msg_002 marked interrupted in-place) + new
 }
+
+#[test]
+fn web_search_pending_turn_state_serde_roundtrip() {
+    use anvil::agent::PendingTurnState;
+    use anvil::tooling::{ToolCallRequest, ToolInput};
+
+    let pending = PendingTurnState {
+        waiting_tool_call_id: "call_ws_001".to_string(),
+        remaining_events: vec![],
+        pending_tool_calls: vec![ToolCallRequest::new(
+            "call_ws_001",
+            "web.search",
+            ToolInput::WebSearch {
+                query: "rust serde tutorial".to_string(),
+            },
+        )],
+    };
+
+    let json = serde_json::to_string(&pending).expect("serialize should succeed");
+    let deserialized: PendingTurnState =
+        serde_json::from_str(&json).expect("deserialize should succeed");
+
+    assert_eq!(pending, deserialized);
+    assert_eq!(deserialized.pending_tool_calls[0].tool_name, "web.search");
+    match &deserialized.pending_tool_calls[0].input {
+        ToolInput::WebSearch { query } => {
+            assert_eq!(query, "rust serde tutorial");
+        }
+        other => panic!("unexpected tool input: {other:?}"),
+    }
+}

--- a/tests/tooling_system.rs
+++ b/tests/tooling_system.rs
@@ -3,16 +3,13 @@ use anvil::tooling::{
     PermissionClass, PlanModePolicy, RollbackPolicy, ToolCallRequest, ToolExecutionError,
     ToolExecutionPayload, ToolExecutionPolicy, ToolExecutionRequest, ToolExecutionResult,
     ToolExecutionStatus, ToolInput, ToolKind, ToolRegistry, ToolValidationError,
+    effective_permission_class, is_safe_shell_command,
 };
 use std::fs;
 
 fn build_registry() -> ToolRegistry {
     let mut registry = ToolRegistry::new();
-    registry.register_file_read();
-    registry.register_file_write();
-    registry.register_file_search();
-    registry.register_shell_exec();
-    registry.register_web_fetch();
+    registry.register_standard_tools();
     registry
 }
 
@@ -384,7 +381,7 @@ fn local_tool_executor_reads_directory_as_listing() {
     let _ = fs::remove_dir_all(&root);
     fs::create_dir_all(root.join("sandbox/test1_001")).expect("dir should exist");
     fs::write(root.join("sandbox/test1_001/index.html"), "<html></html>").expect("file exists");
-    let executor = LocalToolExecutor::new(root.clone());
+    let mut executor = LocalToolExecutor::new_without_rate_limit(root.clone());
 
     let result = executor
         .execute(ToolExecutionRequest {
@@ -538,4 +535,357 @@ fn web_fetch_spec_has_correct_policies() {
     );
     assert_eq!(spec.plan_mode, PlanModePolicy::Allowed);
     assert_eq!(spec.rollback_policy, RollbackPolicy::None);
+}
+
+// --- web.search tests ---
+
+#[test]
+fn web_search_is_registered_after_register_standard_tools() {
+    let mut registry = ToolRegistry::new();
+    registry.register_standard_tools();
+    let spec = registry
+        .get("web.search")
+        .expect("web.search should be registered");
+    assert_eq!(spec.kind, ToolKind::WebSearch);
+    assert_eq!(spec.execution_class, ExecutionClass::Network);
+    assert_eq!(spec.permission_class, PermissionClass::Confirm);
+    assert_eq!(
+        spec.execution_mode,
+        anvil::tooling::ExecutionMode::SequentialOnly
+    );
+    assert_eq!(spec.plan_mode, PlanModePolicy::Allowed);
+    assert_eq!(spec.rollback_policy, RollbackPolicy::None);
+}
+
+#[test]
+fn web_search_input_maps_to_web_search_kind() {
+    let input = ToolInput::WebSearch {
+        query: "rust error handling".to_string(),
+    };
+    assert_eq!(input.kind(), ToolKind::WebSearch);
+}
+
+#[test]
+fn web_search_validation_rejects_empty_query() {
+    let registry = build_registry();
+    let err = registry
+        .validate(ToolCallRequest::new(
+            "call_search_001",
+            "web.search",
+            ToolInput::WebSearch {
+                query: "".to_string(),
+            },
+        ))
+        .expect_err("empty query should be rejected");
+    assert_eq!(
+        err,
+        ToolValidationError::MissingRequiredField("query".to_string())
+    );
+}
+
+#[test]
+fn web_search_validation_rejects_whitespace_only_query() {
+    let registry = build_registry();
+    let err = registry
+        .validate(ToolCallRequest::new(
+            "call_search_002",
+            "web.search",
+            ToolInput::WebSearch {
+                query: "   ".to_string(),
+            },
+        ))
+        .expect_err("whitespace-only query should be rejected");
+    assert_eq!(
+        err,
+        ToolValidationError::MissingRequiredField("query".to_string())
+    );
+}
+
+#[test]
+fn web_search_validation_rejects_query_exceeding_500_chars() {
+    let registry = build_registry();
+    let long_query = "a".repeat(501);
+    let err = registry
+        .validate(ToolCallRequest::new(
+            "call_search_003",
+            "web.search",
+            ToolInput::WebSearch { query: long_query },
+        ))
+        .expect_err("query exceeding 500 characters should be rejected");
+    match err {
+        ToolValidationError::InvalidFieldValue { field, reason } => {
+            assert_eq!(field, "query");
+            assert!(reason.contains("501"));
+            assert!(reason.contains("500"));
+        }
+        other => panic!("unexpected error: {other:?}"),
+    }
+}
+
+#[test]
+fn web_search_validation_accepts_query_at_500_chars() {
+    let registry = build_registry();
+    let query = "a".repeat(500);
+    let result = registry.validate(ToolCallRequest::new(
+        "call_search_004",
+        "web.search",
+        ToolInput::WebSearch { query },
+    ));
+    assert!(
+        result.is_ok(),
+        "query at exactly 500 characters should be accepted"
+    );
+}
+
+#[test]
+fn web_search_validation_accepts_normal_query() {
+    let registry = build_registry();
+    let result = registry.validate(ToolCallRequest::new(
+        "call_search_005",
+        "web.search",
+        ToolInput::WebSearch {
+            query: "rust error handling best practices".to_string(),
+        },
+    ));
+    assert!(result.is_ok(), "normal query should be accepted");
+}
+
+#[test]
+fn web_search_serde_round_trip() {
+    let input = ToolInput::WebSearch {
+        query: "rust serde tutorial".to_string(),
+    };
+    let json = serde_json::to_string(&input).expect("serialize should succeed");
+    let deserialized: ToolInput = serde_json::from_str(&json).expect("deserialize should succeed");
+    assert_eq!(input, deserialized);
+}
+
+// --- is_safe_shell_command tests (23 cases) ---
+
+#[test]
+fn safe_shell_01_gh_api_get_is_safe() {
+    assert!(is_safe_shell_command("gh api repos/o/r/stats/contributors"));
+}
+
+#[test]
+fn safe_shell_02_gh_api_method_post_is_unsafe() {
+    assert!(!is_safe_shell_command(
+        "gh api --method POST repos/o/r/issues"
+    ));
+}
+
+#[test]
+fn safe_shell_03_gh_api_method_eq_post_is_unsafe() {
+    assert!(!is_safe_shell_command(
+        "gh api --method=POST repos/o/r/issues"
+    ));
+}
+
+#[test]
+fn safe_shell_04_gh_api_x_delete_is_unsafe() {
+    assert!(!is_safe_shell_command(
+        "gh api -X DELETE repos/o/r/issues/1"
+    ));
+}
+
+#[test]
+fn safe_shell_05_gh_api_xdelete_combined_is_unsafe() {
+    assert!(!is_safe_shell_command("gh api -XDELETE repos/o/r/issues/1"));
+}
+
+#[test]
+fn safe_shell_06_gh_api_with_pipe_is_unsafe() {
+    assert!(!is_safe_shell_command("gh api repos/o/r/issues | jq ."));
+}
+
+#[test]
+fn safe_shell_07_gh_api_with_semicolon_is_unsafe() {
+    assert!(!is_safe_shell_command("gh api repos/o/r/issues; rm -rf /"));
+}
+
+#[test]
+fn safe_shell_08_git_log_is_safe() {
+    assert!(is_safe_shell_command("git log --oneline"));
+}
+
+#[test]
+fn safe_shell_09_git_status_is_safe() {
+    assert!(is_safe_shell_command("git status"));
+}
+
+#[test]
+fn safe_shell_10_curl_is_not_safe() {
+    assert!(!is_safe_shell_command("curl https://example.com"));
+}
+
+#[test]
+fn safe_shell_11_gh_api_input_flag_is_unsafe() {
+    assert!(!is_safe_shell_command(
+        "gh api --input data.json repos/o/r/issues"
+    ));
+}
+
+#[test]
+fn safe_shell_12_gh_api_input_eq_is_unsafe() {
+    assert!(!is_safe_shell_command(
+        "gh api --input=data.json repos/o/r/issues"
+    ));
+}
+
+#[test]
+fn safe_shell_13_gh_api_xput_is_unsafe() {
+    assert!(!is_safe_shell_command("gh api -XPUT repos/o/r/topics"));
+}
+
+#[test]
+fn safe_shell_14_gh_api_xpatch_is_unsafe() {
+    assert!(!is_safe_shell_command("gh api -XPATCH repos/o/r/issues/1"));
+}
+
+#[test]
+fn safe_shell_15_gh_api_url_with_method_in_path_is_safe() {
+    // Token-based splitting prevents false positive on URLs containing "--method-POST"
+    assert!(is_safe_shell_command(
+        "gh api repos/o/repo-with--method-POST/stats"
+    ));
+}
+
+#[test]
+fn safe_shell_16_gh_api_newline_bypass_is_unsafe() {
+    assert!(!is_safe_shell_command("gh api repos/o/r/issues\nrm -rf /"));
+}
+
+#[test]
+fn safe_shell_17_gh_api_f_flag_implicit_post_is_unsafe() {
+    assert!(!is_safe_shell_command(
+        "gh api -f title=hacked repos/o/r/issues"
+    ));
+}
+
+#[test]
+fn safe_shell_18_gh_api_field_flag_implicit_post_is_unsafe() {
+    assert!(!is_safe_shell_command(
+        "gh api --field title=hacked repos/o/r/issues"
+    ));
+}
+
+#[test]
+fn safe_shell_19_gh_api_f_uppercase_flag_implicit_post_is_unsafe() {
+    assert!(!is_safe_shell_command(
+        "gh api -F body=@file.txt repos/o/r/issues"
+    ));
+}
+
+#[test]
+fn safe_shell_20_gh_api_raw_field_implicit_post_is_unsafe() {
+    assert!(!is_safe_shell_command(
+        "gh api --raw-field body=test repos/o/r/issues"
+    ));
+}
+
+#[test]
+fn safe_shell_21_gh_repo_view_web_is_unsafe() {
+    assert!(!is_safe_shell_command("gh repo view --web"));
+}
+
+#[test]
+fn safe_shell_22_gh_repo_view_json_is_safe() {
+    assert!(is_safe_shell_command("gh repo view --json owner,name"));
+}
+
+#[test]
+fn safe_shell_23_gh_issue_list_browse_is_unsafe() {
+    assert!(!is_safe_shell_command("gh issue list --browse"));
+}
+
+// --- effective_permission_class tests ---
+
+#[test]
+fn effective_permission_class_promotes_safe_shell_to_safe() {
+    let registry = build_registry();
+    let spec = registry.get("shell.exec").expect("shell.exec should exist");
+    let input = ToolInput::ShellExec {
+        command: "git status".to_string(),
+    };
+    assert_eq!(
+        effective_permission_class(&input, spec),
+        PermissionClass::Safe
+    );
+}
+
+#[test]
+fn effective_permission_class_keeps_unsafe_shell_as_confirm() {
+    let registry = build_registry();
+    let spec = registry.get("shell.exec").expect("shell.exec should exist");
+    let input = ToolInput::ShellExec {
+        command: "rm -rf target".to_string(),
+    };
+    assert_eq!(
+        effective_permission_class(&input, spec),
+        PermissionClass::Confirm
+    );
+}
+
+#[test]
+fn effective_permission_class_web_search_stays_confirm() {
+    let registry = build_registry();
+    let spec = registry.get("web.search").expect("web.search should exist");
+    let input = ToolInput::WebSearch {
+        query: "rust error".to_string(),
+    };
+    assert_eq!(
+        effective_permission_class(&input, spec),
+        PermissionClass::Confirm
+    );
+}
+
+#[test]
+fn effective_permission_class_file_read_stays_safe() {
+    let registry = build_registry();
+    let spec = registry.get("file.read").expect("file.read should exist");
+    let input = ToolInput::FileRead {
+        path: "src/main.rs".to_string(),
+    };
+    assert_eq!(
+        effective_permission_class(&input, spec),
+        PermissionClass::Safe
+    );
+}
+
+// --- approval_required uses effective_permission_class ---
+
+#[test]
+fn approval_not_required_for_safe_shell_command() {
+    let registry = build_registry();
+    let validated = registry
+        .validate(ToolCallRequest::new(
+            "call_shell_safe",
+            "shell.exec",
+            ToolInput::ShellExec {
+                command: "git status".to_string(),
+            },
+        ))
+        .expect("should validate");
+    assert!(
+        validated.approval_required(true).is_none(),
+        "safe shell commands should not require approval"
+    );
+}
+
+#[test]
+fn approval_required_for_unsafe_shell_command() {
+    let registry = build_registry();
+    let validated = registry
+        .validate(ToolCallRequest::new(
+            "call_shell_unsafe",
+            "shell.exec",
+            ToolInput::ShellExec {
+                command: "curl https://example.com".to_string(),
+            },
+        ))
+        .expect("should validate");
+    assert!(
+        validated.approval_required(true).is_some(),
+        "unsafe shell commands should require approval"
+    );
 }


### PR DESCRIPTION
## Summary

- **web.search ツール追加**: DuckDuckGo HTML（デフォルト）とSerperAPI（オプション）による検索機能を実装
- **GitHub Insights対応**: システムプロンプトに `gh api` パターンを追記し、`is_safe_shell_command()` でGET系コマンドを自動承認化
- **コードリファクタリング**: execute()のメソッド分割、パース責務のToolInput側への移動、承認フローのヘルパー抽出

### 主な変更内容

| ファイル | 変更内容 |
|---------|---------|
| `Cargo.toml` | `regex` crate追加 |
| `src/tooling/mod.rs` | WebSearch enum追加、DuckDuckGo/SerperAPI実行ロジック、is_safe_shell_command()、effective_permission_class()、レート制限、execute()メソッド分割 |
| `src/agent/mod.rs` | パーサー簡素化（ToolInput::from_json()）、システムプロンプト拡張（web.search + GitHub Insights） |
| `src/app/agentic.rs` | 承認フロー拡張、ヘルパー関数抽出 |
| `src/config/mod.rs` | WebSearchProvider enum、serper_api_key設定追加 |
| `tests/` | is_safe_shell_command() 23ケース、web.searchバリデーション・パーサー・serdeテスト追加 |

### セキュリティ対策

- percent-encode + `--` セパレータによるcurlインジェクション防止
- `serde_json::json!` によるSerperAPI JSONインジェクション防止
- `-f`/`--field`/`-F`/`--raw-field` の暗黙POST検出
- `--web`/`--browse` のブラウザ起動ブロック
- クエリ長上限500文字、CAPTCHA多層検知

## Test plan

- [x] `cargo build` エラー0件
- [x] `cargo clippy --all-targets` 警告0件
- [x] `cargo test` 全164テストパス
- [x] `cargo fmt --check` 差分なし
- [x] 動作確認: GitHub Insights (`gh api` GET) が承認なしで実行できること
- [x] 動作確認: web.search でDuckDuckGo検索が実行されること（CAPTCHA検知含む）

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)