### PR TITLE
fix: SAFE_PREFIXESの不足と既存Blockedパターン回帰テスト追加

### DIFF
--- a/src/tooling/mod.rs
+++ b/src/tooling/mod.rs
@@ -1430,6 +1430,17 @@ pub fn is_safe_shell_command(command: &str) -> bool {
         "npx jest ",
         "npx eslint ",
         "npx prettier --check",
+        // Python test/lint
+        "pytest",
+        "ruff check ",
+        "flake8",
+        // Go build/test/lint
+        "go test",
+        "go vet",
+        "golangci-lint",
+        // Make build/test
+        "make test",
+        "make check",
         // Environment inspection
         "which ",
         "uname",

--- a/tests/tooling_system.rs
+++ b/tests/tooling_system.rs
@@ -932,6 +932,48 @@ mod safe_shell_prefixes {
     fn lsof_i_is_safe() {
         assert!(is_safe_shell_command("lsof -i"));
     }
+
+    #[test]
+    fn pytest_is_safe() {
+        assert!(is_safe_shell_command("pytest"));
+        assert!(is_safe_shell_command("pytest tests/"));
+    }
+
+    #[test]
+    fn ruff_check_is_safe() {
+        assert!(is_safe_shell_command("ruff check ."));
+    }
+
+    #[test]
+    fn flake8_is_safe() {
+        assert!(is_safe_shell_command("flake8"));
+        assert!(is_safe_shell_command("flake8 src/"));
+    }
+
+    #[test]
+    fn go_test_is_safe() {
+        assert!(is_safe_shell_command("go test ./..."));
+    }
+
+    #[test]
+    fn go_vet_is_safe() {
+        assert!(is_safe_shell_command("go vet ./..."));
+    }
+
+    #[test]
+    fn golangci_lint_is_safe() {
+        assert!(is_safe_shell_command("golangci-lint run"));
+    }
+
+    #[test]
+    fn make_test_is_safe() {
+        assert!(is_safe_shell_command("make test"));
+    }
+
+    #[test]
+    fn make_check_is_safe() {
+        assert!(is_safe_shell_command("make check"));
+    }
 }
 
 // --- Injection vector tests ---
@@ -1103,6 +1145,26 @@ mod blocked_commands {
     #[test]
     fn mkfs() {
         assert_blocked("mkfs.ext4 /dev/sda", "mkfs should be blocked");
+    }
+
+    #[test]
+    fn rm_rf_home() {
+        assert_blocked("rm -rf ~", "rm -rf ~ should be blocked");
+    }
+
+    #[test]
+    fn dd_if() {
+        assert_blocked("dd if=/dev/zero of=/dev/sda", "dd if= should be blocked");
+    }
+
+    #[test]
+    fn fork_bomb() {
+        assert_blocked(":(){:|:&};:", "fork bomb should be blocked");
+    }
+
+    #[test]
+    fn process_substitution() {
+        assert_blocked("echo foo >(bar)", "process substitution should be blocked");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- SAFE_PREFIXESにPython系(`pytest`, `ruff check`, `flake8`)、Go系(`go test`, `go vet`, `golangci-lint`)、Make系(`make test`, `make check`)を追加
- 既存Blockedパターン6件の回帰テストを完備（`rm -rf ~`, `dd if=`, fork bomb, process substitution の4件を追加）

## 背景

Issue #8 の受入テスト（UAT）で以下2件のFAILが報告されたため修正:
- **AT-8-4**: Python/Go/Make系のSAFE_PREFIXESが欠落
- **AT-8-7**: 既存Blockedパターン6件中4件の回帰テストが不足

## Test plan

- [x] 新規SAFE_PREFIXESのテスト追加（pytest, flake8, go test, go vet, golangci-lint, make test, make check）
- [x] 既存Blockedパターン回帰テスト4件追加（rm -rf ~, dd if=, fork bomb, process substitution）
- [x] 全250テストパス
- [x] `cargo clippy --all-targets` 警告0件
- [x] `cargo fmt --check` 差分なし

Relates to #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)