### PR TITLE
feat(app): add graceful shutdown via signal handling (#14)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,7 @@ dependencies = [
  "rustyline",
  "serde",
  "serde_json",
+ "signal-hook",
  "tempfile",
  "tracing",
  "tracing-appender",
@@ -463,6 +464,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ regex = { version = "1", default-features = false, features = ["std"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "env-filter", "ansi", "registry"] }
 tracing-appender = "0.2"
+signal-hook = "0.3"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -42,6 +42,11 @@ impl App {
         let mut all_tool_log_views: Vec<ToolLogView> = Vec::new();
 
         for iteration in 0..max_iterations {
+            // Check shutdown flag before tool execution
+            if self.is_shutdown_requested() {
+                break;
+            }
+
             // Show plan for this iteration
             let inferred_plan = infer_plan_from_structured_response(&current);
             let thinking = AppStateSnapshot::new(RuntimeState::Thinking)
@@ -85,6 +90,11 @@ impl App {
             // Skip intermediate Working frames — tool execution output
             // is already shown on stderr (Issue #1).
 
+            // Check shutdown flag before LLM call
+            if self.is_shutdown_requested() {
+                break;
+            }
+
             // Send tool results back to LLM for the next turn
             let spinner = Spinner::start(format!(
                 "Analyzing results. model={} (iteration {})",
@@ -126,12 +136,23 @@ impl App {
                 let _ = std::io::Write::write_fmt(&mut std::io::stderr(), format_args!("\n"));
             }
 
-            stream_result.map_err(|err| match err {
-                crate::provider::ProviderTurnError::Cancelled => {
-                    AppError::ToolExecution("agentic follow-up cancelled".to_string())
+            match stream_result {
+                Err(crate::provider::ProviderTurnError::Cancelled)
+                    if self.is_shutdown_requested() =>
+                {
+                    break;
                 }
-                other => AppError::ToolExecution(format!("agentic follow-up failed: {other}")),
-            })?;
+                other => {
+                    other.map_err(|err| match err {
+                        crate::provider::ProviderTurnError::Cancelled => {
+                            AppError::ToolExecution("agentic follow-up cancelled".to_string())
+                        }
+                        other => {
+                            AppError::ToolExecution(format!("agentic follow-up failed: {other}"))
+                        }
+                    })?;
+                }
+            }
 
             // Parse the follow-up response (retry once on parse failure)
             let next_structured =
@@ -188,7 +209,8 @@ impl App {
         structured: &StructuredAssistantResponse,
     ) -> Result<Vec<ToolExecutionResult>, AppError> {
         let mut executor =
-            LocalToolExecutor::new(self.config.paths.cwd.clone(), &self.config.runtime);
+            LocalToolExecutor::new(self.config.paths.cwd.clone(), &self.config.runtime)
+                .with_shutdown_flag(self.shutdown_flag());
         let mut results = Vec::new();
         for call in &structured.tool_calls {
             let validated = match self.tools.validate(call.clone()) {

--- a/src/app/cli.rs
+++ b/src/app/cli.rs
@@ -12,6 +12,8 @@ use crate::tui::Tui;
 use super::{App, AppError, SessionControl, cli_prompt};
 
 use std::io::{self, BufRead, Write};
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
 
 /// Drive the interactive CLI session loop.
 ///
@@ -52,6 +54,29 @@ pub fn run_session_loop<C: ProviderClient, R: BufRead, W: Write>(
     Ok(())
 }
 
+/// Initialize signal handlers for graceful shutdown.
+///
+/// Registers SIGTERM (always) and SIGINT (non-interactive mode only).
+/// In interactive mode, SIGINT is handled by rustyline.
+fn setup_shutdown_handler(interactive: bool) -> Arc<AtomicBool> {
+    use signal_hook::consts::{SIGINT, SIGTERM};
+    use signal_hook::flag;
+
+    let shutdown_flag = Arc::new(AtomicBool::new(false));
+
+    // SIGTERM is always registered
+    if let Err(e) = flag::register(SIGTERM, Arc::clone(&shutdown_flag)) {
+        eprintln!("Warning: failed to register SIGTERM handler: {e}");
+    }
+
+    // In non-interactive mode, also register SIGINT
+    if !interactive && let Err(e) = flag::register(SIGINT, Arc::clone(&shutdown_flag)) {
+        eprintln!("Warning: failed to register SIGINT handler: {e}");
+    }
+
+    shutdown_flag
+}
+
 /// Application entry point.
 ///
 /// Uses `rustyline` for interactive input, providing cursor movement,
@@ -74,15 +99,18 @@ pub fn run() -> Result<(), AppError> {
         "anvil started with effective config"
     );
 
+    // Setup shutdown handler before config is moved
+    let shutdown_flag = setup_shutdown_handler(config.mode.interactive);
+
     let provider = ProviderRuntimeContext::bootstrap(&config)?;
-    let provider_client = build_local_provider_client(&config)?;
+    let provider_client = build_local_provider_client(&config, Arc::clone(&shutdown_flag))?;
 
     // Health check: warn on failure but continue startup.
     if let Err(warning) = provider_client.health_check() {
         eprintln!("\u{26a0} {warning}");
     }
 
-    let mut app = App::new(config, provider)?;
+    let mut app = App::new(config, provider, Arc::clone(&shutdown_flag))?;
     let tui = Tui::new();
     println!("{}", app.startup_console(&tui)?);
 
@@ -115,8 +143,17 @@ fn run_interactive_loop<C: ProviderClient>(
 
     let prompt = cli_prompt();
     loop {
+        // Check shutdown flag before readline
+        if app.is_shutdown_requested() {
+            break;
+        }
+
         match rl.readline(prompt) {
             Ok(line) => {
+                // Check shutdown flag after readline
+                if app.is_shutdown_requested() {
+                    break;
+                }
                 if !line.trim().is_empty() {
                     let _ = rl.add_history_entry(&line);
                 }
@@ -138,6 +175,9 @@ fn run_interactive_loop<C: ProviderClient>(
             }
         }
     }
+
+    // Save session on exit
+    app.save_session_on_exit();
 
     if let Some(parent) = history_path.parent() {
         let _ = std::fs::create_dir_all(parent);

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -29,6 +29,8 @@ use crate::tooling::ToolRegistry;
 use crate::tui::Tui;
 use std::fmt::{Display, Formatter};
 use std::io::{self, Write};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 // Re-export render helpers that form the public API.
 pub use render::{cli_prompt, render_help_frame, slash_commands};
@@ -58,6 +60,7 @@ pub struct App {
     extensions: ExtensionRegistry,
     tools: ToolRegistry,
     system_prompt: String,
+    shutdown_flag: Arc<AtomicBool>,
 }
 
 /// Whether the session loop should continue or exit.
@@ -147,6 +150,7 @@ impl App {
     pub fn new(
         config: EffectiveConfig,
         provider: ProviderRuntimeContext,
+        shutdown_flag: Arc<AtomicBool>,
     ) -> Result<Self, AppError> {
         let session_store = SessionStore::from_config(&config);
         let mut session = if config.mode.fresh_session {
@@ -180,6 +184,7 @@ impl App {
             session,
             extensions,
             system_prompt,
+            shutdown_flag,
         })
     }
 
@@ -218,6 +223,21 @@ impl App {
 
     pub(crate) fn config(&self) -> &EffectiveConfig {
         &self.config
+    }
+
+    /// Check whether a shutdown has been requested via the shared flag.
+    pub fn is_shutdown_requested(&self) -> bool {
+        self.shutdown_flag.load(Ordering::Relaxed)
+    }
+
+    /// Save the session on exit (wrapper for flush_session).
+    pub(crate) fn save_session_on_exit(&mut self) {
+        let _ = self.flush_session();
+    }
+
+    /// Get a clone of the shutdown flag for injection into sub-components.
+    pub(crate) fn shutdown_flag(&self) -> Arc<AtomicBool> {
+        Arc::clone(&self.shutdown_flag)
     }
 
     pub(crate) fn session_mut(&mut self) -> &mut SessionRecord {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,11 @@
-fn main() {
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
     if let Err(err) = anvil::app::run() {
         eprintln!("anvil error: {err}");
         eprintln!();
         eprintln!("{}", anvil::app::error_guidance(&err));
-        std::process::exit(1);
+        return ExitCode::FAILURE;
     }
+    ExitCode::SUCCESS
 }

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -10,6 +10,8 @@ pub mod transport;
 use crate::agent::AgentEvent;
 use crate::config::EffectiveConfig;
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
 
 // Re-export key types so existing `use crate::provider::*` continues to work.
 pub use ollama::{
@@ -280,8 +282,11 @@ impl ProviderClient for LocalProviderClient {
 /// backoff.
 pub fn build_local_provider_client(
     config: &EffectiveConfig,
+    shutdown_flag: Arc<AtomicBool>,
 ) -> Result<LocalProviderClient, ProviderBootstrapError> {
-    let transport = RetryTransport::new(CurlHttpTransport);
+    let curl_transport = CurlHttpTransport::with_shutdown_flag(Arc::clone(&shutdown_flag));
+    let transport =
+        RetryTransport::with_shutdown_flag(curl_transport, RetryConfig::default(), shutdown_flag);
     match config.runtime.provider.as_str() {
         "ollama" => {
             let client = OllamaProviderClient::with_transport(

--- a/src/provider/ollama.rs
+++ b/src/provider/ollama.rs
@@ -50,7 +50,7 @@ impl OllamaProviderClient {
     pub fn new(base_url: impl Into<String>) -> Self {
         Self {
             base_url: base_url.into(),
-            transport: RetryTransport::new(CurlHttpTransport),
+            transport: RetryTransport::new(CurlHttpTransport::new()),
         }
     }
 
@@ -146,7 +146,7 @@ impl Default for OllamaProviderClient {
     fn default() -> Self {
         Self {
             base_url: "http://127.0.0.1:11434".to_string(),
-            transport: RetryTransport::new(CurlHttpTransport),
+            transport: RetryTransport::new(CurlHttpTransport::new()),
         }
     }
 }

--- a/src/provider/openai.rs
+++ b/src/provider/openai.rs
@@ -74,7 +74,7 @@ impl OpenAiCompatibleProviderClient {
         Self {
             base_url: base_url.into(),
             api_key: None,
-            transport: RetryTransport::new(CurlHttpTransport),
+            transport: RetryTransport::new(CurlHttpTransport::new()),
         }
     }
 
@@ -82,7 +82,7 @@ impl OpenAiCompatibleProviderClient {
         Self {
             base_url: config.runtime.provider_url.clone(),
             api_key: config.runtime.api_key.clone(),
-            transport: RetryTransport::new(CurlHttpTransport),
+            transport: RetryTransport::new(CurlHttpTransport::new()),
         }
     }
 }

--- a/src/provider/transport.rs
+++ b/src/provider/transport.rs
@@ -7,6 +7,8 @@
 use super::ProviderTurnError;
 use std::io::Write;
 use std::process::{Command, Stdio};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 /// Parsed HTTP response returned by an [`HttpTransport`] implementation.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -81,7 +83,31 @@ pub trait HttpTransport {
 ///
 /// This is the default transport.  It works on any system where `curl` is
 /// installed and avoids pulling in native TLS dependencies.
-pub struct CurlHttpTransport;
+pub struct CurlHttpTransport {
+    shutdown_flag: Option<Arc<AtomicBool>>,
+}
+
+impl Default for CurlHttpTransport {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CurlHttpTransport {
+    /// Create a new transport without shutdown flag (backward-compatible).
+    pub fn new() -> Self {
+        Self {
+            shutdown_flag: None,
+        }
+    }
+
+    /// Create a new transport with a shutdown flag for graceful shutdown.
+    pub fn with_shutdown_flag(shutdown_flag: Arc<AtomicBool>) -> Self {
+        Self {
+            shutdown_flag: Some(shutdown_flag),
+        }
+    }
+}
 
 /// Backward-compatible alias.
 pub type TcpHttpTransport = CurlHttpTransport;
@@ -115,7 +141,7 @@ impl HttpTransport for CurlHttpTransport {
         headers: &[(&str, &str)],
         on_line: &mut dyn FnMut(&str),
     ) -> Result<(), ProviderTurnError> {
-        curl_stream_lines(url, body, headers, on_line)
+        curl_stream_lines(url, body, headers, on_line, &self.shutdown_flag)
     }
 }
 
@@ -221,6 +247,7 @@ fn curl_stream_lines(
     body: &[u8],
     extra_headers: &[(&str, &str)],
     on_line: &mut dyn FnMut(&str),
+    shutdown_flag: &Option<Arc<AtomicBool>>,
 ) -> Result<(), ProviderTurnError> {
     let mut cmd = Command::new("curl");
     cmd.args(["-sS", "-N", "-X", "POST"])
@@ -253,6 +280,15 @@ fn curl_stream_lines(
         let reader = std::io::BufReader::new(stdout);
         use std::io::BufRead;
         for line in reader.lines() {
+            // Check shutdown flag before processing each line
+            if shutdown_flag
+                .as_ref()
+                .is_some_and(|f| f.load(Ordering::Relaxed))
+            {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(ProviderTurnError::Cancelled);
+            }
             let line = line.map_err(|err| {
                 ProviderTurnError::Network(format!("failed to read curl output: {err}"))
             })?;
@@ -495,6 +531,7 @@ impl Default for RetryConfig {
 pub struct RetryTransport<T: HttpTransport> {
     inner: T,
     config: RetryConfig,
+    shutdown_flag: Option<Arc<AtomicBool>>,
 }
 
 impl<T: HttpTransport> RetryTransport<T> {
@@ -502,11 +539,44 @@ impl<T: HttpTransport> RetryTransport<T> {
         Self {
             inner,
             config: RetryConfig::default(),
+            shutdown_flag: None,
         }
     }
 
     pub fn with_config(inner: T, config: RetryConfig) -> Self {
-        Self { inner, config }
+        Self {
+            inner,
+            config,
+            shutdown_flag: None,
+        }
+    }
+
+    /// Create a retry transport with a shutdown flag for graceful shutdown.
+    pub fn with_shutdown_flag(inner: T, config: RetryConfig, flag: Arc<AtomicBool>) -> Self {
+        Self {
+            inner,
+            config,
+            shutdown_flag: Some(flag),
+        }
+    }
+
+    fn is_shutdown(&self) -> bool {
+        self.shutdown_flag
+            .as_ref()
+            .is_some_and(|f| f.load(Ordering::Relaxed))
+    }
+
+    /// Interruptible sleep that checks the shutdown flag every 100ms.
+    /// Returns `true` if interrupted by shutdown.
+    fn interruptible_sleep(&self, duration: std::time::Duration) -> bool {
+        let start = std::time::Instant::now();
+        while start.elapsed() < duration {
+            if self.is_shutdown() {
+                return true;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(100));
+        }
+        false
     }
 
     /// Common retry loop with an additional guard closure.
@@ -530,7 +600,9 @@ impl<T: HttpTransport> RetryTransport<T> {
                         .base_delay_ms
                         .saturating_mul(self.config.backoff_factor.saturating_pow(attempt))
                         .min(self.config.max_delay_ms);
-                    std::thread::sleep(std::time::Duration::from_millis(delay));
+                    if self.interruptible_sleep(std::time::Duration::from_millis(delay)) {
+                        return Err(ProviderTurnError::Cancelled);
+                    }
                     last_error = Some(err);
                 }
                 Err(err) => return Err(err),

--- a/src/tooling/mod.rs
+++ b/src/tooling/mod.rs
@@ -578,6 +578,7 @@ pub struct LocalToolExecutor {
     web_search_min_interval: Duration,
     web_search_provider: WebSearchProvider,
     serper_api_key: Option<String>,
+    shutdown_flag: Option<std::sync::Arc<std::sync::atomic::AtomicBool>>,
 }
 
 #[derive(Debug)]
@@ -609,6 +610,7 @@ impl LocalToolExecutor {
             web_search_min_interval: interval,
             web_search_provider: config.web_search_provider,
             serper_api_key: config.serper_api_key.clone(),
+            shutdown_flag: None,
         }
     }
 
@@ -620,7 +622,24 @@ impl LocalToolExecutor {
             web_search_min_interval: Duration::ZERO,
             web_search_provider: WebSearchProvider::DuckDuckGo,
             serper_api_key: None,
+            shutdown_flag: None,
         }
+    }
+
+    /// Set the shutdown flag for graceful shutdown support.
+    pub fn with_shutdown_flag(
+        mut self,
+        flag: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    ) -> Self {
+        self.shutdown_flag = Some(flag);
+        self
+    }
+
+    /// Check whether a shutdown has been requested via the shared flag.
+    fn is_shutdown(&self) -> bool {
+        self.shutdown_flag
+            .as_ref()
+            .is_some_and(|f| f.load(std::sync::atomic::Ordering::Relaxed))
     }
 
     pub fn execute(
@@ -881,17 +900,36 @@ impl LocalToolExecutor {
             captured
         });
 
-        let exit_status = child.wait().ok();
+        // Poll child process with shutdown flag check
+        let exit_status = loop {
+            if self.is_shutdown() {
+                if let Err(e) = child.kill() {
+                    tracing::warn!("failed to kill child process: {e}");
+                }
+                let stdout_buf = stdout_thread.join().unwrap_or_default();
+                let stderr_buf = stderr_thread.join().unwrap_or_default();
+                let _ = child.wait();
+                let combined = combine_process_output(stdout_buf, stderr_buf);
+                return Ok(ToolExecutionResult {
+                    tool_call_id: request.tool_call_id.clone(),
+                    tool_name: request.spec.name.clone(),
+                    status: ToolExecutionStatus::Interrupted,
+                    summary: format!("shell.exec interrupted: {command}"),
+                    payload: ToolExecutionPayload::Text(combined),
+                    artifacts: Vec::new(),
+                    elapsed_ms: started.elapsed().as_millis(),
+                });
+            }
+            match child.try_wait() {
+                Ok(Some(status)) => break Some(status),
+                Ok(None) => std::thread::sleep(Duration::from_millis(50)),
+                Err(_) => break None,
+            }
+        };
         let stdout_buf = stdout_thread.join().unwrap_or_default();
         let stderr_buf = stderr_thread.join().unwrap_or_default();
 
-        let combined = if stderr_buf.trim().is_empty() {
-            stdout_buf
-        } else if stdout_buf.trim().is_empty() {
-            stderr_buf
-        } else {
-            format!("{stdout_buf}--- stderr ---\n{stderr_buf}")
-        };
+        let combined = combine_process_output(stdout_buf, stderr_buf);
 
         let success = exit_status.is_some_and(|s| s.success());
         let status = if success {
@@ -1614,6 +1652,20 @@ fn format_search_results(results: &[SearchResult]) -> String {
         lines.push(String::new());
     }
     lines.join("\n")
+}
+
+/// Combine stdout and stderr into a single output string.
+///
+/// If only one stream has content, returns just that stream.
+/// If both have content, joins them with a `--- stderr ---` separator.
+fn combine_process_output(stdout: String, stderr: String) -> String {
+    if stderr.trim().is_empty() {
+        stdout
+    } else if stdout.trim().is_empty() {
+        stderr
+    } else {
+        format!("{stdout}--- stderr ---\n{stderr}")
+    }
 }
 
 /// Percent-encode a query string for use in URLs.

--- a/tests/cli_session.rs
+++ b/tests/cli_session.rs
@@ -393,7 +393,12 @@ fn startup_console_can_ignore_saved_history_in_fresh_session_mode() {
     config.mode.fresh_session = true;
     let provider = anvil::provider::ProviderRuntimeContext::bootstrap(&config)
         .expect("provider should bootstrap");
-    let mut fresh = anvil::app::App::new(config, provider).expect("app should initialize");
+    let mut fresh = anvil::app::App::new(
+        config,
+        provider,
+        std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+    )
+    .expect("app should initialize");
     let tui = Tui::new();
 
     let startup = fresh.startup_console(&tui).expect("startup should render");

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -4,6 +4,8 @@ use anvil::app::App;
 use anvil::config::EffectiveConfig;
 use anvil::provider::ProviderRuntimeContext;
 use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 pub fn build_app() -> App {
@@ -13,7 +15,8 @@ pub fn build_app() -> App {
 pub fn build_app_in(root: PathBuf) -> App {
     let config = build_config_in(root);
     let provider = ProviderRuntimeContext::bootstrap(&config).expect("provider should bootstrap");
-    App::new(config, provider).expect("app should initialize")
+    let shutdown_flag = Arc::new(AtomicBool::new(false));
+    App::new(config, provider, shutdown_flag).expect("app should initialize")
 }
 
 pub fn build_config_in(root: PathBuf) -> EffectiveConfig {

--- a/tests/config_bootstrap.rs
+++ b/tests/config_bootstrap.rs
@@ -53,7 +53,11 @@ fn provider_runtime_context_bootstraps_capabilities() {
 fn local_provider_client_builds_from_effective_config() {
     let config = EffectiveConfig::load().expect("config should load");
 
-    let client = build_local_provider_client(&config).expect("provider client should build");
+    let client = build_local_provider_client(
+        &config,
+        std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+    )
+    .expect("provider client should build");
 
     assert!(matches!(
         client,
@@ -68,7 +72,11 @@ fn openai_provider_bootstraps_from_config() {
     config.runtime.provider_url = "http://localhost:8080".to_string();
 
     let provider = ProviderRuntimeContext::bootstrap(&config).expect("openai should bootstrap");
-    let client = build_local_provider_client(&config).expect("openai client should build");
+    let client = build_local_provider_client(
+        &config,
+        std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+    )
+    .expect("openai client should build");
 
     assert_eq!(provider.backend, anvil::provider::ProviderBackend::OpenAi);
     assert!(provider.capabilities.streaming);

--- a/tests/provider_integration.rs
+++ b/tests/provider_integration.rs
@@ -181,7 +181,12 @@ fn live_turn_executes_structured_file_write_response_without_approval() {
     config.mode.approval_required = false;
     let provider_ctx =
         anvil::provider::ProviderRuntimeContext::bootstrap(&config).expect("provider bootstrap");
-    let mut app = anvil::app::App::new(config, provider_ctx).expect("app should initialize");
+    let mut app = anvil::app::App::new(
+        config,
+        provider_ctx,
+        std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+    )
+    .expect("app should initialize");
     let tui = Tui::new();
     let provider = RecordingProvider {
         seen_requests: Rc::new(RefCell::new(Vec::new())),
@@ -249,7 +254,12 @@ fn live_turn_executes_complete_structured_response_from_token_stream() {
     config.mode.approval_required = false;
     let provider_ctx =
         anvil::provider::ProviderRuntimeContext::bootstrap(&config).expect("provider bootstrap");
-    let mut app = anvil::app::App::new(config, provider_ctx).expect("app should initialize");
+    let mut app = anvil::app::App::new(
+        config,
+        provider_ctx,
+        std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+    )
+    .expect("app should initialize");
     let tui = Tui::new();
     let provider = RecordingProvider {
         seen_requests: Rc::new(RefCell::new(Vec::new())),
@@ -317,7 +327,12 @@ fn live_turn_executes_malformed_structured_file_write_response() {
     config.mode.approval_required = false;
     let provider_ctx =
         anvil::provider::ProviderRuntimeContext::bootstrap(&config).expect("provider bootstrap");
-    let mut app = anvil::app::App::new(config, provider_ctx).expect("app should initialize");
+    let mut app = anvil::app::App::new(
+        config,
+        provider_ctx,
+        std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+    )
+    .expect("app should initialize");
     let tui = Tui::new();
     let provider = RecordingProvider {
         seen_requests: Rc::new(RefCell::new(Vec::new())),
@@ -585,7 +600,12 @@ fn live_turn_executes_structured_response_from_openai_compatible_provider() {
     config.runtime.provider_url = "http://localhost:1234".to_string();
     let provider_ctx =
         anvil::provider::ProviderRuntimeContext::bootstrap(&config).expect("provider bootstrap");
-    let mut app = anvil::app::App::new(config, provider_ctx).expect("app should initialize");
+    let mut app = anvil::app::App::new(
+        config,
+        provider_ctx,
+        std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+    )
+    .expect("app should initialize");
     let tui = Tui::new();
 
     let transport = MockHttpTransport {
@@ -1104,7 +1124,12 @@ fn agentic_loop_multi_iteration_tool_calls_then_final_answer() {
     config.mode.approval_required = false;
     let provider_ctx =
         anvil::provider::ProviderRuntimeContext::bootstrap(&config).expect("provider bootstrap");
-    let mut app = anvil::app::App::new(config, provider_ctx).expect("app should initialize");
+    let mut app = anvil::app::App::new(
+        config,
+        provider_ctx,
+        std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+    )
+    .expect("app should initialize");
     let tui = Tui::new();
 
     // Create files that the tool calls will read
@@ -1203,7 +1228,12 @@ fn agentic_loop_tool_result_payload_included_in_session_messages() {
     config.mode.approval_required = false;
     let provider_ctx =
         anvil::provider::ProviderRuntimeContext::bootstrap(&config).expect("provider bootstrap");
-    let mut app = anvil::app::App::new(config, provider_ctx).expect("app should initialize");
+    let mut app = anvil::app::App::new(
+        config,
+        provider_ctx,
+        std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+    )
+    .expect("app should initialize");
     let tui = Tui::new();
 
     // Write a test file so file.read has something to return
@@ -1266,7 +1296,12 @@ fn agentic_loop_respects_max_iteration_limit() {
     config.mode.approval_required = false;
     let provider_ctx =
         anvil::provider::ProviderRuntimeContext::bootstrap(&config).expect("provider bootstrap");
-    let mut app = anvil::app::App::new(config, provider_ctx).expect("app should initialize");
+    let mut app = anvil::app::App::new(
+        config,
+        provider_ctx,
+        std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+    )
+    .expect("app should initialize");
     let tui = Tui::new();
 
     // Create file so file.read succeeds
@@ -1337,7 +1372,12 @@ fn agentic_loop_error_during_followup_propagates() {
     config.mode.approval_required = false;
     let provider_ctx =
         anvil::provider::ProviderRuntimeContext::bootstrap(&config).expect("provider bootstrap");
-    let mut app = anvil::app::App::new(config, provider_ctx).expect("app should initialize");
+    let mut app = anvil::app::App::new(
+        config,
+        provider_ctx,
+        std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+    )
+    .expect("app should initialize");
     let tui = Tui::new();
 
     // Create file so file.read succeeds on the first iteration

--- a/tests/tui_console.rs
+++ b/tests/tui_console.rs
@@ -93,7 +93,12 @@ fn tui_renders_approval_and_interrupt_sections() {
     let approval_config = common::build_config_in(common::unique_test_dir("tui_approval"));
     let provider =
         ProviderRuntimeContext::bootstrap(&approval_config).expect("provider should bootstrap");
-    let mut app = anvil::app::App::new(approval_config, provider).expect("app should initialize");
+    let mut app = anvil::app::App::new(
+        approval_config,
+        provider,
+        std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+    )
+    .expect("app should initialize");
     let tui = Tui::new();
 
     let _ = app
@@ -107,8 +112,12 @@ fn tui_renders_approval_and_interrupt_sections() {
     let interrupt_config = common::build_config_in(common::unique_test_dir("tui_interrupt"));
     let provider =
         ProviderRuntimeContext::bootstrap(&interrupt_config).expect("provider should bootstrap");
-    let mut interrupted_app =
-        anvil::app::App::new(interrupt_config, provider).expect("app should initialize");
+    let mut interrupted_app = anvil::app::App::new(
+        interrupt_config,
+        provider,
+        std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+    )
+    .expect("app should initialize");
     let _ = interrupted_app
         .mock_thinking_snapshot()
         .expect("thinking snapshot should build");
@@ -130,7 +139,12 @@ fn tui_renders_approval_and_interrupt_sections() {
 fn startup_screen_shows_logo_model_and_project() {
     let config = common::build_config_in(common::unique_test_dir("startup"));
     let provider = ProviderRuntimeContext::bootstrap(&config).expect("provider should bootstrap");
-    let mut app = anvil::app::App::new(config.clone(), provider).expect("app should initialize");
+    let mut app = anvil::app::App::new(
+        config.clone(),
+        provider,
+        std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+    )
+    .expect("app should initialize");
     let tui = Tui::new();
 
     let rendered = tui.render_startup(
@@ -299,7 +313,12 @@ fn startup_shows_anvil_md_loaded() {
     let mut config = common::build_config_in(common::unique_test_dir("startup_anvil"));
     config.set_project_instructions_for_test(Some("test instructions".to_string()));
     let provider = ProviderRuntimeContext::bootstrap(&config).expect("provider should bootstrap");
-    let mut app = anvil::app::App::new(config.clone(), provider).expect("app should initialize");
+    let mut app = anvil::app::App::new(
+        config.clone(),
+        provider,
+        std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+    )
+    .expect("app should initialize");
     let tui = Tui::new();
 
     let rendered = tui.render_startup(
@@ -315,7 +334,12 @@ fn startup_shows_anvil_md_loaded() {
 fn startup_without_anvil_md() {
     let config = common::build_config_in(common::unique_test_dir("startup_no_anvil"));
     let provider = ProviderRuntimeContext::bootstrap(&config).expect("provider should bootstrap");
-    let mut app = anvil::app::App::new(config.clone(), provider).expect("app should initialize");
+    let mut app = anvil::app::App::new(
+        config.clone(),
+        provider,
+        std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+    )
+    .expect("app should initialize");
     let tui = Tui::new();
 
     let rendered = tui.render_startup(


### PR DESCRIPTION
## Summary

- signal-hookクレートによるSIGTERMハンドリングとArc<AtomicBool>シャットダウンフラグ方式でグレースフルシャットダウンを実装
- CurlHttpTransport/RetryTransport/LocalToolExecutorにシャットダウンフラグを注入し、ストリーミング中・ツール実行中・リトライsleep中の安全な中断を実現
- 子プロセス（curl/shell）のkill+reapによるゾンビ防止
- main.rsをExitCode方式に変更（std::process::exit排除）

## Changes (16 files, +361/-45)

### Core
- `Cargo.toml`: signal-hook = "0.3" 依存追加
- `src/main.rs`: std::process::exit → ExitCode方式
- `src/app/mod.rs`: Appにshutdown_flag, is_shutdown_requested(), save_session_on_exit()
- `src/app/cli.rs`: setup_shutdown_handler(), ループ中断, セッション保存
- `src/app/agentic.rs`: ツールループ中断, LocalToolExecutor注入

### Provider/Transport
- `src/provider/transport.rs`: CurlHttpTransport/RetryTransportにshutdown_flag
- `src/provider/mod.rs`: build_local_provider_client()にshutdown_flag引数
- `src/provider/ollama.rs`: CurlHttpTransport::new()に変更
- `src/provider/openai.rs`: CurlHttpTransport::new()に変更

### Tooling
- `src/tooling/mod.rs`: LocalToolExecutorにshutdown_flag, try_wait()ポーリング

### Tests
- 5テストファイル: ダミーshutdown_flag追加

## Test plan

- [x] `cargo build` エラー0件
- [x] `cargo clippy --all-targets` 警告0件
- [x] `cargo test` 全316テストパス
- [x] `cargo fmt --check` 差分なし
- [ ] 手動テスト: SIGTERM送信時にセッション保存確認
- [ ] 手動テスト: ストリーミング中のSIGTERMで安全な中断確認

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)