### PR TITLE
feat(provider): add health check and retry mechanism (#13)

### DIFF
--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -127,12 +127,10 @@ impl App {
             }
 
             stream_result.map_err(|err| match err {
-                crate::provider::ProviderTurnError::Backend(msg) => {
-                    AppError::ToolExecution(format!("agentic follow-up failed: {msg}"))
-                }
                 crate::provider::ProviderTurnError::Cancelled => {
                     AppError::ToolExecution("agentic follow-up cancelled".to_string())
                 }
+                other => AppError::ToolExecution(format!("agentic follow-up failed: {other}")),
             })?;
 
             // Parse the follow-up response (retry once on parse failure)

--- a/src/app/cli.rs
+++ b/src/app/cli.rs
@@ -76,6 +76,12 @@ pub fn run() -> Result<(), AppError> {
 
     let provider = ProviderRuntimeContext::bootstrap(&config)?;
     let provider_client = build_local_provider_client(&config)?;
+
+    // Health check: warn on failure but continue startup.
+    if let Err(warning) = provider_client.health_check() {
+        eprintln!("\u{26a0} {warning}");
+    }
+
     let mut app = App::new(config, provider)?;
     let tui = Tui::new();
     println!("{}", app.startup_console(&tui)?);

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -417,15 +417,57 @@ impl App {
                     tui,
                 )
             }
-            Err(ProviderTurnError::Backend(message)) => {
-                self.record_provider_error(ProviderTurnError::Backend(message.clone()))?;
+            Err(
+                ref err @ ProviderTurnError::Network(ref msg)
+                | ref err @ ProviderTurnError::ServerError {
+                    message: ref msg, ..
+                }
+                | ref err @ ProviderTurnError::Timeout(ref msg)
+                | ref err @ ProviderTurnError::Backend(ref msg),
+            ) => {
+                self.record_provider_error(err.clone())?;
                 self.execute_runtime_events(
                     &[AgentEvent::Failed {
                         status: "Error. provider turn failed".to_string(),
-                        error_summary: message,
+                        error_summary: msg.clone(),
                         recommended_actions: vec![
                             "retry turn".to_string(),
                             "inspect provider".to_string(),
+                        ],
+                        elapsed_ms: 0,
+                    }],
+                    tui,
+                )
+            }
+            Err(
+                ref err @ ProviderTurnError::ClientError {
+                    status_code,
+                    ref message,
+                },
+            ) => {
+                self.record_provider_error(err.clone())?;
+                self.execute_runtime_events(
+                    &[AgentEvent::Failed {
+                        status: "Error. provider turn failed".to_string(),
+                        error_summary: format!("client error ({status_code}): {message}"),
+                        recommended_actions: vec![
+                            "check authentication credentials".to_string(),
+                            "verify API key and provider URL".to_string(),
+                        ],
+                        elapsed_ms: 0,
+                    }],
+                    tui,
+                )
+            }
+            Err(ref err @ ProviderTurnError::Parse(ref msg)) => {
+                self.record_provider_error(err.clone())?;
+                self.execute_runtime_events(
+                    &[AgentEvent::Failed {
+                        status: "Error. provider turn failed".to_string(),
+                        error_summary: format!("parse error: {msg}"),
+                        recommended_actions: vec![
+                            "retry turn".to_string(),
+                            "check model compatibility".to_string(),
                         ],
                         elapsed_ms: 0,
                     }],
@@ -730,13 +772,8 @@ impl App {
     }
 
     fn record_provider_error(&mut self, error: ProviderTurnError) -> Result<(), AppError> {
-        let (kind, message) = match error {
-            ProviderTurnError::Cancelled => (
-                ProviderErrorKind::Cancelled,
-                "provider turn cancelled".to_string(),
-            ),
-            ProviderTurnError::Backend(message) => (ProviderErrorKind::Backend, message),
-        };
+        let kind = ProviderErrorKind::from(&error);
+        let message = error.to_string();
 
         self.session.push_message(
             SessionMessage::new(MessageRole::System, "provider", message.clone())

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -15,7 +15,13 @@ use serde::{Deserialize, Serialize};
 pub use ollama::{
     OllamaChatMessage, OllamaChatRequest, OllamaProviderClient, resolve_ollama_model_alias,
 };
-pub use transport::{CurlHttpTransport, HttpResponse, HttpTransport, TcpHttpTransport};
+pub use transport::{
+    CurlHttpTransport, HttpResponse, HttpTransport, RetryConfig, RetryTransport, TcpHttpTransport,
+    classify_curl_error, classify_http_error, redact_secrets, sanitize_error_message,
+};
+
+/// Default transport used by provider clients: curl with retry wrapper.
+pub type DefaultTransport = RetryTransport<CurlHttpTransport>;
 
 /// Supported LLM provider backends.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -98,14 +104,40 @@ pub enum ProviderEvent {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ProviderTurnError {
     Cancelled,
+    Network(String),
+    ServerError { status_code: u16, message: String },
+    ClientError { status_code: u16, message: String },
+    Timeout(String),
+    Parse(String),
     Backend(String),
+}
+
+impl ProviderTurnError {
+    /// Returns `true` if this error is eligible for automatic retry.
+    ///
+    /// Network errors, server errors (5xx), and timeouts are retryable.
+    /// Client errors (4xx), parse errors, cancellations, and unclassified
+    /// backend errors are not.
+    pub fn is_retryable(&self) -> bool {
+        matches!(
+            self,
+            Self::Network(_) | Self::ServerError { .. } | Self::Timeout(_)
+        )
+    }
 }
 
 /// Classification of provider errors for persistence.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ProviderErrorKind {
     Cancelled,
+    Network,
+    ServerError,
+    ClientError,
+    Timeout,
+    Parse,
     Backend,
+    #[serde(other)]
+    Unknown,
 }
 
 /// A provider error record stored in the session.
@@ -119,12 +151,37 @@ impl std::fmt::Display for ProviderTurnError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Cancelled => write!(f, "provider turn cancelled"),
+            Self::Network(msg) => write!(f, "network error: {msg}"),
+            Self::ServerError {
+                status_code,
+                message,
+            } => write!(f, "server error ({status_code}): {message}"),
+            Self::ClientError {
+                status_code,
+                message,
+            } => write!(f, "client error ({status_code}): {message}"),
+            Self::Timeout(msg) => write!(f, "timeout: {msg}"),
+            Self::Parse(msg) => write!(f, "parse error: {msg}"),
             Self::Backend(message) => write!(f, "provider backend error: {message}"),
         }
     }
 }
 
 impl std::error::Error for ProviderTurnError {}
+
+impl From<&ProviderTurnError> for ProviderErrorKind {
+    fn from(err: &ProviderTurnError) -> Self {
+        match err {
+            ProviderTurnError::Cancelled => Self::Cancelled,
+            ProviderTurnError::Network(_) => Self::Network,
+            ProviderTurnError::ServerError { .. } => Self::ServerError,
+            ProviderTurnError::ClientError { .. } => Self::ClientError,
+            ProviderTurnError::Timeout(_) => Self::Timeout,
+            ProviderTurnError::Parse(_) => Self::Parse,
+            ProviderTurnError::Backend(_) => Self::Backend,
+        }
+    }
+}
 
 /// Abstraction over LLM provider communication.
 ///
@@ -190,6 +247,19 @@ impl ProviderRuntimeContext {
     }
 }
 
+impl LocalProviderClient {
+    /// Check connectivity to the configured provider.
+    ///
+    /// Dispatches to the inner client's `health_check` method.
+    /// Returns `Ok(())` on success or a human-readable error message on failure.
+    pub fn health_check(&self) -> Result<(), String> {
+        match self {
+            Self::Ollama(client) => client.health_check(),
+            Self::OpenAi(client) => client.health_check(),
+        }
+    }
+}
+
 impl ProviderClient for LocalProviderClient {
     fn stream_turn(
         &self,
@@ -204,16 +274,32 @@ impl ProviderClient for LocalProviderClient {
 }
 
 /// Build a concrete provider client from the effective config.
+///
+/// The returned client wraps its HTTP transport in [`RetryTransport`] so that
+/// transient network/server errors are automatically retried with exponential
+/// backoff.
 pub fn build_local_provider_client(
     config: &EffectiveConfig,
 ) -> Result<LocalProviderClient, ProviderBootstrapError> {
+    let transport = RetryTransport::new(CurlHttpTransport);
     match config.runtime.provider.as_str() {
-        "ollama" => Ok(LocalProviderClient::Ollama(
-            OllamaProviderClient::from_config(config),
-        )),
-        "openai" => Ok(LocalProviderClient::OpenAi(
-            openai::OpenAiCompatibleProviderClient::from_config(config),
-        )),
+        "ollama" => {
+            let client = OllamaProviderClient::with_transport(
+                config.runtime.provider_url.clone(),
+                transport,
+            );
+            Ok(LocalProviderClient::Ollama(client))
+        }
+        "openai" => {
+            let mut client = openai::OpenAiCompatibleProviderClient::with_transport(
+                config.runtime.provider_url.clone(),
+                transport,
+            );
+            if let Some(ref key) = config.runtime.api_key {
+                client = client.with_api_key(key.clone());
+            }
+            Ok(LocalProviderClient::OpenAi(client))
+        }
         other => Err(ProviderBootstrapError::UnsupportedBackend(
             other.to_string(),
         )),

--- a/src/provider/ollama.rs
+++ b/src/provider/ollama.rs
@@ -3,7 +3,7 @@
 //! Implements the [`ProviderClient`] trait for the Ollama local inference
 //! server via its `/api/chat` endpoint.
 
-use super::transport::{CurlHttpTransport, HttpTransport};
+use super::transport::{CurlHttpTransport, HttpTransport, RetryTransport};
 use super::{
     AgentEvent, ProviderClient, ProviderEvent, ProviderMessageRole, ProviderTurnError,
     ProviderTurnRequest,
@@ -41,7 +41,7 @@ struct OllamaChatChunk {
 /// Client for the Ollama local inference server.
 ///
 /// Generic over [`HttpTransport`] so tests can inject a mock.
-pub struct OllamaProviderClient<T = CurlHttpTransport> {
+pub struct OllamaProviderClient<T = RetryTransport<CurlHttpTransport>> {
     base_url: String,
     transport: T,
 }
@@ -50,7 +50,7 @@ impl OllamaProviderClient {
     pub fn new(base_url: impl Into<String>) -> Self {
         Self {
             base_url: base_url.into(),
-            transport: CurlHttpTransport,
+            transport: RetryTransport::new(CurlHttpTransport),
         }
     }
 
@@ -144,7 +144,25 @@ pub fn resolve_ollama_model_alias(requested: &str, available: &[String]) -> Stri
 
 impl Default for OllamaProviderClient {
     fn default() -> Self {
-        Self::new("http://127.0.0.1:11434")
+        Self {
+            base_url: "http://127.0.0.1:11434".to_string(),
+            transport: RetryTransport::new(CurlHttpTransport),
+        }
+    }
+}
+
+impl<T: HttpTransport> OllamaProviderClient<T> {
+    /// Check connectivity to the Ollama server by requesting `/api/tags`.
+    ///
+    /// Returns `Ok(())` if the server responds, or an error message string
+    /// on failure.  The health check uses the client's configured transport
+    /// (which includes [`RetryTransport`] for automatic retry).
+    pub fn health_check(&self) -> Result<(), String> {
+        let url = format!("{}/api/tags", self.base_url.trim_end_matches('/'));
+        match self.transport.get(&url) {
+            Ok(_) => Ok(()),
+            Err(e) => Err(format!("Ollamaに接続できません ({}): {}", self.base_url, e)),
+        }
     }
 }
 

--- a/src/provider/openai.rs
+++ b/src/provider/openai.rs
@@ -3,7 +3,7 @@
 //! Works with the standard `/v1/chat/completions` endpoint used by
 //! OpenAI, Azure OpenAI, LM Studio, and other compatible servers.
 
-use super::transport::{CurlHttpTransport, HttpTransport};
+use super::transport::{CurlHttpTransport, HttpTransport, RetryTransport};
 use super::{AgentEvent, ProviderClient, ProviderEvent, ProviderTurnError, ProviderTurnRequest};
 use crate::config::EffectiveConfig;
 use serde::{Deserialize, Serialize};
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 /// Client for OpenAI-compatible chat completion APIs.
 ///
 /// Generic over [`HttpTransport`] for testability.
-pub struct OpenAiCompatibleProviderClient<T = CurlHttpTransport> {
+pub struct OpenAiCompatibleProviderClient<T = RetryTransport<CurlHttpTransport>> {
     base_url: String,
     api_key: Option<String>,
     transport: T,
@@ -74,7 +74,7 @@ impl OpenAiCompatibleProviderClient {
         Self {
             base_url: base_url.into(),
             api_key: None,
-            transport: CurlHttpTransport,
+            transport: RetryTransport::new(CurlHttpTransport),
         }
     }
 
@@ -82,7 +82,7 @@ impl OpenAiCompatibleProviderClient {
         Self {
             base_url: config.runtime.provider_url.clone(),
             api_key: config.runtime.api_key.clone(),
-            transport: CurlHttpTransport,
+            transport: RetryTransport::new(CurlHttpTransport),
         }
     }
 }
@@ -103,6 +103,34 @@ impl<T> OpenAiCompatibleProviderClient<T> {
 }
 
 impl<T: HttpTransport> OpenAiCompatibleProviderClient<T> {
+    /// Check connectivity to the OpenAI-compatible server by requesting `/v1/models`.
+    ///
+    /// If an API key is configured, it is sent as an `Authorization` header
+    /// (without `Bearer` prefix, matching the existing code pattern in
+    /// `send_chat_request`).
+    pub fn health_check(&self) -> Result<(), String> {
+        let url = format!("{}/v1/models", self.base_url.trim_end_matches('/'));
+        let headers: Vec<(&str, &str)> = self
+            .api_key
+            .as_deref()
+            .map(|key| vec![("Authorization", key)])
+            .unwrap_or_default();
+        match self.transport.get_with_headers(&url, &headers) {
+            Ok(_) => Ok(()),
+            Err(e) => {
+                let guidance = if self.api_key.is_some() {
+                    " (認証情報の形式を確認してください。'Bearer <api-key>' 形式が必要な場合があります)"
+                } else {
+                    ""
+                };
+                Err(format!(
+                    "OpenAI互換プロバイダーに接続できません ({}): {}{}",
+                    self.base_url, e, guidance
+                ))
+            }
+        }
+    }
+
     fn send_chat_request(
         &self,
         request: &ProviderTurnRequest,

--- a/src/provider/transport.rs
+++ b/src/provider/transport.rs
@@ -19,16 +19,34 @@ pub struct HttpResponse {
 ///
 /// The trait is intentionally simple so that it can be backed by `curl`,
 /// a Rust HTTP library, or a test mock.
+///
+/// `post_json_with_headers` and `get_with_headers` are the required methods.
+/// `post_json` and `get` have default implementations that delegate to the
+/// `_with_headers` variants with an empty header slice.
 pub trait HttpTransport {
-    fn post_json(&self, url: &str, body: &[u8]) -> Result<HttpResponse, ProviderTurnError>;
-
+    /// Send a POST request with JSON body and optional extra headers.
     fn post_json_with_headers(
         &self,
         url: &str,
         body: &[u8],
-        _headers: &[(&str, &str)],
-    ) -> Result<HttpResponse, ProviderTurnError> {
-        self.post_json(url, body)
+        headers: &[(&str, &str)],
+    ) -> Result<HttpResponse, ProviderTurnError>;
+
+    /// Send a POST request with JSON body (no extra headers).
+    fn post_json(&self, url: &str, body: &[u8]) -> Result<HttpResponse, ProviderTurnError> {
+        self.post_json_with_headers(url, body, &[])
+    }
+
+    /// Send a GET request with optional extra headers.
+    fn get_with_headers(
+        &self,
+        url: &str,
+        headers: &[(&str, &str)],
+    ) -> Result<HttpResponse, ProviderTurnError>;
+
+    /// Send a GET request (no extra headers).
+    fn get(&self, url: &str) -> Result<HttpResponse, ProviderTurnError> {
+        self.get_with_headers(url, &[])
     }
 
     /// Stream the response body line-by-line via a callback.
@@ -47,11 +65,7 @@ pub trait HttpTransport {
         let response = self.post_json_with_headers(url, body, headers)?;
         if response.status_code != 200 {
             let body_text = String::from_utf8_lossy(&response.body);
-            return Err(ProviderTurnError::Backend(format!(
-                "request failed with status {}: {}",
-                response.status_code,
-                body_text.trim()
-            )));
+            return Err(classify_http_error(response.status_code, body_text.trim()));
         }
         for line in String::from_utf8_lossy(&response.body).lines() {
             let trimmed = line.trim();
@@ -73,11 +87,6 @@ pub struct CurlHttpTransport;
 pub type TcpHttpTransport = CurlHttpTransport;
 
 impl HttpTransport for CurlHttpTransport {
-    fn post_json(&self, url: &str, body: &[u8]) -> Result<HttpResponse, ProviderTurnError> {
-        let raw = post_json_with_curl(url, body, &[])?;
-        parse_raw_http_response(&raw)
-    }
-
     fn post_json_with_headers(
         &self,
         url: &str,
@@ -85,6 +94,15 @@ impl HttpTransport for CurlHttpTransport {
         headers: &[(&str, &str)],
     ) -> Result<HttpResponse, ProviderTurnError> {
         let raw = post_json_with_curl(url, body, headers)?;
+        parse_raw_http_response(&raw)
+    }
+
+    fn get_with_headers(
+        &self,
+        url: &str,
+        headers: &[(&str, &str)],
+    ) -> Result<HttpResponse, ProviderTurnError> {
+        let raw = get_with_curl(url, headers)?;
         parse_raw_http_response(&raw)
     }
 
@@ -110,7 +128,7 @@ pub(crate) fn parse_raw_http_response(raw: &[u8]) -> Result<HttpResponse, Provid
     let header_end = raw
         .windows(4)
         .position(|window| window == b"\r\n\r\n")
-        .ok_or_else(|| ProviderTurnError::Backend("invalid HTTP response headers".to_string()))?;
+        .ok_or_else(|| ProviderTurnError::Parse("invalid HTTP response headers".to_string()))?;
     let headers = &raw[..header_end];
     let body = &raw[header_end + 4..];
 
@@ -118,13 +136,13 @@ pub(crate) fn parse_raw_http_response(raw: &[u8]) -> Result<HttpResponse, Provid
     let mut header_lines = headers_text.lines();
     let status_line = header_lines
         .next()
-        .ok_or_else(|| ProviderTurnError::Backend("missing HTTP status line".to_string()))?;
+        .ok_or_else(|| ProviderTurnError::Parse("missing HTTP status line".to_string()))?;
     let status_code: u16 = status_line
         .split_whitespace()
         .nth(1)
-        .ok_or_else(|| ProviderTurnError::Backend("invalid HTTP status line".to_string()))?
+        .ok_or_else(|| ProviderTurnError::Parse("invalid HTTP status line".to_string()))?
         .parse()
-        .map_err(|_| ProviderTurnError::Backend("non-numeric HTTP status code".to_string()))?;
+        .map_err(|_| ProviderTurnError::Parse("non-numeric HTTP status code".to_string()))?;
 
     let is_chunked = header_lines.any(|line| {
         let lower = line.to_ascii_lowercase();
@@ -152,11 +170,10 @@ fn decode_chunked_body(body: &[u8]) -> Result<Vec<u8>, ProviderTurnError> {
 
     while cursor < body.len() {
         let line_end = find_crlf(body, cursor)
-            .ok_or_else(|| ProviderTurnError::Backend("invalid chunked response".to_string()))?;
+            .ok_or_else(|| ProviderTurnError::Parse("invalid chunked response".to_string()))?;
         let size_text = String::from_utf8_lossy(&body[cursor..line_end]);
-        let size = usize::from_str_radix(size_text.trim(), 16).map_err(|_| {
-            ProviderTurnError::Backend("invalid chunk size in response".to_string())
-        })?;
+        let size = usize::from_str_radix(size_text.trim(), 16)
+            .map_err(|_| ProviderTurnError::Parse("invalid chunk size in response".to_string()))?;
         cursor = line_end + 2;
 
         if size == 0 {
@@ -165,9 +182,9 @@ fn decode_chunked_body(body: &[u8]) -> Result<Vec<u8>, ProviderTurnError> {
 
         let chunk_end = cursor
             .checked_add(size)
-            .ok_or_else(|| ProviderTurnError::Backend("overflow in chunk size".to_string()))?;
+            .ok_or_else(|| ProviderTurnError::Parse("overflow in chunk size".to_string()))?;
         if chunk_end > body.len() {
-            return Err(ProviderTurnError::Backend(
+            return Err(ProviderTurnError::Parse(
                 "truncated chunked response".to_string(),
             ));
         }
@@ -176,7 +193,7 @@ fn decode_chunked_body(body: &[u8]) -> Result<Vec<u8>, ProviderTurnError> {
         cursor = chunk_end;
 
         if body.get(cursor..cursor + 2) != Some(b"\r\n") {
-            return Err(ProviderTurnError::Backend(
+            return Err(ProviderTurnError::Parse(
                 "missing chunk terminator in response".to_string(),
             ));
         }
@@ -212,6 +229,7 @@ fn curl_stream_lines(
         .arg("-H")
         .arg("Content-Type: application/json");
     for (name, value) in extra_headers {
+        validate_header_value(name, value)?;
         cmd.arg("-H").arg(format!("{name}: {value}"));
     }
     let mut child = cmd
@@ -223,11 +241,11 @@ fn curl_stream_lines(
         .stdout(Stdio::piped())
         .stderr(Stdio::null())
         .spawn()
-        .map_err(|err| ProviderTurnError::Backend(format!("failed to spawn curl: {err}")))?;
+        .map_err(|err| ProviderTurnError::Network(format!("failed to spawn curl: {err}")))?;
 
     if let Some(mut stdin) = child.stdin.take() {
         stdin.write_all(body).map_err(|err| {
-            ProviderTurnError::Backend(format!("failed to write to curl stdin: {err}"))
+            ProviderTurnError::Network(format!("failed to write to curl stdin: {err}"))
         })?;
     }
 
@@ -236,7 +254,7 @@ fn curl_stream_lines(
         use std::io::BufRead;
         for line in reader.lines() {
             let line = line.map_err(|err| {
-                ProviderTurnError::Backend(format!("failed to read curl output: {err}"))
+                ProviderTurnError::Network(format!("failed to read curl output: {err}"))
             })?;
             let trimmed = line.trim();
             if !trimmed.is_empty() {
@@ -247,10 +265,12 @@ fn curl_stream_lines(
 
     let status = child
         .wait()
-        .map_err(|err| ProviderTurnError::Backend(format!("curl process error: {err}")))?;
+        .map_err(|err| ProviderTurnError::Network(format!("curl process error: {err}")))?;
     if !status.success() {
-        return Err(ProviderTurnError::Backend(
-            "curl streaming request failed".to_string(),
+        let exit_code = status.code().unwrap_or(-1);
+        return Err(classify_curl_error(
+            exit_code,
+            "curl streaming request failed",
         ));
     }
 
@@ -264,6 +284,137 @@ fn find_crlf(body: &[u8], start: usize) -> Option<usize> {
         .map(|offset| start + offset)
 }
 
+/// Truncate and redact secrets from an error message.
+///
+/// 1. Truncates to 500 characters (D4-007: prevent information leakage)
+/// 2. Redacts Authorization/Bearer/api_key patterns (D4-003: prevent API key leakage)
+pub fn sanitize_error_message(message: &str) -> String {
+    let truncated = if message.len() > 500 {
+        format!(
+            "{}... [truncated, {} bytes total]",
+            &message[..500],
+            message.len()
+        )
+    } else {
+        message.to_string()
+    };
+    redact_secrets(&truncated)
+}
+
+/// Mask known secret patterns in a message string.
+///
+/// Replaces values following `Authorization:`, `Bearer`, and `api_key:` with `[REDACTED]`.
+/// Follows the existing `api_key [REDACTED]` convention from `config/mod.rs`.
+pub fn redact_secrets(message: &str) -> String {
+    let mut result = String::with_capacity(message.len());
+    for line in message.lines() {
+        if !result.is_empty() {
+            result.push('\n');
+        }
+        if let Some(pos) = line.to_ascii_lowercase().find("authorization:") {
+            let prefix_end = pos + "authorization:".len();
+            result.push_str(&line[..prefix_end]);
+            result.push_str(" [REDACTED]");
+        } else if let Some(pos) = line.to_ascii_lowercase().find("bearer ") {
+            let prefix_end = pos + "bearer ".len();
+            result.push_str(&line[..prefix_end]);
+            result.push_str("[REDACTED]");
+        } else if let Some(pos) = line.to_ascii_lowercase().find("api_key:") {
+            let prefix_end = pos + "api_key:".len();
+            result.push_str(&line[..prefix_end]);
+            result.push_str(" [REDACTED]");
+        } else {
+            result.push_str(line);
+        }
+    }
+    result
+}
+
+/// Classify an HTTP error by status code into a typed [`ProviderTurnError`].
+///
+/// - 400-499 → `ClientError`
+/// - 500-599 → `ServerError`
+/// - Other   → `Backend` (unclassified)
+pub fn classify_http_error(status_code: u16, body: &str) -> ProviderTurnError {
+    let sanitized_body = sanitize_error_message(body);
+    match status_code {
+        400..=499 => ProviderTurnError::ClientError {
+            status_code,
+            message: sanitized_body,
+        },
+        500..=599 => ProviderTurnError::ServerError {
+            status_code,
+            message: sanitized_body,
+        },
+        _ => {
+            ProviderTurnError::Backend(format!("unexpected status {status_code}: {sanitized_body}"))
+        }
+    }
+}
+
+/// Classify a curl exit code into a typed [`ProviderTurnError`].
+///
+/// - exit 28 → `Timeout`
+/// - other   → `Network` (includes DNS failure (6), connection refused (7), etc.)
+pub fn classify_curl_error(exit_code: i32, stderr: &str) -> ProviderTurnError {
+    let sanitized_stderr = sanitize_error_message(stderr);
+    match exit_code {
+        28 => ProviderTurnError::Timeout(sanitized_stderr),
+        _ => ProviderTurnError::Network(sanitized_stderr),
+    }
+}
+
+/// Validate that an HTTP header key and value do not contain CRLF characters.
+///
+/// This prevents HTTP header injection attacks where `\r` or `\n` in a header
+/// value could be used to inject additional headers or split the response.
+fn validate_header_value(key: &str, value: &str) -> Result<(), ProviderTurnError> {
+    if key.contains('\r') || key.contains('\n') || value.contains('\r') || value.contains('\n') {
+        return Err(ProviderTurnError::ClientError {
+            status_code: 0,
+            message: format!(
+                "invalid header: header name or value contains newline characters (key: {key})"
+            ),
+        });
+    }
+    Ok(())
+}
+
+/// Execute a GET request using curl.
+///
+/// Similar to [`post_json_with_curl`] but without `-X POST`, `--data-binary`,
+/// or the `Content-Type` header.  Includes `--proto '=http,https'` for
+/// protocol restriction (D4-005) and `--` separator before URL (D4-006).
+fn get_with_curl(url: &str, headers: &[(&str, &str)]) -> Result<Vec<u8>, ProviderTurnError> {
+    let mut cmd = Command::new("curl");
+    cmd.args(["-sS", "--http1.1", "-i"])
+        .arg("--proto")
+        .arg("=http,https")
+        .arg("--max-time")
+        .arg(curl_timeout());
+    for (name, value) in headers {
+        validate_header_value(name, value)?;
+        cmd.arg("-H").arg(format!("{name}: {value}"));
+    }
+    let output = cmd
+        .arg("--")
+        .arg(url)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|err| ProviderTurnError::Network(format!("failed to spawn curl: {err}")))?
+        .wait_with_output()
+        .map_err(|err| ProviderTurnError::Network(format!("failed to read curl output: {err}")))?;
+
+    if !output.status.success() {
+        let exit_code = output.status.code().unwrap_or(-1);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(classify_curl_error(exit_code, stderr.trim()));
+    }
+
+    Ok(output.stdout)
+}
+
 fn post_json_with_curl(
     url: &str,
     body: &[u8],
@@ -271,11 +422,14 @@ fn post_json_with_curl(
 ) -> Result<Vec<u8>, ProviderTurnError> {
     let mut cmd = Command::new("curl");
     cmd.args(["-sS", "--http1.1", "-i", "-X", "POST"])
+        .arg("--proto")
+        .arg("=http,https")
         .arg("--max-time")
         .arg(curl_timeout())
         .arg("-H")
         .arg("Content-Type: application/json");
     for (name, value) in extra_headers {
+        validate_header_value(name, value)?;
         cmd.arg("-H").arg(format!("{name}: {value}"));
     }
     let mut child = cmd
@@ -287,28 +441,146 @@ fn post_json_with_curl(
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()
-        .map_err(|err| ProviderTurnError::Backend(format!("failed to spawn curl: {err}")))?;
+        .map_err(|err| ProviderTurnError::Network(format!("failed to spawn curl: {err}")))?;
 
     child
         .stdin
         .as_mut()
-        .ok_or_else(|| ProviderTurnError::Backend("failed to open curl stdin".to_string()))?
+        .ok_or_else(|| ProviderTurnError::Network("failed to open curl stdin".to_string()))?
         .write_all(body)
         .map_err(|err| {
-            ProviderTurnError::Backend(format!("failed to write to curl stdin: {err}"))
+            ProviderTurnError::Network(format!("failed to write to curl stdin: {err}"))
         })?;
 
     let output = child
         .wait_with_output()
-        .map_err(|err| ProviderTurnError::Backend(format!("failed to read curl output: {err}")))?;
+        .map_err(|err| ProviderTurnError::Network(format!("failed to read curl output: {err}")))?;
 
     if !output.status.success() {
+        let exit_code = output.status.code().unwrap_or(-1);
         let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(ProviderTurnError::Backend(format!(
-            "curl request failed: {}",
-            stderr.trim()
-        )));
+        return Err(classify_curl_error(exit_code, stderr.trim()));
     }
 
     Ok(output.stdout)
+}
+
+// ---------------------------------------------------------------------------
+// RetryTransport
+// ---------------------------------------------------------------------------
+
+/// Configuration for the retry mechanism.
+pub struct RetryConfig {
+    pub max_retries: u32,
+    pub base_delay_ms: u64,
+    pub backoff_factor: u64,
+    pub max_delay_ms: u64,
+}
+
+impl Default for RetryConfig {
+    fn default() -> Self {
+        Self {
+            max_retries: 3,
+            base_delay_ms: 1000,
+            backoff_factor: 2,
+            max_delay_ms: 30_000,
+        }
+    }
+}
+
+/// Transport wrapper that retries retryable errors with exponential backoff.
+///
+/// Wraps any [`HttpTransport`] implementation and automatically retries
+/// operations that fail with retryable errors (network, server, timeout).
+pub struct RetryTransport<T: HttpTransport> {
+    inner: T,
+    config: RetryConfig,
+}
+
+impl<T: HttpTransport> RetryTransport<T> {
+    pub fn new(inner: T) -> Self {
+        Self {
+            inner,
+            config: RetryConfig::default(),
+        }
+    }
+
+    pub fn with_config(inner: T, config: RetryConfig) -> Self {
+        Self { inner, config }
+    }
+
+    /// Common retry loop with an additional guard closure.
+    ///
+    /// The `guard` closure is checked after each failed attempt. If it returns
+    /// `false`, the retry loop stops even if the error is retryable. This is
+    /// used by `stream_lines` to prevent retrying after the callback has been
+    /// invoked (since callback side-effects cannot be rolled back).
+    fn retry_with_guard<F, G, R>(&self, mut operation: F, guard: G) -> Result<R, ProviderTurnError>
+    where
+        F: FnMut() -> Result<R, ProviderTurnError>,
+        G: Fn() -> bool,
+    {
+        let mut last_error = None;
+        for attempt in 0..=self.config.max_retries {
+            match operation() {
+                Ok(result) => return Ok(result),
+                Err(err) if err.is_retryable() && guard() && attempt < self.config.max_retries => {
+                    let delay = self
+                        .config
+                        .base_delay_ms
+                        .saturating_mul(self.config.backoff_factor.saturating_pow(attempt))
+                        .min(self.config.max_delay_ms);
+                    std::thread::sleep(std::time::Duration::from_millis(delay));
+                    last_error = Some(err);
+                }
+                Err(err) => return Err(err),
+            }
+        }
+        Err(last_error.unwrap())
+    }
+}
+
+impl<T: HttpTransport> HttpTransport for RetryTransport<T> {
+    fn post_json_with_headers(
+        &self,
+        url: &str,
+        body: &[u8],
+        headers: &[(&str, &str)],
+    ) -> Result<HttpResponse, ProviderTurnError> {
+        self.retry_with_guard(
+            || self.inner.post_json_with_headers(url, body, headers),
+            || true,
+        )
+    }
+
+    fn get_with_headers(
+        &self,
+        url: &str,
+        headers: &[(&str, &str)],
+    ) -> Result<HttpResponse, ProviderTurnError> {
+        self.retry_with_guard(|| self.inner.get_with_headers(url, headers), || true)
+    }
+
+    fn stream_lines(
+        &self,
+        url: &str,
+        body: &[u8],
+        headers: &[(&str, &str)],
+        on_line: &mut dyn FnMut(&str),
+    ) -> Result<(), ProviderTurnError> {
+        let callback_invoked = std::cell::Cell::new(false);
+        let mut wrapped_on_line = |line: &str| {
+            callback_invoked.set(true);
+            on_line(line);
+        };
+
+        self.retry_with_guard(
+            || {
+                callback_invoked.set(false);
+                self.inner
+                    .stream_lines(url, body, headers, &mut wrapped_on_line)
+            },
+            || !callback_invoked.get(),
+        )
+    }
 }

--- a/tests/provider_integration.rs
+++ b/tests/provider_integration.rs
@@ -33,15 +33,10 @@ struct MockHttpTransport {
     seen_bodies: Rc<RefCell<Vec<Vec<u8>>>>,
     seen_headers: HeaderLog,
     response: HttpResponse,
+    get_response: Option<HttpResponse>,
 }
 
 impl HttpTransport for MockHttpTransport {
-    fn post_json(&self, url: &str, body: &[u8]) -> Result<HttpResponse, ProviderTurnError> {
-        self.seen_urls.borrow_mut().push(url.to_string());
-        self.seen_bodies.borrow_mut().push(body.to_vec());
-        Ok(self.response.clone())
-    }
-
     fn post_json_with_headers(
         &self,
         url: &str,
@@ -57,6 +52,24 @@ impl HttpTransport for MockHttpTransport {
                 .collect(),
         );
         Ok(self.response.clone())
+    }
+
+    fn get_with_headers(
+        &self,
+        url: &str,
+        headers: &[(&str, &str)],
+    ) -> Result<HttpResponse, ProviderTurnError> {
+        self.seen_urls.borrow_mut().push(url.to_string());
+        self.seen_headers.borrow_mut().push(
+            headers
+                .iter()
+                .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+                .collect(),
+        );
+        Ok(self
+            .get_response
+            .clone()
+            .unwrap_or_else(|| self.response.clone()))
     }
 }
 
@@ -420,6 +433,7 @@ fn openai_compatible_provider_maps_response_into_done_event() {
             body: br#"{"choices":[{"message":{"role":"assistant","content":"openai-compatible answer"}}]}"#
                 .to_vec(),
         },
+        get_response: None,
     };
     let client = anvil::provider::openai::OpenAiCompatibleProviderClient::with_transport(
         "http://localhost:1234",
@@ -468,6 +482,7 @@ fn openai_compatible_provider_parses_sse_streams() {
             .as_bytes()
             .to_vec(),
         },
+        get_response: None,
     };
     let client = anvil::provider::openai::OpenAiCompatibleProviderClient::with_transport(
         "http://localhost:1234",
@@ -508,6 +523,7 @@ fn openai_compatible_provider_normalizes_error_message() {
             status_code: 401,
             body: br#"{"error":{"message":"invalid api key"}}"#.to_vec(),
         },
+        get_response: None,
     };
     let client = anvil::provider::openai::OpenAiCompatibleProviderClient::with_transport(
         "http://localhost:1234",
@@ -540,6 +556,7 @@ fn openai_compatible_provider_forwards_authorization_header() {
             status_code: 200,
             body: br#"{"choices":[{"message":{"role":"assistant","content":"ok"}}]}"#.to_vec(),
         },
+        get_response: None,
     };
     let client = anvil::provider::openai::OpenAiCompatibleProviderClient::with_transport(
         "http://localhost:1234",
@@ -579,6 +596,7 @@ fn live_turn_executes_structured_response_from_openai_compatible_provider() {
             status_code: 200,
             body: br#"{"choices":[{"message":{"role":"assistant","content":"```ANVIL_TOOL\n{\"id\":\"call_write_001\",\"tool\":\"file.write\",\"path\":\"./sandbox/openai/index.html\",\"content\":\"<html><body>openai parity</body></html>\"}\n```\n```ANVIL_FINAL\nOpenAI-compatible backend created the file and reviewed the output.\n```"}}]}"#.to_vec(),
         },
+        get_response: None,
     };
     let client = anvil::provider::openai::OpenAiCompatibleProviderClient::with_transport(
         "http://localhost:1234",
@@ -873,6 +891,7 @@ fn ollama_provider_stream_turn_posts_chat_request_and_normalizes_response() {
                 status_code: 200,
                 body: body.as_bytes().to_vec(),
             },
+            get_response: None,
         },
     );
     let request = ProviderTurnRequest::new(
@@ -926,6 +945,7 @@ fn ollama_provider_surfaces_non_success_status_as_backend_error() {
                 status_code: 500,
                 body: b"ollama down".to_vec(),
             },
+            get_response: None,
         },
     );
     let request = ProviderTurnRequest::new(
@@ -940,8 +960,139 @@ fn ollama_provider_surfaces_non_success_status_as_backend_error() {
         .stream_turn(&request, &mut |_event| {})
         .expect_err("non-success status should fail");
 
-    assert!(err.to_string().contains("request failed"));
-    assert!(err.to_string().contains("500"));
+    assert!(
+        matches!(
+            err,
+            ProviderTurnError::ServerError {
+                status_code: 500,
+                ..
+            }
+        ),
+        "500 status should be classified as ServerError, got: {err:?}"
+    );
+}
+
+// --- HttpTransport GET and header validation tests ---
+
+#[test]
+fn mock_transport_get_returns_configured_response() {
+    let transport = MockHttpTransport {
+        seen_urls: Rc::new(RefCell::new(Vec::new())),
+        seen_bodies: Rc::new(RefCell::new(Vec::new())),
+        seen_headers: Rc::new(RefCell::new(Vec::new())),
+        response: HttpResponse {
+            status_code: 200,
+            body: b"post response".to_vec(),
+        },
+        get_response: Some(HttpResponse {
+            status_code: 200,
+            body: b"get response".to_vec(),
+        }),
+    };
+
+    let result = transport.get("http://localhost/api/tags").unwrap();
+    assert_eq!(result.status_code, 200);
+    assert_eq!(result.body, b"get response");
+
+    // Verify the URL was recorded
+    let urls = transport.seen_urls.borrow();
+    assert_eq!(urls.len(), 1);
+    assert_eq!(urls[0], "http://localhost/api/tags");
+}
+
+#[test]
+fn mock_transport_get_with_headers_records_headers() {
+    let seen_headers: HeaderLog = Rc::new(RefCell::new(Vec::new()));
+    let transport = MockHttpTransport {
+        seen_urls: Rc::new(RefCell::new(Vec::new())),
+        seen_bodies: Rc::new(RefCell::new(Vec::new())),
+        seen_headers: seen_headers.clone(),
+        response: HttpResponse {
+            status_code: 200,
+            body: b"ok".to_vec(),
+        },
+        get_response: None,
+    };
+
+    let result = transport
+        .get_with_headers(
+            "http://localhost/v1/models",
+            &[("Authorization", "Bearer sk-test")],
+        )
+        .unwrap();
+    assert_eq!(result.status_code, 200);
+
+    let headers = seen_headers.borrow();
+    assert_eq!(headers.len(), 1);
+    assert_eq!(headers[0].len(), 1);
+    assert_eq!(headers[0][0].0, "Authorization");
+    assert_eq!(headers[0][0].1, "Bearer sk-test");
+}
+
+#[test]
+fn mock_transport_get_falls_back_to_post_response_when_get_response_is_none() {
+    let transport = MockHttpTransport {
+        seen_urls: Rc::new(RefCell::new(Vec::new())),
+        seen_bodies: Rc::new(RefCell::new(Vec::new())),
+        seen_headers: Rc::new(RefCell::new(Vec::new())),
+        response: HttpResponse {
+            status_code: 200,
+            body: b"fallback response".to_vec(),
+        },
+        get_response: None,
+    };
+
+    let result = transport.get("http://localhost/api/tags").unwrap();
+    assert_eq!(result.body, b"fallback response");
+}
+
+#[test]
+fn post_json_default_delegates_to_post_json_with_headers() {
+    let seen_headers: HeaderLog = Rc::new(RefCell::new(Vec::new()));
+    let transport = MockHttpTransport {
+        seen_urls: Rc::new(RefCell::new(Vec::new())),
+        seen_bodies: Rc::new(RefCell::new(Vec::new())),
+        seen_headers: seen_headers.clone(),
+        response: HttpResponse {
+            status_code: 200,
+            body: b"ok".to_vec(),
+        },
+        get_response: None,
+    };
+
+    // post_json should delegate to post_json_with_headers with empty headers
+    let result = transport
+        .post_json("http://localhost/api/chat", b"{}")
+        .unwrap();
+    assert_eq!(result.status_code, 200);
+
+    let headers = seen_headers.borrow();
+    assert_eq!(headers.len(), 1);
+    // Default impl passes empty headers slice
+    assert!(headers[0].is_empty());
+}
+
+#[test]
+fn get_default_delegates_to_get_with_headers() {
+    let seen_headers: HeaderLog = Rc::new(RefCell::new(Vec::new()));
+    let transport = MockHttpTransport {
+        seen_urls: Rc::new(RefCell::new(Vec::new())),
+        seen_bodies: Rc::new(RefCell::new(Vec::new())),
+        seen_headers: seen_headers.clone(),
+        response: HttpResponse {
+            status_code: 200,
+            body: b"ok".to_vec(),
+        },
+        get_response: None,
+    };
+
+    // get() should delegate to get_with_headers with empty headers
+    let result = transport.get("http://localhost/api/tags").unwrap();
+    assert_eq!(result.status_code, 200);
+
+    let headers = seen_headers.borrow();
+    assert_eq!(headers.len(), 1);
+    assert!(headers[0].is_empty());
 }
 
 // --- Agentic loop unit tests ---
@@ -1666,4 +1817,687 @@ fn build_turn_request_with_limit_includes_system_prompt() {
         request.messages[0].content.contains("You are Anvil"),
         "system prompt should contain base prompt"
     );
+}
+
+// ---------------------------------------------------------------------------
+// Phase 1: ProviderTurnError expansion tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn provider_turn_error_is_retryable_network() {
+    let err = ProviderTurnError::Network("connection refused".to_string());
+    assert!(err.is_retryable());
+}
+
+#[test]
+fn provider_turn_error_is_retryable_server_error() {
+    let err = ProviderTurnError::ServerError {
+        status_code: 500,
+        message: "internal server error".to_string(),
+    };
+    assert!(err.is_retryable());
+}
+
+#[test]
+fn provider_turn_error_is_retryable_timeout() {
+    let err = ProviderTurnError::Timeout("request timed out".to_string());
+    assert!(err.is_retryable());
+}
+
+#[test]
+fn provider_turn_error_not_retryable_cancelled() {
+    let err = ProviderTurnError::Cancelled;
+    assert!(!err.is_retryable());
+}
+
+#[test]
+fn provider_turn_error_not_retryable_client_error() {
+    let err = ProviderTurnError::ClientError {
+        status_code: 401,
+        message: "unauthorized".to_string(),
+    };
+    assert!(!err.is_retryable());
+}
+
+#[test]
+fn provider_turn_error_not_retryable_parse() {
+    let err = ProviderTurnError::Parse("invalid JSON".to_string());
+    assert!(!err.is_retryable());
+}
+
+#[test]
+fn provider_turn_error_not_retryable_backend() {
+    let err = ProviderTurnError::Backend("unknown error".to_string());
+    assert!(!err.is_retryable());
+}
+
+#[test]
+fn provider_turn_error_display_network() {
+    let err = ProviderTurnError::Network("connection refused".to_string());
+    assert_eq!(err.to_string(), "network error: connection refused");
+}
+
+#[test]
+fn provider_turn_error_display_server_error() {
+    let err = ProviderTurnError::ServerError {
+        status_code: 502,
+        message: "bad gateway".to_string(),
+    };
+    assert_eq!(err.to_string(), "server error (502): bad gateway");
+}
+
+#[test]
+fn provider_turn_error_display_client_error() {
+    let err = ProviderTurnError::ClientError {
+        status_code: 403,
+        message: "forbidden".to_string(),
+    };
+    assert_eq!(err.to_string(), "client error (403): forbidden");
+}
+
+#[test]
+fn provider_turn_error_display_timeout() {
+    let err = ProviderTurnError::Timeout("timed out after 30s".to_string());
+    assert_eq!(err.to_string(), "timeout: timed out after 30s");
+}
+
+#[test]
+fn provider_turn_error_display_parse() {
+    let err = ProviderTurnError::Parse("expected '{'".to_string());
+    assert_eq!(err.to_string(), "parse error: expected '{'");
+}
+
+#[test]
+fn provider_turn_error_display_cancelled() {
+    let err = ProviderTurnError::Cancelled;
+    assert_eq!(err.to_string(), "provider turn cancelled");
+}
+
+#[test]
+fn provider_turn_error_display_backend() {
+    let err = ProviderTurnError::Backend("something went wrong".to_string());
+    assert_eq!(
+        err.to_string(),
+        "provider backend error: something went wrong"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Phase 1: ProviderErrorKind serde tests
+// ---------------------------------------------------------------------------
+
+use anvil::provider::ProviderErrorKind;
+
+#[test]
+fn provider_error_kind_serde_roundtrip_known_variants() {
+    let variants = vec![
+        ProviderErrorKind::Cancelled,
+        ProviderErrorKind::Network,
+        ProviderErrorKind::ServerError,
+        ProviderErrorKind::ClientError,
+        ProviderErrorKind::Timeout,
+        ProviderErrorKind::Parse,
+        ProviderErrorKind::Backend,
+    ];
+    for variant in variants {
+        let json = serde_json::to_string(&variant).unwrap();
+        let deserialized: ProviderErrorKind = serde_json::from_str(&json).unwrap();
+        assert_eq!(variant, deserialized);
+    }
+}
+
+#[test]
+fn provider_error_kind_unknown_variant_fallback() {
+    // A future variant name that doesn't exist should deserialize to Unknown.
+    let json = r#""RateLimit""#;
+    let deserialized: ProviderErrorKind = serde_json::from_str(json).unwrap();
+    assert_eq!(deserialized, ProviderErrorKind::Unknown);
+}
+
+#[test]
+fn provider_error_kind_unknown_variant_arbitrary_string() {
+    let json = r#""SomethingCompletelyNew""#;
+    let deserialized: ProviderErrorKind = serde_json::from_str(json).unwrap();
+    assert_eq!(deserialized, ProviderErrorKind::Unknown);
+}
+
+// ---------------------------------------------------------------------------
+// Phase 3: Error classification tests
+// ---------------------------------------------------------------------------
+
+use anvil::provider::{
+    classify_curl_error, classify_http_error, redact_secrets, sanitize_error_message,
+};
+
+#[test]
+fn classify_http_error_500_returns_server_error() {
+    let err = classify_http_error(500, "internal server error");
+    assert!(matches!(
+        err,
+        ProviderTurnError::ServerError {
+            status_code: 500,
+            ..
+        }
+    ));
+}
+
+#[test]
+fn classify_http_error_502_returns_server_error() {
+    let err = classify_http_error(502, "bad gateway");
+    assert!(matches!(
+        err,
+        ProviderTurnError::ServerError {
+            status_code: 502,
+            ..
+        }
+    ));
+}
+
+#[test]
+fn classify_http_error_401_returns_client_error() {
+    let err = classify_http_error(401, "unauthorized");
+    assert!(matches!(
+        err,
+        ProviderTurnError::ClientError {
+            status_code: 401,
+            ..
+        }
+    ));
+}
+
+#[test]
+fn classify_http_error_404_returns_client_error() {
+    let err = classify_http_error(404, "not found");
+    assert!(matches!(
+        err,
+        ProviderTurnError::ClientError {
+            status_code: 404,
+            ..
+        }
+    ));
+}
+
+#[test]
+fn classify_http_error_299_returns_backend() {
+    let err = classify_http_error(299, "unexpected");
+    assert!(matches!(err, ProviderTurnError::Backend(_)));
+}
+
+#[test]
+fn classify_curl_error_exit_28_returns_timeout() {
+    let err = classify_curl_error(28, "operation timed out");
+    assert!(matches!(err, ProviderTurnError::Timeout(_)));
+}
+
+#[test]
+fn classify_curl_error_exit_7_returns_network() {
+    let err = classify_curl_error(7, "failed to connect");
+    assert!(matches!(err, ProviderTurnError::Network(_)));
+}
+
+#[test]
+fn classify_curl_error_exit_6_returns_network() {
+    let err = classify_curl_error(6, "could not resolve host");
+    assert!(matches!(err, ProviderTurnError::Network(_)));
+}
+
+#[test]
+fn classify_curl_error_exit_other_returns_network() {
+    let err = classify_curl_error(56, "recv failure");
+    assert!(matches!(err, ProviderTurnError::Network(_)));
+}
+
+#[test]
+fn sanitize_error_message_truncates_to_500_chars() {
+    let long_message = "a".repeat(600);
+    let sanitized = sanitize_error_message(&long_message);
+    assert!(sanitized.contains("... [truncated, 600 bytes total]"));
+    assert!(sanitized.len() < 600);
+}
+
+#[test]
+fn sanitize_error_message_short_message_unchanged() {
+    let msg = "short error";
+    let sanitized = sanitize_error_message(msg);
+    assert_eq!(sanitized, "short error");
+}
+
+#[test]
+fn redact_secrets_authorization_header() {
+    let msg = "Authorization: Bearer sk-1234567890abcdef";
+    let redacted = redact_secrets(msg);
+    assert!(redacted.contains("[REDACTED]"));
+    assert!(!redacted.contains("sk-1234567890abcdef"));
+}
+
+#[test]
+fn redact_secrets_bearer_token() {
+    let msg = "error with Bearer my-secret-token in message";
+    let redacted = redact_secrets(msg);
+    assert!(redacted.contains("[REDACTED]"));
+    assert!(!redacted.contains("my-secret-token"));
+}
+
+#[test]
+fn redact_secrets_api_key() {
+    let msg = "api_key: my-secret-key";
+    let redacted = redact_secrets(msg);
+    assert!(redacted.contains("[REDACTED]"));
+    assert!(!redacted.contains("my-secret-key"));
+}
+
+#[test]
+fn redact_secrets_no_secrets_unchanged() {
+    let msg = "normal error message";
+    let redacted = redact_secrets(msg);
+    assert_eq!(redacted, "normal error message");
+}
+
+#[test]
+fn classify_http_error_sanitizes_body_with_secrets() {
+    let err = classify_http_error(500, "error with Authorization: Bearer sk-secret");
+    if let ProviderTurnError::ServerError { message, .. } = err {
+        assert!(message.contains("[REDACTED]"));
+        assert!(!message.contains("sk-secret"));
+    } else {
+        panic!("expected ServerError");
+    }
+}
+
+#[test]
+fn classify_http_error_is_retryable_for_server_errors() {
+    let err = classify_http_error(500, "internal error");
+    assert!(err.is_retryable());
+}
+
+#[test]
+fn classify_http_error_not_retryable_for_client_errors() {
+    let err = classify_http_error(401, "unauthorized");
+    assert!(!err.is_retryable());
+}
+
+#[test]
+fn classify_curl_error_timeout_is_retryable() {
+    let err = classify_curl_error(28, "timed out");
+    assert!(err.is_retryable());
+}
+
+#[test]
+fn classify_curl_error_network_is_retryable() {
+    let err = classify_curl_error(7, "connection refused");
+    assert!(err.is_retryable());
+}
+
+// ---------------------------------------------------------------------------
+// Phase 4: RetryTransport tests
+// ---------------------------------------------------------------------------
+
+use anvil::provider::{RetryConfig, RetryTransport};
+
+/// Mock transport that fails a configurable number of times before succeeding.
+#[derive(Clone)]
+struct RetryMockTransport {
+    call_count: Rc<RefCell<usize>>,
+    fail_count: usize,
+    error: ProviderTurnError,
+    response: HttpResponse,
+    /// If set, stream_lines will invoke the callback before failing.
+    invoke_callback_before_error: bool,
+}
+
+impl RetryMockTransport {
+    fn new(fail_count: usize, error: ProviderTurnError) -> Self {
+        Self {
+            call_count: Rc::new(RefCell::new(0)),
+            fail_count,
+            error,
+            response: HttpResponse {
+                status_code: 200,
+                body: b"ok".to_vec(),
+            },
+            invoke_callback_before_error: false,
+        }
+    }
+}
+
+impl HttpTransport for RetryMockTransport {
+    fn post_json_with_headers(
+        &self,
+        _url: &str,
+        _body: &[u8],
+        _headers: &[(&str, &str)],
+    ) -> Result<HttpResponse, ProviderTurnError> {
+        let mut count = self.call_count.borrow_mut();
+        *count += 1;
+        if *count <= self.fail_count {
+            Err(self.error.clone())
+        } else {
+            Ok(self.response.clone())
+        }
+    }
+
+    fn get_with_headers(
+        &self,
+        _url: &str,
+        _headers: &[(&str, &str)],
+    ) -> Result<HttpResponse, ProviderTurnError> {
+        let mut count = self.call_count.borrow_mut();
+        *count += 1;
+        if *count <= self.fail_count {
+            Err(self.error.clone())
+        } else {
+            Ok(self.response.clone())
+        }
+    }
+
+    fn stream_lines(
+        &self,
+        _url: &str,
+        _body: &[u8],
+        _headers: &[(&str, &str)],
+        on_line: &mut dyn FnMut(&str),
+    ) -> Result<(), ProviderTurnError> {
+        let mut count = self.call_count.borrow_mut();
+        *count += 1;
+        if *count <= self.fail_count {
+            if self.invoke_callback_before_error {
+                on_line("partial data");
+            }
+            Err(self.error.clone())
+        } else {
+            on_line("success line");
+            Ok(())
+        }
+    }
+}
+
+fn fast_retry_config(max_retries: u32) -> RetryConfig {
+    RetryConfig {
+        max_retries,
+        base_delay_ms: 0,
+        backoff_factor: 2,
+        max_delay_ms: 0,
+    }
+}
+
+#[test]
+fn retry_transport_succeeds_on_second_attempt() {
+    let mock = RetryMockTransport::new(1, ProviderTurnError::Network("fail".into()));
+    let call_count = mock.call_count.clone();
+    let transport = RetryTransport::with_config(mock, fast_retry_config(3));
+
+    let result = transport.post_json_with_headers("http://test", b"body", &[]);
+    assert!(result.is_ok());
+    assert_eq!(*call_count.borrow(), 2);
+}
+
+#[test]
+fn retry_transport_exhausts_max_retries() {
+    // max_retries=3 means 4 total attempts (initial + 3 retries)
+    let mock = RetryMockTransport::new(10, ProviderTurnError::Network("fail".into()));
+    let call_count = mock.call_count.clone();
+    let transport = RetryTransport::with_config(mock, fast_retry_config(3));
+
+    let result = transport.post_json_with_headers("http://test", b"body", &[]);
+    assert!(result.is_err());
+    assert_eq!(*call_count.borrow(), 4);
+}
+
+#[test]
+fn retry_transport_no_retry_on_client_error() {
+    let mock = RetryMockTransport::new(
+        10,
+        ProviderTurnError::ClientError {
+            status_code: 401,
+            message: "unauthorized".into(),
+        },
+    );
+    let call_count = mock.call_count.clone();
+    let transport = RetryTransport::with_config(mock, fast_retry_config(3));
+
+    let result = transport.post_json_with_headers("http://test", b"body", &[]);
+    assert!(result.is_err());
+    assert_eq!(*call_count.borrow(), 1);
+}
+
+#[test]
+fn retry_transport_no_retry_on_parse_error() {
+    let mock = RetryMockTransport::new(10, ProviderTurnError::Parse("bad json".into()));
+    let call_count = mock.call_count.clone();
+    let transport = RetryTransport::with_config(mock, fast_retry_config(3));
+
+    let result = transport.get_with_headers("http://test", &[]);
+    assert!(result.is_err());
+    assert_eq!(*call_count.borrow(), 1);
+}
+
+#[test]
+fn retry_transport_get_succeeds_on_second_attempt() {
+    let mock = RetryMockTransport::new(1, ProviderTurnError::Timeout("slow".into()));
+    let call_count = mock.call_count.clone();
+    let transport = RetryTransport::with_config(mock, fast_retry_config(3));
+
+    let result = transport.get_with_headers("http://test", &[]);
+    assert!(result.is_ok());
+    assert_eq!(*call_count.borrow(), 2);
+}
+
+#[test]
+fn retry_transport_stream_lines_retries_on_connection_error() {
+    let mock = RetryMockTransport::new(1, ProviderTurnError::Network("refused".into()));
+    let call_count = mock.call_count.clone();
+    let transport = RetryTransport::with_config(mock, fast_retry_config(3));
+
+    let mut lines = Vec::new();
+    let result = transport.stream_lines("http://test", b"body", &[], &mut |line| {
+        lines.push(line.to_string());
+    });
+    assert!(result.is_ok());
+    assert_eq!(*call_count.borrow(), 2);
+    assert!(lines.contains(&"success line".to_string()));
+}
+
+#[test]
+fn retry_transport_server_error_retries() {
+    let mock = RetryMockTransport::new(
+        2,
+        ProviderTurnError::ServerError {
+            status_code: 503,
+            message: "service unavailable".into(),
+        },
+    );
+    let call_count = mock.call_count.clone();
+    let transport = RetryTransport::with_config(mock, fast_retry_config(3));
+
+    let result = transport.get_with_headers("http://test", &[]);
+    assert!(result.is_ok());
+    assert_eq!(*call_count.borrow(), 3);
+}
+
+#[test]
+fn retry_transport_stream_lines_no_retry_after_callback_invoked() {
+    let mut mock = RetryMockTransport::new(10, ProviderTurnError::Network("mid-stream".into()));
+    mock.invoke_callback_before_error = true;
+    let call_count = mock.call_count.clone();
+    let transport = RetryTransport::with_config(mock, fast_retry_config(3));
+
+    let mut lines = Vec::new();
+    let result = transport.stream_lines("http://test", b"body", &[], &mut |line| {
+        lines.push(line.to_string());
+    });
+    assert!(result.is_err());
+    // Only 1 call because callback was invoked, so guard prevents retry
+    assert_eq!(*call_count.borrow(), 1);
+}
+
+// ---------------------------------------------------------------------------
+// Phase 6: Health check tests
+// ---------------------------------------------------------------------------
+
+use anvil::provider::openai::OpenAiCompatibleProviderClient;
+
+#[test]
+fn ollama_health_check_success() {
+    let mock = MockHttpTransport {
+        seen_urls: Rc::new(RefCell::new(Vec::new())),
+        seen_bodies: Rc::new(RefCell::new(Vec::new())),
+        seen_headers: Rc::new(RefCell::new(Vec::new())),
+        response: HttpResponse {
+            status_code: 200,
+            body: br#"{"models":[]}"#.to_vec(),
+        },
+        get_response: Some(HttpResponse {
+            status_code: 200,
+            body: br#"{"models":[]}"#.to_vec(),
+        }),
+    };
+    let urls = mock.seen_urls.clone();
+    let client = OllamaProviderClient::with_transport("http://localhost:11434", mock);
+    let result = client.health_check();
+    assert!(result.is_ok());
+    let seen = urls.borrow();
+    assert!(
+        seen.iter().any(|u| u.contains("/api/tags")),
+        "health check should hit /api/tags"
+    );
+}
+
+#[test]
+fn ollama_health_check_failure() {
+    /// Mock transport that always fails with a network error.
+    #[derive(Clone)]
+    struct FailingTransport;
+
+    impl HttpTransport for FailingTransport {
+        fn post_json_with_headers(
+            &self,
+            _url: &str,
+            _body: &[u8],
+            _headers: &[(&str, &str)],
+        ) -> Result<HttpResponse, ProviderTurnError> {
+            Err(ProviderTurnError::Network("connection refused".into()))
+        }
+
+        fn get_with_headers(
+            &self,
+            _url: &str,
+            _headers: &[(&str, &str)],
+        ) -> Result<HttpResponse, ProviderTurnError> {
+            Err(ProviderTurnError::Network("connection refused".into()))
+        }
+    }
+
+    let client = OllamaProviderClient::with_transport("http://localhost:11434", FailingTransport);
+    let result = client.health_check();
+    assert!(result.is_err());
+    let err_msg = result.unwrap_err();
+    assert!(err_msg.contains("Ollamaに接続できません"));
+    assert!(err_msg.contains("localhost:11434"));
+}
+
+#[test]
+fn openai_health_check_success_with_auth() {
+    let mock = MockHttpTransport {
+        seen_urls: Rc::new(RefCell::new(Vec::new())),
+        seen_bodies: Rc::new(RefCell::new(Vec::new())),
+        seen_headers: Rc::new(RefCell::new(Vec::new())),
+        response: HttpResponse {
+            status_code: 200,
+            body: br#"{"data":[]}"#.to_vec(),
+        },
+        get_response: Some(HttpResponse {
+            status_code: 200,
+            body: br#"{"data":[]}"#.to_vec(),
+        }),
+    };
+    let urls = mock.seen_urls.clone();
+    let headers = mock.seen_headers.clone();
+    let client = OpenAiCompatibleProviderClient::with_transport("http://localhost:8080", mock)
+        .with_api_key("test-key-123");
+    let result = client.health_check();
+    assert!(result.is_ok());
+    let seen_urls = urls.borrow();
+    assert!(
+        seen_urls.iter().any(|u| u.contains("/v1/models")),
+        "health check should hit /v1/models"
+    );
+    let seen_headers = headers.borrow();
+    let last_headers = seen_headers.last().expect("should have headers");
+    assert!(
+        last_headers
+            .iter()
+            .any(|(k, v)| k == "Authorization" && v == "test-key-123"),
+        "should send Authorization header with api_key"
+    );
+}
+
+#[test]
+fn openai_health_check_failure_with_auth_guidance() {
+    #[derive(Clone)]
+    struct FailingTransport;
+
+    impl HttpTransport for FailingTransport {
+        fn post_json_with_headers(
+            &self,
+            _url: &str,
+            _body: &[u8],
+            _headers: &[(&str, &str)],
+        ) -> Result<HttpResponse, ProviderTurnError> {
+            Err(ProviderTurnError::Network("connection refused".into()))
+        }
+
+        fn get_with_headers(
+            &self,
+            _url: &str,
+            _headers: &[(&str, &str)],
+        ) -> Result<HttpResponse, ProviderTurnError> {
+            Err(ProviderTurnError::ClientError {
+                status_code: 401,
+                message: "unauthorized".into(),
+            })
+        }
+    }
+
+    let client =
+        OpenAiCompatibleProviderClient::with_transport("http://localhost:8080", FailingTransport)
+            .with_api_key("bad-key");
+    let result = client.health_check();
+    assert!(result.is_err());
+    let err_msg = result.unwrap_err();
+    assert!(err_msg.contains("OpenAI互換プロバイダーに接続できません"));
+    assert!(err_msg.contains("認証情報の形式を確認してください"));
+}
+
+#[test]
+fn openai_health_check_no_auth_no_guidance() {
+    #[derive(Clone)]
+    struct FailingTransport;
+
+    impl HttpTransport for FailingTransport {
+        fn post_json_with_headers(
+            &self,
+            _url: &str,
+            _body: &[u8],
+            _headers: &[(&str, &str)],
+        ) -> Result<HttpResponse, ProviderTurnError> {
+            Err(ProviderTurnError::Network("refused".into()))
+        }
+
+        fn get_with_headers(
+            &self,
+            _url: &str,
+            _headers: &[(&str, &str)],
+        ) -> Result<HttpResponse, ProviderTurnError> {
+            Err(ProviderTurnError::Network("refused".into()))
+        }
+    }
+
+    let client =
+        OpenAiCompatibleProviderClient::with_transport("http://localhost:8080", FailingTransport);
+    let result = client.health_check();
+    assert!(result.is_err());
+    let err_msg = result.unwrap_err();
+    assert!(err_msg.contains("OpenAI互換プロバイダーに接続できません"));
+    // No auth guidance when no api_key is set
+    assert!(!err_msg.contains("認証情報の形式を確認してください"));
 }


### PR DESCRIPTION
## Summary

- 起動時にプロバイダー（Ollama/OpenAI互換）への接続確認（ヘルスチェック）を実行
- 一時的なネットワーク障害に対する指数バックオフリトライ機構を実装
- ProviderTurnErrorを構造化し、リトライ可否の型安全な判定を実現

## 主な変更点

### ヘルスチェック
- Ollama: `/api/tags` エンドポイントへのGETで接続確認
- OpenAI互換: `/v1/models` エンドポイントへのGET（認証ヘッダー付与対応）
- 失敗時は警告メッセージを表示し、起動は継続

### リトライ機構
- `RetryTransport<T: HttpTransport>` によるTransport層リトライ
- 指数バックオフ: 1秒→2秒→4秒（最大3回、上限30秒）
- リトライ対象: Network, ServerError(5xx), Timeout
- リトライ非対象: ClientError(4xx), Parse, Backend
- stream_lines: 接続時エラーのみリトライ（コールバック呼び出し後はリトライ不可）

### エラー型拡張
- `ProviderTurnError` に Network, ServerError, ClientError, Timeout, Parse バリアント追加
- `is_retryable()` メソッドで型安全なリトライ判定
- `ProviderErrorKind` 拡張（serde互換、`#[serde(other)]` による後方互換）

### セキュリティ
- CRLFヘッダーインジェクション防止（`validate_header_value`）
- curl `--proto '=http,https'` によるプロトコル制限
- エラーメッセージのAPIキー除去（`redact_secrets`）
- レスポンスボディ500文字トランケート

## 変更ファイル（8ファイル, +1354/-75行）

| ファイル | 変更内容 |
|---------|---------|
| `src/provider/mod.rs` | エラー型拡張、DefaultTransport、health_check |
| `src/provider/transport.rs` | HttpTransport GET追加、RetryTransport、エラー分類 |
| `src/provider/ollama.rs` | ヘルスチェック、コンストラクタ更新 |
| `src/provider/openai.rs` | ヘルスチェック、コンストラクタ更新 |
| `src/app/mod.rs` | match式更新、record_provider_error |
| `src/app/agentic.rs` | ワイルドカードパターン化 |
| `src/app/cli.rs` | 起動フローにヘルスチェック追加 |
| `tests/provider_integration.rs` | 33テスト追加 |

## Test plan

- [x] `cargo build` エラー0件
- [x] `cargo clippy --all-targets` 警告0件
- [x] `cargo test` 全305テストパス
- [x] `cargo fmt --check` 差分なし
- [x] is_retryable() 全バリアント判定テスト
- [x] RetryTransport リトライ成功/失敗/4xxスキップテスト
- [x] stream_lines コールバックガードテスト
- [x] エラー分類テスト（HTTP status, curl exit code）
- [x] ProviderErrorKind serde互換性テスト
- [x] ヘルスチェック成功/失敗テスト

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)