### PR TITLE
feat(config): add security warnings for API keys in config file (#17)

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,24 @@ anvil [オプション]
 
 優先順位: CLI > 環境変数 > 設定ファイル > デフォルト値
 
+### APIキーのセキュリティ
+
+APIキーは設定ファイルではなく**環境変数**で設定することを推奨します:
+
+```bash
+export ANVIL_API_KEY=sk-...        # OpenAI互換APIキー
+export SERPER_API_KEY=...          # Serper Web検索APIキー
+```
+
+設定ファイル（`.anvil/config`）にAPIキーが記載されている場合、起動時に警告メッセージが表示されます。また、`.anvil/` ディレクトリが `.gitignore` に登録されていない場合も警告が表示されます。
+
+設定ファイルの誤コミットによるAPIキー漏洩を防ぐため、`.gitignore` に `.anvil/` を追加してください:
+
+```
+# .gitignore
+.anvil/
+```
+
 ## カスタムコマンド
 
 `.anvil/slash-commands.json` で独自のスラッシュコマンドを定義できます:

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -124,6 +124,14 @@ impl EffectiveConfig {
         let config_file = cwd.join(".anvil").join("config");
         let mut config = Self::default_for_paths(cwd, workspace_dir, config_file);
         config.apply_standard_sources()?;
+
+        // Check .gitignore for .anvil/ directory
+        if let Some(repo_root) = find_repo_root(&config.paths.cwd)
+            && let Some(warning) = check_gitignore_anvil_dir(&repo_root)
+        {
+            eprintln!("{warning}");
+        }
+
         config.validate()?;
         config.project_instructions = config.paths.load_project_instructions();
         Ok(config)
@@ -198,6 +206,11 @@ impl EffectiveConfig {
                 key.trim().to_string(),
                 value.trim().trim_matches('"').to_string(),
             );
+        }
+
+        // Security warnings for API keys in config file
+        for warning in check_config_security_warnings(&map) {
+            eprintln!("{warning}");
         }
 
         self.apply_map(&map)
@@ -509,6 +522,68 @@ const MAX_PROJECT_INSTRUCTIONS_CHARS: usize = 4000;
 const MIN_CONTEXT_WINDOW: u32 = 1000;
 const MIN_AGENT_ITERATIONS: usize = 1;
 const MAX_AGENT_ITERATIONS: usize = 100;
+
+/// Sensitive keys and their recommended environment variable names.
+/// To add a new sensitive key, simply add an entry to this array.
+const SENSITIVE_KEYS: &[(&str, &str)] = &[
+    ("api_key", "ANVIL_API_KEY"),
+    ("serper_api_key", "SERPER_API_KEY"),
+];
+
+/// Detect API keys in config file map and return warning messages.
+/// Only checks keys from the config file; env/CLI keys are not warned about.
+pub fn check_config_security_warnings(map: &HashMap<String, String>) -> Vec<String> {
+    SENSITIVE_KEYS
+        .iter()
+        .filter(|(key, _)| map.contains_key(*key))
+        .map(|(key, env_var)| {
+            format!(
+                "⚠ Warning: {key} found in config file. \
+                Consider using {env_var} environment variable \
+                instead for better security."
+            )
+        })
+        .collect()
+}
+
+/// Walk up from `start` looking for a `.git` directory to find the repo root.
+fn find_repo_root(start: &Path) -> Option<PathBuf> {
+    let mut current = start.to_path_buf();
+    loop {
+        if current.join(".git").exists() {
+            return Some(current);
+        }
+        if !current.pop() {
+            return None;
+        }
+    }
+}
+
+/// Check whether `.anvil/` is listed in `.gitignore`.
+/// Returns `Some(warning)` if it is missing or `.gitignore` does not exist.
+pub fn check_gitignore_anvil_dir(repo_root: &Path) -> Option<String> {
+    let gitignore_path = repo_root.join(".gitignore");
+    let Ok(contents) = std::fs::read_to_string(&gitignore_path) else {
+        return Some(
+            "⚠ Warning: .gitignore not found. Consider adding .anvil/ \
+            to .gitignore to prevent config files from being committed."
+                .to_string(),
+        );
+    };
+
+    if contents.lines().any(|line| {
+        let trimmed = line.trim();
+        !trimmed.starts_with('#') && trimmed.contains(".anvil")
+    }) {
+        None
+    } else {
+        Some(
+            "⚠ Warning: .anvil/ is not in .gitignore. Consider adding it \
+            to prevent config files from being committed."
+                .to_string(),
+        )
+    }
+}
 
 impl PathConfig {
     /// Load project instructions from ANVIL.md files.

--- a/tests/config_bootstrap.rs
+++ b/tests/config_bootstrap.rs
@@ -1,7 +1,10 @@
 mod common;
 
 use anvil::config::EffectiveConfig;
-use anvil::config::{PathConfig, ReasoningVisibility, sanitize_markers};
+use anvil::config::{
+    PathConfig, ReasoningVisibility, check_config_security_warnings, check_gitignore_anvil_dir,
+    sanitize_markers,
+};
 use anvil::contracts::AppEvent;
 use anvil::provider::{ProviderRuntimeContext, build_local_provider_client};
 use std::collections::HashMap;
@@ -408,4 +411,92 @@ fn validate_skips_context_budget_when_none() {
     config.runtime.context_budget = None;
     config.validate_for_test().unwrap();
     assert!(config.runtime.context_budget.is_none());
+}
+
+// --- Security warning tests ---
+
+#[test]
+fn security_warning_api_key_in_config() {
+    let mut map = HashMap::new();
+    map.insert("api_key".to_string(), "sk-test-key".to_string());
+    let warnings = check_config_security_warnings(&map);
+    assert_eq!(warnings.len(), 1);
+    assert!(warnings[0].contains("api_key"));
+    assert!(warnings[0].contains("ANVIL_API_KEY"));
+}
+
+#[test]
+fn security_warning_serper_api_key_in_config() {
+    let mut map = HashMap::new();
+    map.insert("serper_api_key".to_string(), "test-serper-key".to_string());
+    let warnings = check_config_security_warnings(&map);
+    assert_eq!(warnings.len(), 1);
+    assert!(warnings[0].contains("serper_api_key"));
+    assert!(warnings[0].contains("SERPER_API_KEY"));
+}
+
+#[test]
+fn security_warning_both_api_keys() {
+    let mut map = HashMap::new();
+    map.insert("api_key".to_string(), "sk-test".to_string());
+    map.insert("serper_api_key".to_string(), "serper-test".to_string());
+    let warnings = check_config_security_warnings(&map);
+    assert_eq!(warnings.len(), 2);
+}
+
+#[test]
+fn security_warning_no_api_key() {
+    let mut map = HashMap::new();
+    map.insert("model".to_string(), "gpt-4".to_string());
+    let warnings = check_config_security_warnings(&map);
+    assert!(warnings.is_empty());
+}
+
+#[test]
+fn security_warning_correct_env_var_names() {
+    let mut map = HashMap::new();
+    map.insert("api_key".to_string(), "test".to_string());
+    map.insert("serper_api_key".to_string(), "test".to_string());
+    let warnings = check_config_security_warnings(&map);
+    // api_key should recommend ANVIL_API_KEY (with ANVIL_ prefix)
+    let api_warning = warnings
+        .iter()
+        .find(|w| w.contains("api_key found"))
+        .unwrap();
+    assert!(api_warning.contains("ANVIL_API_KEY"));
+    // serper_api_key should recommend SERPER_API_KEY (NO ANVIL_ prefix)
+    let serper_warning = warnings
+        .iter()
+        .find(|w| w.contains("serper_api_key found"))
+        .unwrap();
+    assert!(serper_warning.contains("SERPER_API_KEY"));
+    assert!(!serper_warning.contains("ANVIL_SERPER_API_KEY"));
+}
+
+#[test]
+fn gitignore_check_with_anvil_dir() {
+    let dir = common::unique_test_dir("gitignore_with");
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join(".gitignore"), ".anvil/\ntarget/\n").unwrap();
+    let result = check_gitignore_anvil_dir(&dir);
+    assert!(result.is_none());
+}
+
+#[test]
+fn gitignore_check_without_anvil_dir() {
+    let dir = common::unique_test_dir("gitignore_without");
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join(".gitignore"), "target/\n*.log\n").unwrap();
+    let result = check_gitignore_anvil_dir(&dir);
+    assert!(result.is_some());
+    assert!(result.unwrap().contains(".anvil"));
+}
+
+#[test]
+fn gitignore_check_no_gitignore_file() {
+    let dir = common::unique_test_dir("gitignore_none");
+    std::fs::create_dir_all(&dir).unwrap();
+    let result = check_gitignore_anvil_dir(&dir);
+    assert!(result.is_some());
+    assert!(result.unwrap().contains(".gitignore"));
 }


### PR DESCRIPTION
## Summary
- 設定ファイルに `api_key` / `serper_api_key` が含まれる場合、起動時に環境変数の使用を推奨する警告を `eprintln!` で表示
- `.gitignore` に `.anvil/` が未登録の場合、追加を推奨する警告を表示
- `SENSITIVE_KEYS` 定数配列によるデータ駆動設計で、新しいセンシティブキーの追加が容易
- 8件のユニットテスト追加（警告チェック5件 + gitignoreチェック3件）
- README.md にAPIキーセキュリティドキュメントを追加

## Changes
| ファイル | 変更内容 |
|---------|---------|
| `src/config/mod.rs` | `SENSITIVE_KEYS`, `check_config_security_warnings()`, `find_repo_root()`, `check_gitignore_anvil_dir()` 追加。`apply_file_overrides()`, `load()` 変更 |
| `tests/config_bootstrap.rs` | 8テスト追加 |
| `README.md` | セキュリティセクション追加 |

## Test plan
- [x] `cargo build` エラー0件
- [x] `cargo clippy --all-targets` 警告0件
- [x] `cargo test --test config_bootstrap` 39テスト全パス
- [x] `cargo fmt --check` 差分なし
- [x] 受入テスト全9項目パス

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)