### PR TITLE
feat(cli): add non-interactive exec mode for CI/CD integration (#27)

### DIFF
--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -216,11 +216,14 @@ impl App {
             }
 
             // Send tool results back to LLM for the next turn
-            let spinner = Spinner::start(format!(
-                "Analyzing results. model={} (iteration {})",
-                self.config.runtime.model,
-                iteration + 2
-            ));
+            let spinner = Spinner::start(
+                format!(
+                    "Analyzing results. model={} (iteration {})",
+                    self.config.runtime.model,
+                    iteration + 2
+                ),
+                self.config.mode.interactive,
+            );
 
             let request = BasicAgentLoop::build_turn_request(
                 self.config.runtime.model.clone(),
@@ -450,14 +453,15 @@ impl App {
 
     /// Push a tool execution result into the session as a tool message.
     fn record_tool_result(&mut self, result: &ToolExecutionResult) {
-        self.session.push_message(
-            SessionMessage::new(
-                MessageRole::Tool,
-                "tool",
-                format_tool_result_message(result, self.config.runtime.tool_result_max_chars),
-            )
-            .with_id(self.next_message_id("tool")),
-        );
+        let is_error = result.status == ToolExecutionStatus::Failed;
+        let mut msg = SessionMessage::new(
+            MessageRole::Tool,
+            "tool",
+            format_tool_result_message(result, self.config.runtime.tool_result_max_chars),
+        )
+        .with_id(self.next_message_id("tool"));
+        msg.is_error = is_error;
+        self.session.push_message(msg);
     }
 
     pub(crate) fn handle_structured_done<C: ProviderClient>(

--- a/src/app/cli.rs
+++ b/src/app/cli.rs
@@ -3,7 +3,7 @@
 //! Contains the `run_session_loop` and `run_interactive_loop` functions
 //! that drive the interactive CLI experience.
 
-use crate::config::{CliArgs, EffectiveConfig};
+use crate::config::{CliArgs, EffectiveConfig, PromptSource};
 use crate::logging::{LogGuard, init_tracing};
 use crate::provider::{ProviderClient, ProviderRuntimeContext, build_local_provider_client};
 use crate::session::SessionError;
@@ -11,7 +11,7 @@ use crate::tui::Tui;
 
 use super::{App, AppError, SessionControl, cli_prompt};
 
-use std::io::{self, BufRead, Write};
+use std::io::{self, BufRead, Read as _, Write};
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 
@@ -121,14 +121,64 @@ fn run_with_config(config: EffectiveConfig) -> Result<(), AppError> {
     }
 
     let mut app = App::new(config, provider, Arc::clone(&shutdown_flag))?;
-    let tui = Tui::new();
-    println!("{}", app.startup_console(&tui)?);
 
-    if !app.config.mode.interactive {
-        return Ok(());
+    match app.config.mode.prompt_source {
+        PromptSource::Interactive => {
+            let tui = Tui::new();
+            println!("{}", app.startup_console(&tui)?);
+            run_interactive_loop(&mut app, &provider_client, &tui)
+        }
+        ref source => {
+            let source = source.clone();
+            run_non_interactive(&mut app, &provider_client, &source)
+        }
+    }
+}
+
+/// Read all of stdin into a string.
+fn read_stdin() -> Result<String, AppError> {
+    let mut buf = String::new();
+    io::stdin().lock().read_to_string(&mut buf).map_err(|e| {
+        AppError::Config(crate::config::ConfigError::ValidationError(format!(
+            "failed to read stdin: {e}"
+        )))
+    })?;
+    Ok(buf)
+}
+
+/// Non-interactive execution path for --exec, --exec-file, and --oneshot modes.
+fn run_non_interactive<C: ProviderClient>(
+    app: &mut App,
+    provider_client: &C,
+    source: &PromptSource,
+) -> Result<(), AppError> {
+    // 1. Get prompt from the appropriate source
+    let prompt = match source {
+        PromptSource::Stdin => read_stdin()?,
+        PromptSource::Exec(s) => s.clone(),
+        PromptSource::ExecFile(path) => std::fs::read_to_string(path).map_err(|e| {
+            AppError::Config(crate::config::ConfigError::ValidationError(format!(
+                "failed to read exec file: {e}"
+            )))
+        })?,
+        PromptSource::Interactive => unreachable!(),
+    };
+
+    // 2. Execute the prompt via run_live_turn
+    let tui = Tui::new();
+    let _frames = app.run_live_turn(&prompt, provider_client, &tui)?;
+
+    // 3. Output the last assistant message to stdout
+    if let Some(response) = app.session().last_assistant_message() {
+        print!("{}", response);
     }
 
-    run_interactive_loop(&mut app, &provider_client, &tui)
+    // 4. Check for tool execution failures
+    if app.has_tool_execution_failure() {
+        return Err(AppError::ToolExecution("tool execution failed".to_string()));
+    }
+
+    Ok(())
 }
 
 /// Interactive session loop powered by `rustyline`.

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -159,6 +159,18 @@ impl Display for AppError {
 
 impl std::error::Error for AppError {}
 
+impl AppError {
+    /// Return the process exit code for non-interactive mode.
+    /// - ToolExecution errors → 2 (tool failure)
+    /// - All other errors → 1 (general error)
+    pub fn exit_code(&self) -> u8 {
+        match self {
+            AppError::ToolExecution(_) => 2,
+            _ => 1,
+        }
+    }
+}
+
 impl From<crate::config::ConfigError> for AppError {
     fn from(value: crate::config::ConfigError) -> Self {
         Self::Config(value)
@@ -280,6 +292,14 @@ impl App {
         self.shutdown_flag.load(Ordering::Relaxed)
     }
 
+    /// Check whether the last turn had any tool execution failures.
+    /// Used by non-interactive mode to determine exit code.
+    pub fn has_tool_execution_failure(&self) -> bool {
+        self.session
+            .last_turn_tool_results()
+            .any(|result| result.is_error)
+    }
+
     /// Save the session on exit (wrapper for flush_session).
     pub(crate) fn save_session_on_exit(&mut self) {
         let _ = self.flush_session();
@@ -381,10 +401,10 @@ impl App {
         );
 
         // Phase 1: Collect events from provider with spinner + streaming output.
-        let mut spinner_opt = Some(Spinner::start(format!(
-            "Thinking. model={}",
-            self.config.runtime.model
-        )));
+        let mut spinner_opt = Some(Spinner::start(
+            format!("Thinking. model={}", self.config.runtime.model),
+            self.config.mode.interactive,
+        ));
 
         let mut token_buffer = String::new();
         let mut collected_events: Vec<ProviderEvent> = Vec::new();
@@ -654,7 +674,11 @@ impl App {
 
     /// Flush session to disk if the dirty flag is set.
     /// Also runs deferred auto-compaction before writing.
+    /// In non-interactive mode, skip disk persistence entirely.
     fn flush_session(&mut self) -> Result<(), AppError> {
+        if !self.config.mode.interactive {
+            return Ok(());
+        }
         self.session.compact_if_needed();
         if self.session.dirty {
             self.session_store.save(&self.session)?;
@@ -664,7 +688,12 @@ impl App {
     }
 
     /// Immediately persist session to disk (for crash-safety critical paths).
+    /// In non-interactive mode, skip disk persistence entirely.
     fn persist_session_immediate(&mut self, event: AppEvent) -> Result<(), AppError> {
+        if !self.config.mode.interactive {
+            self.session.record_event(event);
+            return Ok(());
+        }
         self.session.record_event(event);
         self.session_store.save(&self.session)?;
         self.session.clear_dirty();

--- a/src/config/cli_args.rs
+++ b/src/config/cli_args.rs
@@ -4,6 +4,7 @@
 //! [`super::EffectiveConfig::load_with_args`] for configuration override.
 
 use clap::Parser;
+use std::path::PathBuf;
 
 #[derive(Parser, Debug, Default)]
 #[command(name = "anvil", version, about = "Local coding agent powered by LLM")]
@@ -52,9 +53,17 @@ pub struct CliArgs {
     #[arg(long = "fresh-session")]
     pub fresh_session: bool,
 
-    /// Non-interactive mode
-    #[arg(long)]
+    /// Non-interactive mode (read prompt from stdin)
+    #[arg(long, conflicts_with_all = ["exec", "exec_file"])]
     pub oneshot: bool,
+
+    /// Execute a single prompt and exit (non-interactive)
+    #[arg(long, conflicts_with_all = ["exec_file", "oneshot"])]
+    pub exec: Option<String>,
+
+    /// Execute prompt from a file and exit (non-interactive)
+    #[arg(long = "exec-file", conflicts_with_all = ["exec", "oneshot"])]
+    pub exec_file: Option<PathBuf>,
 
     /// Reasoning visibility level (hidden|summary)
     #[arg(long = "reasoning-visibility")]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -17,6 +17,26 @@ use std::{
     fmt::{Display, Formatter},
 };
 
+/// Determines where the user prompt originates from.
+#[derive(Debug, Clone)]
+pub enum PromptSource {
+    /// Interactive REPL mode (default).
+    Interactive,
+    /// Read prompt from stdin (--oneshot).
+    Stdin,
+    /// Prompt provided directly via --exec flag.
+    Exec(String),
+    /// Prompt read from a file via --exec-file flag.
+    ExecFile(PathBuf),
+}
+
+impl PromptSource {
+    /// Returns true if this source represents an interactive session.
+    pub fn is_interactive(&self) -> bool {
+        matches!(self, PromptSource::Interactive)
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum WebSearchProvider {
     #[default]
@@ -45,6 +65,7 @@ pub struct RuntimeConfig {
 
 #[derive(Debug, Clone)]
 pub struct ModeConfig {
+    pub prompt_source: PromptSource,
     pub interactive: bool,
     pub approval_required: bool,
     pub fresh_session: bool,
@@ -178,6 +199,7 @@ impl EffectiveConfig {
                 serper_api_key: None,
             },
             mode: ModeConfig {
+                prompt_source: PromptSource::Interactive,
                 interactive: true,
                 approval_required: true,
                 fresh_session: false,
@@ -269,6 +291,22 @@ impl EffectiveConfig {
     /// Uses direct field assignment (not `apply_map`) to avoid redundant
     /// string round-trips for already-typed values.
     pub fn apply_cli_args(&mut self, cli: &CliArgs) -> Result<(), ConfigError> {
+        // Determine PromptSource from CLI args
+        if let Some(ref prompt) = cli.exec {
+            self.mode.prompt_source = PromptSource::Exec(prompt.clone());
+        } else if let Some(ref path) = cli.exec_file {
+            self.mode.prompt_source = PromptSource::ExecFile(path.clone());
+        } else if cli.oneshot {
+            self.mode.prompt_source = PromptSource::Stdin;
+        }
+
+        // Derive interactive / approval_required / fresh_session for non-interactive modes
+        if !self.mode.prompt_source.is_interactive() {
+            self.mode.interactive = false;
+            self.mode.approval_required = false;
+            self.mode.fresh_session = true;
+        }
+
         // String fields
         if let Some(ref v) = cli.provider {
             self.runtime.provider = v.clone();

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,10 +5,15 @@ use clap::Parser;
 fn main() -> ExitCode {
     let cli = anvil::config::CliArgs::parse();
     if let Err(err) = anvil::app::run_with_args(&cli) {
+        let code = err.exit_code();
         eprintln!("anvil error: {err}");
-        eprintln!();
-        eprintln!("{}", anvil::app::error_guidance(&err));
-        return ExitCode::FAILURE;
+        // exit_code 1 = config/startup error → show guidance
+        // exit_code 2 = tool execution failure → guidance not needed
+        if code == 1 {
+            eprintln!();
+            eprintln!("{}", anvil::app::error_guidance(&err));
+        }
+        return ExitCode::from(code);
     }
     ExitCode::SUCCESS
 }

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -40,6 +40,10 @@ pub struct SessionMessage {
     pub content: String,
     pub status: MessageStatus,
     pub tool_call_id: Option<String>,
+    /// Whether this tool result represents an error.
+    /// Added for non-interactive mode exit code determination.
+    #[serde(default)]
+    pub is_error: bool,
 }
 
 impl SessionMessage {
@@ -51,6 +55,7 @@ impl SessionMessage {
             content: content.into(),
             status: MessageStatus::Committed,
             tool_call_id: None,
+            is_error: false,
         }
     }
 
@@ -365,6 +370,28 @@ impl SessionRecord {
 
     pub fn clear_dirty(&mut self) {
         self.dirty = false;
+    }
+
+    /// Return the content of the last assistant message, if any.
+    pub fn last_assistant_message(&self) -> Option<&str> {
+        self.messages
+            .iter()
+            .rev()
+            .find(|m| m.role == MessageRole::Assistant)
+            .map(|m| m.content.as_str())
+    }
+
+    /// Return tool result messages from the last turn (after the last user message).
+    pub fn last_turn_tool_results(&self) -> impl Iterator<Item = &SessionMessage> {
+        let last_user_idx = self
+            .messages
+            .iter()
+            .rposition(|m| m.role == MessageRole::User)
+            .unwrap_or(0);
+
+        self.messages[last_user_idx..]
+            .iter()
+            .filter(|m| m.role == MessageRole::Tool)
     }
 }
 

--- a/src/spinner.rs
+++ b/src/spinner.rs
@@ -20,7 +20,16 @@ pub struct Spinner {
 
 impl Spinner {
     /// Start a spinner with the given message.
-    pub fn start(message: impl Into<String>) -> Self {
+    ///
+    /// When `enabled` is false, returns a no-op spinner that does nothing.
+    /// This is used in non-interactive mode to suppress terminal output.
+    pub fn start(message: impl Into<String>, enabled: bool) -> Self {
+        if !enabled {
+            return Self {
+                running: Arc::new(AtomicBool::new(false)),
+                handle: None,
+            };
+        }
         let running = Arc::new(AtomicBool::new(true));
         let flag = running.clone();
         let message = message.into();

--- a/tests/cli_args.rs
+++ b/tests/cli_args.rs
@@ -1,7 +1,8 @@
 mod common;
 
-use anvil::config::{CliArgs, EffectiveConfig, ReasoningVisibility};
+use anvil::config::{CliArgs, EffectiveConfig, PromptSource, ReasoningVisibility};
 use clap::Parser;
+use std::path::PathBuf;
 
 // --- CliArgs parsing tests ---
 
@@ -20,6 +21,8 @@ fn cli_args_default_has_all_none_and_false() {
     assert!(!args.no_approval);
     assert!(!args.fresh_session);
     assert!(!args.oneshot);
+    assert!(args.exec.is_none());
+    assert!(args.exec_file.is_none());
     assert!(args.reasoning_visibility.is_none());
 }
 
@@ -282,4 +285,225 @@ fn apply_cli_args_invalid_reasoning_visibility_errors() {
 
     let result = config.apply_cli_args(&args);
     assert!(result.is_err());
+}
+
+// --- --exec / --exec-file CLI args parsing tests ---
+
+#[test]
+fn cli_args_exec_flag_parse() {
+    let args = CliArgs::try_parse_from(["anvil", "--exec", "analyze this code"]).unwrap();
+    assert_eq!(args.exec.as_deref(), Some("analyze this code"));
+    assert!(args.exec_file.is_none());
+    assert!(!args.oneshot);
+}
+
+#[test]
+fn cli_args_exec_file_flag_parse() {
+    let args = CliArgs::try_parse_from(["anvil", "--exec-file", "/tmp/prompt.txt"]).unwrap();
+    assert_eq!(args.exec_file, Some(PathBuf::from("/tmp/prompt.txt")));
+    assert!(args.exec.is_none());
+    assert!(!args.oneshot);
+}
+
+#[test]
+fn cli_args_exec_oneshot_conflict() {
+    let result = CliArgs::try_parse_from(["anvil", "--exec", "hello", "--oneshot"]);
+    assert!(result.is_err(), "exec and oneshot should conflict");
+}
+
+#[test]
+fn cli_args_exec_exec_file_conflict() {
+    let result = CliArgs::try_parse_from(["anvil", "--exec", "hello", "--exec-file", "/tmp/p.txt"]);
+    assert!(result.is_err(), "exec and exec-file should conflict");
+}
+
+#[test]
+fn cli_args_exec_file_oneshot_conflict() {
+    let result = CliArgs::try_parse_from(["anvil", "--exec-file", "/tmp/p.txt", "--oneshot"]);
+    assert!(result.is_err(), "exec-file and oneshot should conflict");
+}
+
+// --- PromptSource / apply_cli_args integration tests ---
+
+#[test]
+fn prompt_source_default_is_interactive() {
+    let config = EffectiveConfig::default_for_test().unwrap();
+    assert!(config.mode.prompt_source.is_interactive());
+}
+
+#[test]
+fn apply_cli_args_exec_sets_non_interactive() {
+    let mut config = EffectiveConfig::default_for_test().unwrap();
+    let args = CliArgs {
+        exec: Some("do something".to_string()),
+        ..CliArgs::default()
+    };
+    config.apply_cli_args(&args).unwrap();
+
+    assert!(
+        !config.mode.interactive,
+        "exec should set interactive=false"
+    );
+    assert!(matches!(config.mode.prompt_source, PromptSource::Exec(_)));
+}
+
+#[test]
+fn apply_cli_args_exec_sets_approval_false() {
+    let mut config = EffectiveConfig::default_for_test().unwrap();
+    assert!(config.mode.approval_required); // default is true
+    let args = CliArgs {
+        exec: Some("do something".to_string()),
+        ..CliArgs::default()
+    };
+    config.apply_cli_args(&args).unwrap();
+
+    assert!(
+        !config.mode.approval_required,
+        "exec should auto-disable approval"
+    );
+}
+
+#[test]
+fn apply_cli_args_exec_sets_fresh_session() {
+    let mut config = EffectiveConfig::default_for_test().unwrap();
+    assert!(!config.mode.fresh_session); // default is false
+    let args = CliArgs {
+        exec: Some("do something".to_string()),
+        ..CliArgs::default()
+    };
+    config.apply_cli_args(&args).unwrap();
+
+    assert!(
+        config.mode.fresh_session,
+        "exec should auto-set fresh_session=true"
+    );
+}
+
+#[test]
+fn apply_cli_args_exec_file_sets_non_interactive() {
+    let mut config = EffectiveConfig::default_for_test().unwrap();
+    let args = CliArgs {
+        exec_file: Some(PathBuf::from("/tmp/prompt.txt")),
+        ..CliArgs::default()
+    };
+    config.apply_cli_args(&args).unwrap();
+
+    assert!(!config.mode.interactive);
+    assert!(!config.mode.approval_required);
+    assert!(config.mode.fresh_session);
+    assert!(matches!(
+        config.mode.prompt_source,
+        PromptSource::ExecFile(_)
+    ));
+}
+
+#[test]
+fn apply_cli_args_oneshot_sets_stdin_source() {
+    let mut config = EffectiveConfig::default_for_test().unwrap();
+    let args = CliArgs {
+        oneshot: true,
+        ..CliArgs::default()
+    };
+    config.apply_cli_args(&args).unwrap();
+
+    assert!(!config.mode.interactive);
+    assert!(!config.mode.approval_required);
+    assert!(config.mode.fresh_session);
+    assert!(matches!(config.mode.prompt_source, PromptSource::Stdin));
+}
+
+// --- AppError::exit_code tests ---
+
+#[test]
+fn app_error_exit_code_tool_execution() {
+    let err = anvil::app::AppError::ToolExecution("test".to_string());
+    assert_eq!(err.exit_code(), 2);
+}
+
+#[test]
+fn app_error_exit_code_config() {
+    let err = anvil::app::AppError::Config(anvil::config::ConfigError::ValidationError(
+        "test".to_string(),
+    ));
+    assert_eq!(err.exit_code(), 1);
+}
+
+// --- SessionRecord helper tests ---
+
+#[test]
+fn session_last_assistant_message_returns_last() {
+    use anvil::session::{MessageRole, SessionMessage, SessionRecord};
+    use std::path::PathBuf;
+
+    let mut session = SessionRecord::new(PathBuf::from("/tmp/test"));
+    session.push_message(SessionMessage::new(MessageRole::User, "you", "hello"));
+    session.push_message(SessionMessage::new(
+        MessageRole::Assistant,
+        "anvil",
+        "first reply",
+    ));
+    session.push_message(SessionMessage::new(MessageRole::User, "you", "follow up"));
+    session.push_message(SessionMessage::new(
+        MessageRole::Assistant,
+        "anvil",
+        "second reply",
+    ));
+
+    assert_eq!(session.last_assistant_message(), Some("second reply"));
+}
+
+#[test]
+fn session_last_assistant_message_returns_none_when_empty() {
+    use anvil::session::SessionRecord;
+    use std::path::PathBuf;
+
+    let session = SessionRecord::new(PathBuf::from("/tmp/test"));
+    assert_eq!(session.last_assistant_message(), None);
+}
+
+#[test]
+fn session_last_turn_tool_results_returns_tools_after_last_user() {
+    use anvil::session::{MessageRole, SessionMessage, SessionRecord};
+    use std::path::PathBuf;
+
+    let mut session = SessionRecord::new(PathBuf::from("/tmp/test"));
+    // First turn
+    session.push_message(SessionMessage::new(MessageRole::User, "you", "first"));
+    let mut tool1 = SessionMessage::new(MessageRole::Tool, "tool", "result1");
+    tool1.is_error = false;
+    session.push_message(tool1);
+    // Second turn
+    session.push_message(SessionMessage::new(MessageRole::User, "you", "second"));
+    let mut tool2 = SessionMessage::new(MessageRole::Tool, "tool", "result2");
+    tool2.is_error = true;
+    session.push_message(tool2);
+
+    let results: Vec<_> = session.last_turn_tool_results().collect();
+    assert_eq!(results.len(), 1, "should only include tools from last turn");
+    assert!(results[0].is_error);
+}
+
+#[test]
+fn session_message_is_error_deserialize_compat() {
+    // Verify that old JSON without is_error deserializes with default false
+    let json = r#"{
+        "id": "test_1",
+        "role": "Tool",
+        "author": "tool",
+        "content": "result",
+        "status": "Committed",
+        "tool_call_id": null
+    }"#;
+    let msg: anvil::session::SessionMessage = serde_json::from_str(json).unwrap();
+    assert!(!msg.is_error, "is_error should default to false");
+}
+
+// --- Spinner no-op test ---
+
+#[test]
+fn spinner_noop_in_non_interactive() {
+    // Verify that Spinner::start with enabled=false does not panic
+    // and can be stopped immediately.
+    let spinner = anvil::spinner::Spinner::start("test message", false);
+    spinner.stop(); // should be a no-op, no panic
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -36,5 +36,6 @@ pub fn unique_test_dir(label: &str) -> PathBuf {
         .duration_since(UNIX_EPOCH)
         .expect("time should be monotonic")
         .as_nanos();
-    std::env::temp_dir().join(format!("anvil_test_{label}_{nanos}"))
+    let tid = std::thread::current().id();
+    std::env::temp_dir().join(format!("anvil_test_{label}_{nanos}_{tid:?}"))
 }


### PR DESCRIPTION
## Summary
- `--exec` / `--exec-file` フラグによる非対話的プロンプト実行モードを追加
- CI/CD パイプライン（GitHub Actions等）からAnvilを自動実行可能に
- 終了コード 0/1/2 による成功・一般エラー・ツール実行失敗の区別

## Changes
- **Config層**: `PromptSource` enum導入、`--exec`/`--exec-file` CLIフラグ追加（`--oneshot`との排他制御）
- **CLI層**: `run_non_interactive()` 実行パス新規実装、`PromptSource` によるパターンマッチ分岐
- **App層**: `AppError::exit_code()` メソッド、`has_tool_execution_failure()` 判定ロジック
- **Session層**: `is_error` フィールド追加、`last_assistant_message()` / `last_turn_tool_results()` ヘルパー
- **UI層**: Spinner の `enabled` パラメータ追加（非対話時 no-op）
- **Entry**: `main.rs` の終了コード分岐（exit_code 2 = ツール実行失敗）

## Test plan
- [x] `cargo build` エラー0件
- [x] `cargo clippy --all-targets` 警告0件  
- [x] `cargo test` 全テストパス（18件の新規テスト追加）
- [x] `cargo fmt --check` 差分なし
- [ ] `--exec "prompt"` でプロンプト実行確認
- [ ] `--exec-file path` でファイルからプロンプト読み込み確認
- [ ] `--exec` と `--oneshot` の同時指定でエラー確認

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)