### PR TITLE
feat: Hooks（ライフサイクルフック）機構 (#25)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,8 @@ src/
 ├── extensions/
 │   ├── mod.rs           # スラッシュコマンド・拡張
 │   └── skills.rs        # SKILL.mdベースのスキルシステム
+├── hooks/
+│   └── mod.rs           # ライフサイクルフック（HooksConfig, HookRunner, HooksEngine）
 ├── logging.rs           # 構造化ロギング（tracing初期化）
 ├── mcp/
 │   ├── mod.rs           # MCPクライアント（McpManager, McpConnection, McpError）
@@ -140,7 +142,8 @@ tests/
 ├── tooling_system.rs    # ツールシステムテスト
 ├── mcp_integration.rs   # MCP統合テスト
 ├── tui_console.rs       # TUIテスト
-└── skills_system.rs     # スキルシステムテスト
+├── skills_system.rs     # スキルシステムテスト
+└── hooks_system.rs      # フックシステムテスト
 ```
 
 ---

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,6 +71,7 @@ dependencies = [
  "rustyline",
  "serde",
  "serde_json",
+ "shlex",
  "signal-hook",
  "similar",
  "tempfile",
@@ -582,6 +583,12 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ signal-hook = "0.3"
 similar = "2"
 clap = { version = "4", features = ["derive"] }
 base64 = "0.22"
+shlex = "1.3"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -472,8 +472,78 @@ impl App {
         structured: &StructuredAssistantResponse,
     ) -> Result<Vec<ToolExecutionResult>, AppError> {
         // Phase 1: Validation + Approval
-        let (validated_requests, failed_results) =
+        let (validated_requests, mut failed_results) =
             self.validate_and_approve_all(&structured.tool_calls);
+
+        // Phase 1.5: PreToolUse hooks (DR design judgment #1)
+        // Build tool_input_map before grouping (DR3-003, DR3-005)
+        let tool_input_map: std::collections::HashMap<String, (String, serde_json::Value)> =
+            validated_requests
+                .iter()
+                .map(|(_, r)| {
+                    (
+                        r.tool_call_id.clone(),
+                        (
+                            r.spec.name.clone(),
+                            serde_json::to_value(&r.input).unwrap_or_default(),
+                        ),
+                    )
+                })
+                .collect();
+
+        // Run PreToolUse hooks and filter blocked requests
+        let validated_requests = if let Some(ref engine) = self.hooks_engine {
+            let mut remaining = Vec::new();
+            for (idx, request) in validated_requests {
+                if let Some((tool_name, tool_input)) = tool_input_map.get(&request.tool_call_id) {
+                    let event = crate::hooks::PreToolUseEvent {
+                        hook_point: "PreToolUse",
+                        tool_name: tool_name.clone(),
+                        tool_input: tool_input.clone(),
+                        tool_call_id: request.tool_call_id.clone(),
+                    };
+                    match engine.run_pre_tool_use(event) {
+                        Ok(crate::hooks::PreToolUseOutcome::Continue) => {
+                            remaining.push((idx, request));
+                        }
+                        Ok(crate::hooks::PreToolUseOutcome::Block { reason, .. }) => {
+                            tracing::info!(
+                                tool = %tool_name,
+                                reason = %reason,
+                                "PreToolUse hook blocked tool call"
+                            );
+                            failed_results.push((
+                                idx,
+                                ToolExecutionResult {
+                                    tool_call_id: request.tool_call_id.clone(),
+                                    tool_name: request.spec.name.clone(),
+                                    status: ToolExecutionStatus::Failed,
+                                    summary: format!("blocked by hook: {reason}"),
+                                    payload: crate::tooling::ToolExecutionPayload::None,
+                                    artifacts: Vec::new(),
+                                    elapsed_ms: 0,
+                                },
+                            ));
+                        }
+                        Err(crate::hooks::HookError::Shutdown) => {
+                            // Propagate shutdown
+                            remaining.push((idx, request));
+                            break;
+                        }
+                        Err(err) => {
+                            // Soft-fail: continue
+                            tracing::warn!("PreToolUse hook error: {err}");
+                            remaining.push((idx, request));
+                        }
+                    }
+                } else {
+                    remaining.push((idx, request));
+                }
+            }
+            remaining
+        } else {
+            validated_requests
+        };
 
         // Phase 2: Grouping
         let groups = group_by_execution_mode(&validated_requests);
@@ -504,15 +574,37 @@ impl App {
             }
         }
 
-        // Phase 4: Sort by index, batch record, persist session
+        // Phase 4: Sort by index, record results, run PostToolUse hooks (DR2-004)
         indexed_results.sort_by_key(|(idx, _)| *idx);
-        let results: Vec<ToolExecutionResult> = indexed_results
-            .into_iter()
-            .map(|(_, result)| {
-                self.record_tool_result(&result);
-                result
-            })
-            .collect();
+        let mut results: Vec<ToolExecutionResult> = Vec::with_capacity(indexed_results.len());
+        for (_, result) in indexed_results {
+            self.record_tool_result(&result);
+
+            // PostToolUse hook (soft-fail)
+            if let Some(ref engine) = self.hooks_engine
+                && let Some((tool_name, tool_input)) = tool_input_map.get(&result.tool_call_id)
+            {
+                let status_str = match result.status {
+                    ToolExecutionStatus::Completed => "completed",
+                    ToolExecutionStatus::Failed | ToolExecutionStatus::Interrupted => "failed",
+                };
+                let event = crate::hooks::PostToolUseEvent {
+                    hook_point: "PostToolUse",
+                    tool_name: tool_name.clone(),
+                    tool_input: tool_input.clone(),
+                    tool_call_id: result.tool_call_id.clone(),
+                    tool_result: crate::hooks::HookToolResult {
+                        status: status_str.to_string(),
+                        summary: result.summary.clone(),
+                    },
+                };
+                if let Err(err) = engine.run_post_tool_use(event) {
+                    tracing::warn!("PostToolUse hook error: {err}");
+                }
+            }
+
+            results.push(result);
+        }
 
         self.persist_session(crate::contracts::AppEvent::SessionSaved)?;
         Ok(results)

--- a/src/app/cli.rs
+++ b/src/app/cli.rs
@@ -166,19 +166,29 @@ fn run_non_interactive<C: ProviderClient>(
 
     // 2. Execute the prompt via run_live_turn
     let tui = Tui::new();
-    let _frames = app.run_live_turn(&prompt, provider_client, &tui)?;
+    match app.run_live_turn(&prompt, provider_client, &tui) {
+        Ok(_frames) => {
+            // 3. Output the last assistant message to stdout
+            if let Some(response) = app.session().last_assistant_message() {
+                print!("{}", response);
+            }
 
-    // 3. Output the last assistant message to stdout
-    if let Some(response) = app.session().last_assistant_message() {
-        print!("{}", response);
+            // Run PostSession hook (DR3-004: after run_live_turn success)
+            app.run_post_session_hook();
+
+            // 4. Check for tool execution failures
+            if app.has_tool_execution_failure() {
+                return Err(AppError::ToolExecution("tool execution failed".to_string()));
+            }
+
+            Ok(())
+        }
+        Err(err) => {
+            // DR3-004: Run PostSession hook on error paths after run_live_turn
+            app.run_post_session_hook();
+            Err(err)
+        }
     }
-
-    // 4. Check for tool execution failures
-    if app.has_tool_execution_failure() {
-        return Err(AppError::ToolExecution("tool execution failed".to_string()));
-    }
-
-    Ok(())
 }
 
 /// Interactive session loop powered by `rustyline`.
@@ -235,6 +245,9 @@ fn run_interactive_loop<C: ProviderClient>(
             }
         }
     }
+
+    // Run PostSession hook before saving
+    app.run_post_session_hook();
 
     // Save session on exit
     app.save_session_on_exit();

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -113,6 +113,9 @@ pub struct App {
     system_prompt: String,
     shutdown_flag: Arc<AtomicBool>,
     warning_tracker: ContextWarningTracker,
+    /// Hooks engine. `None` when hooks.json is absent or initialization failed.
+    /// Declared before mcp_manager to maintain Drop order (DR3-007).
+    hooks_engine: Option<crate::hooks::HooksEngine>,
     /// MCP server manager. `None` when mcp.json is absent or initialization failed.
     /// [D2-010] Declared last so it is dropped last (Drop order = declaration order).
     mcp_manager: Option<crate::mcp::McpManager>,
@@ -252,6 +255,25 @@ impl App {
             }
         };
 
+        // --- Hooks initialization (MCP pattern, DR3-010) ---
+        let hooks_engine = match crate::config::load_hooks_config(&config.paths) {
+            Ok(Some(hooks_config)) => {
+                if hooks_config.is_empty() {
+                    None
+                } else {
+                    Some(crate::hooks::HooksEngine::new(
+                        hooks_config,
+                        Arc::clone(&shutdown_flag),
+                    ))
+                }
+            }
+            Ok(None) => None, // hooks.json not found → skip completely
+            Err(e) => {
+                eprintln!("Warning: hooks config error: {e}");
+                None // graceful degradation
+            }
+        };
+
         // [D1-009] ToolSpec conversion and ToolRegistry registration done by App side (SRP)
         // [D2-003] standard_tool_registry() is a free function
         let mut tools = standard_tool_registry();
@@ -305,6 +327,7 @@ impl App {
             system_prompt,
             shutdown_flag,
             warning_tracker: ContextWarningTracker::new(),
+            hooks_engine,
             mcp_manager,
         })
     }
@@ -362,6 +385,59 @@ impl App {
     /// Save the session on exit (wrapper for flush_session).
     pub(crate) fn save_session_on_exit(&mut self) {
         let _ = self.flush_session();
+    }
+
+    /// Run PostSession hook (DR2-005, DR2-007 facade method).
+    ///
+    /// Builds PostSessionEvent from config and session, then delegates to
+    /// HooksEngine. Soft-fail: errors are logged but not propagated.
+    pub(crate) fn run_post_session_hook(&mut self) {
+        let Some(ref engine) = self.hooks_engine else {
+            return;
+        };
+        let event = crate::hooks::PostSessionEvent {
+            hook_point: "PostSession",
+            session_id: self.session.metadata.session_id.clone(),
+            mode: if self.config.mode.interactive {
+                "interactive".to_string()
+            } else {
+                "non-interactive".to_string()
+            },
+        };
+        if let Err(err) = engine.run_post_session(event) {
+            tracing::warn!("PostSession hook error: {err}");
+        }
+    }
+
+    /// Run PreCompact hook + compact_history (DR1-005 wrapper, DR2-003).
+    ///
+    /// trigger: "auto" or "manual"
+    /// For auto: checks should_compact() first, keep_recent = threshold/2
+    /// For manual: unconditional, keep_recent = 8
+    fn compact_with_hooks(&mut self, trigger: &str) -> bool {
+        if trigger == "auto" && !self.session.should_compact() {
+            return false;
+        }
+
+        // Run PreCompact hook (soft-fail)
+        if let Some(ref engine) = self.hooks_engine {
+            let event = crate::hooks::PreCompactEvent {
+                hook_point: "PreCompact",
+                session_id: self.session.metadata.session_id.clone(),
+                trigger: trigger.to_string(),
+                message_count: self.session.messages.len(),
+            };
+            if let Err(err) = engine.run_pre_compact(event) {
+                tracing::warn!("PreCompact hook error: {err}");
+            }
+        }
+
+        let keep_recent = if trigger == "auto" {
+            self.session.auto_compact_threshold / 2
+        } else {
+            8
+        };
+        self.session.compact_history(keep_recent)
     }
 
     /// Get a clone of the shutdown flag for injection into sub-components.
@@ -738,7 +814,7 @@ impl App {
         if !self.config.mode.interactive {
             return Ok(());
         }
-        self.session.compact_if_needed();
+        self.compact_with_hooks("auto");
         if self.session.dirty {
             self.session_store.save(&self.session)?;
             self.session.clear_dirty();
@@ -1171,7 +1247,7 @@ impl App {
     }
 
     fn compact_session_history(&mut self) -> Result<String, AppError> {
-        let changed = self.session.compact_history(8);
+        let changed = self.compact_with_hooks("manual");
         if changed {
             self.persist_session(AppEvent::SessionSaved)?;
             let usage = ContextUsageView {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -90,6 +90,7 @@ pub struct PathConfig {
     pub session_file: PathBuf,
     pub logs_dir: PathBuf,
     pub mcp_config_file: PathBuf,
+    pub hooks_config_file: PathBuf,
 }
 
 #[derive(Debug, Clone)]
@@ -210,6 +211,7 @@ impl EffectiveConfig {
             },
             paths: PathConfig {
                 mcp_config_file: cwd.join(".anvil").join("mcp.json"),
+                hooks_config_file: cwd.join(".anvil").join("hooks.json"),
                 cwd,
                 workspace_dir,
                 config_file,
@@ -889,4 +891,62 @@ fn check_mcp_config_security_warnings(configs: &HashMap<String, McpServerConfig>
             }
         }
     }
+}
+
+// --- Hooks configuration loading ---
+
+use crate::hooks::{HookError, HooksConfig, MAX_ENTRIES_PER_HOOK_POINT};
+
+/// Load hooks configuration from `.anvil/hooks.json`.
+///
+/// Returns `Ok(None)` if the file does not exist (hooks are optional).
+/// Returns `Ok(Some(...))` on successful parse.
+/// Returns `Err(...)` on parse errors (DR2-009).
+///
+/// DR4-005: Validates the hooks.json path is within cwd/.anvil/.
+/// DR4-007: Caps entries per hook point to 16.
+pub fn load_hooks_config(paths: &PathConfig) -> Result<Option<HooksConfig>, HookError> {
+    if !paths.hooks_config_file.exists() {
+        return Ok(None);
+    }
+
+    // DR4-005: Validate path is within cwd
+    if let Ok(canonical) = paths.hooks_config_file.canonicalize()
+        && let Ok(cwd_canonical) = paths.cwd.canonicalize()
+        && !canonical.starts_with(&cwd_canonical)
+    {
+        return Err(HookError::ParseError {
+            file: paths.hooks_config_file.clone(),
+            reason: "hooks.json path is outside the project directory".to_string(),
+        });
+    }
+
+    tracing::info!(path = %paths.hooks_config_file.display(), "hooks.json detected");
+
+    let content =
+        std::fs::read_to_string(&paths.hooks_config_file).map_err(|e| HookError::ParseError {
+            file: paths.hooks_config_file.clone(),
+            reason: format!("failed to read: {e}"),
+        })?;
+
+    let mut config: HooksConfig =
+        serde_json::from_str(&content).map_err(|e| HookError::ParseError {
+            file: paths.hooks_config_file.clone(),
+            reason: format!("failed to parse: {e}"),
+        })?;
+
+    // DR4-007: Cap entries per hook point
+    for (point, entries) in config.hooks.iter_mut() {
+        if entries.len() > MAX_ENTRIES_PER_HOOK_POINT {
+            tracing::warn!(
+                hook_point = ?point,
+                count = entries.len(),
+                max = MAX_ENTRIES_PER_HOOK_POINT,
+                "hook entries exceed limit, truncating"
+            );
+            entries.truncate(MAX_ENTRIES_PER_HOOK_POINT);
+        }
+    }
+
+    Ok(Some(config))
 }

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -1,0 +1,793 @@
+//! Hooks lifecycle hook system.
+//!
+//! Provides [`HooksEngine`] for executing user-defined hooks at various
+//! lifecycle points: PreToolUse, PostToolUse, PreCompact, and PostSession.
+//!
+//! All hook-related types are self-contained in this module (DR1-008).
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::fmt::{Display, Formatter};
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// Maximum number of hook entries per hook point (DR4-007).
+pub const MAX_ENTRIES_PER_HOOK_POINT: usize = 16;
+
+/// Maximum stderr capture size in bytes (DR4-011).
+const MAX_STDERR_BYTES: usize = 1024;
+
+// ---------------------------------------------------------------------------
+// HookPoint
+// ---------------------------------------------------------------------------
+
+/// Lifecycle hook points (DR1-002: HashMap-based extensible structure).
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum HookPoint {
+    #[serde(rename = "PreToolUse")]
+    PreToolUse,
+    #[serde(rename = "PostToolUse")]
+    PostToolUse,
+    #[serde(rename = "PreCompact")]
+    PreCompact,
+    #[serde(rename = "PostSession")]
+    PostSession,
+}
+
+// ---------------------------------------------------------------------------
+// HookEntry
+// ---------------------------------------------------------------------------
+
+/// Individual hook definition (DR1-013, DR4-002).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HookEntry {
+    pub command: String,
+    #[serde(default = "default_hook_timeout_ms", alias = "timeout")]
+    pub timeout_ms: u64,
+    #[serde(default = "default_on_timeout")]
+    pub on_timeout: String,
+}
+
+fn default_hook_timeout_ms() -> u64 {
+    5000
+}
+
+fn default_on_timeout() -> String {
+    "continue".to_string()
+}
+
+// ---------------------------------------------------------------------------
+// HooksConfig
+// ---------------------------------------------------------------------------
+
+/// Hook configuration loaded from hooks.json (DR1-002).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HooksConfig {
+    pub hooks: HashMap<HookPoint, Vec<HookEntry>>,
+}
+
+impl HooksConfig {
+    /// Returns true if no hook entries are configured (DR1-002).
+    pub fn is_empty(&self) -> bool {
+        self.hooks.values().all(|entries| entries.is_empty())
+    }
+
+    /// Get entries for a specific hook point.
+    pub fn get_entries(&self, point: &HookPoint) -> &[HookEntry] {
+        self.hooks.get(point).map(|v| v.as_slice()).unwrap_or(&[])
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Event types (DR1-003)
+// ---------------------------------------------------------------------------
+
+/// PreToolUse event data sent to hook via stdin.
+#[derive(Debug, Clone, Serialize)]
+pub struct PreToolUseEvent {
+    pub hook_point: &'static str,
+    pub tool_name: String,
+    pub tool_input: serde_json::Value,
+    pub tool_call_id: String,
+}
+
+/// PostToolUse event data sent to hook via stdin.
+#[derive(Debug, Clone, Serialize)]
+pub struct PostToolUseEvent {
+    pub hook_point: &'static str,
+    pub tool_name: String,
+    pub tool_input: serde_json::Value,
+    pub tool_call_id: String,
+    pub tool_result: HookToolResult,
+}
+
+/// Simplified tool result for hooks (DR1-006, DR2-012).
+#[derive(Debug, Clone, Serialize)]
+pub struct HookToolResult {
+    pub status: String,
+    pub summary: String,
+}
+
+/// PreCompact event data sent to hook via stdin.
+#[derive(Debug, Clone, Serialize)]
+pub struct PreCompactEvent {
+    pub hook_point: &'static str,
+    pub session_id: String,
+    pub trigger: String,
+    pub message_count: usize,
+}
+
+/// PostSession event data sent to hook via stdin (DR1-007, DR2-011).
+#[derive(Debug, Clone, Serialize)]
+pub struct PostSessionEvent {
+    pub hook_point: &'static str,
+    pub session_id: String,
+    pub mode: String,
+}
+
+// ---------------------------------------------------------------------------
+// Outcome types (DR1-003, DR1-010)
+// ---------------------------------------------------------------------------
+
+/// Internal outcome from HookRunner.execute().
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HookOutcome {
+    Continue,
+    Block { reason: String, exit_code: i32 },
+}
+
+/// PreToolUse-specific outcome (DR1-003).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PreToolUseOutcome {
+    Continue,
+    Block { reason: String, exit_code: i32 },
+}
+
+// ---------------------------------------------------------------------------
+// HookError (DR1-009)
+// ---------------------------------------------------------------------------
+
+/// Structured hook execution errors.
+#[derive(Debug)]
+pub enum HookError {
+    CommandParseFailed {
+        command: String,
+        reason: String,
+    },
+    CommandNotFound {
+        command: String,
+    },
+    PermissionDenied {
+        command: String,
+        path: String,
+    },
+    Timeout {
+        command: String,
+        timeout_ms: u64,
+    },
+    ExecutionFailed {
+        command: String,
+        exit_code: Option<i32>,
+        stderr: String,
+    },
+    Shutdown,
+    ParseError {
+        file: PathBuf,
+        reason: String,
+    },
+}
+
+impl Display for HookError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::CommandParseFailed { command, reason } => {
+                write!(f, "hook command parse failed: {command}: {reason}")
+            }
+            Self::CommandNotFound { command } => {
+                write!(f, "hook command not found: {command}")
+            }
+            Self::PermissionDenied { command, path } => {
+                write!(f, "hook permission denied: {command} ({path})")
+            }
+            Self::Timeout {
+                command,
+                timeout_ms,
+            } => {
+                write!(f, "hook timed out after {timeout_ms}ms: {command}")
+            }
+            Self::ExecutionFailed {
+                command,
+                exit_code,
+                stderr,
+            } => {
+                write!(
+                    f,
+                    "hook execution failed: {command} (exit_code={exit_code:?}, stderr={stderr})"
+                )
+            }
+            Self::Shutdown => write!(f, "hook execution aborted: shutdown requested"),
+            Self::ParseError { file, reason } => {
+                write!(f, "hook config parse error: {}: {reason}", file.display())
+            }
+        }
+    }
+}
+
+impl std::error::Error for HookError {}
+
+// ---------------------------------------------------------------------------
+// HookRunner (DR1-001)
+// ---------------------------------------------------------------------------
+
+/// Single hook command execution engine.
+///
+/// Uses shlex for command parsing and std::process::Command for execution.
+/// Supports timeout with 2-stage shutdown (DR4-003).
+pub struct HookRunner {
+    shutdown_flag: Arc<AtomicBool>,
+}
+
+impl HookRunner {
+    pub fn new(shutdown_flag: Arc<AtomicBool>) -> Self {
+        Self { shutdown_flag }
+    }
+
+    /// Validate a command string for safety (DR4-001).
+    ///
+    /// (a) Parse with shlex::split
+    /// (b) Reject paths containing ".."
+    /// (c) Resolve relative paths to absolute
+    /// (d) Check existence and executable permission
+    fn validate_command(&self, command: &str) -> Result<Vec<String>, HookError> {
+        let parts = shlex::split(command).ok_or_else(|| HookError::CommandParseFailed {
+            command: command.to_string(),
+            reason: "invalid shell quoting".to_string(),
+        })?;
+
+        if parts.is_empty() {
+            return Err(HookError::CommandParseFailed {
+                command: command.to_string(),
+                reason: "empty command".to_string(),
+            });
+        }
+
+        let cmd_path = &parts[0];
+
+        // Reject paths containing ".." (path traversal prevention)
+        if cmd_path.contains("..") {
+            return Err(HookError::CommandNotFound {
+                command: command.to_string(),
+            });
+        }
+
+        // Resolve relative paths
+        let resolved = if std::path::Path::new(cmd_path).is_relative() {
+            // For relative paths that look like bare commands (no / or .), skip existence check
+            // as they may be in PATH
+            if !cmd_path.contains('/') {
+                return Ok(parts);
+            }
+            let cwd = std::env::current_dir().unwrap_or_default();
+            cwd.join(cmd_path)
+        } else {
+            PathBuf::from(cmd_path)
+        };
+
+        // Check existence
+        if !resolved.exists() {
+            return Err(HookError::CommandNotFound {
+                command: command.to_string(),
+            });
+        }
+
+        // Check executable permission (Unix)
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            if let Ok(metadata) = resolved.metadata() {
+                let permissions = metadata.permissions();
+                if permissions.mode() & 0o111 == 0 {
+                    return Err(HookError::PermissionDenied {
+                        command: command.to_string(),
+                        path: resolved.display().to_string(),
+                    });
+                }
+            }
+        }
+
+        Ok(parts)
+    }
+
+    /// Execute a single hook command (DR4-003, DR4-011, DR4-012).
+    ///
+    /// - Parses command with shlex
+    /// - Sends stdin_data as JSON to child process
+    /// - Applies timeout with 2-stage shutdown (SIGTERM -> wait -> SIGKILL)
+    /// - Inherits parent environment variables (intentional design)
+    pub fn execute(
+        &self,
+        command: &str,
+        stdin_data: &[u8],
+        timeout_ms: u64,
+        on_timeout: &str,
+    ) -> Result<HookOutcome, HookError> {
+        // Check shutdown before starting
+        if self.shutdown_flag.load(Ordering::Relaxed) {
+            return Err(HookError::Shutdown);
+        }
+
+        let parts = self.validate_command(command)?;
+        let (cmd, args) = parts.split_first().unwrap(); // validated non-empty above
+
+        let mut child = std::process::Command::new(cmd)
+            .args(args)
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .map_err(|e| {
+                if e.kind() == std::io::ErrorKind::NotFound {
+                    HookError::CommandNotFound {
+                        command: command.to_string(),
+                    }
+                } else if e.kind() == std::io::ErrorKind::PermissionDenied {
+                    HookError::PermissionDenied {
+                        command: command.to_string(),
+                        path: cmd.to_string(),
+                    }
+                } else {
+                    HookError::ExecutionFailed {
+                        command: command.to_string(),
+                        exit_code: None,
+                        stderr: e.to_string(),
+                    }
+                }
+            })?;
+
+        // Write stdin data
+        if let Some(mut stdin) = child.stdin.take() {
+            use std::io::Write;
+            let _ = stdin.write_all(stdin_data);
+            // Drop stdin to signal EOF
+        }
+
+        // Wait with timeout
+        let deadline = std::time::Instant::now() + std::time::Duration::from_millis(timeout_ms);
+        let poll_interval = std::time::Duration::from_millis(50);
+
+        loop {
+            // Check shutdown
+            if self.shutdown_flag.load(Ordering::Relaxed) {
+                self.kill_child(&mut child);
+                return Err(HookError::Shutdown);
+            }
+
+            match child.try_wait() {
+                Ok(Some(status)) => {
+                    // Process finished
+                    return self.process_child_output(command, status, &mut child);
+                }
+                Ok(None) => {
+                    // Still running, check timeout
+                    if std::time::Instant::now() >= deadline {
+                        // Timeout: 2-stage shutdown (DR4-003)
+                        self.kill_child(&mut child);
+
+                        return if on_timeout == "block" {
+                            Ok(HookOutcome::Block {
+                                reason: format!("hook timed out after {timeout_ms}ms: {command}"),
+                                exit_code: -1,
+                            })
+                        } else {
+                            Err(HookError::Timeout {
+                                command: command.to_string(),
+                                timeout_ms,
+                            })
+                        };
+                    }
+                    std::thread::sleep(poll_interval);
+                }
+                Err(e) => {
+                    return Err(HookError::ExecutionFailed {
+                        command: command.to_string(),
+                        exit_code: None,
+                        stderr: e.to_string(),
+                    });
+                }
+            }
+        }
+    }
+
+    /// Kill a child process with 2-stage shutdown (DR4-003).
+    /// SIGTERM -> wait 1s -> SIGKILL -> wait to reap zombie.
+    fn kill_child(&self, child: &mut std::process::Child) {
+        #[cfg(unix)]
+        {
+            // Send SIGTERM via the `kill` command (DR4-003).
+            let pid = child.id();
+            let _ = std::process::Command::new("kill")
+                .args(["-TERM", &pid.to_string()])
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .status();
+
+            // Wait up to 1 second for graceful shutdown
+            let grace_deadline = std::time::Instant::now() + std::time::Duration::from_secs(1);
+            loop {
+                match child.try_wait() {
+                    Ok(Some(_)) => return, // Process exited
+                    Ok(None) => {
+                        if std::time::Instant::now() >= grace_deadline {
+                            break; // Grace period expired
+                        }
+                        std::thread::sleep(std::time::Duration::from_millis(50));
+                    }
+                    Err(_) => break,
+                }
+            }
+
+            // SIGKILL if still running
+            let _ = child.kill();
+            let _ = child.wait(); // Reap zombie
+        }
+
+        #[cfg(not(unix))]
+        {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+    }
+
+    /// Process child stdout/stderr and determine outcome.
+    fn process_child_output(
+        &self,
+        command: &str,
+        status: std::process::ExitStatus,
+        child: &mut std::process::Child,
+    ) -> Result<HookOutcome, HookError> {
+        // Read stdout (for outcome parsing)
+        let stdout = child
+            .stdout
+            .take()
+            .map(|mut s| {
+                let mut buf = String::new();
+                use std::io::Read;
+                let _ = s.read_to_string(&mut buf);
+                buf
+            })
+            .unwrap_or_default();
+
+        // Read stderr (for logging, capped at MAX_STDERR_BYTES)
+        let stderr = child
+            .stderr
+            .take()
+            .map(|mut s| {
+                let mut buf = vec![0u8; MAX_STDERR_BYTES + 1];
+                use std::io::Read;
+                let n = s.read(&mut buf).unwrap_or(0);
+                buf.truncate(n.min(MAX_STDERR_BYTES));
+                String::from_utf8_lossy(&buf).to_string()
+            })
+            .unwrap_or_default();
+
+        if !stderr.is_empty() {
+            tracing::warn!(command, stderr = %stderr, "hook stderr output");
+        }
+
+        if status.success() {
+            // Try to parse stdout as JSON for block outcome
+            if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&stdout)
+                && let Some(decision) = parsed.get("decision").and_then(|d| d.as_str())
+                && decision == "block"
+            {
+                let reason = parsed
+                    .get("reason")
+                    .and_then(|r| r.as_str())
+                    .unwrap_or("blocked by hook")
+                    .to_string();
+                return Ok(HookOutcome::Block {
+                    reason,
+                    exit_code: 0,
+                });
+            }
+            Ok(HookOutcome::Continue)
+        } else {
+            let exit_code = status.code();
+            // Non-zero exit code with exit_code=2 means explicit block
+            if exit_code == Some(2) {
+                let reason = if stdout.trim().is_empty() {
+                    format!("blocked by hook (exit code 2): {command}")
+                } else {
+                    stdout.trim().to_string()
+                };
+                return Ok(HookOutcome::Block {
+                    reason,
+                    exit_code: 2,
+                });
+            }
+            Err(HookError::ExecutionFailed {
+                command: command.to_string(),
+                exit_code,
+                stderr,
+            })
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// HooksEngine (DR1-001, DR1-003)
+// ---------------------------------------------------------------------------
+
+/// Orchestrates hook execution for all lifecycle points.
+pub struct HooksEngine {
+    config: HooksConfig,
+    runner: HookRunner,
+}
+
+impl HooksEngine {
+    pub fn new(config: HooksConfig, shutdown_flag: Arc<AtomicBool>) -> Self {
+        Self {
+            config,
+            runner: HookRunner::new(shutdown_flag),
+        }
+    }
+
+    /// Run PreToolUse hooks (DR1-003).
+    ///
+    /// Returns Block on first blocking hook. Timeout with on_timeout="block"
+    /// also produces a Block outcome (DR4-002).
+    pub fn run_pre_tool_use(&self, event: PreToolUseEvent) -> Result<PreToolUseOutcome, HookError> {
+        let entries = self.config.get_entries(&HookPoint::PreToolUse);
+        let entries = Self::capped_entries(entries);
+
+        let stdin_data = serde_json::to_vec(&event).unwrap_or_default();
+
+        for entry in entries {
+            match self.runner.execute(
+                &entry.command,
+                &stdin_data,
+                entry.timeout_ms,
+                &entry.on_timeout,
+            ) {
+                Ok(HookOutcome::Continue) => continue,
+                Ok(HookOutcome::Block { reason, exit_code }) => {
+                    return Ok(PreToolUseOutcome::Block { reason, exit_code });
+                }
+                Err(HookError::Timeout {
+                    command,
+                    timeout_ms,
+                }) => {
+                    // on_timeout=="continue" path (Timeout error only raised for continue)
+                    tracing::warn!(command, timeout_ms, "PreToolUse hook timed out, continuing");
+                    continue;
+                }
+                Err(HookError::Shutdown) => return Err(HookError::Shutdown),
+                Err(err) => {
+                    // Soft-fail: log and continue
+                    tracing::warn!("PreToolUse hook error: {err}");
+                    continue;
+                }
+            }
+        }
+
+        Ok(PreToolUseOutcome::Continue)
+    }
+
+    /// Run PostToolUse hooks (DR1-003, soft-fail).
+    pub fn run_post_tool_use(&self, event: PostToolUseEvent) -> Result<(), HookError> {
+        let stdin_data = serde_json::to_vec(&event).unwrap_or_default();
+        self.run_soft_fail_hooks(&HookPoint::PostToolUse, &stdin_data, "PostToolUse")
+    }
+
+    /// Run PreCompact hooks (DR1-003, soft-fail).
+    pub fn run_pre_compact(&self, event: PreCompactEvent) -> Result<(), HookError> {
+        let stdin_data = serde_json::to_vec(&event).unwrap_or_default();
+        self.run_soft_fail_hooks(&HookPoint::PreCompact, &stdin_data, "PreCompact")
+    }
+
+    /// Run PostSession hooks (DR1-003, soft-fail).
+    pub fn run_post_session(&self, event: PostSessionEvent) -> Result<(), HookError> {
+        let stdin_data = serde_json::to_vec(&event).unwrap_or_default();
+        self.run_soft_fail_hooks(&HookPoint::PostSession, &stdin_data, "PostSession")
+    }
+
+    /// Run all entries for a hook point with soft-fail semantics.
+    ///
+    /// Errors are logged but not propagated (soft-fail pattern).
+    /// Used by PostToolUse, PreCompact, and PostSession hooks.
+    fn run_soft_fail_hooks(
+        &self,
+        point: &HookPoint,
+        stdin_data: &[u8],
+        label: &str,
+    ) -> Result<(), HookError> {
+        let entries = Self::capped_entries(self.config.get_entries(point));
+
+        for entry in entries {
+            if let Err(err) = self.runner.execute(
+                &entry.command,
+                stdin_data,
+                entry.timeout_ms,
+                &entry.on_timeout,
+            ) {
+                tracing::warn!("{label} hook error: {err}");
+            }
+        }
+        Ok(())
+    }
+
+    /// Cap entries to MAX_ENTRIES_PER_HOOK_POINT (DR4-007).
+    fn capped_entries(entries: &[HookEntry]) -> &[HookEntry] {
+        if entries.len() > MAX_ENTRIES_PER_HOOK_POINT {
+            tracing::warn!(
+                count = entries.len(),
+                max = MAX_ENTRIES_PER_HOOK_POINT,
+                "hook entries exceed limit, using first {} entries",
+                MAX_ENTRIES_PER_HOOK_POINT
+            );
+            &entries[..MAX_ENTRIES_PER_HOOK_POINT]
+        } else {
+            entries
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_hook_point_serde() {
+        let json = r#""PreToolUse""#;
+        let point: HookPoint = serde_json::from_str(json).unwrap();
+        assert_eq!(point, HookPoint::PreToolUse);
+
+        let json = r#""PostSession""#;
+        let point: HookPoint = serde_json::from_str(json).unwrap();
+        assert_eq!(point, HookPoint::PostSession);
+    }
+
+    #[test]
+    fn test_hooks_config_parse_full() {
+        let json = r#"{
+            "hooks": {
+                "PreToolUse": [
+                    { "command": "/usr/bin/test", "timeout_ms": 3000 }
+                ],
+                "PostToolUse": [],
+                "PreCompact": [],
+                "PostSession": [
+                    { "command": "/usr/bin/cleanup", "timeout_ms": 10000 }
+                ]
+            }
+        }"#;
+        let config: HooksConfig = serde_json::from_str(json).unwrap();
+        assert!(!config.is_empty());
+        assert_eq!(config.get_entries(&HookPoint::PreToolUse).len(), 1);
+        assert_eq!(config.get_entries(&HookPoint::PostToolUse).len(), 0);
+        assert_eq!(config.get_entries(&HookPoint::PostSession).len(), 1);
+    }
+
+    #[test]
+    fn test_hooks_config_empty() {
+        let json = r#"{ "hooks": {} }"#;
+        let config: HooksConfig = serde_json::from_str(json).unwrap();
+        assert!(config.is_empty());
+    }
+
+    #[test]
+    fn test_hooks_config_all_empty_vecs() {
+        let json = r#"{ "hooks": { "PreToolUse": [], "PostSession": [] } }"#;
+        let config: HooksConfig = serde_json::from_str(json).unwrap();
+        assert!(config.is_empty());
+    }
+
+    #[test]
+    fn test_hook_entry_defaults() {
+        let json = r#"{ "command": "/usr/bin/test" }"#;
+        let entry: HookEntry = serde_json::from_str(json).unwrap();
+        assert_eq!(entry.timeout_ms, 5000);
+        assert_eq!(entry.on_timeout, "continue");
+    }
+
+    #[test]
+    fn test_hook_entry_timeout_alias() {
+        let json = r#"{ "command": "/usr/bin/test", "timeout": 3000 }"#;
+        let entry: HookEntry = serde_json::from_str(json).unwrap();
+        assert_eq!(entry.timeout_ms, 3000);
+    }
+
+    #[test]
+    fn test_hook_entry_on_timeout_block() {
+        let json = r#"{ "command": "/usr/bin/test", "on_timeout": "block" }"#;
+        let entry: HookEntry = serde_json::from_str(json).unwrap();
+        assert_eq!(entry.on_timeout, "block");
+    }
+
+    #[test]
+    fn test_get_entries_missing_point() {
+        let json = r#"{ "hooks": { "PreToolUse": [{ "command": "test" }] } }"#;
+        let config: HooksConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.get_entries(&HookPoint::PostSession).len(), 0);
+    }
+
+    #[test]
+    fn test_hook_error_display() {
+        let err = HookError::Timeout {
+            command: "test.sh".to_string(),
+            timeout_ms: 5000,
+        };
+        assert!(err.to_string().contains("5000ms"));
+        assert!(err.to_string().contains("test.sh"));
+    }
+
+    #[test]
+    fn test_pre_tool_use_event_serialize() {
+        let event = PreToolUseEvent {
+            hook_point: "PreToolUse",
+            tool_name: "file.read".to_string(),
+            tool_input: serde_json::json!({"path": "/tmp/test"}),
+            tool_call_id: "call_1".to_string(),
+        };
+        let json = serde_json::to_string(&event).unwrap();
+        assert!(json.contains("PreToolUse"));
+        assert!(json.contains("file.read"));
+    }
+
+    #[test]
+    fn test_post_session_event_serialize() {
+        let event = PostSessionEvent {
+            hook_point: "PostSession",
+            session_id: "session_123".to_string(),
+            mode: "interactive".to_string(),
+        };
+        let json = serde_json::to_string(&event).unwrap();
+        assert!(json.contains("interactive"));
+    }
+
+    #[test]
+    fn test_pre_tool_use_outcome_variants() {
+        let cont = PreToolUseOutcome::Continue;
+        assert_eq!(cont, PreToolUseOutcome::Continue);
+
+        let block = PreToolUseOutcome::Block {
+            reason: "test".to_string(),
+            exit_code: 2,
+        };
+        if let PreToolUseOutcome::Block { reason, exit_code } = block {
+            assert_eq!(reason, "test");
+            assert_eq!(exit_code, 2);
+        } else {
+            panic!("expected Block");
+        }
+    }
+
+    #[test]
+    fn test_capped_entries() {
+        let entries: Vec<HookEntry> = (0..20)
+            .map(|i| HookEntry {
+                command: format!("cmd_{i}"),
+                timeout_ms: 5000,
+                on_timeout: "continue".to_string(),
+            })
+            .collect();
+        let capped = HooksEngine::capped_entries(&entries);
+        assert_eq!(capped.len(), MAX_ENTRIES_PER_HOOK_POINT);
+    }
+
+    #[test]
+    fn test_capped_entries_within_limit() {
+        let entries = vec![HookEntry {
+            command: "test".to_string(),
+            timeout_ms: 5000,
+            on_timeout: "continue".to_string(),
+        }];
+        let capped = HooksEngine::capped_entries(&entries);
+        assert_eq!(capped.len(), 1);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod app;
 pub mod config;
 pub mod contracts;
 pub mod extensions;
+pub mod hooks;
 pub mod logging;
 pub mod mcp;
 pub mod metrics;

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -159,6 +159,12 @@ impl SessionRecord {
         self.touch();
     }
 
+    /// Check whether auto-compaction should run (DR3-001).
+    /// Zero-guard: returns false if auto_compact_threshold == 0.
+    pub fn should_compact(&self) -> bool {
+        self.auto_compact_threshold > 0 && self.messages.len() > self.auto_compact_threshold
+    }
+
     /// Run auto-compaction if message count exceeds the threshold.
     /// Called at turn boundaries (before flush) to avoid per-message overhead.
     pub fn compact_if_needed(&mut self) -> bool {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -29,6 +29,7 @@ pub fn build_config_in(root: PathBuf) -> EffectiveConfig {
     config.paths.session_file = config.paths.session_dir.join("session.json");
     config.paths.logs_dir = root.join(".anvil").join("logs");
     config.paths.mcp_config_file = root.join(".anvil").join("mcp.json");
+    config.paths.hooks_config_file = root.join(".anvil").join("hooks.json");
     config
 }
 

--- a/tests/hooks_system.rs
+++ b/tests/hooks_system.rs
@@ -208,6 +208,7 @@ fn hook_runner_execute_block_via_json_stdout() {
         writeln!(f, "#!/bin/sh").unwrap();
         writeln!(f, "echo 'blocked by security policy'").unwrap();
         writeln!(f, "exit 2").unwrap();
+        f.sync_all().unwrap();
     }
     #[cfg(unix)]
     {
@@ -243,6 +244,7 @@ fn hook_runner_execute_block_via_json() {
         )
         .unwrap();
         writeln!(f, "exit 0").unwrap();
+        f.sync_all().unwrap();
     }
     #[cfg(unix)]
     {
@@ -377,6 +379,7 @@ fn hook_runner_stdin_receives_json() {
         let mut f = std::fs::File::create(&script_path).unwrap();
         writeln!(f, "#!/bin/sh").unwrap();
         writeln!(f, "cat > {}", output_file.display()).unwrap();
+        f.sync_all().unwrap();
     }
     #[cfg(unix)]
     {
@@ -752,6 +755,7 @@ fn create_block_script(dir: &std::path::Path) -> PathBuf {
         writeln!(f, "#!/bin/sh").unwrap();
         writeln!(f, "echo 'blocked by hook'").unwrap();
         writeln!(f, "exit 2").unwrap();
+        f.sync_all().unwrap();
     }
     #[cfg(unix)]
     {

--- a/tests/hooks_system.rs
+++ b/tests/hooks_system.rs
@@ -5,10 +5,31 @@ mod common;
 use anvil::config::load_hooks_config;
 use anvil::hooks::*;
 use std::collections::HashMap;
-use std::io::Write;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
+
+/// Helper: write a shell script atomically, wait for the kernel to release it,
+/// then set the executable bit.  The short sleep avoids ETXTBSY on Linux CI.
+#[cfg(unix)]
+fn create_test_script(dir: &Path, name: &str, body: &str) -> PathBuf {
+    use std::os::unix::fs::PermissionsExt;
+    let path = dir.join(name);
+    let content = format!("#!/bin/sh\n{body}\n");
+    std::fs::write(&path, content).unwrap();
+    // Ensure the file is fully flushed and closed before chmod + exec
+    std::thread::sleep(std::time::Duration::from_millis(10));
+    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
+    path
+}
+
+#[cfg(not(unix))]
+fn create_test_script(dir: &Path, name: &str, body: &str) -> PathBuf {
+    let path = dir.join(name);
+    let content = format!("#!/bin/sh\n{body}\n");
+    std::fs::write(&path, content).unwrap();
+    path
+}
 
 // ---------------------------------------------------------------------------
 // HooksConfig parsing tests
@@ -202,19 +223,11 @@ fn hook_runner_execute_block_via_json_stdout() {
 
     // Test block via exit code 2
     let tmpdir = tempfile::tempdir().unwrap();
-    let script_path = tmpdir.path().join("block.sh");
-    {
-        let mut f = std::fs::File::create(&script_path).unwrap();
-        writeln!(f, "#!/bin/sh").unwrap();
-        writeln!(f, "echo 'blocked by security policy'").unwrap();
-        writeln!(f, "exit 2").unwrap();
-        f.sync_all().unwrap();
-    }
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755)).unwrap();
-    }
+    let script_path = create_test_script(
+        tmpdir.path(),
+        "block.sh",
+        "echo 'blocked by security policy'\nexit 2",
+    );
 
     let result = runner
         .execute(script_path.to_str().unwrap(), b"{}", 5000, "continue")
@@ -234,23 +247,12 @@ fn hook_runner_execute_block_via_json() {
     let runner = HookRunner::new(shutdown);
 
     let tmpdir = tempfile::tempdir().unwrap();
-    let script_path = tmpdir.path().join("block_json.sh");
-    {
-        let mut f = std::fs::File::create(&script_path).unwrap();
-        writeln!(f, "#!/bin/sh").unwrap();
-        writeln!(
-            f,
-            r#"echo '{{"decision":"block","reason":"forbidden tool"}}'"#
-        )
-        .unwrap();
-        writeln!(f, "exit 0").unwrap();
-        f.sync_all().unwrap();
-    }
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755)).unwrap();
-    }
+    let script_path = create_test_script(
+        tmpdir.path(),
+        "block_json.sh",
+        r#"echo '{"decision":"block","reason":"forbidden tool"}'
+exit 0"#,
+    );
 
     let result = runner
         .execute(script_path.to_str().unwrap(), b"{}", 5000, "continue")
@@ -374,18 +376,11 @@ fn hook_runner_stdin_receives_json() {
 
     let tmpdir = tempfile::tempdir().unwrap();
     let output_file = tmpdir.path().join("stdin_output.txt");
-    let script_path = tmpdir.path().join("read_stdin.sh");
-    {
-        let mut f = std::fs::File::create(&script_path).unwrap();
-        writeln!(f, "#!/bin/sh").unwrap();
-        writeln!(f, "cat > {}", output_file.display()).unwrap();
-        f.sync_all().unwrap();
-    }
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755)).unwrap();
-    }
+    let script_path = create_test_script(
+        tmpdir.path(),
+        "read_stdin.sh",
+        &format!("cat > {}", output_file.display()),
+    );
 
     let input_json = r#"{"tool_name":"file.read","tool_call_id":"call_001"}"#;
     let result = runner.execute(
@@ -749,18 +744,5 @@ fn make_config_with_command(point_name: &str, command: &str) -> HooksConfig {
 }
 
 fn create_block_script(dir: &std::path::Path) -> PathBuf {
-    let script_path = dir.join("block_hook.sh");
-    {
-        let mut f = std::fs::File::create(&script_path).unwrap();
-        writeln!(f, "#!/bin/sh").unwrap();
-        writeln!(f, "echo 'blocked by hook'").unwrap();
-        writeln!(f, "exit 2").unwrap();
-        f.sync_all().unwrap();
-    }
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755)).unwrap();
-    }
-    script_path
+    create_test_script(dir, "block_hook.sh", "echo 'blocked by hook'\nexit 2")
 }

--- a/tests/hooks_system.rs
+++ b/tests/hooks_system.rs
@@ -1,0 +1,762 @@
+//! Integration tests for the hooks lifecycle hook system (Issue #25).
+
+mod common;
+
+use anvil::config::load_hooks_config;
+use anvil::hooks::*;
+use std::collections::HashMap;
+use std::io::Write;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
+
+// ---------------------------------------------------------------------------
+// HooksConfig parsing tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn hooks_config_parse_full_json() {
+    let json = r#"{
+        "hooks": {
+            "PreToolUse": [
+                { "command": "/usr/bin/validator", "timeout_ms": 3000 }
+            ],
+            "PostToolUse": [],
+            "PreCompact": [],
+            "PostSession": [
+                { "command": "/usr/bin/cleanup", "timeout_ms": 10000 }
+            ]
+        }
+    }"#;
+    let config: HooksConfig = serde_json::from_str(json).unwrap();
+    assert!(!config.is_empty());
+    assert_eq!(config.get_entries(&HookPoint::PreToolUse).len(), 1);
+    assert_eq!(config.get_entries(&HookPoint::PostToolUse).len(), 0);
+    assert_eq!(config.get_entries(&HookPoint::PostSession).len(), 1);
+    assert_eq!(
+        config.get_entries(&HookPoint::PreToolUse)[0].timeout_ms,
+        3000
+    );
+}
+
+#[test]
+fn hooks_config_parse_empty() {
+    let json = r#"{ "hooks": {} }"#;
+    let config: HooksConfig = serde_json::from_str(json).unwrap();
+    assert!(config.is_empty());
+}
+
+#[test]
+fn hooks_config_is_empty_with_empty_vecs() {
+    let json = r#"{ "hooks": { "PreToolUse": [], "PostSession": [] } }"#;
+    let config: HooksConfig = serde_json::from_str(json).unwrap();
+    assert!(config.is_empty());
+}
+
+#[test]
+fn hooks_config_get_entries_missing_point() {
+    let json = r#"{ "hooks": { "PreToolUse": [{ "command": "test" }] } }"#;
+    let config: HooksConfig = serde_json::from_str(json).unwrap();
+    assert!(config.get_entries(&HookPoint::PostSession).is_empty());
+}
+
+#[test]
+fn hook_entry_default_timeout_and_on_timeout() {
+    let json = r#"{ "command": "/usr/bin/test" }"#;
+    let entry: HookEntry = serde_json::from_str(json).unwrap();
+    assert_eq!(entry.timeout_ms, 5000);
+    assert_eq!(entry.on_timeout, "continue");
+}
+
+#[test]
+fn hook_entry_timeout_alias() {
+    let json = r#"{ "command": "/usr/bin/test", "timeout": 3000 }"#;
+    let entry: HookEntry = serde_json::from_str(json).unwrap();
+    assert_eq!(entry.timeout_ms, 3000);
+}
+
+#[test]
+fn hook_entry_on_timeout_block() {
+    let json = r#"{ "command": "/usr/bin/test", "on_timeout": "block" }"#;
+    let entry: HookEntry = serde_json::from_str(json).unwrap();
+    assert_eq!(entry.on_timeout, "block");
+}
+
+#[test]
+fn hook_point_serde_roundtrip() {
+    let points = vec![
+        HookPoint::PreToolUse,
+        HookPoint::PostToolUse,
+        HookPoint::PreCompact,
+        HookPoint::PostSession,
+    ];
+    for point in points {
+        let json = serde_json::to_string(&point).unwrap();
+        let parsed: HookPoint = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, point);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Event serialization tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn pre_tool_use_event_serializes_correctly() {
+    let event = PreToolUseEvent {
+        hook_point: "PreToolUse",
+        tool_name: "file.read".to_string(),
+        tool_input: serde_json::json!({"path": "/tmp/test.txt"}),
+        tool_call_id: "call_001".to_string(),
+    };
+    let json = serde_json::to_string(&event).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(parsed["hook_point"], "PreToolUse");
+    assert_eq!(parsed["tool_name"], "file.read");
+    assert_eq!(parsed["tool_input"]["path"], "/tmp/test.txt");
+}
+
+#[test]
+fn post_tool_use_event_serializes_correctly() {
+    let event = PostToolUseEvent {
+        hook_point: "PostToolUse",
+        tool_name: "shell.exec".to_string(),
+        tool_input: serde_json::json!({"command": "ls"}),
+        tool_call_id: "call_002".to_string(),
+        tool_result: HookToolResult {
+            status: "completed".to_string(),
+            summary: "command executed successfully".to_string(),
+        },
+    };
+    let json = serde_json::to_string(&event).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(parsed["tool_result"]["status"], "completed");
+}
+
+#[test]
+fn pre_compact_event_serializes_correctly() {
+    let event = PreCompactEvent {
+        hook_point: "PreCompact",
+        session_id: "session_abc".to_string(),
+        trigger: "auto".to_string(),
+        message_count: 100,
+    };
+    let json = serde_json::to_string(&event).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(parsed["trigger"], "auto");
+    assert_eq!(parsed["message_count"], 100);
+}
+
+#[test]
+fn post_session_event_mode_string() {
+    let event = PostSessionEvent {
+        hook_point: "PostSession",
+        session_id: "session_xyz".to_string(),
+        mode: "interactive".to_string(),
+    };
+    let json = serde_json::to_string(&event).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(parsed["mode"], "interactive");
+
+    let event_non = PostSessionEvent {
+        hook_point: "PostSession",
+        session_id: "session_xyz".to_string(),
+        mode: "non-interactive".to_string(),
+    };
+    let json = serde_json::to_string(&event_non).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(parsed["mode"], "non-interactive");
+}
+
+// ---------------------------------------------------------------------------
+// HookRunner tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn hook_runner_execute_echo_continue() {
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let runner = HookRunner::new(shutdown);
+
+    // echo outputs nothing meaningful -> Continue
+    let result = runner.execute("echo hello", b"{}", 5000, "continue");
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), HookOutcome::Continue);
+}
+
+#[test]
+fn hook_runner_execute_block_via_json_stdout() {
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let runner = HookRunner::new(shutdown);
+
+    // Use printf to output a block decision JSON
+    let result = runner.execute(
+        r#"printf '{"decision":"block","reason":"test block"}'"#,
+        b"{}",
+        5000,
+        "continue",
+    );
+    // printf is not directly available via shlex; use sh -c or a script
+    // Since we use shlex parsing (not shell), we need a different approach
+    // Let's test with a simple exit code 2 for block
+    let _ = result; // printf may not work via shlex
+
+    // Test block via exit code 2
+    let tmpdir = tempfile::tempdir().unwrap();
+    let script_path = tmpdir.path().join("block.sh");
+    {
+        let mut f = std::fs::File::create(&script_path).unwrap();
+        writeln!(f, "#!/bin/sh").unwrap();
+        writeln!(f, "echo 'blocked by security policy'").unwrap();
+        writeln!(f, "exit 2").unwrap();
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
+
+    let result = runner
+        .execute(script_path.to_str().unwrap(), b"{}", 5000, "continue")
+        .unwrap();
+    assert_eq!(
+        result,
+        HookOutcome::Block {
+            reason: "blocked by security policy".to_string(),
+            exit_code: 2,
+        }
+    );
+}
+
+#[test]
+fn hook_runner_execute_block_via_json() {
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let runner = HookRunner::new(shutdown);
+
+    let tmpdir = tempfile::tempdir().unwrap();
+    let script_path = tmpdir.path().join("block_json.sh");
+    {
+        let mut f = std::fs::File::create(&script_path).unwrap();
+        writeln!(f, "#!/bin/sh").unwrap();
+        writeln!(
+            f,
+            r#"echo '{{"decision":"block","reason":"forbidden tool"}}'"#
+        )
+        .unwrap();
+        writeln!(f, "exit 0").unwrap();
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
+
+    let result = runner
+        .execute(script_path.to_str().unwrap(), b"{}", 5000, "continue")
+        .unwrap();
+    assert_eq!(
+        result,
+        HookOutcome::Block {
+            reason: "forbidden tool".to_string(),
+            exit_code: 0,
+        }
+    );
+}
+
+#[test]
+fn hook_runner_command_not_found() {
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let runner = HookRunner::new(shutdown);
+
+    let result = runner.execute("/nonexistent/path/to/hook", b"{}", 5000, "continue");
+    assert!(result.is_err());
+    match result.unwrap_err() {
+        HookError::CommandNotFound { .. } => {}
+        other => panic!("expected CommandNotFound, got: {other:?}"),
+    }
+}
+
+#[test]
+fn hook_runner_command_parse_failed() {
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let runner = HookRunner::new(shutdown);
+
+    // Unterminated quote
+    let result = runner.execute("echo 'unterminated", b"{}", 5000, "continue");
+    assert!(result.is_err());
+    match result.unwrap_err() {
+        HookError::CommandParseFailed { .. } => {}
+        other => panic!("expected CommandParseFailed, got: {other:?}"),
+    }
+}
+
+#[test]
+fn hook_runner_path_traversal_rejected() {
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let runner = HookRunner::new(shutdown);
+
+    let result = runner.execute("../../../etc/passwd", b"{}", 5000, "continue");
+    assert!(result.is_err());
+    match result.unwrap_err() {
+        HookError::CommandNotFound { .. } => {}
+        other => panic!("expected CommandNotFound, got: {other:?}"),
+    }
+}
+
+#[test]
+fn hook_runner_timeout_continue() {
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let runner = HookRunner::new(shutdown);
+
+    let result = runner.execute("sleep 60", b"{}", 200, "continue");
+    assert!(result.is_err());
+    match result.unwrap_err() {
+        HookError::Timeout { timeout_ms, .. } => assert_eq!(timeout_ms, 200),
+        other => panic!("expected Timeout, got: {other:?}"),
+    }
+}
+
+#[test]
+fn hook_runner_timeout_block() {
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let runner = HookRunner::new(shutdown);
+
+    let result = runner.execute("sleep 60", b"{}", 200, "block");
+    assert!(result.is_ok());
+    match result.unwrap() {
+        HookOutcome::Block { reason, .. } => {
+            assert!(reason.contains("timed out"));
+        }
+        other => panic!("expected Block, got: {other:?}"),
+    }
+}
+
+#[test]
+fn hook_runner_shutdown_flag() {
+    let shutdown = Arc::new(AtomicBool::new(true));
+    let runner = HookRunner::new(shutdown);
+
+    let result = runner.execute("echo hello", b"{}", 5000, "continue");
+    assert!(result.is_err());
+    match result.unwrap_err() {
+        HookError::Shutdown => {}
+        other => panic!("expected Shutdown, got: {other:?}"),
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn hook_runner_permission_denied() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let tmpdir = tempfile::tempdir().unwrap();
+    let script_path = tmpdir.path().join("no_exec.sh");
+    std::fs::write(&script_path, "#!/bin/sh\necho hello").unwrap();
+    // Set to no execute permission
+    std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let runner = HookRunner::new(shutdown);
+
+    let result = runner.execute(script_path.to_str().unwrap(), b"{}", 5000, "continue");
+    assert!(result.is_err());
+    match result.unwrap_err() {
+        HookError::PermissionDenied { .. } => {}
+        other => panic!("expected PermissionDenied, got: {other:?}"),
+    }
+}
+
+#[test]
+fn hook_runner_stdin_receives_json() {
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let runner = HookRunner::new(shutdown);
+
+    let tmpdir = tempfile::tempdir().unwrap();
+    let output_file = tmpdir.path().join("stdin_output.txt");
+    let script_path = tmpdir.path().join("read_stdin.sh");
+    {
+        let mut f = std::fs::File::create(&script_path).unwrap();
+        writeln!(f, "#!/bin/sh").unwrap();
+        writeln!(f, "cat > {}", output_file.display()).unwrap();
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
+
+    let input_json = r#"{"tool_name":"file.read","tool_call_id":"call_001"}"#;
+    let result = runner.execute(
+        script_path.to_str().unwrap(),
+        input_json.as_bytes(),
+        5000,
+        "continue",
+    );
+    assert!(result.is_ok());
+
+    let captured = std::fs::read_to_string(&output_file).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&captured).unwrap();
+    assert_eq!(parsed["tool_name"], "file.read");
+    assert_eq!(parsed["tool_call_id"], "call_001");
+}
+
+// ---------------------------------------------------------------------------
+// HooksEngine tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn hooks_engine_pre_tool_use_continue() {
+    let config = make_config_with_echo("PreToolUse");
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let engine = HooksEngine::new(config, shutdown);
+
+    let event = PreToolUseEvent {
+        hook_point: "PreToolUse",
+        tool_name: "file.read".to_string(),
+        tool_input: serde_json::json!({}),
+        tool_call_id: "call_1".to_string(),
+    };
+
+    let result = engine.run_pre_tool_use(event).unwrap();
+    assert_eq!(result, PreToolUseOutcome::Continue);
+}
+
+#[test]
+fn hooks_engine_pre_tool_use_block() {
+    let tmpdir = tempfile::tempdir().unwrap();
+    let script_path = create_block_script(tmpdir.path());
+    let config = make_config_with_command("PreToolUse", script_path.to_str().unwrap());
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let engine = HooksEngine::new(config, shutdown);
+
+    let event = PreToolUseEvent {
+        hook_point: "PreToolUse",
+        tool_name: "shell.exec".to_string(),
+        tool_input: serde_json::json!({}),
+        tool_call_id: "call_2".to_string(),
+    };
+
+    let result = engine.run_pre_tool_use(event).unwrap();
+    match result {
+        PreToolUseOutcome::Block { reason, .. } => {
+            assert!(reason.contains("blocked"));
+        }
+        other => panic!("expected Block, got: {other:?}"),
+    }
+}
+
+#[test]
+fn hooks_engine_post_tool_use_soft_fail() {
+    let config = make_config_with_command("PostToolUse", "/nonexistent/hook");
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let engine = HooksEngine::new(config, shutdown);
+
+    let event = PostToolUseEvent {
+        hook_point: "PostToolUse",
+        tool_name: "file.read".to_string(),
+        tool_input: serde_json::json!({}),
+        tool_call_id: "call_3".to_string(),
+        tool_result: HookToolResult {
+            status: "completed".to_string(),
+            summary: "ok".to_string(),
+        },
+    };
+
+    // Should not error even though command doesn't exist (soft-fail)
+    let result = engine.run_post_tool_use(event);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn hooks_engine_pre_compact_soft_fail() {
+    let config = make_config_with_command("PreCompact", "/nonexistent/hook");
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let engine = HooksEngine::new(config, shutdown);
+
+    let event = PreCompactEvent {
+        hook_point: "PreCompact",
+        session_id: "session_1".to_string(),
+        trigger: "auto".to_string(),
+        message_count: 100,
+    };
+
+    let result = engine.run_pre_compact(event);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn hooks_engine_post_session_soft_fail() {
+    let config = make_config_with_command("PostSession", "/nonexistent/hook");
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let engine = HooksEngine::new(config, shutdown);
+
+    let event = PostSessionEvent {
+        hook_point: "PostSession",
+        session_id: "session_1".to_string(),
+        mode: "interactive".to_string(),
+    };
+
+    let result = engine.run_post_session(event);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn hooks_engine_no_entries_returns_continue() {
+    let config: HooksConfig = serde_json::from_str(r#"{ "hooks": {} }"#).unwrap();
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let engine = HooksEngine::new(config, shutdown);
+
+    let event = PreToolUseEvent {
+        hook_point: "PreToolUse",
+        tool_name: "file.read".to_string(),
+        tool_input: serde_json::json!({}),
+        tool_call_id: "call_1".to_string(),
+    };
+
+    let result = engine.run_pre_tool_use(event).unwrap();
+    assert_eq!(result, PreToolUseOutcome::Continue);
+}
+
+// ---------------------------------------------------------------------------
+// load_hooks_config tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn load_hooks_config_file_not_found() {
+    let root = common::unique_test_dir("hooks_notfound");
+    let config = common::build_config_in(root);
+
+    let result = load_hooks_config(&config.paths);
+    assert!(result.is_ok());
+    assert!(result.unwrap().is_none());
+}
+
+#[test]
+fn load_hooks_config_valid_file() {
+    let root = common::unique_test_dir("hooks_valid");
+    std::fs::create_dir_all(root.join(".anvil")).unwrap();
+    std::fs::write(
+        root.join(".anvil").join("hooks.json"),
+        r#"{
+            "hooks": {
+                "PreToolUse": [{ "command": "echo test" }],
+                "PostSession": []
+            }
+        }"#,
+    )
+    .unwrap();
+
+    let config = common::build_config_in(root);
+    let result = load_hooks_config(&config.paths).unwrap();
+    assert!(result.is_some());
+    let hooks = result.unwrap();
+    assert_eq!(hooks.get_entries(&HookPoint::PreToolUse).len(), 1);
+}
+
+#[test]
+fn load_hooks_config_parse_error() {
+    let root = common::unique_test_dir("hooks_parse_err");
+    std::fs::create_dir_all(root.join(".anvil")).unwrap();
+    std::fs::write(root.join(".anvil").join("hooks.json"), "invalid json!!!").unwrap();
+
+    let config = common::build_config_in(root);
+    let result = load_hooks_config(&config.paths);
+    assert!(result.is_err());
+    match result.unwrap_err() {
+        HookError::ParseError { reason, .. } => {
+            assert!(reason.contains("failed to parse"));
+        }
+        other => panic!("expected ParseError, got: {other:?}"),
+    }
+}
+
+#[test]
+fn load_hooks_config_entry_limit() {
+    let root = common::unique_test_dir("hooks_limit");
+    std::fs::create_dir_all(root.join(".anvil")).unwrap();
+
+    // Create 20 entries (exceeding limit of 16)
+    let entries: Vec<String> = (0..20)
+        .map(|i| format!(r#"{{ "command": "echo {i}" }}"#))
+        .collect();
+    let json = format!(
+        r#"{{ "hooks": {{ "PreToolUse": [{}] }} }}"#,
+        entries.join(",")
+    );
+    std::fs::write(root.join(".anvil").join("hooks.json"), json).unwrap();
+
+    let config = common::build_config_in(root);
+    let result = load_hooks_config(&config.paths).unwrap().unwrap();
+    assert_eq!(result.get_entries(&HookPoint::PreToolUse).len(), 16);
+}
+
+// ---------------------------------------------------------------------------
+// SessionRecord.should_compact tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn should_compact_returns_false_when_threshold_zero() {
+    let mut session = anvil::session::SessionRecord::new(PathBuf::from("/tmp/test"));
+    session.auto_compact_threshold = 0;
+    // Add messages
+    for i in 0..100 {
+        session.push_message(anvil::session::SessionMessage::new(
+            anvil::session::MessageRole::User,
+            "test",
+            format!("message {i}"),
+        ));
+    }
+    assert!(!session.should_compact());
+}
+
+#[test]
+fn should_compact_returns_false_below_threshold() {
+    let mut session = anvil::session::SessionRecord::new(PathBuf::from("/tmp/test"));
+    session.auto_compact_threshold = 64;
+    for i in 0..10 {
+        session.push_message(anvil::session::SessionMessage::new(
+            anvil::session::MessageRole::User,
+            "test",
+            format!("message {i}"),
+        ));
+    }
+    assert!(!session.should_compact());
+}
+
+#[test]
+fn should_compact_returns_true_above_threshold() {
+    let mut session = anvil::session::SessionRecord::new(PathBuf::from("/tmp/test"));
+    session.auto_compact_threshold = 5;
+    for i in 0..10 {
+        session.push_message(anvil::session::SessionMessage::new(
+            anvil::session::MessageRole::User,
+            "test",
+            format!("message {i}"),
+        ));
+    }
+    assert!(session.should_compact());
+}
+
+// ---------------------------------------------------------------------------
+// App integration tests (hooks_engine initialization)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn app_initializes_without_hooks_config() {
+    let app = common::build_app();
+    // App should initialize fine without hooks.json
+    assert!(app.session().message_count() == 0 || app.session().message_count() > 0);
+}
+
+#[test]
+fn app_initializes_with_hooks_config() {
+    let root = common::unique_test_dir("hooks_app");
+    std::fs::create_dir_all(root.join(".anvil")).unwrap();
+    std::fs::write(
+        root.join(".anvil").join("hooks.json"),
+        r#"{
+            "hooks": {
+                "PreToolUse": [{ "command": "echo ok" }]
+            }
+        }"#,
+    )
+    .unwrap();
+
+    let app = common::build_app_in(root);
+    // App should initialize with hooks.json
+    assert!(app.session().message_count() == 0 || app.session().message_count() > 0);
+}
+
+#[test]
+fn app_graceful_degradation_on_invalid_hooks_json() {
+    let root = common::unique_test_dir("hooks_invalid");
+    std::fs::create_dir_all(root.join(".anvil")).unwrap();
+    std::fs::write(root.join(".anvil").join("hooks.json"), "not valid json").unwrap();
+
+    // App should still initialize (graceful degradation)
+    let app = common::build_app_in(root);
+    assert!(app.session().message_count() == 0 || app.session().message_count() > 0);
+}
+
+// ---------------------------------------------------------------------------
+// HookError display tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn hook_error_display_variants() {
+    let errors: Vec<HookError> = vec![
+        HookError::CommandParseFailed {
+            command: "cmd".to_string(),
+            reason: "bad quotes".to_string(),
+        },
+        HookError::CommandNotFound {
+            command: "/bad/path".to_string(),
+        },
+        HookError::PermissionDenied {
+            command: "cmd".to_string(),
+            path: "/path".to_string(),
+        },
+        HookError::Timeout {
+            command: "slow".to_string(),
+            timeout_ms: 5000,
+        },
+        HookError::ExecutionFailed {
+            command: "fail".to_string(),
+            exit_code: Some(1),
+            stderr: "error".to_string(),
+        },
+        HookError::Shutdown,
+        HookError::ParseError {
+            file: PathBuf::from("hooks.json"),
+            reason: "bad json".to_string(),
+        },
+    ];
+
+    for err in errors {
+        let display = format!("{err}");
+        assert!(!display.is_empty());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn make_config_with_echo(point_name: &str) -> HooksConfig {
+    make_config_with_command(point_name, "echo ok")
+}
+
+fn make_config_with_command(point_name: &str, command: &str) -> HooksConfig {
+    let point = match point_name {
+        "PreToolUse" => HookPoint::PreToolUse,
+        "PostToolUse" => HookPoint::PostToolUse,
+        "PreCompact" => HookPoint::PreCompact,
+        "PostSession" => HookPoint::PostSession,
+        _ => panic!("unknown hook point: {point_name}"),
+    };
+    let mut hooks = HashMap::new();
+    hooks.insert(
+        point,
+        vec![HookEntry {
+            command: command.to_string(),
+            timeout_ms: 5000,
+            on_timeout: "continue".to_string(),
+        }],
+    );
+    HooksConfig { hooks }
+}
+
+fn create_block_script(dir: &std::path::Path) -> PathBuf {
+    let script_path = dir.join("block_hook.sh");
+    {
+        let mut f = std::fs::File::create(&script_path).unwrap();
+        writeln!(f, "#!/bin/sh").unwrap();
+        writeln!(f, "echo 'blocked by hook'").unwrap();
+        writeln!(f, "exit 2").unwrap();
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
+    script_path
+}


### PR DESCRIPTION
## Summary
- ツール実行前後やセッションイベントにカスタム処理を挟めるライフサイクルフック機構を実装
- PreToolUse, PostToolUse, PreCompact, PostSession の4フックポイントをサポート
- `.anvil/hooks.json` による設定、タイムアウト制御、エントリ数上限（16件）を実装

## Changes
- `src/hooks/mod.rs` (新規): HooksConfig, HookRunner, HooksEngine
- `src/app/agentic.rs`: ツール実行前後にフック呼び出し追加
- `src/app/mod.rs`: HooksEngine統合
- `src/config/mod.rs`: フック設定読み込み
- `tests/hooks_system.rs` (新規): 40件の統合テスト

## Quality
- cargo build: Pass
- cargo clippy --all-targets: Pass (0 warnings)
- cargo test: Pass (561 tests)
- cargo fmt --check: Pass

## Test plan
- [x] PreToolUseフックでツール実行をブロックできる
- [x] PostToolUseフックでツール実行結果を受け取れる
- [x] フックがタイムアウト時にスキップされる
- [x] `.anvil/hooks.json` でフックが設定できる

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)