### PR TITLE
feat: undo/ロールバック機構 (#68)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,7 +133,7 @@ src/
 ├── spinner.rs           # スピナーUI
 ├── state/mod.rs         # 状態マシン
 ├── tooling/
-│   ├── mod.rs           # ツール実行・検証
+│   ├── mod.rs           # ツール実行・検証・CheckpointStack（undo用チェックポイント管理）
 │   └── diff.rs          # 差分プレビュー生成（file.write/file.edit承認時）
 └── tui/mod.rs           # TUI描画
 tests/

--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -548,12 +548,17 @@ impl App {
             );
         }
 
-        // Built-in tools: delegate to LocalToolExecutor
-        let mut executor =
-            LocalToolExecutor::new(self.config.paths.cwd.clone(), &self.config.runtime)
-                .with_shutdown_flag(self.shutdown_flag());
+        // Capture checkpoint before file-mutating tools (Issue #68)
+        let cwd = self.config.paths.cwd.clone();
+        let checkpoint_idx = self
+            .capture_checkpoint_if_needed(&request, &cwd)
+            .map(|entry| self.checkpoint_stack.push(entry));
 
-        executor
+        // Built-in tools: delegate to LocalToolExecutor
+        let mut executor = LocalToolExecutor::new(cwd, &self.config.runtime)
+            .with_shutdown_flag(self.shutdown_flag());
+
+        let result = executor
             .execute(request)
             .unwrap_or_else(|err| ToolExecutionResult {
                 tool_call_id: String::new(),
@@ -563,7 +568,16 @@ impl App {
                 payload: ToolExecutionPayload::Text(err.to_string()),
                 artifacts: Vec::new(),
                 elapsed_ms: 0,
-            })
+            });
+
+        // Remove checkpoint if tool execution failed
+        if result.status == ToolExecutionStatus::Failed
+            && let Some(idx) = checkpoint_idx
+        {
+            self.checkpoint_stack.remove(idx);
+        }
+
+        result
     }
 
     /// Execute an MCP tool call via the McpManager.

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -30,8 +30,8 @@ use crate::session::{
 use crate::spinner::Spinner;
 use crate::state::{StateMachine, StateTransition};
 use crate::tooling::{
-    ExecutionClass, ExecutionMode, PermissionClass, PlanModePolicy, RollbackPolicy, ToolKind,
-    ToolRegistry, ToolSpec,
+    CheckpointStack, ExecutionClass, ExecutionMode, PermissionClass, PlanModePolicy,
+    RollbackPolicy, ToolKind, ToolRegistry, ToolSpec,
 };
 use crate::tui::Tui;
 use std::fmt::{Display, Formatter};
@@ -114,6 +114,8 @@ pub struct App {
     system_prompt: String,
     shutdown_flag: Arc<AtomicBool>,
     warning_tracker: ContextWarningTracker,
+    /// Undo checkpoint stack. In-memory only, discarded on session exit.
+    checkpoint_stack: CheckpointStack,
     /// Hooks engine. `None` when hooks.json is absent or initialization failed.
     /// Declared before mcp_manager to maintain Drop order (DR3-007).
     hooks_engine: Option<crate::hooks::HooksEngine>,
@@ -346,6 +348,7 @@ impl App {
             system_prompt,
             shutdown_flag,
             warning_tracker: ContextWarningTracker::new(),
+            checkpoint_stack: CheckpointStack::new(),
             hooks_engine,
             mcp_manager,
         })
@@ -1276,6 +1279,13 @@ impl App {
                 frames: vec!["Exiting Anvil.".to_string()],
                 control: SessionControl::Exit,
             },
+            Some(SlashCommandAction::Undo(n)) => {
+                let msg = self.execute_undo(n)?;
+                CliTurnOutput {
+                    frames: vec![msg],
+                    control: SessionControl::Continue,
+                }
+            }
             Some(SlashCommandAction::Prompt(prompt)) => {
                 self.run_turn_to_output(prompt, provider_client, tui)?
             }
@@ -1332,6 +1342,103 @@ impl App {
             self.persist_session(AppEvent::SessionSaved)?;
         }
         Ok(render_retrieval_result(&result))
+    }
+
+    /// Capture a checkpoint for file-mutating tools before execution.
+    ///
+    /// Returns `Some(CheckpointEntry)` when the tool has
+    /// `RollbackPolicy::CheckpointBeforeWrite` and the file can be read.
+    pub(crate) fn capture_checkpoint_if_needed(
+        &self,
+        request: &crate::tooling::ToolExecutionRequest,
+        cwd: &std::path::Path,
+    ) -> Option<crate::tooling::CheckpointEntry> {
+        use crate::tooling::{
+            CHECKPOINT_FILE_SIZE_LIMIT, RollbackPolicy, ToolInput, diff::is_binary_content,
+        };
+
+        if request.spec.rollback_policy != RollbackPolicy::CheckpointBeforeWrite {
+            return None;
+        }
+
+        let rel_path = match &request.input {
+            ToolInput::FileWrite { path, .. } | ToolInput::FileEdit { path, .. } => path,
+            _ => return None,
+        };
+
+        let resolved = crate::tooling::resolve_sandbox_path(cwd, rel_path).ok()?;
+
+        match std::fs::read(&resolved) {
+            Ok(bytes) => {
+                if is_binary_content(&bytes) || bytes.len() as u64 > CHECKPOINT_FILE_SIZE_LIMIT {
+                    return None;
+                }
+                let content = String::from_utf8(bytes).ok()?;
+                let byte_size = content.len();
+                Some(crate::tooling::CheckpointEntry {
+                    path: resolved,
+                    previous_content: Some(content),
+                    byte_size,
+                })
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                // New file -- record None so undo can delete it
+                Some(crate::tooling::CheckpointEntry {
+                    path: resolved,
+                    previous_content: None,
+                    byte_size: 0,
+                })
+            }
+            Err(_) => None,
+        }
+    }
+
+    /// Execute an undo operation, restoring up to `n` checkpoint entries.
+    fn execute_undo(&mut self, n: usize) -> Result<String, AppError> {
+        if self.checkpoint_stack.is_empty() {
+            return Ok("No changes to undo.".to_string());
+        }
+
+        let entries = self.checkpoint_stack.pop_n(n);
+        let results: Vec<crate::tooling::RestoreResult> =
+            entries.iter().map(|entry| entry.restore()).collect();
+
+        let restored_count = results
+            .iter()
+            .filter(|r| r.action != crate::tooling::RestoreAction::Skipped)
+            .count();
+
+        // Build result message
+        let mut lines = Vec::new();
+        for result in &results {
+            let action_str = match result.action {
+                crate::tooling::RestoreAction::ContentRestored => "restored",
+                crate::tooling::RestoreAction::FileRemoved => "removed",
+                crate::tooling::RestoreAction::Skipped => "skipped",
+            };
+            lines.push(format!("  {} {}", action_str, result.path.display()));
+            if let Some(ref preview) = result.diff_preview {
+                for diff_line in preview.lines().take(10) {
+                    lines.push(format!("    {diff_line}"));
+                }
+            }
+        }
+
+        let summary = if restored_count == entries.len() {
+            format!("Undid {} change(s).", restored_count)
+        } else {
+            format!("Undid {} of {} requested change(s).", restored_count, n)
+        };
+        lines.insert(0, summary.clone());
+
+        // Record in session
+        self.session.push_message(
+            SessionMessage::new(MessageRole::System, "anvil", format!("[undo] {summary}"))
+                .with_id(self.next_message_id("undo")),
+        );
+        self.persist_session(AppEvent::UndoExecuted)?;
+
+        Ok(lines.join("\n"))
     }
 
     fn compact_session_history(&mut self) -> Result<String, AppError> {

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -34,6 +34,7 @@ pub enum AppEvent {
     SessionLoaded,
     SessionSaved,
     SessionNormalizedAfterInterrupt,
+    UndoExecuted,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -31,6 +31,7 @@ pub enum SlashCommandAction {
         content: String,
         skill_dir: PathBuf,
     },
+    Undo(usize),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -133,6 +134,9 @@ impl ExtensionRegistry {
     }
 
     pub fn find_slash_command(&self, command: &str) -> Option<SlashCommandSpec> {
+        if let Some(parsed) = parse_undo_command(command) {
+            return Some(parsed);
+        }
         if let Some(parsed) = parse_plan_command(command) {
             return Some(parsed);
         }
@@ -259,6 +263,12 @@ pub fn builtin_slash_commands() -> Vec<SlashCommandSpec> {
             scope: None,
         },
         SlashCommandSpec {
+            name: "/undo".to_string(),
+            description: "undo the last file change(s)".to_string(),
+            action: SlashCommandAction::Undo(1),
+            scope: None,
+        },
+        SlashCommandSpec {
             name: "/exit".to_string(),
             description: "exit the session".to_string(),
             action: SlashCommandAction::Exit,
@@ -349,6 +359,30 @@ fn edit_distance(a: &str, b: &str) -> usize {
         std::mem::swap(&mut prev, &mut curr);
     }
     prev[n]
+}
+
+/// Maximum number of undo steps allowed in a single `/undo N` command.
+const MAX_UNDO_STEPS: usize = 20;
+
+fn parse_undo_command(command: &str) -> Option<SlashCommandSpec> {
+    let n = if command == "/undo" {
+        1
+    } else if let Some(rest) = command.strip_prefix("/undo ") {
+        let parsed = rest.trim().parse::<usize>().ok()?;
+        if parsed == 0 {
+            return None;
+        }
+        parsed.min(MAX_UNDO_STEPS)
+    } else {
+        return None;
+    };
+
+    Some(SlashCommandSpec {
+        name: "/undo".to_string(),
+        description: "undo the last file change(s)".to_string(),
+        action: SlashCommandAction::Undo(n),
+        scope: None,
+    })
 }
 
 fn parse_repo_command(command: &str) -> Option<SlashCommandSpec> {

--- a/src/tooling/mod.rs
+++ b/src/tooling/mod.rs
@@ -2055,6 +2055,240 @@ fn is_searchable_file(path: &Path) -> bool {
     )
 }
 
+// ---------------------------------------------------------------------------
+// Checkpoint / Undo types (Issue #68)
+// ---------------------------------------------------------------------------
+
+/// Maximum file size for checkpoint capture (1 MB).
+pub const CHECKPOINT_FILE_SIZE_LIMIT: u64 = 1_048_576;
+
+/// Checkpoint entry representing a single file state before a tool write.
+#[derive(Debug, Clone)]
+pub struct CheckpointEntry {
+    /// Sandbox-resolved absolute path.
+    pub path: PathBuf,
+    /// File content before the write (`None` = file did not exist).
+    pub previous_content: Option<String>,
+    /// Byte size of the stored content (for capacity tracking).
+    pub byte_size: usize,
+}
+
+impl CheckpointEntry {
+    /// Generate a diff preview showing current file state vs. the checkpoint.
+    ///
+    /// Returns `None` when the file cannot be read (e.g. already deleted).
+    pub fn generate_restore_preview(&self) -> Option<String> {
+        let current = match std::fs::read_to_string(&self.path) {
+            Ok(content) => content,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                if self.previous_content.is_none() {
+                    return Some("(file does not exist, nothing to restore)".to_string());
+                }
+                return Some("(file was deleted externally, will recreate)".to_string());
+            }
+            Err(_) => return None,
+        };
+
+        let previous = self.previous_content.as_deref().unwrap_or("");
+        if current == previous {
+            return Some("(no changes to undo)".to_string());
+        }
+
+        let diff = similar::TextDiff::from_lines(current.as_str(), previous);
+        let diff_text = diff
+            .unified_diff()
+            .context_radius(3)
+            .header("a (current)", "b (restored)")
+            .to_string();
+
+        if diff_text.trim().is_empty() {
+            Some("(no changes to undo)".to_string())
+        } else {
+            Some(diff_text)
+        }
+    }
+
+    /// Restore this checkpoint entry to disk.
+    ///
+    /// Returns a [`RestoreResult`] describing the outcome.
+    pub fn restore(&self) -> RestoreResult {
+        let diff_preview = self.generate_restore_preview();
+        match &self.previous_content {
+            None => match std::fs::remove_file(&self.path) {
+                Ok(()) => RestoreResult {
+                    path: self.path.clone(),
+                    action: RestoreAction::FileRemoved,
+                    diff_preview,
+                },
+                Err(err) if err.kind() == std::io::ErrorKind::NotFound => RestoreResult {
+                    path: self.path.clone(),
+                    action: RestoreAction::Skipped,
+                    diff_preview: Some("(file already removed)".to_string()),
+                },
+                Err(err) => {
+                    tracing::warn!(
+                        path = %self.path.display(),
+                        "undo: failed to remove file: {err}"
+                    );
+                    RestoreResult {
+                        path: self.path.clone(),
+                        action: RestoreAction::Skipped,
+                        diff_preview: Some(format!("(IO error: {err})")),
+                    }
+                }
+            },
+            Some(content) => match std::fs::write(&self.path, content) {
+                Ok(()) => RestoreResult {
+                    path: self.path.clone(),
+                    action: RestoreAction::ContentRestored,
+                    diff_preview,
+                },
+                Err(err) => {
+                    tracing::warn!(
+                        path = %self.path.display(),
+                        "undo: failed to restore file: {err}"
+                    );
+                    RestoreResult {
+                        path: self.path.clone(),
+                        action: RestoreAction::Skipped,
+                        diff_preview: Some(format!("(IO error: {err})")),
+                    }
+                }
+            },
+        }
+    }
+}
+
+/// Result of restoring a single checkpoint entry.
+#[derive(Debug, Clone)]
+pub struct RestoreResult {
+    /// Path of the restored file.
+    pub path: PathBuf,
+    /// What kind of restoration was performed.
+    pub action: RestoreAction,
+    /// Diff preview (for display).
+    pub diff_preview: Option<String>,
+}
+
+/// Describes the type of restore action taken.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RestoreAction {
+    /// File content was restored to its previous state.
+    ContentRestored,
+    /// A newly created file was removed.
+    FileRemoved,
+    /// The entry was skipped (e.g. IO error).
+    Skipped,
+}
+
+/// Stack-based checkpoint store for undo functionality.
+pub struct CheckpointStack {
+    entries: Vec<CheckpointEntry>,
+    total_bytes: usize,
+    max_depth: usize,
+    max_bytes: usize,
+}
+
+impl CheckpointStack {
+    /// Default max depth = 20, max bytes = 10 MB.
+    pub fn new() -> Self {
+        Self {
+            entries: Vec::new(),
+            total_bytes: 0,
+            max_depth: 20,
+            max_bytes: 10 * 1024 * 1024,
+        }
+    }
+
+    /// Push a checkpoint entry. Returns the index at which it was stored.
+    ///
+    /// When the stack exceeds depth or byte limits, the oldest entries are
+    /// discarded automatically.
+    pub fn push(&mut self, entry: CheckpointEntry) -> usize {
+        self.total_bytes += entry.byte_size;
+        self.entries.push(entry);
+
+        // Evict oldest entries if depth exceeded
+        while self.entries.len() > self.max_depth {
+            let removed = self.entries.remove(0);
+            self.total_bytes = self.total_bytes.saturating_sub(removed.byte_size);
+        }
+
+        // Evict oldest entries if byte limit exceeded
+        while self.total_bytes > self.max_bytes && !self.entries.is_empty() {
+            let removed = self.entries.remove(0);
+            self.total_bytes = self.total_bytes.saturating_sub(removed.byte_size);
+        }
+
+        self.entries.len() - 1
+    }
+
+    /// Remove the entry at the given index (for rollback on tool failure).
+    pub fn remove(&mut self, index: usize) -> Option<CheckpointEntry> {
+        if index < self.entries.len() {
+            let removed = self.entries.remove(index);
+            self.total_bytes = self.total_bytes.saturating_sub(removed.byte_size);
+            Some(removed)
+        } else {
+            None
+        }
+    }
+
+    /// Pop the most recent entry.
+    pub fn pop(&mut self) -> Option<CheckpointEntry> {
+        let entry = self.entries.pop()?;
+        self.total_bytes = self.total_bytes.saturating_sub(entry.byte_size);
+        Some(entry)
+    }
+
+    /// Pop up to `n` entries from the stack (newest first).
+    ///
+    /// When the same file path appears multiple times, only the oldest
+    /// entry (earliest checkpoint) is kept so that undo restores the file
+    /// to its state before the first change.
+    pub fn pop_n(&mut self, n: usize) -> Vec<CheckpointEntry> {
+        let actual = n.min(self.entries.len());
+        let mut popped = Vec::with_capacity(actual);
+        for _ in 0..actual {
+            if let Some(entry) = self.pop() {
+                popped.push(entry);
+            }
+        }
+
+        // Deduplicate by path: keep the oldest entry for each path.
+        // Since we pop newest-first, the last occurrence in `popped` is the
+        // oldest checkpoint. We iterate in reverse (oldest-first) and keep the
+        // first occurrence we see for each path.
+        let mut seen = std::collections::HashSet::new();
+        let mut deduped = Vec::new();
+        for entry in popped.into_iter().rev() {
+            if !seen.insert(entry.path.clone()) {
+                continue;
+            }
+            deduped.push(entry);
+        }
+        // Reverse back to newest-first order
+        deduped.reverse();
+        deduped
+    }
+
+    /// Number of entries currently in the stack.
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Whether the stack is empty.
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+}
+
+impl Default for CheckpointStack {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 fn render_directory_listing(path: &Path) -> Result<String, ToolRuntimeError> {
     let entries = fs::read_dir(path).map_err(|err| {
         ToolRuntimeError::Io(format!("file.read failed for {}: {err}", path.display()))

--- a/tests/cli_session.rs
+++ b/tests/cli_session.rs
@@ -678,3 +678,82 @@ fn repo_find_adds_retrieval_context_to_following_provider_turn() {
             && message.content.contains("src/provider_notes.rs")
     }));
 }
+
+// ---------------------------------------------------------------------------
+// /undo command tests (Issue #68)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn undo_command_is_recognized() {
+    let mut app = common::build_app();
+    let tui = Tui::new();
+    let provider = RecordingProvider {
+        seen_requests: Rc::new(RefCell::new(Vec::new())),
+        events: Vec::new(),
+    };
+
+    let result = app
+        .handle_cli_line("/undo", &provider, &tui)
+        .expect("undo should be recognized");
+    assert_eq!(result.control, SessionControl::Continue);
+    assert!(
+        result
+            .frames
+            .last()
+            .expect("undo frame")
+            .contains("No changes to undo"),
+        "empty undo stack should show appropriate message"
+    );
+}
+
+#[test]
+fn undo_command_parses_numeric_argument() {
+    let mut app = common::build_app();
+    let tui = Tui::new();
+    let provider = RecordingProvider {
+        seen_requests: Rc::new(RefCell::new(Vec::new())),
+        events: Vec::new(),
+    };
+
+    let result = app
+        .handle_cli_line("/undo 3", &provider, &tui)
+        .expect("undo with argument should be recognized");
+    assert_eq!(result.control, SessionControl::Continue);
+    assert!(
+        result
+            .frames
+            .last()
+            .expect("undo frame")
+            .contains("No changes to undo"),
+        "empty undo stack should show appropriate message even with N argument"
+    );
+}
+
+#[test]
+fn undo_command_no_target_shows_message() {
+    let mut app = common::build_app();
+    let tui = Tui::new();
+    let provider = RecordingProvider {
+        seen_requests: Rc::new(RefCell::new(Vec::new())),
+        events: Vec::new(),
+    };
+
+    let result = app
+        .handle_cli_line("/undo", &provider, &tui)
+        .expect("undo should work");
+    let frame = result.frames.last().expect("frame");
+    assert!(
+        frame.contains("No changes to undo"),
+        "should indicate nothing to undo"
+    );
+}
+
+#[test]
+fn help_frame_includes_undo_command() {
+    let help = anvil::app::render_help_frame();
+    assert!(help.contains("/undo"), "help should list /undo command");
+    assert!(
+        help.contains("undo the last file change"),
+        "help should show undo description"
+    );
+}

--- a/tests/tooling_system.rs
+++ b/tests/tooling_system.rs
@@ -1,10 +1,10 @@
 use anvil::app::agentic::{ExecutionGroup, group_by_execution_mode};
 use anvil::tooling::{
-    ExecutionClass, ExecutionMode, LocalToolExecutor, ParallelExecutionPlan,
-    ParallelExecutionPlanError, PermissionClass, PlanModePolicy, RollbackPolicy, ToolCallRequest,
-    ToolExecutionError, ToolExecutionPayload, ToolExecutionPolicy, ToolExecutionRequest,
-    ToolExecutionResult, ToolExecutionStatus, ToolInput, ToolKind, ToolRegistry,
-    ToolValidationError, detect_image_mime,
+    CheckpointEntry, CheckpointStack, ExecutionClass, ExecutionMode, LocalToolExecutor,
+    ParallelExecutionPlan, ParallelExecutionPlanError, PermissionClass, PlanModePolicy,
+    RollbackPolicy, ToolCallRequest, ToolExecutionError, ToolExecutionPayload, ToolExecutionPolicy,
+    ToolExecutionRequest, ToolExecutionResult, ToolExecutionStatus, ToolInput, ToolKind,
+    ToolRegistry, ToolValidationError, detect_image_mime,
 };
 use std::fs;
 use std::path::Path;
@@ -2629,4 +2629,189 @@ fn check_offline_blocked_blocks_web_search_in_offline_mode() {
     let result = check_offline_blocked(&config, &call);
     assert!(result.is_some());
     assert!(result.unwrap().contains("web.search"));
+}
+
+// ---------------------------------------------------------------------------
+// CheckpointStack tests (Issue #68)
+// ---------------------------------------------------------------------------
+
+fn make_checkpoint_entry(path: &str, content: Option<&str>) -> CheckpointEntry {
+    let byte_size = content.map_or(0, |c| c.len());
+    CheckpointEntry {
+        path: std::path::PathBuf::from(path),
+        previous_content: content.map(String::from),
+        byte_size,
+    }
+}
+
+#[test]
+fn checkpoint_stack_new_initial_state() {
+    let stack = CheckpointStack::new();
+    assert_eq!(stack.len(), 0);
+    assert!(stack.is_empty());
+}
+
+#[test]
+fn checkpoint_stack_push_pop_basic() {
+    let mut stack = CheckpointStack::new();
+    let entry = make_checkpoint_entry("/tmp/a.rs", Some("hello"));
+    stack.push(entry);
+    assert_eq!(stack.len(), 1);
+    assert!(!stack.is_empty());
+
+    let popped = stack.pop().expect("should pop");
+    assert_eq!(popped.path, std::path::PathBuf::from("/tmp/a.rs"));
+    assert_eq!(popped.previous_content.as_deref(), Some("hello"));
+    assert!(stack.is_empty());
+}
+
+#[test]
+fn checkpoint_stack_push_returns_index_and_remove_works() {
+    let mut stack = CheckpointStack::new();
+    let idx0 = stack.push(make_checkpoint_entry("/tmp/a.rs", Some("a")));
+    let idx1 = stack.push(make_checkpoint_entry("/tmp/b.rs", Some("b")));
+    assert_eq!(idx0, 0);
+    assert_eq!(idx1, 1);
+
+    let removed = stack.remove(0).expect("should remove");
+    assert_eq!(removed.path, std::path::PathBuf::from("/tmp/a.rs"));
+    assert_eq!(stack.len(), 1);
+
+    let remaining = stack.pop().expect("should pop remaining");
+    assert_eq!(remaining.path, std::path::PathBuf::from("/tmp/b.rs"));
+}
+
+#[test]
+fn checkpoint_stack_pop_n_partial() {
+    let mut stack = CheckpointStack::new();
+    stack.push(make_checkpoint_entry("/tmp/a.rs", Some("a")));
+    stack.push(make_checkpoint_entry("/tmp/b.rs", Some("b")));
+    stack.push(make_checkpoint_entry("/tmp/c.rs", Some("c")));
+
+    let popped = stack.pop_n(2);
+    assert_eq!(popped.len(), 2);
+    // Newest first
+    assert_eq!(popped[0].path, std::path::PathBuf::from("/tmp/c.rs"));
+    assert_eq!(popped[1].path, std::path::PathBuf::from("/tmp/b.rs"));
+    assert_eq!(stack.len(), 1);
+}
+
+#[test]
+fn checkpoint_stack_pop_n_exceeds_depth() {
+    let mut stack = CheckpointStack::new();
+    stack.push(make_checkpoint_entry("/tmp/a.rs", Some("a")));
+    stack.push(make_checkpoint_entry("/tmp/b.rs", Some("b")));
+
+    let popped = stack.pop_n(10);
+    assert_eq!(popped.len(), 2);
+    assert!(stack.is_empty());
+}
+
+#[test]
+fn checkpoint_stack_pop_n_deduplicates_same_file() {
+    let mut stack = CheckpointStack::new();
+    stack.push(make_checkpoint_entry("/tmp/a.rs", Some("original")));
+    stack.push(make_checkpoint_entry("/tmp/b.rs", Some("b")));
+    stack.push(make_checkpoint_entry("/tmp/a.rs", Some("modified")));
+
+    let popped = stack.pop_n(3);
+    // Same file /tmp/a.rs appeared twice; only the oldest ("original") should be kept
+    assert_eq!(popped.len(), 2);
+    let a_entry = popped
+        .iter()
+        .find(|e| e.path == Path::new("/tmp/a.rs"))
+        .expect("a.rs should exist");
+    assert_eq!(a_entry.previous_content.as_deref(), Some("original"));
+}
+
+#[test]
+fn checkpoint_stack_depth_limit_evicts_oldest() {
+    let mut stack = CheckpointStack::new();
+    for i in 0..25 {
+        stack.push(make_checkpoint_entry(&format!("/tmp/{i}.rs"), Some("x")));
+    }
+    // max_depth = 20
+    assert_eq!(stack.len(), 20);
+    // The first 5 should have been evicted; entry at index 0 should be /tmp/5.rs
+    let first = stack.pop().expect("should pop");
+    assert_eq!(first.path, std::path::PathBuf::from("/tmp/24.rs"));
+}
+
+#[test]
+fn checkpoint_stack_byte_limit_evicts_oldest() {
+    let mut stack = CheckpointStack::new();
+    // Each entry is ~1MB (1_048_576 bytes). Push 12 to exceed 10MB limit.
+    let big_content = "x".repeat(1_048_576);
+    for i in 0..12 {
+        stack.push(make_checkpoint_entry(
+            &format!("/tmp/{i}.rs"),
+            Some(&big_content),
+        ));
+    }
+    // Should have evicted enough to stay under 10MB
+    assert!(stack.len() < 12);
+    assert!(stack.len() >= 9); // floor(10MB / 1MB) = 10, but some eviction margin
+}
+
+#[test]
+fn checkpoint_stack_new_file_entry_has_none_content() {
+    let mut stack = CheckpointStack::new();
+    stack.push(make_checkpoint_entry("/tmp/new.rs", None));
+    let popped = stack.pop().expect("should pop");
+    assert!(popped.previous_content.is_none());
+    assert_eq!(popped.byte_size, 0);
+}
+
+#[test]
+fn checkpoint_entry_generate_restore_preview_for_existing_file() {
+    let dir = std::env::temp_dir().join(format!(
+        "anvil_test_restore_preview_{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    fs::create_dir_all(&dir).unwrap();
+    let file_path = dir.join("test.rs");
+    fs::write(&file_path, "modified content").unwrap();
+
+    let entry = CheckpointEntry {
+        path: file_path.clone(),
+        previous_content: Some("original content".to_string()),
+        byte_size: 16,
+    };
+
+    let preview = entry.generate_restore_preview();
+    assert!(preview.is_some());
+    let text = preview.unwrap();
+    // Should contain diff information
+    assert!(text.contains("current") || text.contains("restored") || text.contains("-"));
+
+    fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn checkpoint_entry_generate_restore_preview_no_changes() {
+    let dir = std::env::temp_dir().join(format!(
+        "anvil_test_no_change_preview_{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    fs::create_dir_all(&dir).unwrap();
+    let file_path = dir.join("test.rs");
+    fs::write(&file_path, "same content").unwrap();
+
+    let entry = CheckpointEntry {
+        path: file_path.clone(),
+        previous_content: Some("same content".to_string()),
+        byte_size: 12,
+    };
+
+    let preview = entry.generate_restore_preview();
+    assert!(preview.is_some());
+    assert!(preview.unwrap().contains("no changes to undo"));
+
+    fs::remove_dir_all(&dir).ok();
 }


### PR DESCRIPTION
## Summary
- CheckpointStackによるファイル変更の取り消し機能を実装
- `/undo`コマンドで直前のfile.write/file.editを復元

Closes #68
🤖 Generated with [Claude Code](https://claude.com/claude-code)