### PR TITLE
feat(tui): add context overflow warning with /compact suggestion (#19)

### DIFF
--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -199,7 +199,8 @@ impl App {
                 saved_status.to_string(),
             )
             .with_elapsed_ms(elapsed_ms);
-        let _ = self.transition_with_context(done, StateTransition::Finish)?;
+        let mut done_snapshot = self.transition_with_context(done, StateTransition::Finish)?;
+        self.evaluate_context_warning(&mut done_snapshot);
         frames.push(self.render_console(tui)?);
         Ok(frames)
     }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -12,7 +12,10 @@ pub mod render;
 use crate::agent::BasicAgentLoop;
 use crate::agent::{AgentEvent, AgentRuntime, PendingTurnState, ProjectLanguage};
 use crate::config::EffectiveConfig;
-use crate::contracts::{AppEvent, AppStateSnapshot, ConsoleRenderContext, RuntimeState};
+use crate::contracts::{
+    AppEvent, AppStateSnapshot, ConsoleRenderContext, ContextUsageView, ContextWarningLevel,
+    RuntimeState,
+};
 use crate::extensions::{ExtensionLoadError, ExtensionRegistry, SlashCommandAction};
 use crate::provider::{
     ProviderBootstrapError, ProviderClient, ProviderErrorKind, ProviderErrorRecord, ProviderEvent,
@@ -50,6 +53,51 @@ pub fn detect_project_languages(project_root: &std::path::Path) -> Vec<ProjectLa
     languages
 }
 
+/// Tracks context overflow warning state to avoid duplicate notifications.
+///
+/// Private to the app module; not persisted across sessions.
+struct ContextWarningTracker {
+    warned_warning: bool,
+    warned_critical: bool,
+}
+
+impl ContextWarningTracker {
+    fn new() -> Self {
+        Self {
+            warned_warning: false,
+            warned_critical: false,
+        }
+    }
+
+    /// Evaluate current context usage and return a warning level if not yet notified.
+    fn evaluate(&mut self, usage: &ContextUsageView) -> Option<ContextWarningLevel> {
+        let level = usage.warning_level();
+        match level {
+            Some(ContextWarningLevel::Critical) if !self.warned_critical => {
+                self.warned_critical = true;
+                self.warned_warning = true;
+                Some(ContextWarningLevel::Critical)
+            }
+            Some(ContextWarningLevel::Warning) if !self.warned_warning => {
+                self.warned_warning = true;
+                Some(ContextWarningLevel::Warning)
+            }
+            _ => None,
+        }
+    }
+
+    /// Reset flags when usage drops below thresholds (e.g. after /compact).
+    fn reset_if_below_threshold(&mut self, usage: &ContextUsageView) {
+        let ratio = usage.usage_ratio();
+        if ratio < 0.8 {
+            self.warned_warning = false;
+        }
+        if ratio < 0.9 {
+            self.warned_critical = false;
+        }
+    }
+}
+
 /// Central application state.
 pub struct App {
     config: EffectiveConfig,
@@ -61,6 +109,7 @@ pub struct App {
     tools: ToolRegistry,
     system_prompt: String,
     shutdown_flag: Arc<AtomicBool>,
+    warning_tracker: ContextWarningTracker,
 }
 
 /// Whether the session loop should continue or exit.
@@ -185,6 +234,7 @@ impl App {
             extensions,
             system_prompt,
             shutdown_flag,
+            warning_tracker: ContextWarningTracker::new(),
         })
     }
 
@@ -528,12 +578,8 @@ impl App {
         )?;
         let snapshot = AppStateSnapshot::new(RuntimeState::Ready)
             .with_status("Approval denied. Ready for the next task".to_string())
-            .with_completion_summary("Approval denied. No tool was executed.", "no changes made")
-            .with_context_usage(
-                self.session.estimated_token_count(),
-                self.config.runtime.context_window,
-            );
-        self.apply_transition(snapshot, StateTransition::ResetToReady)?;
+            .with_completion_summary("Approval denied. No tool was executed.", "no changes made");
+        self.transition_with_context(snapshot, StateTransition::ResetToReady)?;
         self.flush_session()?;
         Ok(vec![self.render_console(tui)?])
     }
@@ -541,12 +587,8 @@ impl App {
     pub fn reset_to_ready(&mut self) -> Result<AppStateSnapshot, AppError> {
         self.clear_pending_turn()?;
         let snapshot = AppStateSnapshot::new(RuntimeState::Ready)
-            .with_status("Ready for the next task".to_string())
-            .with_context_usage(
-                self.session.estimated_token_count(),
-                self.config.runtime.context_window,
-            );
-        self.apply_transition(snapshot, StateTransition::ResetToReady)
+            .with_status("Ready for the next task".to_string());
+        self.transition_with_context(snapshot, StateTransition::ResetToReady)
     }
 
     pub(crate) fn apply_transition_for_mock(
@@ -584,6 +626,18 @@ impl App {
             self.config.runtime.context_window,
         );
         self.apply_transition(snapshot, transition)
+    }
+
+    /// Evaluate context warning on a snapshot and update the state machine if needed.
+    pub(crate) fn evaluate_context_warning(&mut self, snapshot: &mut AppStateSnapshot) {
+        if let Some(usage) = &snapshot.context_usage
+            && let Some(level) = self.warning_tracker.evaluate(usage)
+        {
+            snapshot.context_warning = Some(level);
+            self.state_machine.replace_snapshot(snapshot.clone());
+            self.session
+                .set_last_snapshot(self.state_machine.snapshot().clone());
+        }
     }
 
     pub(crate) fn persist_session_event_for_mock(
@@ -715,7 +769,10 @@ impl App {
                     .with_tool_logs(render::build_tool_logs(tool_logs))
                     .with_completion_summary(completion_summary.clone(), saved_status.clone())
                     .with_elapsed_ms(*elapsed_ms);
-                self.transition_with_context(snapshot, StateTransition::Finish)
+                let mut snapshot =
+                    self.transition_with_context(snapshot, StateTransition::Finish)?;
+                self.evaluate_context_warning(&mut snapshot);
+                Ok(snapshot)
             }
             AgentEvent::Interrupted {
                 status,
@@ -782,12 +839,8 @@ impl App {
     fn begin_live_turn_state(&mut self) -> Result<(), AppError> {
         let snapshot = AppStateSnapshot::new(RuntimeState::Thinking)
             .with_status(format!("Thinking. model={}", self.config.runtime.model))
-            .with_elapsed_ms(0)
-            .with_context_usage(
-                self.session.estimated_token_count(),
-                self.config.runtime.context_window,
-            );
-        self.apply_transition(snapshot, StateTransition::StartThinking)?;
+            .with_elapsed_ms(0);
+        self.transition_with_context(snapshot, StateTransition::StartThinking)?;
         Ok(())
     }
 
@@ -877,7 +930,11 @@ impl App {
                 control: SessionControl::Continue,
             },
             Some(SlashCommandAction::Status) => CliTurnOutput {
-                frames: vec![self.render_console(tui)?],
+                frames: vec![format!(
+                    "{}\n{}",
+                    self.render_console(tui)?,
+                    render::render_status_detail(self.state_machine.snapshot())
+                )],
                 control: SessionControl::Continue,
             },
             Some(SlashCommandAction::Plan) => CliTurnOutput {
@@ -1003,6 +1060,11 @@ impl App {
         let changed = self.session.compact_history(8);
         if changed {
             self.persist_session(AppEvent::SessionSaved)?;
+            let usage = ContextUsageView {
+                estimated_tokens: self.session.estimated_token_count(),
+                max_tokens: self.config.runtime.context_window,
+            };
+            self.warning_tracker.reset_if_below_threshold(&usage);
             Ok("[A] anvil > compacted older session history".to_string())
         } else {
             Ok("[A] anvil > nothing to compact".to_string())
@@ -1074,3 +1136,86 @@ fn standard_tool_registry() -> ToolRegistry {
 
 // Re-export CLI entry points from the cli module.
 pub use cli::{run, run_session_loop};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_usage(estimated: usize, max: u32) -> ContextUsageView {
+        ContextUsageView {
+            estimated_tokens: estimated,
+            max_tokens: max,
+        }
+    }
+
+    #[test]
+    fn tracker_evaluate_first_warning() {
+        let mut tracker = ContextWarningTracker::new();
+        let usage = make_usage(8500, 10000);
+        assert_eq!(tracker.evaluate(&usage), Some(ContextWarningLevel::Warning));
+    }
+
+    #[test]
+    fn tracker_evaluate_suppresses_duplicate_warning() {
+        let mut tracker = ContextWarningTracker::new();
+        let usage = make_usage(8500, 10000);
+        assert_eq!(tracker.evaluate(&usage), Some(ContextWarningLevel::Warning));
+        assert_eq!(tracker.evaluate(&usage), None);
+    }
+
+    #[test]
+    fn tracker_evaluate_first_critical() {
+        let mut tracker = ContextWarningTracker::new();
+        let usage = make_usage(9500, 10000);
+        assert_eq!(
+            tracker.evaluate(&usage),
+            Some(ContextWarningLevel::Critical)
+        );
+    }
+
+    #[test]
+    fn tracker_evaluate_critical_also_sets_warning_flag() {
+        let mut tracker = ContextWarningTracker::new();
+        let critical = make_usage(9500, 10000);
+        assert_eq!(
+            tracker.evaluate(&critical),
+            Some(ContextWarningLevel::Critical)
+        );
+        // Warning should also be suppressed since critical set the flag
+        let warning = make_usage(8500, 10000);
+        assert_eq!(tracker.evaluate(&warning), None);
+    }
+
+    #[test]
+    fn tracker_evaluate_below_threshold_returns_none() {
+        let mut tracker = ContextWarningTracker::new();
+        let usage = make_usage(5000, 10000);
+        assert_eq!(tracker.evaluate(&usage), None);
+    }
+
+    #[test]
+    fn tracker_reset_below_80_clears_warning() {
+        let mut tracker = ContextWarningTracker::new();
+        let high = make_usage(8500, 10000);
+        tracker.evaluate(&high);
+        assert!(tracker.warned_warning);
+
+        let low = make_usage(7000, 10000);
+        tracker.reset_if_below_threshold(&low);
+        assert!(!tracker.warned_warning);
+    }
+
+    #[test]
+    fn tracker_reset_below_90_clears_critical() {
+        let mut tracker = ContextWarningTracker::new();
+        let high = make_usage(9500, 10000);
+        tracker.evaluate(&high);
+        assert!(tracker.warned_critical);
+
+        let medium = make_usage(8500, 10000);
+        tracker.reset_if_below_threshold(&medium);
+        assert!(!tracker.warned_critical);
+        // Warning flag should remain since 85% >= 80%
+        assert!(tracker.warned_warning);
+    }
+}

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -100,6 +100,19 @@ pub fn slash_commands() -> Vec<SlashCommandSpec> {
     ExtensionRegistry::new().slash_commands().to_vec()
 }
 
+pub fn render_status_detail(snapshot: &AppStateSnapshot) -> String {
+    if let Some(usage) = &snapshot.context_usage {
+        format!(
+            "  tokens: {}/{} ({}%)",
+            usage.estimated_tokens,
+            usage.max_tokens,
+            usage.usage_percent()
+        )
+    } else {
+        "  tokens: -/-".to_string()
+    }
+}
+
 pub fn render_pending_approval_frame(snapshot: &AppStateSnapshot) -> String {
     if let Some(approval) = &snapshot.approval {
         format!(

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -69,10 +69,49 @@ pub struct ToolLogView {
     pub target: String,
 }
 
+/// Context usage warning level based on threshold evaluation.
+///
+/// Used as `Option<ContextWarningLevel>` where `None` means no warning.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ContextWarningLevel {
+    /// Usage >= 80%: warning
+    Warning,
+    /// Usage >= 90%: critical
+    Critical,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ContextUsageView {
     pub estimated_tokens: usize,
     pub max_tokens: u32,
+}
+
+impl ContextUsageView {
+    /// Context usage ratio clamped to 0.0..=1.0. Returns 0.0 if max_tokens is 0.
+    pub fn usage_ratio(&self) -> f64 {
+        if self.max_tokens == 0 {
+            return 0.0;
+        }
+        let ratio = self.estimated_tokens as f64 / self.max_tokens as f64;
+        ratio.clamp(0.0, 1.0)
+    }
+
+    /// Warning level based on usage thresholds (>=0.9 Critical, >=0.8 Warning, else None).
+    pub fn warning_level(&self) -> Option<ContextWarningLevel> {
+        let ratio = self.usage_ratio();
+        if ratio >= 0.9 {
+            Some(ContextWarningLevel::Critical)
+        } else if ratio >= 0.8 {
+            Some(ContextWarningLevel::Warning)
+        } else {
+            None
+        }
+    }
+
+    /// Usage percentage for display (0..=100).
+    pub fn usage_percent(&self) -> u32 {
+        (self.usage_ratio() * 100.0).round() as u32
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -140,6 +179,9 @@ pub struct AppStateSnapshot {
     /// Suggested recovery actions. Used in: Error, Interrupted.
     #[serde(default)]
     pub recommended_actions: Vec<String>,
+    /// Context overflow warning level. Used in: Done.
+    #[serde(default)]
+    pub context_warning: Option<ContextWarningLevel>,
 }
 
 impl AppStateSnapshot {
@@ -161,6 +203,7 @@ impl AppStateSnapshot {
             saved_status: None,
             error_summary: None,
             recommended_actions: Vec::new(),
+            context_warning: None,
         }
     }
 
@@ -254,6 +297,11 @@ impl AppStateSnapshot {
         self.recommended_actions = recommended_actions;
         self
     }
+
+    pub fn with_context_warning(mut self, level: ContextWarningLevel) -> Self {
+        self.context_warning = Some(level);
+        self
+    }
 }
 
 #[cfg(test)]
@@ -284,5 +332,124 @@ impl AppStateSnapshot {
             }
             _ => {}
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn usage_ratio_normal() {
+        let usage = ContextUsageView {
+            estimated_tokens: 5000,
+            max_tokens: 10000,
+        };
+        assert!((usage.usage_ratio() - 0.5).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn usage_ratio_zero_max_tokens() {
+        let usage = ContextUsageView {
+            estimated_tokens: 100,
+            max_tokens: 0,
+        };
+        assert!((usage.usage_ratio() - 0.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn usage_ratio_clamped_above_one() {
+        let usage = ContextUsageView {
+            estimated_tokens: 15000,
+            max_tokens: 10000,
+        };
+        assert!((usage.usage_ratio() - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn usage_ratio_boundary_values() {
+        let usage_80 = ContextUsageView {
+            estimated_tokens: 8000,
+            max_tokens: 10000,
+        };
+        assert!((usage_80.usage_ratio() - 0.8).abs() < f64::EPSILON);
+
+        let usage_90 = ContextUsageView {
+            estimated_tokens: 9000,
+            max_tokens: 10000,
+        };
+        assert!((usage_90.usage_ratio() - 0.9).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn warning_level_below_80_is_none() {
+        let usage = ContextUsageView {
+            estimated_tokens: 7999,
+            max_tokens: 10000,
+        };
+        assert_eq!(usage.warning_level(), None);
+    }
+
+    #[test]
+    fn warning_level_at_80_is_warning() {
+        let usage = ContextUsageView {
+            estimated_tokens: 8000,
+            max_tokens: 10000,
+        };
+        assert_eq!(usage.warning_level(), Some(ContextWarningLevel::Warning));
+    }
+
+    #[test]
+    fn warning_level_at_89_is_warning() {
+        let usage = ContextUsageView {
+            estimated_tokens: 8999,
+            max_tokens: 10000,
+        };
+        assert_eq!(usage.warning_level(), Some(ContextWarningLevel::Warning));
+    }
+
+    #[test]
+    fn warning_level_at_90_is_critical() {
+        let usage = ContextUsageView {
+            estimated_tokens: 9000,
+            max_tokens: 10000,
+        };
+        assert_eq!(usage.warning_level(), Some(ContextWarningLevel::Critical));
+    }
+
+    #[test]
+    fn warning_level_at_100_is_critical() {
+        let usage = ContextUsageView {
+            estimated_tokens: 10000,
+            max_tokens: 10000,
+        };
+        assert_eq!(usage.warning_level(), Some(ContextWarningLevel::Critical));
+    }
+
+    #[test]
+    fn usage_percent_normal() {
+        let usage = ContextUsageView {
+            estimated_tokens: 2200,
+            max_tokens: 10000,
+        };
+        assert_eq!(usage.usage_percent(), 22);
+    }
+
+    #[test]
+    fn usage_percent_rounding() {
+        let usage = ContextUsageView {
+            estimated_tokens: 3333,
+            max_tokens: 10000,
+        };
+        assert_eq!(usage.usage_percent(), 33);
+    }
+
+    #[test]
+    fn usage_percent_zero_max() {
+        let usage = ContextUsageView {
+            estimated_tokens: 100,
+            max_tokens: 0,
+        };
+        assert_eq!(usage.usage_percent(), 0);
     }
 }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -5,7 +5,8 @@
 
 use crate::config::EffectiveConfig;
 use crate::contracts::{
-    AppStateSnapshot, ConsoleMessageRole, ConsoleMessageView, ConsoleRenderContext, RuntimeState,
+    AppStateSnapshot, ConsoleMessageRole, ConsoleMessageView, ConsoleRenderContext,
+    ContextWarningLevel, RuntimeState,
 };
 
 /// Stateless console renderer.
@@ -152,6 +153,26 @@ impl Tui {
             }
         }
 
+        if let Some(warning_level) = &snapshot.context_warning {
+            let percent = snapshot
+                .context_usage
+                .as_ref()
+                .map(|u| u.usage_percent())
+                .unwrap_or(0);
+            match warning_level {
+                ContextWarningLevel::Warning => {
+                    lines.push(format!(
+                        "[!] Warning: Context usage at {percent}%. Consider running /compact to free space."
+                    ));
+                }
+                ContextWarningLevel::Critical => {
+                    lines.push(format!(
+                        "[!] CRITICAL: Context usage at {percent}%! Run /compact immediately to avoid degraded responses."
+                    ));
+                }
+            }
+        }
+
         lines.push(status_divider());
         lines.push(self.render_footer(snapshot, &view.model_name));
         lines.push(render_hint_line(snapshot));
@@ -188,15 +209,7 @@ impl Tui {
         let ctx = snapshot
             .context_usage
             .as_ref()
-            .map(|usage| {
-                let percent = if usage.max_tokens == 0 {
-                    0
-                } else {
-                    ((usage.estimated_tokens as f64 / usage.max_tokens as f64) * 100.0).round()
-                        as u32
-                };
-                format!("ctx:{percent}%")
-            })
+            .map(|usage| format!("ctx:{}%", usage.usage_percent()))
             .unwrap_or_else(|| "ctx:-".to_string());
 
         let active = snapshot
@@ -233,7 +246,7 @@ fn render_hint_line(snapshot: &crate::contracts::AppStateSnapshot) -> String {
         RuntimeState::Working => "ESC stop  /help  /status  /plan  tools active".to_string(),
         RuntimeState::AwaitingApproval => "approve:y  deny:n  /help  /status".to_string(),
         RuntimeState::Interrupted => "/status  /resume  /reset".to_string(),
-        RuntimeState::Done => "/diff  /save  /continue".to_string(),
+        RuntimeState::Done => "/diff  /save  /continue  /compact".to_string(),
         RuntimeState::Error => "/status  /retry  /reset".to_string(),
     }
 }

--- a/tests/tui_console.rs
+++ b/tests/tui_console.rs
@@ -208,6 +208,7 @@ fn tui_renders_working_and_done_views_with_tool_logs() {
     assert!(done.contains("[A] anvil > result"));
     assert!(done.contains("session saved"));
     assert!(done.contains("/continue"));
+    assert!(done.contains("/compact"));
 }
 
 #[test]
@@ -349,6 +350,117 @@ fn startup_without_anvil_md() {
     );
 
     assert!(!rendered.contains("ANVIL.md: loaded"));
+}
+
+#[test]
+fn context_warning_bar_displayed_for_warning_level() {
+    let tui = Tui::new();
+    let snapshot = anvil::contracts::AppStateSnapshot::new(anvil::contracts::RuntimeState::Done)
+        .with_status("Done. session saved".to_string())
+        .with_completion_summary("completed task", "session saved")
+        .with_context_usage(8500, 10000)
+        .with_context_warning(anvil::contracts::ContextWarningLevel::Warning);
+
+    let context = anvil::contracts::ConsoleRenderContext {
+        snapshot,
+        model_name: "test-model".to_string(),
+        messages: vec![],
+        history_summary: None,
+    };
+
+    let rendered = tui.render_console(&context);
+    assert!(
+        rendered.contains("[!] Warning: Context usage at 85%"),
+        "warning bar should display at 85% usage"
+    );
+    assert!(
+        rendered.contains("/compact"),
+        "warning should suggest /compact"
+    );
+}
+
+#[test]
+fn context_warning_bar_displayed_for_critical_level() {
+    let tui = Tui::new();
+    let snapshot = anvil::contracts::AppStateSnapshot::new(anvil::contracts::RuntimeState::Done)
+        .with_status("Done. session saved".to_string())
+        .with_completion_summary("completed task", "session saved")
+        .with_context_usage(9500, 10000)
+        .with_context_warning(anvil::contracts::ContextWarningLevel::Critical);
+
+    let context = anvil::contracts::ConsoleRenderContext {
+        snapshot,
+        model_name: "test-model".to_string(),
+        messages: vec![],
+        history_summary: None,
+    };
+
+    let rendered = tui.render_console(&context);
+    assert!(
+        rendered.contains("[!] CRITICAL: Context usage at 95%"),
+        "critical bar should display at 95% usage"
+    );
+    assert!(
+        rendered.contains("/compact immediately"),
+        "critical warning should suggest immediate /compact"
+    );
+}
+
+#[test]
+fn context_warning_bar_absent_when_no_warning() {
+    let tui = Tui::new();
+    let snapshot = anvil::contracts::AppStateSnapshot::new(anvil::contracts::RuntimeState::Done)
+        .with_status("Done. session saved".to_string())
+        .with_completion_summary("completed task", "session saved")
+        .with_context_usage(5000, 10000);
+
+    let context = anvil::contracts::ConsoleRenderContext {
+        snapshot,
+        model_name: "test-model".to_string(),
+        messages: vec![],
+        history_summary: None,
+    };
+
+    let rendered = tui.render_console(&context);
+    assert!(
+        !rendered.contains("[!]"),
+        "no warning bar should appear when usage is below threshold"
+    );
+}
+
+#[test]
+fn done_hint_line_includes_compact() {
+    let tui = Tui::new();
+    let snapshot = anvil::contracts::AppStateSnapshot::new(anvil::contracts::RuntimeState::Done)
+        .with_status("Done. session saved".to_string())
+        .with_completion_summary("completed task", "session saved")
+        .with_context_usage(5000, 10000);
+
+    let context = anvil::contracts::ConsoleRenderContext {
+        snapshot,
+        model_name: "test-model".to_string(),
+        messages: vec![],
+        history_summary: None,
+    };
+
+    let rendered = tui.render_console(&context);
+    assert!(
+        rendered.contains("/compact"),
+        "Done hint line should include /compact"
+    );
+}
+
+#[test]
+fn status_detail_shows_token_usage() {
+    let snapshot = anvil::contracts::AppStateSnapshot::new(anvil::contracts::RuntimeState::Done)
+        .with_status("Done. session saved".to_string())
+        .with_completion_summary("completed task", "session saved")
+        .with_context_usage(45000, 200000);
+
+    let detail = anvil::app::render::render_status_detail(&snapshot);
+    assert!(detail.contains("45000"));
+    assert!(detail.contains("200000"));
+    assert!(detail.contains("22%") || detail.contains("23%"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- コンテキスト使用率80%超過時にWarning警告バー、90%超過時にCritical警告バーをTUIに表示
- 警告メッセージに `/compact` 実行の提案を含む
- 同一閾値の警告は1回のみ表示（`ContextWarningTracker` で重複抑制）
- `/compact` 実行後にフラグリセットし、再度閾値超過時に警告を再表示
- `/status` コマンドにトークン使用率の詳細情報（推定トークン数/最大トークン数、使用率%）を追加
- `render_footer()` のインラインパーセント計算を `usage_percent()` に置換（DRY改善）
- 既存3メソッド (`deny_and_abort`, `reset_to_ready`, `begin_live_turn_state`) を `transition_with_context()` に統一（リファクタリング）

## Changes

| ファイル | 変更内容 |
|---------|---------|
| `src/contracts/mod.rs` | `ContextWarningLevel` enum、`ContextUsageView` メソッド追加、`AppStateSnapshot.context_warning` フィールド |
| `src/app/mod.rs` | `ContextWarningTracker`、`evaluate_context_warning()`、Done分岐警告評価、`/compact` リセット、`/status` 詳細 |
| `src/app/agentic.rs` | `complete_structured_response()` Done遷移後の警告評価 |
| `src/tui/mod.rs` | 警告バー表示、`render_footer()` DRY改善、Done状態ヒントに `/compact` 追加 |
| `src/app/render.rs` | `render_status_detail()` 関数 |
| `tests/tui_console.rs` | 統合テスト5件追加 |

## Test plan

- [x] `cargo build` エラー0件
- [x] `cargo clippy --all-targets` 警告0件
- [x] `cargo test` 全354テストパス
- [x] `cargo fmt --check` 差分なし
- [x] ユニットテスト: `ContextUsageView` 境界値テスト（80%/90%閾値）
- [x] ユニットテスト: `ContextWarningTracker` 重複抑制・リセットテスト
- [x] 統合テスト: TUI警告バー表示（Warning/Critical/None）
- [x] 統合テスト: `/status` トークン詳細表示

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)