### PR TITLE
feat: コンテキスト枠自動取得 (#65)

### DIFF
--- a/src/app/cli.rs
+++ b/src/app/cli.rs
@@ -92,8 +92,37 @@ pub fn run() -> Result<(), AppError> {
     run_with_config(config)
 }
 
+/// If the provider is Ollama and the user did not explicitly set
+/// `context_window`, query the model's actual context length via
+/// `/api/show` and apply it.
+fn auto_detect_and_apply_context_window(
+    config: &mut EffectiveConfig,
+    provider: &ProviderRuntimeContext,
+) {
+    use crate::provider::{ProviderBackend, fetch_context_length_from_ollama};
+
+    if provider.backend != ProviderBackend::Ollama {
+        return;
+    }
+    if config.runtime.context_window_explicitly_set {
+        return;
+    }
+
+    if let Some(detected) =
+        fetch_context_length_from_ollama(&config.runtime.provider_url, &config.runtime.model)
+    {
+        eprintln!(
+            "Auto-detected context_window={detected} from Ollama model '{}'",
+            config.runtime.model
+        );
+        config.runtime.context_window = detected;
+        config.clamp_context_window();
+        config.clamp_context_budget();
+    }
+}
+
 /// Common startup logic shared by `run_with_args` and `run`.
-fn run_with_config(config: EffectiveConfig) -> Result<(), AppError> {
+fn run_with_config(mut config: EffectiveConfig) -> Result<(), AppError> {
     let _guard: Option<LogGuard> = init_tracing(
         config.mode.log_filter.as_deref(),
         config.mode.debug_logging,
@@ -113,6 +142,10 @@ fn run_with_config(config: EffectiveConfig) -> Result<(), AppError> {
     let shutdown_flag = setup_shutdown_handler(config.mode.interactive);
 
     let provider = ProviderRuntimeContext::bootstrap(&config)?;
+
+    // Auto-detect context_window from Ollama if not explicitly set.
+    auto_detect_and_apply_context_window(&mut config, &provider);
+
     let provider_client = build_local_provider_client(&config, Arc::clone(&shutdown_flag))?;
 
     // Health check: warn on failure but continue startup.

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -61,6 +61,10 @@ pub struct RuntimeConfig {
     pub stream: bool,
     pub web_search_provider: WebSearchProvider,
     pub serper_api_key: Option<String>,
+    /// `true` when the user explicitly set `context_window` via config file,
+    /// environment variable, or CLI flag.  When `false`, the auto-detect
+    /// logic in `cli.rs` may override `context_window` from the provider.
+    pub context_window_explicitly_set: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -199,6 +203,7 @@ impl EffectiveConfig {
                 stream: true,
                 web_search_provider: WebSearchProvider::default(),
                 serper_api_key: None,
+                context_window_explicitly_set: false,
             },
             mode: ModeConfig {
                 prompt_source: PromptSource::Interactive,
@@ -222,6 +227,12 @@ impl EffectiveConfig {
             },
             project_instructions: None,
         }
+    }
+
+    /// Set `context_window` and mark it as explicitly set by the user.
+    fn set_context_window(&mut self, value: u32) {
+        self.runtime.context_window = value;
+        self.runtime.context_window_explicitly_set = true;
     }
 
     fn apply_file_and_env_overrides(&mut self) -> Result<(), ConfigError> {
@@ -327,7 +338,7 @@ impl EffectiveConfig {
 
         // Numeric fields (already parsed by clap)
         if let Some(v) = cli.context_window {
-            self.runtime.context_window = v;
+            self.set_context_window(v);
         }
         if let Some(v) = cli.context_budget {
             self.runtime.context_budget = Some(v);
@@ -382,9 +393,10 @@ impl EffectiveConfig {
                     };
                 }
                 "context_window" | "ANVIL_CONTEXT_WINDOW" => {
-                    self.runtime.context_window = value
+                    let v: u32 = value
                         .parse()
                         .map_err(|_| ConfigError::InvalidNumericValue(value.clone()))?;
+                    self.set_context_window(v);
                 }
                 "context_budget" | "ANVIL_CONTEXT_BUDGET" => {
                     self.runtime.context_budget = if value.is_empty() {
@@ -502,7 +514,7 @@ impl EffectiveConfig {
         Ok(())
     }
 
-    fn clamp_context_window(&mut self) {
+    pub(crate) fn clamp_context_window(&mut self) {
         if self.runtime.context_window < MIN_CONTEXT_WINDOW {
             let old = self.runtime.context_window;
             self.runtime.context_window = MIN_CONTEXT_WINDOW;
@@ -512,7 +524,7 @@ impl EffectiveConfig {
         }
     }
 
-    fn clamp_context_budget(&mut self) {
+    pub(crate) fn clamp_context_budget(&mut self) {
         if let Some(budget) = self.runtime.context_budget
             && budget >= self.runtime.context_window
         {
@@ -788,6 +800,10 @@ impl std::fmt::Debug for RuntimeConfig {
             .field("stream", &self.stream)
             .field("web_search_provider", &self.web_search_provider)
             .field("serper_api_key", &"[REDACTED]")
+            .field(
+                "context_window_explicitly_set",
+                &self.context_window_explicitly_set,
+            )
             .finish()
     }
 }

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -15,7 +15,8 @@ use std::sync::atomic::AtomicBool;
 
 // Re-export key types so existing `use crate::provider::*` continues to work.
 pub use ollama::{
-    OllamaChatMessage, OllamaChatRequest, OllamaProviderClient, resolve_ollama_model_alias,
+    OllamaChatMessage, OllamaChatRequest, OllamaProviderClient, fetch_context_length_from_ollama,
+    parse_context_length_from_show_response, resolve_ollama_model_alias,
 };
 pub use transport::{
     CurlHttpTransport, HttpResponse, HttpTransport, RetryConfig, RetryTransport, TcpHttpTransport,

--- a/src/provider/ollama.rs
+++ b/src/provider/ollama.rs
@@ -247,6 +247,81 @@ impl<T: HttpTransport> ProviderClient for OllamaProviderClient<T> {
     }
 }
 
+/// Request body for the Ollama `/api/show` endpoint.
+#[derive(Serialize)]
+struct ShowRequest {
+    model: String,
+}
+
+/// Maximum allowed response size from `/api/show` (1 MiB).
+const MAX_SHOW_RESPONSE_SIZE: usize = 1_048_576;
+
+/// Upper bound for a sane `context_length` value (10 million tokens).
+const MAX_CONTEXT_LENGTH: u32 = 10_000_000;
+
+/// Query the Ollama `/api/show` endpoint and extract the model's
+/// `context_length` from `model_info`.
+///
+/// Returns `None` on any failure (network, parse, missing key).
+pub fn fetch_context_length_from_ollama(provider_url: &str, model: &str) -> Option<u32> {
+    let url = format!("{}/api/show", provider_url.trim_end_matches('/'));
+    let body = serde_json::to_vec(&ShowRequest {
+        model: model.to_string(),
+    })
+    .ok()?;
+
+    let output = Command::new("curl")
+        .arg("-sS")
+        .arg("--max-time")
+        .arg("5")
+        .arg("--proto")
+        .arg("=http,https")
+        .arg("--max-filesize")
+        .arg(MAX_SHOW_RESPONSE_SIZE.to_string())
+        .arg("--data-binary")
+        .arg("@-")
+        .arg("--")
+        .arg(&url)
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .ok()
+        .and_then(|mut child| {
+            use std::io::Write;
+            if let Some(ref mut stdin) = child.stdin {
+                let _ = stdin.write_all(&body);
+            }
+            child.wait_with_output().ok()
+        })?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    parse_context_length_from_show_response(&output.stdout)
+}
+
+/// Parse an Ollama `/api/show` JSON response body and extract context_length.
+///
+/// This is the pure-logic core of [`fetch_context_length_from_ollama`],
+/// extracted for unit testing without network access.
+pub fn parse_context_length_from_show_response(json_bytes: &[u8]) -> Option<u32> {
+    let value: Value = serde_json::from_slice(json_bytes).ok()?;
+    let model_info = value.get("model_info")?.as_object()?;
+
+    for (key, val) in model_info {
+        if key.ends_with(".context_length") {
+            let ctx_len = val.as_u64()?;
+            let clamped = u32::try_from(ctx_len.min(u64::from(MAX_CONTEXT_LENGTH))).ok()?;
+            if clamped > 0 {
+                return Some(clamped);
+            }
+        }
+    }
+    None
+}
+
 fn resolve_model_with_ollama_tags(base_url: &str, requested: &str) -> String {
     let url = format!("{}/api/tags", base_url.trim_end_matches('/'));
     let output = Command::new("curl")

--- a/tests/config_bootstrap.rs
+++ b/tests/config_bootstrap.rs
@@ -508,3 +508,58 @@ fn gitignore_check_no_gitignore_file() {
     assert!(result.is_some());
     assert!(result.unwrap().contains(".gitignore"));
 }
+
+// --- context_window_explicitly_set tests ---
+
+#[test]
+fn context_window_explicitly_set_defaults_to_false() {
+    let config = EffectiveConfig::default_for_test().unwrap();
+    assert!(
+        !config.runtime.context_window_explicitly_set,
+        "default config should have context_window_explicitly_set=false"
+    );
+}
+
+#[test]
+fn context_window_explicitly_set_via_config_file_map() {
+    let mut config = EffectiveConfig::default_for_test().unwrap();
+    let mut file_values = HashMap::new();
+    file_values.insert("context_window".to_string(), "8192".to_string());
+    config
+        .apply_overrides_for_test(&file_values, &HashMap::new(), &HashMap::new())
+        .expect("should apply");
+    assert!(
+        config.runtime.context_window_explicitly_set,
+        "context_window set via config file should mark explicitly_set=true"
+    );
+    assert_eq!(config.runtime.context_window, 8192);
+}
+
+#[test]
+fn context_window_explicitly_set_via_env_map() {
+    let mut config = EffectiveConfig::default_for_test().unwrap();
+    let mut env_values = HashMap::new();
+    env_values.insert("ANVIL_CONTEXT_WINDOW".to_string(), "16384".to_string());
+    config
+        .apply_overrides_for_test(&HashMap::new(), &env_values, &HashMap::new())
+        .expect("should apply");
+    assert!(
+        config.runtime.context_window_explicitly_set,
+        "context_window set via env should mark explicitly_set=true"
+    );
+    assert_eq!(config.runtime.context_window, 16384);
+}
+
+#[test]
+fn context_window_explicitly_set_remains_false_when_not_set() {
+    let mut config = EffectiveConfig::default_for_test().unwrap();
+    let mut file_values = HashMap::new();
+    file_values.insert("model".to_string(), "some-model".to_string());
+    config
+        .apply_overrides_for_test(&file_values, &HashMap::new(), &HashMap::new())
+        .expect("should apply");
+    assert!(
+        !config.runtime.context_window_explicitly_set,
+        "setting other config keys should not mark context_window as explicitly set"
+    );
+}

--- a/tests/provider_integration.rs
+++ b/tests/provider_integration.rs
@@ -2592,3 +2592,81 @@ fn ollama_build_chat_request_maps_provider_images() {
         &vec!["dGVzdA==".to_string()]
     );
 }
+
+// --- parse_context_length_from_show_response tests ---
+
+use anvil::provider::parse_context_length_from_show_response;
+
+#[test]
+fn parse_context_length_typical_ollama_show_response() {
+    let json = br#"{
+        "model_info": {
+            "general.architecture": "llama",
+            "llama.context_length": 131072,
+            "llama.embedding_length": 4096
+        }
+    }"#;
+    let result = parse_context_length_from_show_response(json);
+    assert_eq!(result, Some(131072));
+}
+
+#[test]
+fn parse_context_length_qwen_architecture() {
+    let json = br#"{
+        "model_info": {
+            "general.architecture": "qwen2",
+            "qwen2.context_length": 32768
+        }
+    }"#;
+    let result = parse_context_length_from_show_response(json);
+    assert_eq!(result, Some(32768));
+}
+
+#[test]
+fn parse_context_length_missing_model_info() {
+    let json = br#"{"details": {"family": "llama"}}"#;
+    let result = parse_context_length_from_show_response(json);
+    assert_eq!(result, None);
+}
+
+#[test]
+fn parse_context_length_no_context_length_key() {
+    let json = br#"{
+        "model_info": {
+            "general.architecture": "llama",
+            "llama.embedding_length": 4096
+        }
+    }"#;
+    let result = parse_context_length_from_show_response(json);
+    assert_eq!(result, None);
+}
+
+#[test]
+fn parse_context_length_zero_value_returns_none() {
+    let json = br#"{
+        "model_info": {
+            "llama.context_length": 0
+        }
+    }"#;
+    let result = parse_context_length_from_show_response(json);
+    assert_eq!(result, None);
+}
+
+#[test]
+fn parse_context_length_invalid_json_returns_none() {
+    let json = b"not json";
+    let result = parse_context_length_from_show_response(json);
+    assert_eq!(result, None);
+}
+
+#[test]
+fn parse_context_length_clamped_to_max() {
+    // Value exceeding MAX_CONTEXT_LENGTH (10_000_000) should be clamped
+    let json = br#"{
+        "model_info": {
+            "llama.context_length": 999999999
+        }
+    }"#;
+    let result = parse_context_length_from_show_response(json);
+    assert_eq!(result, Some(10_000_000));
+}


### PR DESCRIPTION
## Summary
- Ollama `/api/show`からモデルのcontext_lengthを自動取得
- 手動設定がある場合はそちらを優先

## Quality
- cargo test: 602テスト全パス, clippy 0警告, fmt OK

Closes #65
🤖 Generated with [Claude Code](https://claude.com/claude-code)