### PR TITLE
feat(cli): add --help and --version flags via clap crate (#20)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,9 +12,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anvil"
 version = "0.0.2"
 dependencies = [
+ "clap",
  "regex",
  "rustyline",
  "serde",
@@ -51,6 +102,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "clap"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "clipboard-win"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -58,6 +149,12 @@ checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
 dependencies = [
  "error-code",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "crossbeam-channel"
@@ -196,6 +293,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -287,6 +390,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "pin-project-lite"
@@ -491,6 +600,12 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "env-filter", "ansi", "registry"] }
 tracing-appender = "0.2"
 signal-hook = "0.3"
+clap = { version = "4", features = ["derive"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -213,19 +213,23 @@ ANVIL_API_KEY=sk-...              # OpenAI互換APIキー
 ### CLI オプション
 
 ```
-anvil [オプション]
+anvil [OPTIONS]
 
---provider <名前>           プロバイダー (ollama / openai)
---model <名前>              モデル名
---provider-url <URL>        プロバイダーURL
---context-window <数値>     コンテキストウィンドウサイズ
---context-budget <数値>     トークンバジェット明示指定
---max-iterations <数値>     agenticループ最大反復数
---no-approval               全ツール自動承認
---no-stream                 ストリーミング無効
---fresh-session             新規セッションで開始
---oneshot                   非対話モード
---debug                     デバッグログ有効
+  -p, --provider <PROVIDER>              プロバイダー (ollama|openai)
+  -m, --model <MODEL>                    モデル名
+  -u, --provider-url <URL>               プロバイダーURL
+      --sidecar-model <MODEL>            サイドカーモデル名
+      --context-window <SIZE>            コンテキストウィンドウサイズ
+      --context-budget <TOKENS>          トークンバジェット明示指定
+      --max-iterations <N>               agenticループ最大反復数
+      --no-stream                        ストリーミング無効
+      --debug                            デバッグログ有効
+      --no-approval                      全ツール自動承認
+      --fresh-session                    新規セッションで開始
+      --oneshot                          非対話モード
+      --reasoning-visibility <LEVEL>     推論表示レベル (hidden|summary)
+  -h, --help                             ヘルプ表示
+  -V, --version                          バージョン表示
 ```
 
 優先順位: CLI > 環境変数 > 設定ファイル > デフォルト値

--- a/src/app/cli.rs
+++ b/src/app/cli.rs
@@ -3,7 +3,7 @@
 //! Contains the `run_session_loop` and `run_interactive_loop` functions
 //! that drive the interactive CLI experience.
 
-use crate::config::EffectiveConfig;
+use crate::config::{CliArgs, EffectiveConfig};
 use crate::logging::{LogGuard, init_tracing};
 use crate::provider::{ProviderClient, ProviderRuntimeContext, build_local_provider_client};
 use crate::session::SessionError;
@@ -77,13 +77,23 @@ fn setup_shutdown_handler(interactive: bool) -> Arc<AtomicBool> {
     shutdown_flag
 }
 
-/// Application entry point.
+/// Production entry point: parse pre-built CLI args into config, then run.
+pub fn run_with_args(cli: &CliArgs) -> Result<(), AppError> {
+    let config = EffectiveConfig::load_with_args(cli)?;
+    run_with_config(config)
+}
+
+/// Test-compatible entry point (no CliArgs required).
 ///
-/// Uses `rustyline` for interactive input, providing cursor movement,
-/// line editing, and input history.
+/// Uses `EffectiveConfig::load()` which falls back gracefully when
+/// `std::env::args()` contains test-harness arguments.
 pub fn run() -> Result<(), AppError> {
     let config = EffectiveConfig::load()?;
+    run_with_config(config)
+}
 
+/// Common startup logic shared by `run_with_args` and `run`.
+fn run_with_config(config: EffectiveConfig) -> Result<(), AppError> {
     let _guard: Option<LogGuard> = init_tracing(
         config.mode.log_filter.as_deref(),
         config.mode.debug_logging,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1073,4 +1073,4 @@ fn standard_tool_registry() -> ToolRegistry {
 }
 
 // Re-export CLI entry points from the cli module.
-pub use cli::{run, run_session_loop};
+pub use cli::{run, run_session_loop, run_with_args};

--- a/src/config/cli_args.rs
+++ b/src/config/cli_args.rs
@@ -1,0 +1,62 @@
+//! CLI argument definitions using `clap` derive macros.
+//!
+//! [`CliArgs`] is parsed in `main.rs` and passed to
+//! [`super::EffectiveConfig::load_with_args`] for configuration override.
+
+use clap::Parser;
+
+#[derive(Parser, Debug, Default)]
+#[command(name = "anvil", version, about = "Local coding agent powered by LLM")]
+pub struct CliArgs {
+    /// Provider (ollama|openai)
+    #[arg(short = 'p', long)]
+    pub provider: Option<String>,
+
+    /// LLM model name
+    #[arg(short = 'm', long)]
+    pub model: Option<String>,
+
+    /// Provider URL
+    #[arg(short = 'u', long = "provider-url")]
+    pub provider_url: Option<String>,
+
+    /// Sidecar model name
+    #[arg(long = "sidecar-model")]
+    pub sidecar_model: Option<String>,
+
+    /// Context window size
+    #[arg(long = "context-window")]
+    pub context_window: Option<u32>,
+
+    /// Context budget (token count)
+    #[arg(long = "context-budget")]
+    pub context_budget: Option<u32>,
+
+    /// Max agent iterations
+    #[arg(long = "max-iterations")]
+    pub max_iterations: Option<usize>,
+
+    /// Disable streaming
+    #[arg(long = "no-stream")]
+    pub no_stream: bool,
+
+    /// Enable debug logging
+    #[arg(long)]
+    pub debug: bool,
+
+    /// Skip tool execution approval
+    #[arg(long = "no-approval")]
+    pub no_approval: bool,
+
+    /// Force new session
+    #[arg(long = "fresh-session")]
+    pub fresh_session: bool,
+
+    /// Non-interactive mode
+    #[arg(long)]
+    pub oneshot: bool,
+
+    /// Reasoning visibility level (hidden|summary)
+    #[arg(long = "reasoning-visibility")]
+    pub reasoning_visibility: Option<String>,
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -4,6 +4,10 @@
 //! settings.  It is assembled once at startup and then treated as
 //! immutable for the lifetime of the session.
 
+pub mod cli_args;
+pub use cli_args::CliArgs;
+
+use clap::Parser;
 use std::collections::HashMap;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
@@ -118,12 +122,26 @@ impl EffectiveConfig {
         self.project_instructions = instructions;
     }
 
+    /// Test-compatible entry point. In production, use `load_with_args()` via
+    /// `main.rs -> CliArgs::parse() -> run_with_args() -> load_with_args()`.
+    ///
+    /// Attempts to parse CLI args from `std::env::args()`. Falls back to
+    /// `CliArgs::default()` when parsing fails (e.g. cargo-test harness args).
     pub fn load() -> Result<Self, ConfigError> {
+        match CliArgs::try_parse_from(std::env::args()) {
+            Ok(cli) => Self::load_with_args(&cli),
+            Err(_) => Self::load_with_args(&CliArgs::default()),
+        }
+    }
+
+    /// Production entry point: apply file, env, then CLI arg overrides.
+    pub fn load_with_args(cli: &CliArgs) -> Result<Self, ConfigError> {
         let cwd = std::env::current_dir().map_err(ConfigError::CurrentDirUnavailable)?;
         let workspace_dir = cwd.join("workspace");
         let config_file = cwd.join(".anvil").join("config");
         let mut config = Self::default_for_paths(cwd, workspace_dir, config_file);
-        config.apply_standard_sources()?;
+        config.apply_file_and_env_overrides()?;
+        config.apply_cli_args(cli)?;
 
         // Check .gitignore for .anvil/ directory
         if let Some(repo_root) = find_repo_root(&config.paths.cwd)
@@ -180,12 +198,11 @@ impl EffectiveConfig {
         }
     }
 
-    fn apply_standard_sources(&mut self) -> Result<(), ConfigError> {
+    fn apply_file_and_env_overrides(&mut self) -> Result<(), ConfigError> {
         if self.paths.config_file.exists() {
             self.apply_file_overrides()?;
         }
         self.apply_env_overrides()?;
-        self.apply_cli_overrides()?;
         Ok(())
     }
 
@@ -247,72 +264,59 @@ impl EffectiveConfig {
         self.apply_map(&map)
     }
 
-    fn apply_cli_overrides(&mut self) -> Result<(), ConfigError> {
-        let mut args = std::env::args().skip(1);
-        let mut map = HashMap::new();
-
-        while let Some(arg) = args.next() {
-            match arg.as_str() {
-                "--provider" => {
-                    if let Some(value) = args.next() {
-                        map.insert("ANVIL_PROVIDER".to_string(), value);
-                    }
-                }
-                "--model" => {
-                    if let Some(value) = args.next() {
-                        map.insert("ANVIL_MODEL".to_string(), value);
-                    }
-                }
-                "--provider-url" => {
-                    if let Some(value) = args.next() {
-                        map.insert("ANVIL_PROVIDER_URL".to_string(), value);
-                    }
-                }
-                "--sidecar-model" => {
-                    if let Some(value) = args.next() {
-                        map.insert("ANVIL_SIDECAR_MODEL".to_string(), value);
-                    }
-                }
-                "--context-window" => {
-                    if let Some(value) = args.next() {
-                        map.insert("ANVIL_CONTEXT_WINDOW".to_string(), value);
-                    }
-                }
-                "--context-budget" => {
-                    if let Some(value) = args.next() {
-                        map.insert("ANVIL_CONTEXT_BUDGET".to_string(), value);
-                    }
-                }
-                "--max-iterations" => {
-                    if let Some(value) = args.next() {
-                        map.insert("ANVIL_MAX_AGENT_ITERATIONS".to_string(), value);
-                    }
-                }
-                "--no-stream" => {
-                    map.insert("ANVIL_STREAM".to_string(), "false".to_string());
-                }
-                "--debug" => {
-                    map.insert("ANVIL_DEBUG".to_string(), "true".to_string());
-                }
-                "--no-approval" => {
-                    map.insert("ANVIL_APPROVAL_REQUIRED".to_string(), "false".to_string());
-                }
-                "--fresh-session" => {
-                    map.insert("ANVIL_FRESH_SESSION".to_string(), "true".to_string());
-                }
-                "--oneshot" => {
-                    map.insert("ANVIL_INTERACTIVE".to_string(), "false".to_string());
-                }
-                "--reasoning-visibility" => {
-                    if let Some(value) = args.next() {
-                        map.insert("ANVIL_REASONING_VISIBILITY".to_string(), value);
-                    }
-                }
-                _ => {}
-            }
+    /// Apply CLI argument overrides from a parsed [`CliArgs`] struct.
+    ///
+    /// Uses direct field assignment (not `apply_map`) to avoid redundant
+    /// string round-trips for already-typed values.
+    pub fn apply_cli_args(&mut self, cli: &CliArgs) -> Result<(), ConfigError> {
+        // String fields
+        if let Some(ref v) = cli.provider {
+            self.runtime.provider = v.clone();
+        }
+        if let Some(ref v) = cli.model {
+            self.runtime.model = v.clone();
+        }
+        if let Some(ref v) = cli.provider_url {
+            self.runtime.provider_url = v.clone();
+        }
+        if let Some(ref v) = cli.sidecar_model {
+            self.runtime.sidecar_model = Some(v.clone());
         }
 
-        self.apply_map(&map)
+        // Numeric fields (already parsed by clap)
+        if let Some(v) = cli.context_window {
+            self.runtime.context_window = v;
+        }
+        if let Some(v) = cli.context_budget {
+            self.runtime.context_budget = Some(v);
+        }
+        if let Some(v) = cli.max_iterations {
+            self.runtime.max_agent_iterations = v;
+        }
+
+        // Boolean flags: only apply when set (true)
+        if cli.no_stream {
+            self.runtime.stream = false;
+        }
+        if cli.debug {
+            self.mode.debug_logging = true;
+        }
+        if cli.no_approval {
+            self.mode.approval_required = false;
+        }
+        if cli.fresh_session {
+            self.mode.fresh_session = true;
+        }
+        if cli.oneshot {
+            self.mode.interactive = false;
+        }
+
+        // Enum field
+        if let Some(ref v) = cli.reasoning_visibility {
+            self.mode.reasoning_visibility = parse_reasoning_visibility(v)?;
+        }
+
+        Ok(())
     }
 
     fn apply_map(&mut self, map: &HashMap<String, String>) -> Result<(), ConfigError> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,10 @@
 use std::process::ExitCode;
 
+use clap::Parser;
+
 fn main() -> ExitCode {
-    if let Err(err) = anvil::app::run() {
+    let cli = anvil::config::CliArgs::parse();
+    if let Err(err) = anvil::app::run_with_args(&cli) {
         eprintln!("anvil error: {err}");
         eprintln!();
         eprintln!("{}", anvil::app::error_guidance(&err));

--- a/tests/cli_args.rs
+++ b/tests/cli_args.rs
@@ -1,0 +1,285 @@
+mod common;
+
+use anvil::config::{CliArgs, EffectiveConfig, ReasoningVisibility};
+use clap::Parser;
+
+// --- CliArgs parsing tests ---
+
+#[test]
+fn cli_args_default_has_all_none_and_false() {
+    let args = CliArgs::default();
+    assert!(args.provider.is_none());
+    assert!(args.model.is_none());
+    assert!(args.provider_url.is_none());
+    assert!(args.sidecar_model.is_none());
+    assert!(args.context_window.is_none());
+    assert!(args.context_budget.is_none());
+    assert!(args.max_iterations.is_none());
+    assert!(!args.no_stream);
+    assert!(!args.debug);
+    assert!(!args.no_approval);
+    assert!(!args.fresh_session);
+    assert!(!args.oneshot);
+    assert!(args.reasoning_visibility.is_none());
+}
+
+#[test]
+fn cli_args_parse_model_long() {
+    let args = CliArgs::try_parse_from(["anvil", "--model", "gpt-4"]).unwrap();
+    assert_eq!(args.model.as_deref(), Some("gpt-4"));
+}
+
+#[test]
+fn cli_args_parse_model_short() {
+    let args = CliArgs::try_parse_from(["anvil", "-m", "gpt-4"]).unwrap();
+    assert_eq!(args.model.as_deref(), Some("gpt-4"));
+}
+
+#[test]
+fn cli_args_parse_provider_long() {
+    let args = CliArgs::try_parse_from(["anvil", "--provider", "openai"]).unwrap();
+    assert_eq!(args.provider.as_deref(), Some("openai"));
+}
+
+#[test]
+fn cli_args_parse_provider_short() {
+    let args = CliArgs::try_parse_from(["anvil", "-p", "openai"]).unwrap();
+    assert_eq!(args.provider.as_deref(), Some("openai"));
+}
+
+#[test]
+fn cli_args_parse_provider_url() {
+    let args =
+        CliArgs::try_parse_from(["anvil", "--provider-url", "http://localhost:8080"]).unwrap();
+    assert_eq!(args.provider_url.as_deref(), Some("http://localhost:8080"));
+}
+
+#[test]
+fn cli_args_parse_provider_url_short() {
+    let args = CliArgs::try_parse_from(["anvil", "-u", "http://localhost:8080"]).unwrap();
+    assert_eq!(args.provider_url.as_deref(), Some("http://localhost:8080"));
+}
+
+#[test]
+fn cli_args_parse_sidecar_model() {
+    let args = CliArgs::try_parse_from(["anvil", "--sidecar-model", "llama3"]).unwrap();
+    assert_eq!(args.sidecar_model.as_deref(), Some("llama3"));
+}
+
+#[test]
+fn cli_args_parse_context_window() {
+    let args = CliArgs::try_parse_from(["anvil", "--context-window", "128000"]).unwrap();
+    assert_eq!(args.context_window, Some(128000));
+}
+
+#[test]
+fn cli_args_parse_context_budget() {
+    let args = CliArgs::try_parse_from(["anvil", "--context-budget", "4096"]).unwrap();
+    assert_eq!(args.context_budget, Some(4096));
+}
+
+#[test]
+fn cli_args_parse_max_iterations() {
+    let args = CliArgs::try_parse_from(["anvil", "--max-iterations", "20"]).unwrap();
+    assert_eq!(args.max_iterations, Some(20));
+}
+
+#[test]
+fn cli_args_parse_reasoning_visibility() {
+    let args = CliArgs::try_parse_from(["anvil", "--reasoning-visibility", "hidden"]).unwrap();
+    assert_eq!(args.reasoning_visibility.as_deref(), Some("hidden"));
+}
+
+#[test]
+fn cli_args_parse_bool_flags() {
+    let args = CliArgs::try_parse_from([
+        "anvil",
+        "--no-stream",
+        "--debug",
+        "--no-approval",
+        "--fresh-session",
+        "--oneshot",
+    ])
+    .unwrap();
+    assert!(args.no_stream);
+    assert!(args.debug);
+    assert!(args.no_approval);
+    assert!(args.fresh_session);
+    assert!(args.oneshot);
+}
+
+#[test]
+fn cli_args_rejects_unknown_argument() {
+    let result = CliArgs::try_parse_from(["anvil", "--unknown-flag"]);
+    assert!(result.is_err());
+}
+
+#[test]
+fn cli_args_reasoning_visibility_requires_value() {
+    let result = CliArgs::try_parse_from(["anvil", "--reasoning-visibility"]);
+    assert!(result.is_err());
+}
+
+#[test]
+fn cli_args_parse_multiple_options() {
+    let args = CliArgs::try_parse_from([
+        "anvil",
+        "-p",
+        "openai",
+        "-m",
+        "gpt-4",
+        "-u",
+        "https://api.openai.com",
+        "--no-stream",
+        "--debug",
+    ])
+    .unwrap();
+    assert_eq!(args.provider.as_deref(), Some("openai"));
+    assert_eq!(args.model.as_deref(), Some("gpt-4"));
+    assert_eq!(args.provider_url.as_deref(), Some("https://api.openai.com"));
+    assert!(args.no_stream);
+    assert!(args.debug);
+}
+
+// --- apply_cli_args tests ---
+
+#[test]
+fn apply_cli_args_default_changes_nothing() {
+    let mut config = EffectiveConfig::default_for_test().unwrap();
+    let original_model = config.runtime.model.clone();
+    let original_stream = config.runtime.stream;
+    let original_interactive = config.mode.interactive;
+
+    config
+        .apply_cli_args(&CliArgs::default())
+        .expect("default args should apply cleanly");
+
+    assert_eq!(config.runtime.model, original_model);
+    assert_eq!(config.runtime.stream, original_stream);
+    assert_eq!(config.mode.interactive, original_interactive);
+}
+
+#[test]
+fn apply_cli_args_overrides_string_fields() {
+    let mut config = EffectiveConfig::default_for_test().unwrap();
+    let args = CliArgs {
+        provider: Some("openai".to_string()),
+        model: Some("gpt-4".to_string()),
+        provider_url: Some("https://api.openai.com".to_string()),
+        sidecar_model: Some("llama3".to_string()),
+        ..CliArgs::default()
+    };
+
+    config.apply_cli_args(&args).unwrap();
+
+    assert_eq!(config.runtime.provider, "openai");
+    assert_eq!(config.runtime.model, "gpt-4");
+    assert_eq!(config.runtime.provider_url, "https://api.openai.com");
+    assert_eq!(config.runtime.sidecar_model.as_deref(), Some("llama3"));
+}
+
+#[test]
+fn apply_cli_args_overrides_numeric_fields() {
+    let mut config = EffectiveConfig::default_for_test().unwrap();
+    let args = CliArgs {
+        context_window: Some(128000),
+        context_budget: Some(4096),
+        max_iterations: Some(25),
+        ..CliArgs::default()
+    };
+
+    config.apply_cli_args(&args).unwrap();
+
+    assert_eq!(config.runtime.context_window, 128000);
+    assert_eq!(config.runtime.context_budget, Some(4096));
+    assert_eq!(config.runtime.max_agent_iterations, 25);
+}
+
+#[test]
+fn apply_cli_args_bool_flag_inversion() {
+    let mut config = EffectiveConfig::default_for_test().unwrap();
+    // Defaults: stream=true, approval_required=true, interactive=true
+    assert!(config.runtime.stream);
+    assert!(config.mode.approval_required);
+    assert!(config.mode.interactive);
+    assert!(!config.mode.debug_logging);
+    assert!(!config.mode.fresh_session);
+
+    let args = CliArgs {
+        no_stream: true,
+        no_approval: true,
+        oneshot: true,
+        debug: true,
+        fresh_session: true,
+        ..CliArgs::default()
+    };
+
+    config.apply_cli_args(&args).unwrap();
+
+    assert!(!config.runtime.stream, "no_stream should set stream=false");
+    assert!(
+        !config.mode.approval_required,
+        "no_approval should set approval_required=false"
+    );
+    assert!(
+        !config.mode.interactive,
+        "oneshot should set interactive=false"
+    );
+    assert!(
+        config.mode.debug_logging,
+        "debug should set debug_logging=true"
+    );
+    assert!(
+        config.mode.fresh_session,
+        "fresh_session should set fresh_session=true"
+    );
+}
+
+#[test]
+fn apply_cli_args_bool_flags_false_changes_nothing() {
+    let mut config = EffectiveConfig::default_for_test().unwrap();
+    let args = CliArgs {
+        no_stream: false,
+        no_approval: false,
+        oneshot: false,
+        debug: false,
+        fresh_session: false,
+        ..CliArgs::default()
+    };
+
+    config.apply_cli_args(&args).unwrap();
+
+    // All defaults should remain
+    assert!(config.runtime.stream);
+    assert!(config.mode.approval_required);
+    assert!(config.mode.interactive);
+    assert!(!config.mode.debug_logging);
+    assert!(!config.mode.fresh_session);
+}
+
+#[test]
+fn apply_cli_args_reasoning_visibility() {
+    let mut config = EffectiveConfig::default_for_test().unwrap();
+    let args = CliArgs {
+        reasoning_visibility: Some("hidden".to_string()),
+        ..CliArgs::default()
+    };
+
+    config.apply_cli_args(&args).unwrap();
+    assert_eq!(
+        config.mode.reasoning_visibility,
+        ReasoningVisibility::Hidden
+    );
+}
+
+#[test]
+fn apply_cli_args_invalid_reasoning_visibility_errors() {
+    let mut config = EffectiveConfig::default_for_test().unwrap();
+    let args = CliArgs {
+        reasoning_visibility: Some("invalid_value".to_string()),
+        ..CliArgs::default()
+    };
+
+    let result = config.apply_cli_args(&args);
+    assert!(result.is_err());
+}


### PR DESCRIPTION
## Summary

- `clap` クレート（derive マクロ）を導入し、手動CLI引数パースを構造化された定義に置き換え
- `--help` / `--version` フラグを追加、未知引数のエラー検出を実現
- 既存の全13 CLIオプションを後方互換で維持

## Changes

- **Cargo.toml**: `clap = { version = "4", features = ["derive"] }` 追加
- **src/config/cli_args.rs** (新規): `CliArgs` 構造体定義（clap derive）
- **src/config/mod.rs**: `apply_cli_args()` / `load_with_args()` 追加、旧 `apply_cli_overrides()` 削除
- **src/main.rs**: `CliArgs::parse()` → `run_with_args()` パターンに変更
- **src/app/cli.rs**: `run_with_args()` / `run_with_config()` 追加、`run()` をラッパー化
- **src/app/mod.rs**: `run_with_args` の re-export 追加
- **tests/cli_args.rs** (新規): 23テスト（パース、apply_cli_args、boolフラグ反転）
- **README.md**: CLIオプション一覧更新

## Test plan

- [x] `cargo build` エラー0件
- [x] `cargo clippy --all-targets` 警告0件
- [x] `cargo test` 全テストパス（23新規テスト含む）
- [x] `cargo fmt --check` 差分なし
- [x] `anvil --help` で全15オプション表示
- [x] `anvil --version` で `anvil 0.0.2` 表示
- [x] 未知引数（`--foo`）でエラーメッセージ表示

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)