### PR TITLE
feat: 初回体験/エラーUX改善 (#64)

### DIFF
--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -378,6 +378,14 @@ impl App {
                 {
                     break;
                 }
+                Err(
+                    ref err @ crate::provider::ProviderTurnError::ConnectionRefused(_)
+                    | ref err @ crate::provider::ProviderTurnError::DnsFailure(_)
+                    | ref err @ crate::provider::ProviderTurnError::AuthenticationFailed { .. }
+                    | ref err @ crate::provider::ProviderTurnError::ModelNotFound { .. },
+                ) => {
+                    return Err(AppError::ProviderTurn(err.clone()));
+                }
                 other => {
                     other.map_err(|err| match err {
                         crate::provider::ProviderTurnError::Cancelled => {

--- a/src/app/cli.rs
+++ b/src/app/cli.rs
@@ -5,11 +5,13 @@
 
 use crate::config::{CliArgs, EffectiveConfig, PromptSource};
 use crate::logging::{LogGuard, init_tracing};
-use crate::provider::{ProviderClient, ProviderRuntimeContext, build_local_provider_client};
+use crate::provider::{
+    ProviderClient, ProviderRuntimeContext, ProviderTurnError, build_local_provider_client,
+};
 use crate::session::SessionError;
 use crate::tui::Tui;
 
-use super::{App, AppError, SessionControl, cli_prompt};
+use super::{App, AppError, SessionControl, cli_prompt, error_guidance};
 
 use std::io::{self, BufRead, Read as _, Write};
 use std::sync::Arc;
@@ -115,9 +117,32 @@ fn run_with_config(config: EffectiveConfig) -> Result<(), AppError> {
     let provider = ProviderRuntimeContext::bootstrap(&config)?;
     let provider_client = build_local_provider_client(&config, Arc::clone(&shutdown_flag))?;
 
-    // Health check: warn on failure but continue startup.
-    if let Err(warning) = provider_client.health_check() {
-        eprintln!("\u{26a0} {warning}");
+    // Health check: staged error handling based on error type.
+    match provider_client.health_check() {
+        Ok(()) => {}
+        Err(ref err @ ProviderTurnError::ConnectionRefused(_))
+        | Err(ref err @ ProviderTurnError::DnsFailure(_)) => {
+            eprintln!("Error: {err}");
+            eprintln!("{}", error_guidance(&AppError::ProviderTurn(err.clone())));
+            return Err(AppError::ProviderTurn(err.clone()));
+        }
+        Err(ref err @ ProviderTurnError::AuthenticationFailed { .. }) => {
+            if config.runtime.api_key.is_some() {
+                // api_key configured -> authentication problem -> error exit
+                eprintln!("Error: {err}");
+                eprintln!("Hint: Your API key appears to be invalid. Verify the key.");
+                return Err(AppError::ProviderTurn(err.clone()));
+            } else {
+                // api_key not configured -> LM Studio etc. possibility -> warn and continue
+                eprintln!("Warning: {err}");
+                eprintln!("Hint: If this server requires an API key, set ANVIL_API_KEY.");
+                eprintln!("      If using LM Studio or similar, verify the server URL.");
+            }
+        }
+        Err(ref err) => {
+            // Timeout, ServerError etc. -> warn and continue
+            eprintln!("Warning: {err}");
+        }
     }
 
     let mut app = App::new(config, provider, Arc::clone(&shutdown_flag))?;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -645,6 +645,66 @@ impl App {
                     tui,
                 )
             }
+            Err(ref err @ ProviderTurnError::ConnectionRefused(ref msg)) => {
+                self.record_provider_error(err.clone())?;
+                self.execute_runtime_events(
+                    &[AgentEvent::Failed {
+                        status: "Error. connection refused".to_string(),
+                        error_summary: msg.clone(),
+                        recommended_actions: vec![
+                            "check provider is running (e.g. ollama serve)".to_string(),
+                            "verify provider URL".to_string(),
+                        ],
+                        elapsed_ms: 0,
+                    }],
+                    tui,
+                )
+            }
+            Err(ref err @ ProviderTurnError::DnsFailure(ref msg)) => {
+                self.record_provider_error(err.clone())?;
+                self.execute_runtime_events(
+                    &[AgentEvent::Failed {
+                        status: "Error. DNS resolution failed".to_string(),
+                        error_summary: msg.clone(),
+                        recommended_actions: vec![
+                            "check provider URL for typos".to_string(),
+                            "verify DNS settings and network connectivity".to_string(),
+                        ],
+                        elapsed_ms: 0,
+                    }],
+                    tui,
+                )
+            }
+            Err(ref err @ ProviderTurnError::ModelNotFound { ref model, .. }) => {
+                self.record_provider_error(err.clone())?;
+                self.execute_runtime_events(
+                    &[AgentEvent::Failed {
+                        status: "Error. model not found".to_string(),
+                        error_summary: format!("model '{}' not found", model),
+                        recommended_actions: vec![
+                            format!("download model: ollama pull {}", model),
+                            "list available models: ollama list".to_string(),
+                        ],
+                        elapsed_ms: 0,
+                    }],
+                    tui,
+                )
+            }
+            Err(ref err @ ProviderTurnError::AuthenticationFailed { ref message, .. }) => {
+                self.record_provider_error(err.clone())?;
+                self.execute_runtime_events(
+                    &[AgentEvent::Failed {
+                        status: "Error. authentication failed".to_string(),
+                        error_summary: message.clone(),
+                        recommended_actions: vec![
+                            "check API key: export ANVIL_API_KEY=<key>".to_string(),
+                            "verify provider credentials".to_string(),
+                        ],
+                        elapsed_ms: 0,
+                    }],
+                    tui,
+                )
+            }
             Err(
                 ref err @ ProviderTurnError::Network(ref msg)
                 | ref err @ ProviderTurnError::ServerError {
@@ -1306,17 +1366,48 @@ pub fn error_guidance(err: &AppError) -> String {
             "  - Each entry needs: name, description, prompt"
         )
         .to_string(),
-        AppError::ProviderTurn(turn_err) => {
-            let detail = turn_err.to_string();
-            if detail.contains("timeout") || detail.contains("max-time") {
-                "Hint: the request timed out\n  - Increase timeout: ANVIL_CURL_TIMEOUT=600\n  - Check if the model is responding: ollama ps".to_string()
-            } else if detail.contains("401") || detail.contains("403") || detail.contains("api key")
-            {
-                "Hint: authentication failed\n  - Set your API key: ANVIL_API_KEY=<key>\n  - Check the key format (some providers require 'Bearer ' prefix)".to_string()
-            } else {
-                "Hint: the provider turn failed\n  - Check if the model is available: ollama list\n  - Network issues may cause transient failures — try again".to_string()
+        AppError::ProviderTurn(turn_err) => match turn_err {
+            ProviderTurnError::ConnectionRefused(_) => concat!(
+                "Hint: Connection refused\n",
+                "  - Is the provider running? Try: ollama serve\n",
+                "  - Check URL: --provider-url http://127.0.0.1:11434\n",
+            )
+            .to_string(),
+            ProviderTurnError::DnsFailure(_) => concat!(
+                "Hint: DNS resolution failed\n",
+                "  - Check the provider URL for typos\n",
+                "  - Verify network connectivity\n",
+            )
+            .to_string(),
+            ProviderTurnError::ModelNotFound { model, .. } => format!(
+                "Hint: Model '{}' not found\n\
+                 \x20 - Download it: ollama pull {}\n\
+                 \x20 - List available models: ollama list\n",
+                model, model
+            ),
+            ProviderTurnError::AuthenticationFailed { .. } => concat!(
+                "Hint: Authentication failed\n",
+                "  - Check your API key or server configuration\n",
+                "  - Set API key: export ANVIL_API_KEY=<your-key>\n",
+                "  - API key format: some providers require 'Bearer <key>' prefix\n",
+                "  - IMPORTANT: Never share your API key in error reports or forums\n",
+            )
+            .to_string(),
+            ProviderTurnError::Timeout(_) => concat!(
+                "Hint: Request timed out\n",
+                "  - The provider may be overloaded\n",
+                "  - Try again or use a smaller model\n",
+            )
+            .to_string(),
+            _ => {
+                let detail = turn_err.to_string();
+                if detail.contains("401") || detail.contains("403") || detail.contains("api key") {
+                    "Hint: authentication failed\n  - Set your API key: ANVIL_API_KEY=<key>\n  - Check the key format (some providers require 'Bearer ' prefix)".to_string()
+                } else {
+                    "Hint: the provider turn failed\n  - Check if the model is available: ollama list\n  - Network issues may cause transient failures — try again".to_string()
+                }
             }
-        }
+        },
         _ => String::new(),
     }
 }

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -121,11 +121,15 @@ pub enum ProviderEvent {
 pub enum ProviderTurnError {
     Cancelled,
     Network(String),
+    ConnectionRefused(String),
+    DnsFailure(String),
     ServerError { status_code: u16, message: String },
     ClientError { status_code: u16, message: String },
     Timeout(String),
     Parse(String),
     Backend(String),
+    ModelNotFound { model: String, message: String },
+    AuthenticationFailed { status_code: u16, message: String },
 }
 
 impl ProviderTurnError {
@@ -140,6 +144,16 @@ impl ProviderTurnError {
             Self::Network(_) | Self::ServerError { .. } | Self::Timeout(_)
         )
     }
+
+    /// Returns `true` if this error represents a connection refused condition.
+    pub fn is_connection_refused(&self) -> bool {
+        matches!(self, Self::ConnectionRefused(_))
+    }
+
+    /// Returns `true` if this error represents a DNS failure condition.
+    pub fn is_dns_failure(&self) -> bool {
+        matches!(self, Self::DnsFailure(_))
+    }
 }
 
 /// Classification of provider errors for persistence.
@@ -152,6 +166,10 @@ pub enum ProviderErrorKind {
     Timeout,
     Parse,
     Backend,
+    ConnectionRefused,
+    DnsFailure,
+    ModelNotFound,
+    AuthenticationFailed,
     #[serde(other)]
     Unknown,
 }
@@ -168,6 +186,14 @@ impl std::fmt::Display for ProviderTurnError {
         match self {
             Self::Cancelled => write!(f, "provider turn cancelled"),
             Self::Network(msg) => write!(f, "network error: {msg}"),
+            Self::ConnectionRefused(msg) => {
+                let redacted = redact_secrets(msg);
+                write!(f, "connection refused: {redacted}")
+            }
+            Self::DnsFailure(msg) => {
+                let redacted = redact_secrets(msg);
+                write!(f, "DNS resolution failed: {redacted}")
+            }
             Self::ServerError {
                 status_code,
                 message,
@@ -179,6 +205,17 @@ impl std::fmt::Display for ProviderTurnError {
             Self::Timeout(msg) => write!(f, "timeout: {msg}"),
             Self::Parse(msg) => write!(f, "parse error: {msg}"),
             Self::Backend(message) => write!(f, "provider backend error: {message}"),
+            Self::ModelNotFound { model, message } => {
+                let redacted = redact_secrets(message);
+                write!(f, "model '{model}' not found: {redacted}")
+            }
+            Self::AuthenticationFailed {
+                status_code,
+                message,
+            } => {
+                let redacted = redact_secrets(message);
+                write!(f, "authentication failed ({status_code}): {redacted}")
+            }
         }
     }
 }
@@ -190,11 +227,15 @@ impl From<&ProviderTurnError> for ProviderErrorKind {
         match err {
             ProviderTurnError::Cancelled => Self::Cancelled,
             ProviderTurnError::Network(_) => Self::Network,
+            ProviderTurnError::ConnectionRefused(_) => Self::ConnectionRefused,
+            ProviderTurnError::DnsFailure(_) => Self::DnsFailure,
             ProviderTurnError::ServerError { .. } => Self::ServerError,
             ProviderTurnError::ClientError { .. } => Self::ClientError,
             ProviderTurnError::Timeout(_) => Self::Timeout,
             ProviderTurnError::Parse(_) => Self::Parse,
             ProviderTurnError::Backend(_) => Self::Backend,
+            ProviderTurnError::ModelNotFound { .. } => Self::ModelNotFound,
+            ProviderTurnError::AuthenticationFailed { .. } => Self::AuthenticationFailed,
         }
     }
 }
@@ -268,7 +309,7 @@ impl LocalProviderClient {
     ///
     /// Dispatches to the inner client's `health_check` method.
     /// Returns `Ok(())` on success or a human-readable error message on failure.
-    pub fn health_check(&self) -> Result<(), String> {
+    pub fn health_check(&self) -> Result<(), ProviderTurnError> {
         match self {
             Self::Ollama(client) => client.health_check(),
             Self::OpenAi(client) => client.health_check(),

--- a/src/provider/ollama.rs
+++ b/src/provider/ollama.rs
@@ -3,11 +3,18 @@
 //! Implements the [`ProviderClient`] trait for the Ollama local inference
 //! server via its `/api/chat` endpoint.
 
-use super::transport::{CurlHttpTransport, HttpTransport, RetryTransport};
+use super::transport::{CurlHttpTransport, HttpTransport, RetryTransport, sanitize_error_message};
 use super::{
     AgentEvent, ProviderClient, ProviderEvent, ProviderMessageRole, ProviderTurnError,
     ProviderTurnRequest,
 };
+
+/// Patterns in Ollama error messages that indicate a model is not found.
+///
+/// Ollama error response examples (v0.5.x verified):
+/// {"error":"model 'nonexistent' not found, try pulling it first"}
+/// {"error":"no such model 'invalid-name'"}
+const MODEL_NOT_FOUND_PATTERNS: &[&str] = &["not found", "no such model"];
 use crate::config::EffectiveConfig;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -166,12 +173,9 @@ impl<T: HttpTransport> OllamaProviderClient<T> {
     /// Returns `Ok(())` if the server responds, or an error message string
     /// on failure.  The health check uses the client's configured transport
     /// (which includes [`RetryTransport`] for automatic retry).
-    pub fn health_check(&self) -> Result<(), String> {
+    pub fn health_check(&self) -> Result<(), ProviderTurnError> {
         let url = format!("{}/api/tags", self.base_url.trim_end_matches('/'));
-        match self.transport.get(&url) {
-            Ok(_) => Ok(()),
-            Err(e) => Err(format!("Ollamaに接続できません ({}): {}", self.base_url, e)),
-        }
+        self.transport.get(&url).map(|_| ())
     }
 }
 
@@ -229,7 +233,15 @@ impl<T: HttpTransport> ProviderClient for OllamaProviderClient<T> {
                         if let Ok(value) = serde_json::from_str::<serde_json::Value>(line)
                             && let Some(error) = value.get("error").and_then(|v| v.as_str())
                         {
-                            had_error = Some(ProviderTurnError::Backend(error.to_string()));
+                            if MODEL_NOT_FOUND_PATTERNS.iter().any(|p| error.contains(p)) {
+                                let model = resolved_request.model.clone();
+                                had_error = Some(ProviderTurnError::ModelNotFound {
+                                    model,
+                                    message: sanitize_error_message(error),
+                                });
+                            } else {
+                                had_error = Some(ProviderTurnError::Backend(error.to_string()));
+                            }
                             return;
                         }
                         had_error = Some(ProviderTurnError::Backend(format!(

--- a/src/provider/openai.rs
+++ b/src/provider/openai.rs
@@ -3,7 +3,7 @@
 //! Works with the standard `/v1/chat/completions` endpoint used by
 //! OpenAI, Azure OpenAI, LM Studio, and other compatible servers.
 
-use super::transport::{CurlHttpTransport, HttpTransport, RetryTransport};
+use super::transport::{CurlHttpTransport, HttpTransport, RetryTransport, sanitize_error_message};
 use super::{
     AgentEvent, ImageContent, ProviderClient, ProviderEvent, ProviderTurnError, ProviderTurnRequest,
 };
@@ -147,7 +147,7 @@ impl<T: HttpTransport> OpenAiCompatibleProviderClient<T> {
     /// If an API key is configured, it is sent as an `Authorization` header
     /// (without `Bearer` prefix, matching the existing code pattern in
     /// `send_chat_request`).
-    pub fn health_check(&self) -> Result<(), String> {
+    pub fn health_check(&self) -> Result<(), ProviderTurnError> {
         let url = format!("{}/v1/models", self.base_url.trim_end_matches('/'));
         let headers: Vec<(&str, &str)> = self
             .api_key
@@ -155,18 +155,27 @@ impl<T: HttpTransport> OpenAiCompatibleProviderClient<T> {
             .map(|key| vec![("Authorization", key)])
             .unwrap_or_default();
         match self.transport.get_with_headers(&url, &headers) {
-            Ok(_) => Ok(()),
-            Err(e) => {
-                let guidance = if self.api_key.is_some() {
-                    " (認証情報の形式を確認してください。'Bearer <api-key>' 形式が必要な場合があります)"
-                } else {
-                    ""
-                };
-                Err(format!(
-                    "OpenAI互換プロバイダーに接続できません ({}): {}{}",
-                    self.base_url, e, guidance
-                ))
+            Ok(response) => {
+                let status_code = response.status_code;
+                match status_code {
+                    401 | 403 => Err(ProviderTurnError::AuthenticationFailed {
+                        status_code,
+                        message: sanitize_error_message(&format!(
+                            "HTTP {} from {}",
+                            status_code, self.base_url
+                        )),
+                    }),
+                    s if s >= 500 => Err(ProviderTurnError::ServerError {
+                        status_code: s,
+                        message: sanitize_error_message(&format!(
+                            "HTTP {} from {}",
+                            s, self.base_url
+                        )),
+                    }),
+                    _ => Ok(()),
+                }
             }
+            Err(e) => Err(e),
         }
     }
 
@@ -209,11 +218,18 @@ impl<T: HttpTransport> OpenAiCompatibleProviderClient<T> {
             .post_json_with_headers(&url, &request_body, &headers)?;
         if response.status_code != 200 {
             let body_text = normalize_openai_error(&response.body);
-            return Err(ProviderTurnError::Backend(format!(
+            let message = sanitize_error_message(&format!(
                 "openai request failed with status {}: {}",
                 response.status_code,
                 body_text.trim()
-            )));
+            ));
+            return Err(match response.status_code {
+                401 | 403 => ProviderTurnError::AuthenticationFailed {
+                    status_code: response.status_code,
+                    message,
+                },
+                _ => ProviderTurnError::Backend(message),
+            });
         }
 
         if request.stream && looks_like_sse_stream(&response.body) {

--- a/src/provider/transport.rs
+++ b/src/provider/transport.rs
@@ -390,11 +390,15 @@ pub fn classify_http_error(status_code: u16, body: &str) -> ProviderTurnError {
 
 /// Classify a curl exit code into a typed [`ProviderTurnError`].
 ///
+/// - exit 6  → `DnsFailure`
+/// - exit 7  → `ConnectionRefused`
 /// - exit 28 → `Timeout`
-/// - other   → `Network` (includes DNS failure (6), connection refused (7), etc.)
+/// - other   → `Network`
 pub fn classify_curl_error(exit_code: i32, stderr: &str) -> ProviderTurnError {
     let sanitized_stderr = sanitize_error_message(stderr);
     match exit_code {
+        6 => ProviderTurnError::DnsFailure(sanitized_stderr),
+        7 => ProviderTurnError::ConnectionRefused(sanitized_stderr),
         28 => ProviderTurnError::Timeout(sanitized_stderr),
         _ => ProviderTurnError::Network(sanitized_stderr),
     }

--- a/tests/provider_integration.rs
+++ b/tests/provider_integration.rs
@@ -2071,15 +2071,15 @@ fn classify_curl_error_exit_28_returns_timeout() {
 }
 
 #[test]
-fn classify_curl_error_exit_7_returns_network() {
+fn classify_curl_error_exit_7_returns_connection_refused() {
     let err = classify_curl_error(7, "failed to connect");
-    assert!(matches!(err, ProviderTurnError::Network(_)));
+    assert!(matches!(err, ProviderTurnError::ConnectionRefused(_)));
 }
 
 #[test]
-fn classify_curl_error_exit_6_returns_network() {
+fn classify_curl_error_exit_6_returns_dns_failure() {
     let err = classify_curl_error(6, "could not resolve host");
-    assert!(matches!(err, ProviderTurnError::Network(_)));
+    assert!(matches!(err, ProviderTurnError::DnsFailure(_)));
 }
 
 #[test]
@@ -2164,9 +2164,15 @@ fn classify_curl_error_timeout_is_retryable() {
 }
 
 #[test]
-fn classify_curl_error_network_is_retryable() {
+fn classify_curl_error_connection_refused_is_not_retryable() {
     let err = classify_curl_error(7, "connection refused");
-    assert!(err.is_retryable());
+    assert!(!err.is_retryable());
+}
+
+#[test]
+fn classify_curl_error_dns_failure_is_not_retryable() {
+    let err = classify_curl_error(6, "dns failure");
+    assert!(!err.is_retryable());
 }
 
 // ---------------------------------------------------------------------------
@@ -2405,7 +2411,7 @@ fn ollama_health_check_success() {
 
 #[test]
 fn ollama_health_check_failure() {
-    /// Mock transport that always fails with a network error.
+    /// Mock transport that always fails with a connection refused error.
     #[derive(Clone)]
     struct FailingTransport;
 
@@ -2416,7 +2422,9 @@ fn ollama_health_check_failure() {
             _body: &[u8],
             _headers: &[(&str, &str)],
         ) -> Result<HttpResponse, ProviderTurnError> {
-            Err(ProviderTurnError::Network("connection refused".into()))
+            Err(ProviderTurnError::ConnectionRefused(
+                "connection refused".into(),
+            ))
         }
 
         fn get_with_headers(
@@ -2424,16 +2432,17 @@ fn ollama_health_check_failure() {
             _url: &str,
             _headers: &[(&str, &str)],
         ) -> Result<HttpResponse, ProviderTurnError> {
-            Err(ProviderTurnError::Network("connection refused".into()))
+            Err(ProviderTurnError::ConnectionRefused(
+                "connection refused".into(),
+            ))
         }
     }
 
     let client = OllamaProviderClient::with_transport("http://localhost:11434", FailingTransport);
     let result = client.health_check();
     assert!(result.is_err());
-    let err_msg = result.unwrap_err();
-    assert!(err_msg.contains("Ollamaに接続できません"));
-    assert!(err_msg.contains("localhost:11434"));
+    let err = result.unwrap_err();
+    assert!(matches!(err, ProviderTurnError::ConnectionRefused(_)));
 }
 
 #[test]
@@ -2473,18 +2482,22 @@ fn openai_health_check_success_with_auth() {
 }
 
 #[test]
-fn openai_health_check_failure_with_auth_guidance() {
+fn openai_health_check_failure_with_auth_returns_authentication_failed() {
+    /// Mock transport that returns HTTP 401 for GET requests.
     #[derive(Clone)]
-    struct FailingTransport;
+    struct AuthFailTransport;
 
-    impl HttpTransport for FailingTransport {
+    impl HttpTransport for AuthFailTransport {
         fn post_json_with_headers(
             &self,
             _url: &str,
             _body: &[u8],
             _headers: &[(&str, &str)],
         ) -> Result<HttpResponse, ProviderTurnError> {
-            Err(ProviderTurnError::Network("connection refused".into()))
+            Ok(HttpResponse {
+                status_code: 401,
+                body: b"unauthorized".to_vec(),
+            })
         }
 
         fn get_with_headers(
@@ -2492,25 +2505,30 @@ fn openai_health_check_failure_with_auth_guidance() {
             _url: &str,
             _headers: &[(&str, &str)],
         ) -> Result<HttpResponse, ProviderTurnError> {
-            Err(ProviderTurnError::ClientError {
+            Ok(HttpResponse {
                 status_code: 401,
-                message: "unauthorized".into(),
+                body: b"unauthorized".to_vec(),
             })
         }
     }
 
     let client =
-        OpenAiCompatibleProviderClient::with_transport("http://localhost:8080", FailingTransport)
+        OpenAiCompatibleProviderClient::with_transport("http://localhost:8080", AuthFailTransport)
             .with_api_key("bad-key");
     let result = client.health_check();
     assert!(result.is_err());
-    let err_msg = result.unwrap_err();
-    assert!(err_msg.contains("OpenAI互換プロバイダーに接続できません"));
-    assert!(err_msg.contains("認証情報の形式を確認してください"));
+    let err = result.unwrap_err();
+    assert!(matches!(
+        err,
+        ProviderTurnError::AuthenticationFailed {
+            status_code: 401,
+            ..
+        }
+    ));
 }
 
 #[test]
-fn openai_health_check_no_auth_no_guidance() {
+fn openai_health_check_no_auth_returns_transport_error() {
     #[derive(Clone)]
     struct FailingTransport;
 
@@ -2521,7 +2539,7 @@ fn openai_health_check_no_auth_no_guidance() {
             _body: &[u8],
             _headers: &[(&str, &str)],
         ) -> Result<HttpResponse, ProviderTurnError> {
-            Err(ProviderTurnError::Network("refused".into()))
+            Err(ProviderTurnError::ConnectionRefused("refused".into()))
         }
 
         fn get_with_headers(
@@ -2529,7 +2547,7 @@ fn openai_health_check_no_auth_no_guidance() {
             _url: &str,
             _headers: &[(&str, &str)],
         ) -> Result<HttpResponse, ProviderTurnError> {
-            Err(ProviderTurnError::Network("refused".into()))
+            Err(ProviderTurnError::ConnectionRefused("refused".into()))
         }
     }
 
@@ -2537,10 +2555,99 @@ fn openai_health_check_no_auth_no_guidance() {
         OpenAiCompatibleProviderClient::with_transport("http://localhost:8080", FailingTransport);
     let result = client.health_check();
     assert!(result.is_err());
-    let err_msg = result.unwrap_err();
-    assert!(err_msg.contains("OpenAI互換プロバイダーに接続できません"));
-    // No auth guidance when no api_key is set
-    assert!(!err_msg.contains("認証情報の形式を確認してください"));
+    let err = result.unwrap_err();
+    assert!(matches!(err, ProviderTurnError::ConnectionRefused(_)));
+}
+
+#[test]
+fn openai_health_check_403_returns_authentication_failed() {
+    #[derive(Clone)]
+    struct ForbiddenTransport;
+
+    impl HttpTransport for ForbiddenTransport {
+        fn post_json_with_headers(
+            &self,
+            _url: &str,
+            _body: &[u8],
+            _headers: &[(&str, &str)],
+        ) -> Result<HttpResponse, ProviderTurnError> {
+            Ok(HttpResponse {
+                status_code: 403,
+                body: b"forbidden".to_vec(),
+            })
+        }
+
+        fn get_with_headers(
+            &self,
+            _url: &str,
+            _headers: &[(&str, &str)],
+        ) -> Result<HttpResponse, ProviderTurnError> {
+            Ok(HttpResponse {
+                status_code: 403,
+                body: b"forbidden".to_vec(),
+            })
+        }
+    }
+
+    let client =
+        OpenAiCompatibleProviderClient::with_transport("http://localhost:8080", ForbiddenTransport)
+            .with_api_key("some-key");
+    let result = client.health_check();
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(matches!(
+        err,
+        ProviderTurnError::AuthenticationFailed {
+            status_code: 403,
+            ..
+        }
+    ));
+}
+
+#[test]
+fn openai_health_check_500_returns_server_error() {
+    #[derive(Clone)]
+    struct ServerErrorTransport;
+
+    impl HttpTransport for ServerErrorTransport {
+        fn post_json_with_headers(
+            &self,
+            _url: &str,
+            _body: &[u8],
+            _headers: &[(&str, &str)],
+        ) -> Result<HttpResponse, ProviderTurnError> {
+            Ok(HttpResponse {
+                status_code: 500,
+                body: b"internal server error".to_vec(),
+            })
+        }
+
+        fn get_with_headers(
+            &self,
+            _url: &str,
+            _headers: &[(&str, &str)],
+        ) -> Result<HttpResponse, ProviderTurnError> {
+            Ok(HttpResponse {
+                status_code: 500,
+                body: b"internal server error".to_vec(),
+            })
+        }
+    }
+
+    let client = OpenAiCompatibleProviderClient::with_transport(
+        "http://localhost:8080",
+        ServerErrorTransport,
+    );
+    let result = client.health_check();
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(matches!(
+        err,
+        ProviderTurnError::ServerError {
+            status_code: 500,
+            ..
+        }
+    ));
 }
 
 // -----------------------------------------------------------------------
@@ -2591,4 +2698,247 @@ fn ollama_build_chat_request_maps_provider_images() {
         first.images.as_ref().unwrap(),
         &vec!["dGVzdA==".to_string()]
     );
+}
+
+// ---------------------------------------------------------------------------
+// Phase 7: New error variant tests (Issue #64)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn connection_refused_display_contains_message() {
+    let err = ProviderTurnError::ConnectionRefused("Failed to connect".into());
+    let display = err.to_string();
+    assert!(display.contains("connection refused"));
+    assert!(display.contains("Failed to connect"));
+}
+
+#[test]
+fn dns_failure_display_contains_message() {
+    let err = ProviderTurnError::DnsFailure("Could not resolve host".into());
+    let display = err.to_string();
+    assert!(display.contains("DNS resolution failed"));
+    assert!(display.contains("Could not resolve host"));
+}
+
+#[test]
+fn model_not_found_display_contains_model_name() {
+    let err = ProviderTurnError::ModelNotFound {
+        model: "llama3:8b".into(),
+        message: "not found".into(),
+    };
+    let display = err.to_string();
+    assert!(display.contains("llama3:8b"));
+    assert!(display.contains("not found"));
+}
+
+#[test]
+fn authentication_failed_display_contains_status() {
+    let err = ProviderTurnError::AuthenticationFailed {
+        status_code: 401,
+        message: "unauthorized".into(),
+    };
+    let display = err.to_string();
+    assert!(display.contains("authentication failed"));
+    assert!(display.contains("401"));
+}
+
+#[test]
+fn connection_refused_is_not_retryable() {
+    let err = ProviderTurnError::ConnectionRefused("refused".into());
+    assert!(!err.is_retryable());
+}
+
+#[test]
+fn dns_failure_is_not_retryable() {
+    let err = ProviderTurnError::DnsFailure("dns fail".into());
+    assert!(!err.is_retryable());
+}
+
+#[test]
+fn model_not_found_is_not_retryable() {
+    let err = ProviderTurnError::ModelNotFound {
+        model: "x".into(),
+        message: "not found".into(),
+    };
+    assert!(!err.is_retryable());
+}
+
+#[test]
+fn authentication_failed_is_not_retryable() {
+    let err = ProviderTurnError::AuthenticationFailed {
+        status_code: 401,
+        message: "unauthorized".into(),
+    };
+    assert!(!err.is_retryable());
+}
+
+#[test]
+fn connection_refused_from_converts_to_provider_error_kind() {
+    let err = ProviderTurnError::ConnectionRefused("refused".into());
+    let kind = ProviderErrorKind::from(&err);
+    assert_eq!(kind, ProviderErrorKind::ConnectionRefused);
+}
+
+#[test]
+fn dns_failure_from_converts_to_provider_error_kind() {
+    let err = ProviderTurnError::DnsFailure("dns".into());
+    let kind = ProviderErrorKind::from(&err);
+    assert_eq!(kind, ProviderErrorKind::DnsFailure);
+}
+
+#[test]
+fn model_not_found_from_converts_to_provider_error_kind() {
+    let err = ProviderTurnError::ModelNotFound {
+        model: "x".into(),
+        message: "not found".into(),
+    };
+    let kind = ProviderErrorKind::from(&err);
+    assert_eq!(kind, ProviderErrorKind::ModelNotFound);
+}
+
+#[test]
+fn authentication_failed_from_converts_to_provider_error_kind() {
+    let err = ProviderTurnError::AuthenticationFailed {
+        status_code: 403,
+        message: "forbidden".into(),
+    };
+    let kind = ProviderErrorKind::from(&err);
+    assert_eq!(kind, ProviderErrorKind::AuthenticationFailed);
+}
+
+#[test]
+fn display_redacts_secrets_in_connection_refused() {
+    let err =
+        ProviderTurnError::ConnectionRefused("Authorization: Bearer sk-secret-key-123".into());
+    let display = err.to_string();
+    assert!(display.contains("[REDACTED]"));
+    assert!(!display.contains("sk-secret-key-123"));
+}
+
+#[test]
+fn display_redacts_secrets_in_authentication_failed() {
+    let err = ProviderTurnError::AuthenticationFailed {
+        status_code: 401,
+        message: "Bearer my-secret-token was rejected".into(),
+    };
+    let display = err.to_string();
+    assert!(display.contains("[REDACTED]"));
+    assert!(!display.contains("my-secret-token"));
+}
+
+#[test]
+fn provider_error_kind_serde_roundtrip_new_variants() {
+    let variants = vec![
+        ProviderErrorKind::ConnectionRefused,
+        ProviderErrorKind::DnsFailure,
+        ProviderErrorKind::ModelNotFound,
+        ProviderErrorKind::AuthenticationFailed,
+    ];
+    for variant in variants {
+        let json = serde_json::to_string(&variant).unwrap();
+        let deserialized: ProviderErrorKind = serde_json::from_str(&json).unwrap();
+        assert_eq!(variant, deserialized);
+    }
+}
+
+#[test]
+fn provider_error_kind_unknown_fallback() {
+    let json = r#""SomeNewFutureVariant""#;
+    let deserialized: ProviderErrorKind = serde_json::from_str(json).unwrap();
+    assert_eq!(deserialized, ProviderErrorKind::Unknown);
+}
+
+#[test]
+fn retry_transport_no_retry_on_connection_refused() {
+    let mock = RetryMockTransport::new(10, ProviderTurnError::ConnectionRefused("refused".into()));
+    let call_count = mock.call_count.clone();
+    let transport = RetryTransport::with_config(mock, fast_retry_config(3));
+
+    let result = transport.post_json_with_headers("http://test", b"body", &[]);
+    assert!(result.is_err());
+    assert_eq!(
+        *call_count.borrow(),
+        1,
+        "ConnectionRefused should not retry"
+    );
+}
+
+#[test]
+fn retry_transport_no_retry_on_dns_failure() {
+    let mock = RetryMockTransport::new(10, ProviderTurnError::DnsFailure("dns fail".into()));
+    let call_count = mock.call_count.clone();
+    let transport = RetryTransport::with_config(mock, fast_retry_config(3));
+
+    let result = transport.get_with_headers("http://test", &[]);
+    assert!(result.is_err());
+    assert_eq!(*call_count.borrow(), 1, "DnsFailure should not retry");
+}
+
+#[test]
+fn retry_transport_no_retry_on_authentication_failed() {
+    let mock = RetryMockTransport::new(
+        10,
+        ProviderTurnError::AuthenticationFailed {
+            status_code: 401,
+            message: "unauthorized".into(),
+        },
+    );
+    let call_count = mock.call_count.clone();
+    let transport = RetryTransport::with_config(mock, fast_retry_config(3));
+
+    let result = transport.post_json_with_headers("http://test", b"body", &[]);
+    assert!(result.is_err());
+    assert_eq!(
+        *call_count.borrow(),
+        1,
+        "AuthenticationFailed should not retry"
+    );
+}
+
+#[test]
+fn error_guidance_connection_refused() {
+    let err =
+        anvil::app::AppError::ProviderTurn(ProviderTurnError::ConnectionRefused("refused".into()));
+    let guidance = anvil::app::error_guidance(&err);
+    assert!(guidance.contains("Connection refused"));
+    assert!(guidance.contains("ollama serve"));
+}
+
+#[test]
+fn error_guidance_dns_failure() {
+    let err = anvil::app::AppError::ProviderTurn(ProviderTurnError::DnsFailure("dns fail".into()));
+    let guidance = anvil::app::error_guidance(&err);
+    assert!(guidance.contains("DNS resolution failed"));
+    assert!(guidance.contains("typos"));
+}
+
+#[test]
+fn error_guidance_model_not_found() {
+    let err = anvil::app::AppError::ProviderTurn(ProviderTurnError::ModelNotFound {
+        model: "llama3:8b".into(),
+        message: "not found".into(),
+    });
+    let guidance = anvil::app::error_guidance(&err);
+    assert!(guidance.contains("llama3:8b"));
+    assert!(guidance.contains("ollama pull"));
+}
+
+#[test]
+fn error_guidance_authentication_failed() {
+    let err = anvil::app::AppError::ProviderTurn(ProviderTurnError::AuthenticationFailed {
+        status_code: 401,
+        message: "unauthorized".into(),
+    });
+    let guidance = anvil::app::error_guidance(&err);
+    assert!(guidance.contains("Authentication failed"));
+    assert!(guidance.contains("ANVIL_API_KEY"));
+    assert!(guidance.contains("Never share your API key"));
+}
+
+#[test]
+fn error_guidance_timeout() {
+    let err = anvil::app::AppError::ProviderTurn(ProviderTurnError::Timeout("timed out".into()));
+    let guidance = anvil::app::error_guidance(&err);
+    assert!(guidance.contains("timed out"));
+    assert!(guidance.contains("smaller model"));
 }


### PR DESCRIPTION
## Summary
- Ollama未起動・モデル未DL時にユーザーフレンドリーなガイダンスを表示
- ProviderErrorKindにガイダンス情報を付加

## Quality
- cargo test: 618テスト全パス, clippy 0警告, fmt OK

Closes #64
🤖 Generated with [Claude Code](https://claude.com/claude-code)