### PR TITLE
feat(tooling): add diff preview for file.write/file.edit approval prompts (#21)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,7 +122,9 @@ src/
 ├── session/mod.rs       # セッション永続化
 ├── spinner.rs           # スピナーUI
 ├── state/mod.rs         # 状態マシン
-├── tooling/mod.rs       # ツール実行・検証
+├── tooling/
+│   ├── mod.rs           # ツール実行・検証
+│   └── diff.rs          # 差分プレビュー生成（file.write/file.edit承認時）
 └── tui/mod.rs           # TUI描画
 tests/
 ├── cli_session.rs       # CLIセッションテスト

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,6 +20,7 @@ dependencies = [
  "serde",
  "serde_json",
  "signal-hook",
+ "similar",
  "tempfile",
  "tracing",
  "tracing-appender",
@@ -485,6 +486,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "smallvec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "env-filter", "ansi", "registry"] }
 tracing-appender = "0.2"
 signal-hook = "0.3"
+similar = "2"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -12,6 +12,7 @@ use crate::spinner::Spinner;
 use crate::state::StateTransition;
 use crate::tooling::{
     LocalToolExecutor, ToolExecutionPayload, ToolExecutionPolicy, ToolExecutionResult,
+    diff::generate_diff_preview,
 };
 use crate::tui::Tui;
 
@@ -226,8 +227,9 @@ impl App {
             // Check if this tool needs approval in the current mode
             if self.config.mode.approval_required && validated.approval_required(true).is_some() {
                 let summary = tool_call_approval_summary(call);
+                let diff_preview = generate_diff_preview(&self.config.paths.cwd, &call.input);
                 // Ask user inline via stderr/stdin
-                let approved = prompt_inline_approval(&summary);
+                let approved = prompt_inline_approval(&summary, diff_preview.as_deref());
                 if !approved {
                     let denied_result = build_failed_result(call, "denied by user".to_string());
                     self.record_tool_result(&denied_result);
@@ -421,8 +423,11 @@ fn tool_call_approval_summary(call: &crate::tooling::ToolCallRequest) -> String 
 
 /// Prompt the user for inline approval via stderr/stdin.
 /// Returns `true` if the user approves, `false` otherwise.
-fn prompt_inline_approval(summary: &str) -> bool {
+fn prompt_inline_approval(summary: &str, diff_preview: Option<&str>) -> bool {
     use std::io::{BufRead, Write};
+    if let Some(diff) = diff_preview {
+        let _ = write!(std::io::stderr(), "\n{}\n", crate::tui::colorize_diff(diff));
+    }
     let _ = write!(std::io::stderr(), "\n  Allow {summary}? [y/n] ");
     let _ = std::io::stderr().flush();
     let mut input = String::new();

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -676,6 +676,23 @@ impl App {
                 tool_call_id,
                 elapsed_ms,
             } => {
+                // Attempt to generate a diff preview from pending tool calls.
+                let diff_preview = self
+                    .session
+                    .pending_turn
+                    .as_ref()
+                    .and_then(|pending| {
+                        pending
+                            .pending_tool_calls
+                            .iter()
+                            .find(|tc| tc.tool_call_id == *tool_call_id)
+                    })
+                    .and_then(|tc| {
+                        crate::tooling::diff::generate_diff_preview(
+                            &self.config.paths.cwd,
+                            &tc.input,
+                        )
+                    });
                 let snapshot = AppStateSnapshot::new(RuntimeState::AwaitingApproval)
                     .with_status(status.clone())
                     .with_approval(
@@ -684,6 +701,7 @@ impl App {
                         risk.clone(),
                         tool_call_id.clone(),
                     )
+                    .with_diff_preview(diff_preview)
                     .with_elapsed_ms(*elapsed_ms);
                 self.transition_with_context(snapshot, StateTransition::RequestApproval)
             }

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -102,10 +102,14 @@ pub fn slash_commands() -> Vec<SlashCommandSpec> {
 
 pub fn render_pending_approval_frame(snapshot: &AppStateSnapshot) -> String {
     if let Some(approval) = &snapshot.approval {
-        format!(
+        let mut text = format!(
             "[A] anvil > resolve the pending approval before starting a new turn\n  pending: {} {}\n  call: {}\n  use /approve or /deny",
             approval.tool_name, approval.summary, approval.tool_call_id
-        )
+        );
+        if let Some(diff) = &approval.diff_preview {
+            text.push_str(&format!("\n{}", crate::tui::colorize_diff(diff)));
+        }
+        text
     } else {
         "[A] anvil > resolve the pending approval before starting a new turn\n  use /approve or /deny"
             .to_string()

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -53,6 +53,8 @@ pub struct ApprovalView {
     pub summary: String,
     pub risk: String,
     pub tool_call_id: String,
+    #[serde(skip)]
+    pub diff_preview: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -199,7 +201,15 @@ impl AppStateSnapshot {
             summary,
             risk,
             tool_call_id,
+            diff_preview: None,
         });
+        self
+    }
+
+    pub fn with_diff_preview(mut self, preview: Option<String>) -> Self {
+        if let Some(ref mut approval) = self.approval {
+            approval.diff_preview = preview;
+        }
         self
     }
 

--- a/src/tooling/diff.rs
+++ b/src/tooling/diff.rs
@@ -1,0 +1,197 @@
+//! Diff preview generation for file.write and file.edit approval prompts.
+//!
+//! Generates plain-text unified diffs (without ANSI colour) so that the
+//! presentation layer can apply its own styling.
+
+use super::{ToolInput, resolve_sandbox_path};
+use std::path::Path;
+
+/// Maximum number of lines shown for a brand-new file preview.
+const NEW_FILE_PREVIEW_MAX_LINES: usize = 20;
+/// Maximum characters per line before truncation.
+const LINE_MAX_CHARS: usize = 200;
+/// When the total number of added + deleted lines exceeds this threshold the
+/// diff is truncated with a summary line.
+const DIFF_TRUNCATE_THRESHOLD: usize = 50;
+/// Files larger than this are skipped for diff generation.
+const MAX_FILE_SIZE: u64 = 1_048_576; // 1 MB
+/// Number of leading bytes inspected for binary (NUL byte) detection.
+const BINARY_CHECK_BYTES: usize = 8192;
+/// `new_content` strings larger than this are skipped for diff generation.
+const MAX_NEW_CONTENT_SIZE: usize = 1_048_576; // 1 MB
+
+/// Generate a diff preview string for a tool input, if applicable.
+///
+/// Returns `Some(diff_text)` for `FileWrite` and `FileEdit` inputs, and
+/// `None` for all other tool input variants.
+pub fn generate_diff_preview(workspace_root: &Path, tool_input: &ToolInput) -> Option<String> {
+    match tool_input {
+        ToolInput::FileWrite { path, content } => {
+            generate_file_write_diff(workspace_root, path, content)
+        }
+        ToolInput::FileEdit {
+            old_string,
+            new_string,
+            ..
+        } => generate_file_edit_diff(old_string, new_string),
+        _ => None,
+    }
+}
+
+/// Check whether content appears to be binary by looking for NUL bytes in the
+/// first [`BINARY_CHECK_BYTES`].
+pub fn is_binary_content(content: &[u8]) -> bool {
+    let check_len = content.len().min(BINARY_CHECK_BYTES);
+    content[..check_len].contains(&0)
+}
+
+/// Generate a diff preview for `file.write`.
+fn generate_file_write_diff(
+    workspace_root: &Path,
+    path: &str,
+    new_content: &str,
+) -> Option<String> {
+    // Guard: new_content size
+    if new_content.len() > MAX_NEW_CONTENT_SIZE {
+        return None;
+    }
+
+    // Resolve path within sandbox
+    let resolved = match resolve_sandbox_path(workspace_root, path) {
+        Ok(p) => p,
+        Err(_) => return None,
+    };
+
+    // Try to read the existing file
+    match std::fs::metadata(&resolved) {
+        Ok(meta) => {
+            if meta.len() > MAX_FILE_SIZE {
+                return Some(format!(
+                    "(file too large for diff preview: {} bytes)",
+                    meta.len()
+                ));
+            }
+        }
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            // New file
+            return Some(format_new_file_preview(new_content));
+        }
+        Err(_) => return None,
+    }
+
+    // Read existing content
+    let existing_bytes = match std::fs::read(&resolved) {
+        Ok(bytes) => bytes,
+        Err(_) => return None,
+    };
+
+    if is_binary_content(&existing_bytes) {
+        return Some("(binary file - diff not available)".to_string());
+    }
+
+    let existing_content = match String::from_utf8(existing_bytes) {
+        Ok(s) => s,
+        Err(_) => return None,
+    };
+
+    // Generate unified diff
+    let diff = similar::TextDiff::from_lines(existing_content.as_str(), new_content);
+    let diff_text = diff
+        .unified_diff()
+        .context_radius(3)
+        .header("a (existing)", "b (new)")
+        .to_string();
+
+    if diff_text.trim().is_empty() {
+        return Some("(no changes)".to_string());
+    }
+
+    Some(truncate_diff(&diff_text))
+}
+
+/// Generate a diff preview for `file.edit` (old_string -> new_string).
+///
+/// This does not require any file I/O — it works purely on the provided
+/// strings.
+fn generate_file_edit_diff(old_string: &str, new_string: &str) -> Option<String> {
+    if old_string == new_string {
+        return Some("(no changes)".to_string());
+    }
+
+    let diff = similar::TextDiff::from_lines(old_string, new_string);
+    let diff_text = diff
+        .unified_diff()
+        .context_radius(3)
+        .header("a (old)", "b (new)")
+        .to_string();
+
+    if diff_text.trim().is_empty() {
+        return Some("(no changes)".to_string());
+    }
+
+    Some(truncate_diff(&diff_text))
+}
+
+/// Truncate a diff if the number of added/deleted lines exceeds the threshold.
+fn truncate_diff(diff_text: &str) -> String {
+    let mut additions = 0usize;
+    let mut deletions = 0usize;
+
+    for line in diff_text.lines() {
+        if line.starts_with('+') && !line.starts_with("+++") {
+            additions += 1;
+        } else if line.starts_with('-') && !line.starts_with("---") {
+            deletions += 1;
+        }
+    }
+
+    if additions + deletions <= DIFF_TRUNCATE_THRESHOLD {
+        return diff_text.to_string();
+    }
+
+    // Keep the header and first few lines, then add a truncation notice
+    let mut result = String::new();
+    let mut change_count = 0usize;
+    for line in diff_text.lines() {
+        let is_change = (line.starts_with('+') && !line.starts_with("+++"))
+            || (line.starts_with('-') && !line.starts_with("---"));
+        if is_change {
+            change_count += 1;
+        }
+        if change_count > DIFF_TRUNCATE_THRESHOLD {
+            break;
+        }
+        result.push_str(line);
+        result.push('\n');
+    }
+    result.push_str(&format!(
+        "... (+{} lines added, -{} lines deleted)\n",
+        additions, deletions
+    ));
+    result
+}
+
+/// Format a preview for a brand-new file (showing the first N lines).
+fn format_new_file_preview(content: &str) -> String {
+    let mut lines = Vec::new();
+    lines.push("(new file)".to_string());
+
+    let all_lines: Vec<&str> = content.lines().collect();
+    for (i, line) in all_lines.iter().enumerate() {
+        if i >= NEW_FILE_PREVIEW_MAX_LINES {
+            lines.push(format!(
+                "... ({} more lines)",
+                all_lines.len() - NEW_FILE_PREVIEW_MAX_LINES
+            ));
+            break;
+        }
+        if line.chars().count() > LINE_MAX_CHARS {
+            let truncated: String = line.chars().take(LINE_MAX_CHARS).collect();
+            lines.push(format!("+{truncated}..."));
+        } else {
+            lines.push(format!("+{line}"));
+        }
+    }
+
+    lines.join("\n")
+}

--- a/src/tooling/mod.rs
+++ b/src/tooling/mod.rs
@@ -4,6 +4,8 @@
 //! through a permission and plan-mode pipeline, and executed by
 //! [`LocalToolExecutor`] within a sandboxed workspace root.
 
+pub mod diff;
+
 use crate::config::{RuntimeConfig, WebSearchProvider};
 use crate::contracts::ToolLogView;
 use serde::{Deserialize, Serialize};
@@ -1126,35 +1128,45 @@ impl LocalToolExecutor {
     }
 
     fn resolve_path(&self, raw: &str) -> Result<PathBuf, ToolRuntimeError> {
-        let candidate = Path::new(raw);
-        if candidate.is_absolute() {
-            return Err(ToolRuntimeError::InvalidPath(raw.to_string()));
-        }
-        if candidate
-            .components()
-            .any(|component| matches!(component, Component::ParentDir))
-        {
-            return Err(ToolRuntimeError::InvalidPath(raw.to_string()));
-        }
-        let joined = self.root.join(candidate);
-        // If the path exists, canonicalize to resolve symlinks and verify
-        // the result is still within the sandbox root.
-        if joined.exists() {
-            let canonical = fs::canonicalize(&joined).map_err(|err| {
-                ToolRuntimeError::Io(format!(
-                    "failed to resolve path {}: {err}",
-                    joined.display()
-                ))
-            })?;
-            let root_canonical = fs::canonicalize(&self.root).unwrap_or_else(|_| self.root.clone());
-            if !canonical.starts_with(&root_canonical) {
-                return Err(ToolRuntimeError::InvalidPath(format!(
-                    "{raw} resolves outside sandbox"
-                )));
-            }
-        }
-        Ok(joined)
+        resolve_sandbox_path(&self.root, raw)
     }
+}
+
+/// Resolve a relative path within a sandbox root directory.
+///
+/// Rejects absolute paths, parent-directory traversal (`..`), and symlinks
+/// that resolve outside the sandbox root.  This is the same logic used by
+/// [`LocalToolExecutor::resolve_path`], extracted as a pure function for
+/// reuse in diff preview generation.
+pub(crate) fn resolve_sandbox_path(root: &Path, raw: &str) -> Result<PathBuf, ToolRuntimeError> {
+    let candidate = Path::new(raw);
+    if candidate.is_absolute() {
+        return Err(ToolRuntimeError::InvalidPath(raw.to_string()));
+    }
+    if candidate
+        .components()
+        .any(|component| matches!(component, Component::ParentDir))
+    {
+        return Err(ToolRuntimeError::InvalidPath(raw.to_string()));
+    }
+    let joined = root.join(candidate);
+    // If the path exists, canonicalize to resolve symlinks and verify
+    // the result is still within the sandbox root.
+    if joined.exists() {
+        let canonical = fs::canonicalize(&joined).map_err(|err| {
+            ToolRuntimeError::Io(format!(
+                "failed to resolve path {}: {err}",
+                joined.display()
+            ))
+        })?;
+        let root_canonical = fs::canonicalize(root).unwrap_or_else(|_| root.to_path_buf());
+        if !canonical.starts_with(&root_canonical) {
+            return Err(ToolRuntimeError::InvalidPath(format!(
+                "{raw} resolves outside sandbox"
+            )));
+        }
+    }
+    Ok(joined)
 }
 
 /// Build a [`ToolExecutionResult`] with `Completed` status.

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -111,6 +111,12 @@ impl Tui {
             lines.push(format!("  action : {}", approval.summary));
             lines.push(format!("  risk : {}", approval.risk));
             lines.push(format!("  call : {}", approval.tool_call_id));
+            if let Some(diff) = &approval.diff_preview {
+                lines.push("  diff :".to_string());
+                for diff_line in colorize_diff(diff).lines() {
+                    lines.push(format!("    {diff_line}"));
+                }
+            }
         }
 
         if let Some(interrupt) = &snapshot.interrupt {
@@ -240,6 +246,31 @@ fn render_hint_line(snapshot: &crate::contracts::AppStateSnapshot) -> String {
 
 fn status_divider() -> String {
     "--------------------------------------------------------------".to_string()
+}
+
+/// Apply ANSI colour codes to a plain-text diff string.
+///
+/// - Lines starting with `+` (but not `+++`) are coloured green.
+/// - Lines starting with `-` (but not `---`) are coloured red.
+/// - All other lines are left unmodified.
+pub fn colorize_diff(diff_text: &str) -> String {
+    const GREEN: &str = "\x1b[32m";
+    const RED: &str = "\x1b[31m";
+    const RESET: &str = "\x1b[0m";
+
+    diff_text
+        .lines()
+        .map(|line| {
+            if line.starts_with('+') && !line.starts_with("+++") {
+                format!("{GREEN}{line}{RESET}")
+            } else if line.starts_with('-') && !line.starts_with("---") {
+                format!("{RED}{line}{RESET}")
+            } else {
+                line.to_string()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 fn summarize_tool_logs(logs: &[crate::contracts::ToolLogView]) -> (usize, usize, usize) {

--- a/tests/tooling_system.rs
+++ b/tests/tooling_system.rs
@@ -1513,3 +1513,188 @@ fn file_edit_sandbox_escape_rejected() {
 
     assert!(err.to_string().contains("invalid tool path"));
 }
+
+// ---- Diff preview tests ----
+
+use anvil::tooling::diff::{generate_diff_preview, is_binary_content};
+
+#[test]
+fn test_diff_preview_existing_file() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let file_path = dir.path().join("hello.txt");
+    fs::write(&file_path, "line1\nline2\nline3\n").expect("write");
+
+    let input = ToolInput::FileWrite {
+        path: "hello.txt".to_string(),
+        content: "line1\nline2 modified\nline3\nline4\n".to_string(),
+    };
+    let result = generate_diff_preview(dir.path(), &input);
+    assert!(result.is_some());
+    let diff = result.unwrap();
+    assert!(diff.contains("-line2"));
+    assert!(diff.contains("+line2 modified"));
+    assert!(diff.contains("+line4"));
+}
+
+#[test]
+fn test_diff_preview_new_file() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let input = ToolInput::FileWrite {
+        path: "brand_new.txt".to_string(),
+        content: "first line\nsecond line\n".to_string(),
+    };
+    let result = generate_diff_preview(dir.path(), &input);
+    assert!(result.is_some());
+    let preview = result.unwrap();
+    assert!(preview.contains("(new file)"));
+    assert!(preview.contains("+first line"));
+    assert!(preview.contains("+second line"));
+}
+
+#[test]
+fn test_diff_preview_binary_file() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let file_path = dir.path().join("binary.bin");
+    let mut content = vec![0u8; 100];
+    content[50] = 0; // NUL byte
+    fs::write(&file_path, &content).expect("write");
+
+    let input = ToolInput::FileWrite {
+        path: "binary.bin".to_string(),
+        content: "new content".to_string(),
+    };
+    let result = generate_diff_preview(dir.path(), &input);
+    assert!(result.is_some());
+    assert!(result.unwrap().contains("binary file"));
+}
+
+#[test]
+fn test_diff_preview_large_file() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let file_path = dir.path().join("big.txt");
+    // Create a file larger than 1MB
+    let big_content = "x".repeat(1_048_577);
+    fs::write(&file_path, &big_content).expect("write");
+
+    let input = ToolInput::FileWrite {
+        path: "big.txt".to_string(),
+        content: "replacement".to_string(),
+    };
+    let result = generate_diff_preview(dir.path(), &input);
+    assert!(result.is_some());
+    assert!(result.unwrap().contains("file too large"));
+}
+
+#[test]
+fn test_diff_preview_large_diff() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let file_path = dir.path().join("many_lines.txt");
+    // Create a file with many lines
+    let old_lines: Vec<String> = (0..100).map(|i| format!("old line {i}")).collect();
+    fs::write(&file_path, old_lines.join("\n")).expect("write");
+
+    let new_lines: Vec<String> = (0..100).map(|i| format!("new line {i}")).collect();
+    let input = ToolInput::FileWrite {
+        path: "many_lines.txt".to_string(),
+        content: new_lines.join("\n"),
+    };
+    let result = generate_diff_preview(dir.path(), &input);
+    assert!(result.is_some());
+    let diff = result.unwrap();
+    // Should be truncated
+    assert!(diff.contains("..."));
+    assert!(diff.contains("lines added"));
+    assert!(diff.contains("lines deleted"));
+}
+
+#[test]
+fn test_diff_preview_file_edit() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let input = ToolInput::FileEdit {
+        path: "some_file.rs".to_string(),
+        old_string: "fn old_function() {}".to_string(),
+        new_string: "fn new_function() {\n    println!(\"hello\");\n}".to_string(),
+    };
+    let result = generate_diff_preview(dir.path(), &input);
+    assert!(result.is_some());
+    let diff = result.unwrap();
+    assert!(diff.contains("-fn old_function() {}"));
+    assert!(diff.contains("+fn new_function() {"));
+}
+
+#[test]
+fn test_diff_preview_nonexistent_file() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let input = ToolInput::FileWrite {
+        path: "does_not_exist.txt".to_string(),
+        content: "hello world\n".to_string(),
+    };
+    let result = generate_diff_preview(dir.path(), &input);
+    assert!(result.is_some());
+    let preview = result.unwrap();
+    assert!(preview.contains("(new file)"));
+    assert!(preview.contains("+hello world"));
+}
+
+#[test]
+fn test_diff_preview_line_truncation() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    // Create a new file with a very long line (> 200 chars)
+    let long_line = "a".repeat(300);
+    let input = ToolInput::FileWrite {
+        path: "long_line.txt".to_string(),
+        content: format!("{long_line}\nshort\n"),
+    };
+    let result = generate_diff_preview(dir.path(), &input);
+    assert!(result.is_some());
+    let preview = result.unwrap();
+    assert!(preview.contains("(new file)"));
+    // The long line should be truncated with "..."
+    assert!(preview.contains("..."));
+    // Should not contain the full 300-char line
+    assert!(!preview.contains(&"a".repeat(300)));
+}
+
+#[test]
+fn test_is_binary_content() {
+    // Text content
+    assert!(!is_binary_content(b"hello world\nfoo bar\n"));
+    // Binary content with NUL byte
+    assert!(is_binary_content(b"hello\x00world"));
+    // Empty content
+    assert!(!is_binary_content(b""));
+    // Pure NUL
+    assert!(is_binary_content(&[0u8; 10]));
+}
+
+#[test]
+fn test_file_edit_diff_no_file_access() {
+    // file.edit diff generation should work without any file on disk
+    let dir = tempfile::tempdir().expect("tempdir");
+    // No files created in dir
+
+    let input = ToolInput::FileEdit {
+        path: "nonexistent.rs".to_string(),
+        old_string: "old code".to_string(),
+        new_string: "new code".to_string(),
+    };
+    let result = generate_diff_preview(dir.path(), &input);
+    assert!(result.is_some());
+    let diff = result.unwrap();
+    assert!(diff.contains("-old code"));
+    assert!(diff.contains("+new code"));
+}
+
+#[test]
+fn test_diff_preview_other_tool_input_returns_none() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let input = ToolInput::FileRead {
+        path: "foo.txt".to_string(),
+    };
+    assert!(generate_diff_preview(dir.path(), &input).is_none());
+
+    let input = ToolInput::ShellExec {
+        command: "ls".to_string(),
+    };
+    assert!(generate_diff_preview(dir.path(), &input).is_none());
+}

--- a/tests/tui_console.rs
+++ b/tests/tui_console.rs
@@ -365,3 +365,61 @@ fn busy_prompt_hints_include_slash_commands() {
     assert!(rendered.contains("/status"));
     assert!(rendered.contains("[U] you > /status /help /plan"));
 }
+
+#[test]
+fn test_approval_view_serialize_skips_diff_preview() {
+    let view = anvil::contracts::ApprovalView {
+        tool_name: "file.write".to_string(),
+        summary: "write foo.txt".to_string(),
+        risk: "medium".to_string(),
+        tool_call_id: "call_001".to_string(),
+        diff_preview: Some("--- a\n+++ b\n-old\n+new\n".to_string()),
+    };
+    let json = serde_json::to_string(&view).expect("serialize");
+    // #[serde(skip)] means diff_preview should not appear in output
+    assert!(!json.contains("diff_preview"));
+    assert!(!json.contains("old"));
+}
+
+#[test]
+fn test_approval_view_deserialize_without_diff_preview() {
+    // Old JSON without diff_preview field should still deserialize
+    let json = r#"{"tool_name":"file.write","summary":"write foo.txt","risk":"medium","tool_call_id":"call_001"}"#;
+    let view: anvil::contracts::ApprovalView =
+        serde_json::from_str(json).expect("deserialize should succeed");
+    assert_eq!(view.tool_name, "file.write");
+    assert!(view.diff_preview.is_none());
+}
+
+#[test]
+fn test_approval_view_with_diff_preview() {
+    use anvil::contracts::{AppStateSnapshot, RuntimeState};
+    let snapshot = AppStateSnapshot::new(RuntimeState::AwaitingApproval)
+        .with_approval(
+            "file.write".to_string(),
+            "write test.txt".to_string(),
+            "medium".to_string(),
+            "call_002".to_string(),
+        )
+        .with_diff_preview(Some("-old line\n+new line\n".to_string()));
+
+    let approval = snapshot.approval.as_ref().expect("approval present");
+    assert_eq!(
+        approval.diff_preview.as_deref(),
+        Some("-old line\n+new line\n")
+    );
+}
+
+#[test]
+fn test_approval_view_without_diff_preview() {
+    use anvil::contracts::{AppStateSnapshot, RuntimeState};
+    let snapshot = AppStateSnapshot::new(RuntimeState::AwaitingApproval).with_approval(
+        "file.write".to_string(),
+        "write test.txt".to_string(),
+        "medium".to_string(),
+        "call_003".to_string(),
+    );
+
+    let approval = snapshot.approval.as_ref().expect("approval present");
+    assert!(approval.diff_preview.is_none());
+}


### PR DESCRIPTION
## Summary

- file.write / file.edit の承認プロンプトで既存ファイルとの差分（unified diff）を表示する機能を追加
- 新規ファイルの場合は先頭20行のプレビューを表示
- エッジケース対応: バイナリファイル、巨大ファイル(>1MB)、大きなdiff(>50行)、長い行(>200文字)
- インライン承認（y/n）とターン間承認（/approve, /deny）の両方に対応
- `similar` クレートによるunified diff生成、ANSIカラー出力対応

## Changes

| ファイル | 変更内容 |
|---------|---------|
| `Cargo.toml` | `similar = "2"` 追加 |
| `src/tooling/diff.rs` | 新規: diff生成サブモジュール |
| `src/tooling/mod.rs` | `resolve_sandbox_path()` 抽出、`pub mod diff` 追加 |
| `src/contracts/mod.rs` | `ApprovalView` に `diff_preview` フィールド追加 |
| `src/app/agentic.rs` | インライン承認にdiffプレビュー統合 |
| `src/app/mod.rs` | ターン間承認にdiffプレビュー統合 |
| `src/app/render.rs` | 承認フレームにdiff表示追加 |
| `src/tui/mod.rs` | `colorize_diff()` 追加、approval描画にdiff表示 |
| `tests/tooling_system.rs` | diff関連テスト12件追加 |
| `tests/tui_console.rs` | ApprovalView diffテスト4件追加 |
| `CLAUDE.md` | モジュール構成更新 |

## Test plan

- [x] `cargo build` エラー0件
- [x] `cargo clippy --all-targets` 警告0件
- [x] `cargo test` 全テストパス
- [x] `cargo fmt --check` 差分なし
- [x] 既存ファイルへのfile.writeでunified diffが生成される
- [x] 新規ファイル作成時にプレビューが表示される
- [x] file.editでold_string→new_stringの差分が生成される
- [x] バイナリファイル、巨大ファイル、大きなdiffのエッジケース処理
- [x] ApprovalViewのserde後方互換性（#[serde(skip)]）

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)