### PR TITLE
chore: release v0.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [Unreleased]
+
+## [0.0.2] - 2026-03-16
+
+### Added
+- web.search tool and GitHub Insights support (#6)
+- web.fetch tool for HTTP content retrieval (#2)
+- Release skills and GitHub Actions release workflow (#34)
+- Issue-enhance, pm-auto-issue2dev, pm-auto-design2dev slash commands
+- Port remaining slash commands from MyCodeBranchDesk
+
+### Fixed
+- Duplicate response output in assistant messages (#1)
+- Exclude all messages from live-turn frames and skip intermediate frames (#1)
+
+### Documentation
+- Restructure README with user-focused quick start and developer section
+- Add binary download instructions to README
+
 ## [0.0.1] - 2026-03-15
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "anvil"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "regex",
  "rustyline",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anvil"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2024"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ```bash
 # macOS (Apple Silicon)
-curl -L https://github.com/Kewton/Anvil/releases/download/v0.0.1/anvil-darwin-arm64.gz -o anvil.gz
+curl -L https://github.com/Kewton/Anvil/releases/download/v0.0.2/anvil-darwin-arm64.gz -o anvil.gz
 gunzip anvil.gz
 chmod +x anvil
 sudo mv anvil /usr/local/bin/


### PR DESCRIPTION
## Release v0.0.2

### 変更内容
- web.search tool and GitHub Insights support (#6)
- web.fetch tool for HTTP content retrieval (#2)
- Release skills and GitHub Actions release workflow (#34)
- Issue-enhance, pm-auto-issue2dev, pm-auto-design2dev slash commands
- Fix: Duplicate response output in assistant messages (#1)

### チェックリスト
- [x] Cargo.toml バージョン更新済み
- [x] Cargo.lock 更新済み
- [x] README.md バージョン更新済み
- [x] CHANGELOG.md 更新済み
- [x] cargo build 成功
- [x] cargo test 全パス (164テスト)
- [x] cargo clippy 警告ゼロ