### PR TITLE
feat: add SKILL.md-based skills system (Phase 1) (#22)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,7 +110,9 @@ src/
 ├── contracts/
 │   ├── mod.rs           # 共通型定義
 │   └── tokens.rs        # トークン推定（CJK対応ヒューリスティック）
-├── extensions/mod.rs    # スラッシュコマンド・拡張
+├── extensions/
+│   ├── mod.rs           # スラッシュコマンド・拡張
+│   └── skills.rs        # SKILL.mdベースのスキルシステム
 ├── logging.rs           # 構造化ロギング（tracing初期化）
 ├── metrics/mod.rs       # ベンチマーク
 ├── provider/
@@ -133,7 +135,8 @@ tests/
 ├── runtime_flow.rs      # ランタイムフローテスト
 ├── state_session.rs     # 状態・セッションテスト
 ├── tooling_system.rs    # ツールシステムテスト
-└── tui_console.rs       # TUIテスト
+├── tui_console.rs       # TUIテスト
+└── skills_system.rs     # スキルシステムテスト
 ```
 
 ---

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -211,7 +211,8 @@ impl App {
             .last_snapshot
             .clone()
             .unwrap_or_else(|| AppStateSnapshot::new(RuntimeState::Ready));
-        let extensions = ExtensionRegistry::load(&config.paths.cwd)?;
+        let home_dir = std::env::var("HOME").ok().map(std::path::PathBuf::from);
+        let extensions = ExtensionRegistry::load(&config.paths.cwd, home_dir.as_deref())?;
         session.auto_compact_threshold = config.runtime.auto_compact_threshold;
 
         let detected_languages = detect_project_languages(&config.paths.cwd);
@@ -902,7 +903,17 @@ impl App {
             return self.handle_slash_command(trimmed, provider_client, tui);
         }
 
-        match self.run_live_turn(trimmed, provider_client, tui) {
+        self.run_turn_to_output(trimmed, provider_client, tui)
+    }
+
+    /// Run a live turn and wrap the result into a `CliTurnOutput`.
+    fn run_turn_to_output<C: ProviderClient>(
+        &mut self,
+        prompt: impl Into<String>,
+        provider_client: &C,
+        tui: &Tui,
+    ) -> Result<CliTurnOutput, AppError> {
+        match self.run_live_turn(prompt, provider_client, tui) {
             Ok(frames) => Ok(CliTurnOutput {
                 frames,
                 control: SessionControl::Continue,
@@ -1015,19 +1026,17 @@ impl App {
                 control: SessionControl::Exit,
             },
             Some(SlashCommandAction::Prompt(prompt)) => {
-                match self.run_live_turn(prompt, provider_client, tui) {
-                    Ok(frames) => CliTurnOutput {
-                        frames,
-                        control: SessionControl::Continue,
-                    },
-                    Err(AppError::PendingApprovalRequired) => CliTurnOutput {
-                        frames: vec![render::render_pending_approval_frame(
-                            self.state_machine.snapshot(),
-                        )],
-                        control: SessionControl::Continue,
-                    },
-                    Err(err) => return Err(err),
-                }
+                self.run_turn_to_output(prompt, provider_client, tui)?
+            }
+            Some(SlashCommandAction::Skill {
+                args,
+                content,
+                skill_dir,
+                ..
+            }) => {
+                let prompt =
+                    crate::extensions::skills::expand_variables(&content, &args, &skill_dir);
+                self.run_turn_to_output(prompt, provider_client, tui)?
             }
             _ => {
                 let suggestion = self.extensions.suggest_command(command);

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -5,6 +5,7 @@
 
 use crate::config::EffectiveConfig;
 use crate::contracts::{AppStateSnapshot, ToolLogView};
+use crate::extensions::skills::SkillScope;
 use crate::extensions::{ExtensionRegistry, SlashCommandSpec, builtin_slash_commands};
 use crate::tooling::{ToolExecutionPayload, ToolExecutionResult, ToolExecutionStatus};
 
@@ -31,8 +32,18 @@ pub fn render_help_frame() -> String {
 
 pub fn render_help_frame_for(commands: &[SlashCommandSpec]) -> String {
     let mut lines = vec!["Anvil slash commands".to_string(), String::new()];
+    let max_name_len = commands.iter().map(|s| s.name.len()).max().unwrap_or(10);
+    let width = max_name_len.max(10);
     for spec in commands {
-        lines.push(format!("{:<10} {}", spec.name, spec.description));
+        let scope_tag = match &spec.scope {
+            Some(SkillScope::User) => " [user]",
+            Some(SkillScope::Project) => " [project]",
+            None => "",
+        };
+        lines.push(format!(
+            "{:<width$} {}{}",
+            spec.name, spec.description, scope_tag
+        ));
     }
     lines.join("\n")
 }

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -1,6 +1,9 @@
+pub mod skills;
+
 use serde::Deserialize;
+use skills::SkillScope;
 use std::fmt::{Display, Formatter};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 /// Action to perform when a slash command is invoked.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -22,6 +25,12 @@ pub enum SlashCommandAction {
     Reset,
     Exit,
     Prompt(String),
+    Skill {
+        name: String,
+        args: String,
+        content: String,
+        skill_dir: PathBuf,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -29,6 +38,7 @@ pub struct SlashCommandSpec {
     pub name: String,
     pub description: String,
     pub action: SlashCommandAction,
+    pub scope: Option<SkillScope>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -85,30 +95,35 @@ impl ExtensionRegistry {
         }
     }
 
-    pub fn load(cwd: &Path) -> Result<Self, ExtensionLoadError> {
+    pub fn load(cwd: &Path, home_dir: Option<&Path>) -> Result<Self, ExtensionLoadError> {
         let mut registry = Self::new();
+
+        // Load custom slash commands from .anvil/slash-commands.json
         let custom_path = cwd.join(".anvil").join("slash-commands.json");
-        if !custom_path.exists() {
-            return Ok(registry);
-        }
+        if custom_path.exists() {
+            let contents =
+                std::fs::read_to_string(&custom_path).map_err(ExtensionLoadError::Unreadable)?;
+            let parsed: CustomSlashCommandFile =
+                serde_json::from_str(&contents).map_err(ExtensionLoadError::InvalidJson)?;
 
-        let contents =
-            std::fs::read_to_string(&custom_path).map_err(ExtensionLoadError::Unreadable)?;
-        let parsed: CustomSlashCommandFile =
-            serde_json::from_str(&contents).map_err(ExtensionLoadError::InvalidJson)?;
-
-        for command in parsed.commands {
-            let name = normalize_command_name(&command.name)
-                .ok_or_else(|| ExtensionLoadError::InvalidCommandName(command.name.clone()))?;
-            if registry.commands.iter().any(|spec| spec.name == name) {
-                return Err(ExtensionLoadError::DuplicateCommand(name));
+            for command in parsed.commands {
+                let name = normalize_command_name(&command.name)
+                    .ok_or_else(|| ExtensionLoadError::InvalidCommandName(command.name.clone()))?;
+                if registry.commands.iter().any(|spec| spec.name == name) {
+                    return Err(ExtensionLoadError::DuplicateCommand(name));
+                }
+                registry.commands.push(SlashCommandSpec {
+                    name,
+                    description: command.description,
+                    action: SlashCommandAction::Prompt(command.prompt),
+                    scope: None,
+                });
             }
-            registry.commands.push(SlashCommandSpec {
-                name,
-                description: command.description,
-                action: SlashCommandAction::Prompt(command.prompt),
-            });
         }
+
+        // Load skills from user and project scopes
+        let skill_commands = skills::discover_and_load(cwd, home_dir, &registry.commands);
+        registry.commands.extend(skill_commands);
 
         Ok(registry)
     }
@@ -124,10 +139,19 @@ impl ExtensionRegistry {
         if let Some(parsed) = parse_repo_command(command) {
             return Some(parsed);
         }
-        self.commands
+        if let found @ Some(_) = self
+            .commands
             .iter()
             .find(|spec| spec.name == command || (spec.name == "/exit" && command == "/quit"))
             .cloned()
+        {
+            return found;
+        }
+        // Try skill command with argument separation
+        if let Some(spec) = skills::parse_skill_command(command, &self.commands) {
+            return Some(spec);
+        }
+        None
     }
 
     /// Suggest the closest matching command name for typo correction.
@@ -148,86 +172,102 @@ pub fn builtin_slash_commands() -> Vec<SlashCommandSpec> {
             name: "/help".to_string(),
             description: "show available commands".to_string(),
             action: SlashCommandAction::Help,
+            scope: None,
         },
         SlashCommandSpec {
             name: "/status".to_string(),
             description: "show the current console state".to_string(),
             action: SlashCommandAction::Status,
+            scope: None,
         },
         SlashCommandSpec {
             name: "/plan".to_string(),
             description: "show the current plan and active step".to_string(),
             action: SlashCommandAction::Plan,
+            scope: None,
         },
         SlashCommandSpec {
             name: "/plan-add".to_string(),
             description: "append a new item to the current plan".to_string(),
             action: SlashCommandAction::PlanAdd(String::new()),
+            scope: None,
         },
         SlashCommandSpec {
             name: "/plan-focus".to_string(),
             description: "set the active plan step by 1-based index".to_string(),
             action: SlashCommandAction::PlanFocus(0),
+            scope: None,
         },
         SlashCommandSpec {
             name: "/plan-clear".to_string(),
             description: "clear the current plan".to_string(),
             action: SlashCommandAction::PlanClear,
+            scope: None,
         },
         SlashCommandSpec {
             name: "/checkpoint".to_string(),
             description: "save a planning checkpoint note".to_string(),
             action: SlashCommandAction::Checkpoint(String::new()),
+            scope: None,
         },
         SlashCommandSpec {
             name: "/repo-find".to_string(),
             description: "search the repo by path and content".to_string(),
             action: SlashCommandAction::RepoFind(String::new()),
+            scope: None,
         },
         SlashCommandSpec {
             name: "/timeline".to_string(),
             description: "show the recent session timeline".to_string(),
             action: SlashCommandAction::Timeline,
+            scope: None,
         },
         SlashCommandSpec {
             name: "/compact".to_string(),
             description: "compact older session history into a summary".to_string(),
             action: SlashCommandAction::Compact,
+            scope: None,
         },
         SlashCommandSpec {
             name: "/model".to_string(),
             description: "show the current model context".to_string(),
             action: SlashCommandAction::Model,
+            scope: None,
         },
         SlashCommandSpec {
             name: "/provider".to_string(),
             description: "show provider backend and capability diagnostics".to_string(),
             action: SlashCommandAction::Provider,
+            scope: None,
         },
         SlashCommandSpec {
             name: "/approve".to_string(),
             description: "continue the pending approved tool call".to_string(),
             action: SlashCommandAction::Approve,
+            scope: None,
         },
         SlashCommandSpec {
             name: "/deny".to_string(),
             description: "reject the pending tool call".to_string(),
             action: SlashCommandAction::Deny,
+            scope: None,
         },
         SlashCommandSpec {
             name: "/reset".to_string(),
             description: "return to Ready".to_string(),
             action: SlashCommandAction::Reset,
+            scope: None,
         },
         SlashCommandSpec {
             name: "/exit".to_string(),
             description: "exit the session".to_string(),
             action: SlashCommandAction::Exit,
+            scope: None,
         },
     ]
 }
 
-fn normalize_command_name(name: &str) -> Option<String> {
+pub(crate) fn normalize_command_name(name: &str) -> Option<String> {
     let trimmed = name.trim();
     if !trimmed.starts_with('/') || trimmed.len() <= 1 {
         return None;
@@ -252,6 +292,7 @@ fn parse_plan_command(command: &str) -> Option<SlashCommandSpec> {
             name: "/plan-add".to_string(),
             description: "append a new item to the current plan".to_string(),
             action: SlashCommandAction::PlanAdd(item.to_string()),
+            scope: None,
         });
     }
 
@@ -264,6 +305,7 @@ fn parse_plan_command(command: &str) -> Option<SlashCommandSpec> {
             name: "/plan-focus".to_string(),
             description: "set the active plan step by 1-based index".to_string(),
             action: SlashCommandAction::PlanFocus(one_based - 1),
+            scope: None,
         });
     }
 
@@ -272,6 +314,7 @@ fn parse_plan_command(command: &str) -> Option<SlashCommandSpec> {
             name: "/plan-clear".to_string(),
             description: "clear the current plan".to_string(),
             action: SlashCommandAction::PlanClear,
+            scope: None,
         });
     }
 
@@ -284,6 +327,7 @@ fn parse_plan_command(command: &str) -> Option<SlashCommandSpec> {
             name: "/checkpoint".to_string(),
             description: "save a planning checkpoint note".to_string(),
             action: SlashCommandAction::Checkpoint(note.to_string()),
+            scope: None,
         });
     }
 
@@ -317,5 +361,6 @@ fn parse_repo_command(command: &str) -> Option<SlashCommandSpec> {
         name: "/repo-find".to_string(),
         description: "search the repo by path and content".to_string(),
         action: SlashCommandAction::RepoFind(query.to_string()),
+        scope: None,
     })
 }

--- a/src/extensions/skills.rs
+++ b/src/extensions/skills.rs
@@ -1,0 +1,336 @@
+use std::path::{Path, PathBuf};
+
+use super::{SlashCommandAction, SlashCommandSpec, normalize_command_name};
+
+/// Scope indicating where a skill was loaded from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SkillScope {
+    User,
+    Project,
+}
+
+/// Parsed SKILL.md frontmatter fields.
+#[derive(Debug, Clone)]
+pub struct SkillFrontmatter {
+    pub name: String,
+    pub description: String,
+    pub argument_hint: String,
+    pub disable_auto_invocation: bool,
+    pub user_invocable: bool,
+}
+
+/// A fully parsed skill ready for registration.
+#[derive(Debug, Clone)]
+pub struct ParsedSkill {
+    pub frontmatter: SkillFrontmatter,
+    pub content: String,
+    pub skill_dir: PathBuf,
+    pub scope: SkillScope,
+}
+
+/// Maximum file size for SKILL.md (100 KB).
+const MAX_SKILL_FILE_SIZE: u64 = 100 * 1024;
+
+/// Parse frontmatter from SKILL.md content.
+///
+/// Extracts the YAML block between `---` delimiters and parses key: value pairs.
+/// Returns the parsed frontmatter and the remaining markdown body content.
+pub fn parse_frontmatter(content: &str) -> Result<(SkillFrontmatter, String), String> {
+    let lines: Vec<&str> = content.lines().collect();
+
+    // First line must be ---
+    if lines.is_empty() || lines[0].trim() != "---" {
+        return Err("frontmatter must start with ---".to_string());
+    }
+
+    // Find closing ---
+    let closing_index = lines
+        .iter()
+        .enumerate()
+        .skip(1)
+        .find(|(_, line)| line.trim() == "---")
+        .map(|(i, _)| i);
+
+    let closing_index = match closing_index {
+        Some(i) => i,
+        None => return Err("frontmatter closing --- not found".to_string()),
+    };
+
+    // Parse key: value pairs from frontmatter
+    let mut name: Option<String> = None;
+    let mut description: Option<String> = None;
+    let mut argument_hint = String::new();
+    let mut disable_auto_invocation = true;
+    let mut user_invocable = true;
+
+    for line in &lines[1..closing_index] {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        let Some((key, value)) = trimmed.split_once(':') else {
+            return Err(format!("invalid frontmatter line: {trimmed}"));
+        };
+        let key = key.trim();
+        let value = value.trim();
+        match key {
+            "name" => name = Some(value.to_string()),
+            "description" => description = Some(value.to_string()),
+            "argument-hint" => argument_hint = value.to_string(),
+            "disable-auto-invocation" => {
+                disable_auto_invocation = value == "true";
+            }
+            "user-invocable" => {
+                user_invocable = value == "true";
+            }
+            _ => {} // Ignore unknown fields
+        }
+    }
+
+    let name = name.ok_or_else(|| "missing required field: name".to_string())?;
+    let description =
+        description.ok_or_else(|| "missing required field: description".to_string())?;
+
+    // Remaining content after frontmatter
+    let body_lines = &lines[(closing_index + 1)..];
+    let body = body_lines.join("\n");
+
+    Ok((
+        SkillFrontmatter {
+            name,
+            description,
+            argument_hint,
+            disable_auto_invocation,
+            user_invocable,
+        },
+        body,
+    ))
+}
+
+/// Parse a SKILL.md file from disk.
+///
+/// Validates file size, frontmatter, and name/directory consistency.
+fn parse_skill_md(path: &Path, dir_name: &str, scope: SkillScope) -> Result<ParsedSkill, String> {
+    // Check file size
+    let metadata =
+        std::fs::metadata(path).map_err(|e| format!("cannot read {}: {e}", path.display()))?;
+    if metadata.len() > MAX_SKILL_FILE_SIZE {
+        return Err(format!(
+            "SKILL.md exceeds size limit ({}KB > {}KB)",
+            metadata.len() / 1024,
+            MAX_SKILL_FILE_SIZE / 1024
+        ));
+    }
+
+    let content = std::fs::read_to_string(path)
+        .map_err(|e| format!("cannot read {}: {e}", path.display()))?;
+
+    let (frontmatter, body) = parse_frontmatter(&content)?;
+
+    // Validate name matches directory name
+    if frontmatter.name != dir_name {
+        return Err(format!(
+            "skill name '{}' does not match directory name '{}'",
+            frontmatter.name, dir_name
+        ));
+    }
+
+    // Validate skill name would be a valid command name
+    let command_name = format!("/{}", frontmatter.name);
+    if normalize_command_name(&command_name).is_none() {
+        return Err(format!("invalid skill name: {}", frontmatter.name));
+    }
+
+    let skill_dir = path.parent().unwrap_or(Path::new(".")).to_path_buf();
+
+    Ok(ParsedSkill {
+        frontmatter,
+        content: body,
+        skill_dir,
+        scope,
+    })
+}
+
+/// Discover and load skills from user and project scopes.
+///
+/// Scans `~/.anvil/skills/` (user scope) and `{cwd}/.anvil/skills/` (project scope).
+/// Returns a list of `SlashCommandSpec` entries for discovered skills.
+/// Errors are logged as warnings and individual skills are skipped.
+pub fn discover_and_load(
+    cwd: &Path,
+    home_dir: Option<&Path>,
+    existing_commands: &[SlashCommandSpec],
+) -> Vec<SlashCommandSpec> {
+    let mut result: Vec<SlashCommandSpec> = Vec::new();
+
+    // User scope: ~/.anvil/skills/*/SKILL.md
+    if let Some(home) = home_dir {
+        let user_skills_dir = home.join(".anvil").join("skills");
+        load_skills_from_dir(
+            &user_skills_dir,
+            SkillScope::User,
+            existing_commands,
+            &mut result,
+        );
+    }
+
+    // Project scope: {cwd}/.anvil/skills/*/SKILL.md
+    let project_skills_dir = cwd.join(".anvil").join("skills");
+    load_skills_from_dir(
+        &project_skills_dir,
+        SkillScope::Project,
+        existing_commands,
+        &mut result,
+    );
+
+    result
+}
+
+/// Load skills from a directory, applying collision and invocability checks.
+fn load_skills_from_dir(
+    skills_dir: &Path,
+    scope: SkillScope,
+    existing_commands: &[SlashCommandSpec],
+    result: &mut Vec<SlashCommandSpec>,
+) {
+    let entries = match std::fs::read_dir(skills_dir) {
+        Ok(entries) => entries,
+        Err(_) => return, // Directory doesn't exist or isn't readable
+    };
+
+    for entry in entries {
+        let entry = match entry {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+
+        let dir_name = match path.file_name().and_then(|n| n.to_str()) {
+            Some(name) => name.to_string(),
+            None => continue,
+        };
+
+        let skill_md_path = path.join("SKILL.md");
+        if !skill_md_path.exists() {
+            continue;
+        }
+
+        let parsed = match parse_skill_md(&skill_md_path, &dir_name, scope) {
+            Ok(skill) => skill,
+            Err(e) => {
+                tracing::warn!("skipping skill '{}': {}", dir_name, e);
+                continue;
+            }
+        };
+
+        // Skip non-user-invocable skills
+        if !parsed.frontmatter.user_invocable {
+            tracing::info!("skipping non-user-invocable skill '{}'", dir_name);
+            continue;
+        }
+
+        let command_name = format!("/{}", parsed.frontmatter.name);
+
+        // Check collision with existing builtin/custom commands
+        if existing_commands
+            .iter()
+            .any(|spec| spec.name == command_name)
+        {
+            tracing::warn!(
+                "skipping skill '{}': conflicts with existing command",
+                dir_name
+            );
+            continue;
+        }
+
+        // Check collision with already-loaded skills (project scope overrides user scope)
+        if let Some(idx) = result.iter().position(|spec| spec.name == command_name) {
+            if scope == SkillScope::Project {
+                // Project scope overrides user scope
+                tracing::info!("project skill '{}' overrides user skill", dir_name);
+                result.remove(idx);
+            } else {
+                // Same scope collision: skip
+                tracing::warn!("skipping duplicate skill '{}'", dir_name);
+                continue;
+            }
+        }
+
+        let description = if parsed.frontmatter.argument_hint.is_empty() {
+            parsed.frontmatter.description.clone()
+        } else {
+            format!(
+                "{} ({})",
+                parsed.frontmatter.description, parsed.frontmatter.argument_hint
+            )
+        };
+
+        result.push(SlashCommandSpec {
+            name: command_name,
+            description,
+            action: SlashCommandAction::Skill {
+                name: parsed.frontmatter.name.clone(),
+                args: String::new(),
+                content: parsed.content,
+                skill_dir: parsed.skill_dir,
+            },
+            scope: Some(scope),
+        });
+    }
+}
+
+/// Expand variables in skill content before execution.
+///
+/// Expansion order:
+/// 1. `${ANVIL_SKILL_DIR}` -> skill directory path
+/// 2. `${ARGUMENTS}` -> args string
+/// 3. `$ARGUMENTS` -> args string
+pub fn expand_variables(content: &str, args: &str, skill_dir: &Path) -> String {
+    let skill_dir_str = skill_dir.display().to_string();
+    // First expand ${...} forms, then $NAME forms
+    let result = content.replace("${ANVIL_SKILL_DIR}", &skill_dir_str);
+    let result = result.replace("${ARGUMENTS}", args);
+    result.replace("$ARGUMENTS", args)
+}
+
+/// Parse a skill command with argument separation.
+///
+/// Given input like "/my-skill arg1 arg2", finds the matching Skill command
+/// and returns a new SlashCommandSpec with the args field populated.
+pub fn parse_skill_command(
+    command: &str,
+    commands: &[SlashCommandSpec],
+) -> Option<SlashCommandSpec> {
+    // No arguments means exact match handled elsewhere
+    let (cmd_name, args) = command.split_once(' ')?;
+    let args = args.trim();
+
+    commands.iter().find_map(|spec| {
+        if spec.name != cmd_name {
+            return None;
+        }
+        match &spec.action {
+            SlashCommandAction::Skill {
+                name,
+                content,
+                skill_dir,
+                ..
+            } => Some(SlashCommandSpec {
+                name: spec.name.clone(),
+                description: spec.description.clone(),
+                action: SlashCommandAction::Skill {
+                    name: name.clone(),
+                    args: args.to_string(),
+                    content: content.clone(),
+                    skill_dir: skill_dir.clone(),
+                },
+                scope: spec.scope,
+            }),
+            _ => None,
+        }
+    })
+}

--- a/tests/skills_system.rs
+++ b/tests/skills_system.rs
@@ -1,0 +1,323 @@
+mod common;
+
+use anvil::extensions::skills::{self, SkillScope};
+use anvil::extensions::{ExtensionRegistry, SlashCommandAction, SlashCommandSpec};
+use std::fs;
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn unique_test_dir(label: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("time should be monotonic")
+        .as_nanos();
+    std::env::temp_dir().join(format!("anvil_skill_test_{label}_{nanos}"))
+}
+
+fn write_skill_md(base: &std::path::Path, skill_name: &str, content: &str) {
+    let skill_dir = base.join(".anvil").join("skills").join(skill_name);
+    fs::create_dir_all(&skill_dir).expect("create skill dir");
+    fs::write(skill_dir.join("SKILL.md"), content).expect("write SKILL.md");
+}
+
+fn valid_skill_md(name: &str) -> String {
+    format!(
+        r#"---
+name: {name}
+description: A test skill
+argument-hint: <arg>
+user-invocable: true
+disable-auto-invocation: true
+---
+
+This is the skill body with $ARGUMENTS and ${{ANVIL_SKILL_DIR}}.
+"#
+    )
+}
+
+// --- Test 1: skill_md_parse_valid ---
+#[test]
+fn skill_md_parse_valid() {
+    let content = r#"---
+name: my-skill
+description: A useful skill
+argument-hint: <file>
+user-invocable: true
+disable-auto-invocation: false
+---
+
+Do something with $ARGUMENTS.
+"#;
+    let (fm, body) = skills::parse_frontmatter(content).expect("should parse valid frontmatter");
+    assert_eq!(fm.name, "my-skill");
+    assert_eq!(fm.description, "A useful skill");
+    assert_eq!(fm.argument_hint, "<file>");
+    assert!(fm.user_invocable);
+    assert!(!fm.disable_auto_invocation);
+    assert!(body.contains("Do something with $ARGUMENTS."));
+}
+
+// --- Test 2: skill_md_parse_missing_required ---
+#[test]
+fn skill_md_parse_missing_required() {
+    // Missing description
+    let content = r#"---
+name: incomplete
+---
+
+Body content.
+"#;
+    let result = skills::parse_frontmatter(content);
+    assert!(result.is_err());
+    assert!(
+        result
+            .unwrap_err()
+            .contains("missing required field: description")
+    );
+
+    // Missing name
+    let content2 = r#"---
+description: no name skill
+---
+
+Body content.
+"#;
+    let result2 = skills::parse_frontmatter(content2);
+    assert!(result2.is_err());
+    assert!(
+        result2
+            .unwrap_err()
+            .contains("missing required field: name")
+    );
+}
+
+// --- Test 3: skill_md_parse_invalid_yaml ---
+#[test]
+fn skill_md_parse_invalid_yaml() {
+    // No opening ---
+    let content = "name: bad\ndescription: no delimiters\n";
+    let result = skills::parse_frontmatter(content);
+    assert!(result.is_err());
+    assert!(
+        result
+            .unwrap_err()
+            .contains("frontmatter must start with ---")
+    );
+
+    // No closing ---
+    let content2 = "---\nname: bad\ndescription: no close\n";
+    let result2 = skills::parse_frontmatter(content2);
+    assert!(result2.is_err());
+    assert!(result2.unwrap_err().contains("closing --- not found"));
+}
+
+// --- Test 4: skill_md_name_dir_mismatch ---
+#[test]
+fn skill_md_name_dir_mismatch() {
+    let root = unique_test_dir("name_mismatch");
+    let skill_dir = root.join(".anvil").join("skills").join("wrong-name");
+    fs::create_dir_all(&skill_dir).expect("create skill dir");
+    fs::write(
+        skill_dir.join("SKILL.md"),
+        r#"---
+name: correct-name
+description: Mismatch test
+---
+
+Body.
+"#,
+    )
+    .expect("write SKILL.md");
+
+    let result = skills::discover_and_load(&root, None, &[]);
+    // Should be empty because name doesn't match directory
+    assert!(result.is_empty());
+}
+
+// --- Test 5: skill_discover_user_scope ---
+#[test]
+fn skill_discover_user_scope() {
+    let home = unique_test_dir("user_scope_home");
+    write_skill_md(&home, "user-tool", &valid_skill_md("user-tool"));
+
+    let cwd = unique_test_dir("user_scope_cwd");
+    fs::create_dir_all(&cwd).expect("create cwd");
+
+    let result = skills::discover_and_load(&cwd, Some(&home), &[]);
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].name, "/user-tool");
+    assert_eq!(result[0].scope, Some(SkillScope::User));
+}
+
+// --- Test 6: skill_discover_project_scope ---
+#[test]
+fn skill_discover_project_scope() {
+    let root = unique_test_dir("project_scope");
+    write_skill_md(&root, "proj-tool", &valid_skill_md("proj-tool"));
+
+    let result = skills::discover_and_load(&root, None, &[]);
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].name, "/proj-tool");
+    assert_eq!(result[0].scope, Some(SkillScope::Project));
+}
+
+// --- Test 7: skill_scope_priority ---
+#[test]
+fn skill_scope_priority() {
+    let home = unique_test_dir("scope_prio_home");
+    let cwd = unique_test_dir("scope_prio_cwd");
+
+    write_skill_md(&home, "shared-skill", &valid_skill_md("shared-skill"));
+    write_skill_md(&cwd, "shared-skill", &valid_skill_md("shared-skill"));
+
+    let result = skills::discover_and_load(&cwd, Some(&home), &[]);
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].name, "/shared-skill");
+    // Project scope should override user scope
+    assert_eq!(result[0].scope, Some(SkillScope::Project));
+}
+
+// --- Test 8: skill_name_collision_builtin ---
+#[test]
+fn skill_name_collision_builtin() {
+    let root = unique_test_dir("collision_builtin");
+    // "help" conflicts with /help builtin
+    write_skill_md(&root, "help", &valid_skill_md("help"));
+
+    let builtin = anvil::extensions::builtin_slash_commands();
+    let result = skills::discover_and_load(&root, None, &builtin);
+    // Should be skipped due to collision
+    assert!(result.is_empty());
+}
+
+// --- Test 9: skill_name_collision_custom ---
+#[test]
+fn skill_name_collision_custom() {
+    let root = unique_test_dir("collision_custom");
+    write_skill_md(&root, "invaders", &valid_skill_md("invaders"));
+
+    let existing = vec![SlashCommandSpec {
+        name: "/invaders".to_string(),
+        description: "custom command".to_string(),
+        action: SlashCommandAction::Prompt("do something".to_string()),
+        scope: None,
+    }];
+
+    let result = skills::discover_and_load(&root, None, &existing);
+    assert!(result.is_empty());
+}
+
+// --- Test 10: skill_args_separation ---
+#[test]
+fn skill_args_separation() {
+    let commands = vec![SlashCommandSpec {
+        name: "/my-skill".to_string(),
+        description: "test skill".to_string(),
+        action: SlashCommandAction::Skill {
+            name: "my-skill".to_string(),
+            args: String::new(),
+            content: "skill body".to_string(),
+            skill_dir: PathBuf::from("/tmp/skills/my-skill"),
+        },
+        scope: Some(SkillScope::User),
+    }];
+
+    let result = skills::parse_skill_command("/my-skill arg1 arg2", &commands);
+    assert!(result.is_some());
+    let spec = result.unwrap();
+    assert_eq!(spec.name, "/my-skill");
+    match &spec.action {
+        SlashCommandAction::Skill { args, .. } => {
+            assert_eq!(args, "arg1 arg2");
+        }
+        _ => panic!("expected Skill action"),
+    }
+}
+
+// --- Test 11: skill_variable_expansion_arguments ---
+#[test]
+fn skill_variable_expansion_arguments() {
+    let content = "Run with $ARGUMENTS and also ${ARGUMENTS} here.";
+    let expanded = skills::expand_variables(content, "hello world", std::path::Path::new("/tmp"));
+    assert_eq!(expanded, "Run with hello world and also hello world here.");
+}
+
+// --- Test 12: skill_variable_expansion_skill_dir ---
+#[test]
+fn skill_variable_expansion_skill_dir() {
+    let content = "Dir is ${ANVIL_SKILL_DIR}/templates.";
+    let expanded = skills::expand_variables(
+        content,
+        "",
+        std::path::Path::new("/home/user/.anvil/skills/my-skill"),
+    );
+    assert_eq!(
+        expanded,
+        "Dir is /home/user/.anvil/skills/my-skill/templates."
+    );
+}
+
+// --- Test 13: skill_user_invocable_false_skip ---
+#[test]
+fn skill_user_invocable_false_skip() {
+    let root = unique_test_dir("not_invocable");
+    let skill_dir = root.join(".anvil").join("skills").join("hidden");
+    fs::create_dir_all(&skill_dir).expect("create skill dir");
+    fs::write(
+        skill_dir.join("SKILL.md"),
+        r#"---
+name: hidden
+description: Not user invocable
+user-invocable: false
+---
+
+Hidden body.
+"#,
+    )
+    .expect("write SKILL.md");
+
+    let result = skills::discover_and_load(&root, None, &[]);
+    assert!(result.is_empty());
+}
+
+// --- Test 14: skill_parse_error_skip_continue ---
+#[test]
+fn skill_parse_error_skip_continue() {
+    let root = unique_test_dir("parse_error_skip");
+
+    // Valid skill
+    write_skill_md(&root, "good-skill", &valid_skill_md("good-skill"));
+
+    // Invalid skill (no frontmatter)
+    let bad_dir = root.join(".anvil").join("skills").join("bad-skill");
+    fs::create_dir_all(&bad_dir).expect("create dir");
+    fs::write(bad_dir.join("SKILL.md"), "no frontmatter here").expect("write bad skill");
+
+    let result = skills::discover_and_load(&root, None, &[]);
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].name, "/good-skill");
+}
+
+// --- Test 15: skill_suggest_command_typo_correction ---
+#[test]
+fn skill_suggest_command_typo_correction() {
+    let root = unique_test_dir("typo_correction");
+    write_skill_md(&root, "deploy", &valid_skill_md("deploy"));
+
+    let registry = ExtensionRegistry::load(&root, None).expect("load should succeed");
+    // "/deplpy" is a typo for "/deploy" (edit distance 2)
+    let suggestion = registry.suggest_command("/deplpy");
+    assert_eq!(suggestion, Some("/deploy"));
+}
+
+// --- Test 16: skill_discover_no_slash_commands_json ---
+#[test]
+fn skill_discover_no_slash_commands_json() {
+    let root = unique_test_dir("no_slash_json");
+    write_skill_md(&root, "standalone", &valid_skill_md("standalone"));
+    // No .anvil/slash-commands.json exists
+
+    let registry = ExtensionRegistry::load(&root, None).expect("load should succeed");
+    let commands = registry.slash_commands();
+    assert!(commands.iter().any(|c| c.name == "/standalone"));
+}


### PR DESCRIPTION
## Summary

- SKILL.mdベースのスキルシステム Phase 1 を実装
- ユーザースコープ(`~/.anvil/skills/`)とプロジェクトスコープ(`.anvil/skills/`)からのスキル探索・パース
- `/skill-name arg1 arg2` 形式での手動実行と `$ARGUMENTS` / `${ANVIL_SKILL_DIR}` 変数展開
- プロジェクトスコープ優先、名前衝突防止、パースエラー時の警告スキップ
- `/help` にスキル一覧表示（`[user]`/`[project]` スコープタグ付き）

## Changes

| ファイル | 種別 | 内容 |
|---------|------|------|
| `src/extensions/skills.rs` | 新規 | スキル探索・パース・変数展開・引数分離 |
| `src/extensions/mod.rs` | 変更 | Skillバリアント追加、scope追加、load拡張 |
| `src/app/mod.rs` | 変更 | Skillアーム追加、home_dir渡し |
| `src/app/render.rs` | 変更 | スコープ表示、動的フォーマット幅 |
| `tests/skills_system.rs` | 新規 | 16テスト |
| `CLAUDE.md` | 変更 | モジュール構成更新 |

## Test plan

- [x] `cargo build` エラー0件
- [x] `cargo clippy --all-targets` 警告0件
- [x] `cargo test` 全414テストパス（新規16テスト含む）
- [x] `cargo fmt --check` 差分なし
- [x] 受け入れ基準10項目すべて達成

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)