### PR TITLE
feat(logging): add structured logging with tracing crate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,7 @@ src/
 ├── config/mod.rs        # 設定管理
 ├── contracts/mod.rs     # 共通型定義
 ├── extensions/mod.rs    # スラッシュコマンド・拡張
+├── logging.rs           # 構造化ロギング（tracing初期化）
 ├── metrics/mod.rs       # ベンチマーク
 ├── provider/
 │   ├── mod.rs           # プロバイダー抽象化

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,9 @@ dependencies = [
  "rustyline",
  "serde",
  "serde_json",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -46,6 +49,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
 dependencies = [
  "error-code",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
 ]
 
 [[package]]
@@ -97,6 +124,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -113,6 +146,15 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
 
 [[package]]
 name = "memchr"
@@ -140,6 +182,39 @@ dependencies = [
  "cfg_aliases",
  "libc",
 ]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "proc-macro2"
@@ -277,6 +352,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -291,6 +375,125 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
+dependencies = [
+ "crossbeam-channel",
+ "thiserror",
+ "time",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "thread_local",
+ "tracing",
+ "tracing-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,6 @@ rustyline = "15"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 regex = { version = "1", default-features = false, features = ["std"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "env-filter", "ansi", "registry"] }
+tracing-appender = "0.2"

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -168,6 +168,13 @@ impl BasicAgentLoop {
 
         selected.reverse();
 
+        tracing::debug!(
+            selected_messages = selected.len(),
+            used_tokens = used_tokens,
+            budget = token_budget,
+            "built turn request"
+        );
+
         ProviderTurnRequest::new(
             model.into(),
             std::iter::once(ProviderMessage::new(
@@ -324,7 +331,13 @@ fn derive_context_budget(context_window: u32) -> usize {
     }
     let quarter = (context_window / 4) as usize;
     let half = (context_window / 2) as usize;
-    quarter.clamp(256, half)
+    let budget = quarter.clamp(256, half);
+    tracing::debug!(
+        budget = budget,
+        context_window = context_window,
+        "context budget derived"
+    );
+    budget
 }
 
 fn estimate_message_tokens(content: &str) -> usize {

--- a/src/app/cli.rs
+++ b/src/app/cli.rs
@@ -4,6 +4,7 @@
 //! that drive the interactive CLI experience.
 
 use crate::config::EffectiveConfig;
+use crate::logging::{LogGuard, init_tracing};
 use crate::provider::{ProviderClient, ProviderRuntimeContext, build_local_provider_client};
 use crate::session::SessionError;
 use crate::tui::Tui;
@@ -57,6 +58,22 @@ pub fn run_session_loop<C: ProviderClient, R: BufRead, W: Write>(
 /// line editing, and input history.
 pub fn run() -> Result<(), AppError> {
     let config = EffectiveConfig::load()?;
+
+    let _guard: Option<LogGuard> = init_tracing(
+        config.mode.log_filter.as_deref(),
+        config.mode.debug_logging,
+        &config.paths.logs_dir,
+        config.session_key(),
+    );
+
+    tracing::info!(
+        provider = %config.runtime.provider,
+        model = %config.runtime.model,
+        context_window = config.runtime.context_window,
+        debug_logging = config.mode.debug_logging,
+        "anvil started with effective config"
+    );
+
     let provider = ProviderRuntimeContext::bootstrap(&config)?;
     let provider_client = build_local_provider_client(&config)?;
     let mut app = App::new(config, provider)?;

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -20,7 +20,7 @@ pub enum WebSearchProvider {
     SerperApi,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 /// Provider, model, and transport settings.
 pub struct RuntimeConfig {
     pub provider: String,
@@ -46,6 +46,7 @@ pub struct ModeConfig {
     pub fresh_session: bool,
     pub reasoning_visibility: ReasoningVisibility,
     pub debug_logging: bool,
+    pub log_filter: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -62,6 +63,7 @@ pub struct PathConfig {
     pub state_dir: PathBuf,
     pub session_dir: PathBuf,
     pub session_file: PathBuf,
+    pub logs_dir: PathBuf,
 }
 
 #[derive(Debug, Clone)]
@@ -116,6 +118,7 @@ impl EffectiveConfig {
         let state_dir = cwd.join(".anvil").join("state");
         let session_dir = cwd.join(".anvil").join("sessions");
         let session_file = session_dir.join(format!("{}.json", session_key_for_cwd(&cwd)));
+        let logs_dir = cwd.join(".anvil").join("logs");
         Self {
             runtime: RuntimeConfig {
                 provider: "ollama".to_string(),
@@ -139,6 +142,7 @@ impl EffectiveConfig {
                 fresh_session: false,
                 reasoning_visibility: ReasoningVisibility::Summary,
                 debug_logging: false,
+                log_filter: None,
             },
             paths: PathConfig {
                 cwd,
@@ -147,6 +151,7 @@ impl EffectiveConfig {
                 state_dir,
                 session_dir,
                 session_file,
+                logs_dir,
             },
         }
     }
@@ -204,6 +209,7 @@ impl EffectiveConfig {
             "ANVIL_DEBUG",
             "ANVIL_WEB_SEARCH_PROVIDER",
             "SERPER_API_KEY",
+            "ANVIL_LOG",
         ] {
             if let Ok(value) = std::env::var(key) {
                 map.insert(key.to_string(), value);
@@ -364,6 +370,9 @@ impl EffectiveConfig {
                         Some(value.clone())
                     };
                 }
+                "log_filter" | "ANVIL_LOG" => {
+                    self.mode.log_filter = Some(value.clone());
+                }
                 _ => {}
             }
         }
@@ -380,6 +389,14 @@ impl EffectiveConfig {
         self.apply_map(env_values)?;
         self.apply_map(cli_values)?;
         Ok(())
+    }
+
+    pub fn session_key(&self) -> &str {
+        self.paths
+            .session_file
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("unknown")
     }
 
     pub fn default_for_test() -> Result<Self, ConfigError> {
@@ -410,6 +427,27 @@ fn parse_reasoning_visibility(value: &str) -> Result<ReasoningVisibility, Config
         "hidden" => Ok(ReasoningVisibility::Hidden),
         "summary" => Ok(ReasoningVisibility::Summary),
         other => Err(ConfigError::InvalidReasoningVisibility(other.to_string())),
+    }
+}
+
+impl std::fmt::Debug for RuntimeConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RuntimeConfig")
+            .field("provider", &self.provider)
+            .field("provider_url", &self.provider_url)
+            .field("model", &self.model)
+            .field("sidecar_model", &self.sidecar_model)
+            .field("api_key", &"[REDACTED]")
+            .field("context_window", &self.context_window)
+            .field("context_budget", &self.context_budget)
+            .field("max_agent_iterations", &self.max_agent_iterations)
+            .field("max_console_messages", &self.max_console_messages)
+            .field("auto_compact_threshold", &self.auto_compact_threshold)
+            .field("tool_result_max_chars", &self.tool_result_max_chars)
+            .field("stream", &self.stream)
+            .field("web_search_provider", &self.web_search_provider)
+            .field("serper_api_key", &"[REDACTED]")
+            .finish()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod app;
 pub mod config;
 pub mod contracts;
 pub mod extensions;
+pub mod logging;
 pub mod metrics;
 pub mod provider;
 pub mod retrieval;

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,0 +1,114 @@
+//! Structured logging initialization using the `tracing` framework.
+//!
+//! Provides [`init_tracing`] for subscriber setup and [`LogGuard`] as an
+//! opaque wrapper around the file-appender worker guard.
+
+use std::path::Path;
+use tracing_subscriber::Layer;
+
+/// Opaque wrapper around the file-appender worker guard.
+///
+/// Prevents callers from depending on `tracing-appender` directly.
+/// The inner guard is dropped when this value goes out of scope,
+/// flushing any buffered log output.
+pub struct LogGuard(#[allow(dead_code)] Option<tracing_appender::non_blocking::WorkerGuard>);
+
+/// Initialise the tracing subscriber.
+///
+/// Filter resolution:
+/// 1. `log_filter` is `Some` -> use that value as the `EnvFilter` directive
+/// 2. `debug_logging` is `true` -> use `"debug"`
+/// 3. Otherwise -> use `"warn"`
+///
+/// File layer: always writes to `logs_dir/anvil-{session_id}.log`.
+/// Stderr layer: enabled only when `debug_logging` is `true`.
+///
+/// Returns `Some(LogGuard)` on success, `None` when the log directory
+/// cannot be created (graceful degradation).
+pub fn init_tracing(
+    log_filter: Option<&str>,
+    debug_logging: bool,
+    logs_dir: &Path,
+    session_id: &str,
+) -> Option<LogGuard> {
+    use tracing_subscriber::layer::SubscriberExt;
+    use tracing_subscriber::util::SubscriberInitExt;
+
+    let directive = resolve_filter_directive(log_filter, debug_logging);
+
+    let (non_blocking, guard) = build_file_writer(logs_dir, session_id)?;
+
+    let file_filter = tracing_subscriber::EnvFilter::try_new(&directive)
+        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("warn"));
+    let file_layer = tracing_subscriber::fmt::layer()
+        .with_writer(non_blocking)
+        .with_ansi(false)
+        .with_filter(file_filter);
+
+    let registry = tracing_subscriber::registry().with(file_layer);
+
+    if debug_logging {
+        let stderr_filter = tracing_subscriber::EnvFilter::try_new(&directive)
+            .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("warn"));
+        let stderr_layer = tracing_subscriber::fmt::layer()
+            .with_writer(std::io::stderr)
+            .with_ansi(true)
+            .with_filter(stderr_filter);
+        let _ = registry.with(stderr_layer).try_init();
+    } else {
+        let _ = registry.try_init();
+    }
+
+    Some(LogGuard(Some(guard)))
+}
+
+fn resolve_filter_directive(log_filter: Option<&str>, debug_logging: bool) -> String {
+    if let Some(filter) = log_filter {
+        filter.to_string()
+    } else if debug_logging {
+        "debug".to_string()
+    } else {
+        "warn".to_string()
+    }
+}
+
+fn build_file_writer(
+    logs_dir: &Path,
+    session_id: &str,
+) -> Option<(
+    tracing_appender::non_blocking::NonBlocking,
+    tracing_appender::non_blocking::WorkerGuard,
+)> {
+    // Create the logs directory with restricted permissions.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::DirBuilderExt;
+        let mut builder = std::fs::DirBuilder::new();
+        builder.recursive(true).mode(0o700);
+        if builder.create(logs_dir).is_err() {
+            return None;
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        if std::fs::create_dir_all(logs_dir).is_err() {
+            return None;
+        }
+    }
+
+    let file_name = format!("anvil-{session_id}.log");
+    let file_appender = tracing_appender::rolling::never(logs_dir, &file_name);
+    let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
+
+    // Set log file permissions to 0o600 on Unix.
+    #[cfg(unix)]
+    {
+        let log_path = logs_dir.join(&file_name);
+        if log_path.exists() {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = std::fs::set_permissions(log_path, std::fs::Permissions::from_mode(0o600));
+        }
+    }
+
+    Some((non_blocking, guard))
+}

--- a/src/provider/ollama.rs
+++ b/src/provider/ollama.rs
@@ -163,6 +163,13 @@ impl<T: HttpTransport> ProviderClient for OllamaProviderClient<T> {
         })?;
         let url = format!("{}/api/chat", self.base_url.trim_end_matches('/'));
 
+        tracing::debug!(
+            model = %resolved_request.model,
+            messages = resolved_request.messages.len(),
+            stream = resolved_request.stream,
+            "sending ollama chat request"
+        );
+
         let mut assistant_output = String::new();
         let mut had_error: Option<ProviderTurnError> = None;
 
@@ -206,6 +213,7 @@ impl<T: HttpTransport> ProviderClient for OllamaProviderClient<T> {
             })?;
 
         if let Some(err) = had_error {
+            tracing::error!(error = %err, "ollama provider request failed");
             return Err(err);
         }
         Ok(())

--- a/src/provider/openai.rs
+++ b/src/provider/openai.rs
@@ -225,6 +225,13 @@ impl<T: HttpTransport> OpenAiCompatibleProviderClient<T> {
             "{}/v1/chat/completions",
             self.base_url.trim_end_matches('/')
         );
+        tracing::debug!(
+            model = %request.model,
+            messages = request.messages.len(),
+            stream = request.stream,
+            "sending openai chat request"
+        );
+
         let mut headers = Vec::new();
         if let Some(api_key) = &self.api_key {
             headers.push(("Authorization", api_key.as_str()));
@@ -314,6 +321,7 @@ impl<T: HttpTransport> OpenAiCompatibleProviderClient<T> {
             })?;
 
         if let Some(err) = had_error {
+            tracing::error!(error = %err, "openai provider request failed");
             return Err(err);
         }
         if !emitted_done {

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -269,6 +269,13 @@ impl SessionRecord {
             return false;
         }
 
+        let messages_to_compact = self.messages.len() - keep_recent;
+        tracing::debug!(
+            compacted = messages_to_compact,
+            kept = keep_recent,
+            "compacting session history"
+        );
+
         let split_at = self.messages.len() - keep_recent;
         let compacted = &self.messages[..split_at];
         let summary = summarize_messages(compacted);
@@ -375,6 +382,7 @@ impl SessionStore {
     }
 
     pub fn load_or_create(&self, cwd: &Path) -> Result<SessionRecord, SessionError> {
+        tracing::debug!(path = %self.file_path.display(), "loading session");
         if self.file_path.exists() {
             match self.load() {
                 Ok(mut record) => {
@@ -382,6 +390,7 @@ impl SessionStore {
                     return Ok(record);
                 }
                 Err(SessionError::SessionDeserializeFailed(_)) => {
+                    tracing::debug!("creating new session");
                     let mut record = SessionRecord::new(cwd.to_path_buf());
                     record.record_event(AppEvent::SessionLoaded);
                     self.save(&record)?;
@@ -391,6 +400,7 @@ impl SessionStore {
             }
         }
 
+        tracing::debug!("creating new session");
         let mut record = SessionRecord::new(cwd.to_path_buf());
         record.record_event(AppEvent::SessionLoaded);
         self.save(&record)?;
@@ -410,7 +420,9 @@ impl SessionStore {
 
         let contents =
             serde_json::to_string_pretty(record).map_err(SessionError::SessionSerializeFailed)?;
-        std::fs::write(&self.file_path, contents).map_err(SessionError::SessionWriteFailed)
+        std::fs::write(&self.file_path, contents).map_err(SessionError::SessionWriteFailed)?;
+        tracing::debug!(path = %self.file_path.display(), "session saved");
+        Ok(())
     }
 }
 

--- a/src/tooling/mod.rs
+++ b/src/tooling/mod.rs
@@ -560,8 +560,10 @@ impl LocalToolExecutor {
         &mut self,
         request: ToolExecutionRequest,
     ) -> Result<ToolExecutionResult, ToolRuntimeError> {
+        let tool_name = &request.spec.name;
+        tracing::info!(tool = %tool_name, "executing tool");
         let started = Instant::now();
-        match request.input {
+        let result = match request.input {
             ToolInput::FileRead { ref path } => self.execute_file_read(&request, path, started),
             ToolInput::FileWrite {
                 ref path,
@@ -576,7 +578,13 @@ impl LocalToolExecutor {
                 self.execute_shell_exec(&request, command, started)
             }
             ToolInput::WebSearch { ref query } => self.execute_web_search(&request, query, started),
-        }
+        };
+        tracing::info!(
+            tool = %tool_name,
+            elapsed_ms = %started.elapsed().as_millis(),
+            "tool execution completed"
+        );
+        result
     }
 
     fn execute_file_read(

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -24,6 +24,7 @@ pub fn build_config_in(root: PathBuf) -> EffectiveConfig {
     config.paths.state_dir = root.join(".anvil").join("state");
     config.paths.session_dir = root.join(".anvil").join("sessions");
     config.paths.session_file = config.paths.session_dir.join("session.json");
+    config.paths.logs_dir = root.join(".anvil").join("logs");
     config
 }
 

--- a/tests/config_bootstrap.rs
+++ b/tests/config_bootstrap.rs
@@ -36,6 +36,8 @@ fn effective_config_derives_workspace_and_session_paths() {
         ReasoningVisibility::Summary
     );
     assert!(!config.mode.debug_logging);
+    assert!(config.paths.logs_dir.ends_with("logs"));
+    assert!(config.mode.log_filter.is_none());
 }
 
 #[test]

--- a/tests/state_session.rs
+++ b/tests/state_session.rs
@@ -118,6 +118,7 @@ fn session_store_persists_and_restores_messages() {
     config.paths.state_dir = root.join(".anvil").join("state");
     config.paths.session_dir = root.join(".anvil").join("sessions");
     config.paths.session_file = config.paths.session_dir.join("session_roundtrip.json");
+    config.paths.logs_dir = root.join(".anvil").join("logs");
 
     let store = SessionStore::from_config(&config);
     let mut session = store
@@ -359,6 +360,7 @@ fn session_interrupt_persists_and_resumes_correctly() {
     config.paths.cwd = root.clone();
     config.paths.session_dir = root.join(".anvil").join("sessions");
     config.paths.session_file = config.paths.session_dir.join("session_interrupt.json");
+    config.paths.logs_dir = root.join(".anvil").join("logs");
 
     let store = anvil::session::SessionStore::from_config(&config);
     let mut session = store


### PR DESCRIPTION
## Summary

- `tracing`クレートを導入し、構造化ロギングを全主要モジュールに実装
- `ANVIL_LOG`環境変数によるフィルタ制御、`--debug`フラグによるstderr出力を追加
- ログファイルを`.anvil/logs/`に自動出力（ディレクトリ自動作成、graceful degradation対応）
- `RuntimeConfig`のカスタムDebug実装でAPIキーをマスクし、シークレット漏洩を防止

## 変更内容

### 新規ファイル
- `src/logging.rs`: `LogGuard`ラッパー型、`init_tracing()`、フィルタ解決ロジック、ファイルwriter構築

### 設定拡張 (`src/config/mod.rs`)
- `PathConfig`に`logs_dir`フィールド追加
- `ModeConfig`に`log_filter`フィールド追加
- `ANVIL_LOG`環境変数パース処理追加
- `EffectiveConfig::session_key()`メソッド追加
- `RuntimeConfig`カスタムDebug実装（`api_key`/`serper_api_key`を`[REDACTED]`にマスク）

### ログ挿入
- **Provider** (`ollama.rs`, `openai.rs`): リクエストメタデータ(debug)、エラー(error)
- **Tooling** (`tooling/mod.rs`): ツール実行開始/完了(info)
- **Session** (`session/mod.rs`): 保存/読込/圧縮(debug)
- **Agent** (`agent/mod.rs`): コンテキストバジェット/リクエスト構築(debug)

### テスト修正
- `tests/common/mod.rs`, `tests/state_session.rs`, `tests/config_bootstrap.rs`に新フィールド対応追加

## Test plan

- [x] `cargo build` エラー0件
- [x] `cargo clippy --all-targets` 警告0件
- [x] `cargo test` 全テストパス
- [x] `cargo fmt --check` 差分なし
- [ ] 手動テスト: `ANVIL_LOG=debug cargo run` でログファイル出力確認
- [ ] 手動テスト: `--debug` フラグでstderr出力確認

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)