### PR TITLE
feat: バッチ承認 --trust モード (#70)

### DIFF
--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -19,6 +19,9 @@ use crate::tooling::{
 use crate::tui::Tui;
 use std::sync::atomic::Ordering;
 
+use crate::tooling::{PermissionClass, ToolKind};
+use std::collections::HashSet;
+
 use super::policy::{OFFLINE_BLOCK_PAYLOAD, check_offline_blocked};
 use super::{App, AppError};
 
@@ -499,13 +502,27 @@ impl App {
             }
 
             if self.config.mode.approval_required && validated.approval_required(true).is_some() {
-                let summary = tool_call_approval_summary(call);
-                let diff_preview = generate_diff_preview(&self.config.paths.cwd, &call.input);
-                let approved = prompt_inline_approval(&summary, diff_preview.as_deref());
-                if !approved {
-                    failed_results
-                        .push((idx, build_failed_result(call, "denied by user".to_string())));
-                    continue;
+                if is_trusted(
+                    &call.tool_name,
+                    validated.spec.kind,
+                    validated.spec.permission_class,
+                    self.trust_all,
+                    &self.trusted_tools,
+                ) {
+                    let summary = tool_call_approval_summary(call);
+                    let _ = std::io::Write::write_fmt(
+                        &mut std::io::stderr(),
+                        format_args!("\n  [trusted] {summary}\n"),
+                    );
+                } else {
+                    let summary = tool_call_approval_summary(call);
+                    let diff_preview = generate_diff_preview(&self.config.paths.cwd, &call.input);
+                    let approved = prompt_inline_approval(&summary, diff_preview.as_deref());
+                    if !approved {
+                        failed_results
+                            .push((idx, build_failed_result(call, "denied by user".to_string())));
+                        continue;
+                    }
                 }
             }
             match validated
@@ -978,5 +995,103 @@ fn truncate_chars(s: &str, max_chars: usize) -> String {
     } else {
         let truncated: String = s.chars().take(max_chars).collect();
         format!("{truncated}...")
+    }
+}
+
+/// Determine whether a tool call should be auto-approved based on trust settings.
+///
+/// This is a pure function for testability; it does not access `App` state directly.
+pub(crate) fn is_trusted(
+    tool_name: &str,
+    kind: ToolKind,
+    permission_class: PermissionClass,
+    trust_all: bool,
+    trusted_tools: &HashSet<String>,
+) -> bool {
+    if permission_class == PermissionClass::Restricted {
+        return false;
+    }
+    if trust_all && kind != ToolKind::Mcp {
+        return true;
+    }
+    trusted_tools.contains(tool_name)
+}
+
+#[cfg(test)]
+mod trust_tests {
+    use super::*;
+
+    #[test]
+    fn trust_all_auto_approves_confirm_tools() {
+        let trusted_tools = HashSet::new();
+        assert!(is_trusted(
+            "shell.exec",
+            ToolKind::ShellExec,
+            PermissionClass::Confirm,
+            true,
+            &trusted_tools,
+        ));
+    }
+
+    #[test]
+    fn trust_all_blocks_restricted_tools() {
+        let trusted_tools = HashSet::new();
+        assert!(!is_trusted(
+            "some.restricted",
+            ToolKind::ShellExec,
+            PermissionClass::Restricted,
+            true,
+            &trusted_tools,
+        ));
+    }
+
+    #[test]
+    fn trust_all_blocks_mcp_tools() {
+        let trusted_tools = HashSet::new();
+        assert!(!is_trusted(
+            "mcp__github__create_issue",
+            ToolKind::Mcp,
+            PermissionClass::Confirm,
+            true,
+            &trusted_tools,
+        ));
+    }
+
+    #[test]
+    fn individual_trust_approves_specific_tool() {
+        let mut trusted_tools = HashSet::new();
+        trusted_tools.insert("file.edit".to_string());
+        assert!(is_trusted(
+            "file.edit",
+            ToolKind::FileEdit,
+            PermissionClass::Confirm,
+            false,
+            &trusted_tools,
+        ));
+    }
+
+    #[test]
+    fn individual_trust_allows_mcp() {
+        let mut trusted_tools = HashSet::new();
+        trusted_tools.insert("mcp__github__create_issue".to_string());
+        assert!(is_trusted(
+            "mcp__github__create_issue",
+            ToolKind::Mcp,
+            PermissionClass::Confirm,
+            false,
+            &trusted_tools,
+        ));
+    }
+
+    #[test]
+    fn untrusted_tool_returns_false() {
+        let trusted_tools = HashSet::new();
+        assert!(!is_trusted(
+            "file.edit",
+            ToolKind::FileEdit,
+            PermissionClass::Confirm,
+            false,
+            &trusted_tools,
+        ));
     }
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -17,7 +17,7 @@ use crate::contracts::{
     AppEvent, AppStateSnapshot, ConsoleRenderContext, ContextUsageView, ContextWarningLevel,
     RuntimeState,
 };
-use crate::extensions::{ExtensionLoadError, ExtensionRegistry, SlashCommandAction};
+use crate::extensions::{ExtensionLoadError, ExtensionRegistry, SlashCommandAction, TrustAction};
 use crate::provider::{
     ProviderBootstrapError, ProviderClient, ProviderErrorKind, ProviderErrorRecord, ProviderEvent,
     ProviderRuntimeContext, ProviderTurnError,
@@ -34,6 +34,7 @@ use crate::tooling::{
     ToolRegistry, ToolSpec,
 };
 use crate::tui::Tui;
+use std::collections::HashSet;
 use std::fmt::{Display, Formatter};
 use std::io::{self, Write};
 use std::sync::Arc;
@@ -120,6 +121,10 @@ pub struct App {
     /// MCP server manager. `None` when mcp.json is absent or initialization failed.
     /// [D2-010] Declared last so it is dropped last (Drop order = declaration order).
     mcp_manager: Option<crate::mcp::McpManager>,
+    /// Trust mode: auto-approve built-in (non-MCP) tool execution.
+    trust_all: bool,
+    /// Individually trusted tool names (including MCP tools).
+    trusted_tools: HashSet<String>,
 }
 
 /// Whether the session loop should continue or exit.
@@ -335,6 +340,8 @@ impl App {
             );
         }
 
+        let trust_all = config.mode.trust_all;
+
         Ok(Self {
             tools,
             config,
@@ -348,6 +355,8 @@ impl App {
             warning_tracker: ContextWarningTracker::new(),
             hooks_engine,
             mcp_manager,
+            trust_all,
+            trusted_tools: HashSet::new(),
         })
     }
 
@@ -1265,6 +1274,57 @@ impl App {
                 frames: self.deny_and_abort(tui)?,
                 control: SessionControl::Continue,
             },
+            Some(SlashCommandAction::Trust(action)) => {
+                let msg = match action {
+                    TrustAction::Show => {
+                        if self.trust_all {
+                            let mut lines = vec![
+                                "Trust mode: ON (all)".to_string(),
+                                "  Trusted tools: (all non-MCP tools)".to_string(),
+                            ];
+                            if !self.trusted_tools.is_empty() {
+                                let mut tools: Vec<_> =
+                                    self.trusted_tools.iter().cloned().collect();
+                                tools.sort();
+                                lines.push(format!("  Individually trusted: {}", tools.join(", ")));
+                            }
+                            lines.join("\n")
+                        } else if !self.trusted_tools.is_empty() {
+                            let mut tools: Vec<_> = self.trusted_tools.iter().cloned().collect();
+                            tools.sort();
+                            let mut lines = vec!["Trust mode: ON (selective)".to_string()];
+                            lines.push("  Trusted tools:".to_string());
+                            for tool in &tools {
+                                lines.push(format!("    - {tool}"));
+                            }
+                            lines.join("\n")
+                        } else {
+                            "Trust mode: OFF\n  No tools are trusted. Use /trust <tool> or /trust all.".to_string()
+                        }
+                    }
+                    TrustAction::Tool(name) => {
+                        if self.tools.get(&name).is_some() {
+                            self.trusted_tools.insert(name.clone());
+                            format!("Trusted: {name}")
+                        } else {
+                            format!("Unknown tool: {name}. Use /trust to see trusted tools.")
+                        }
+                    }
+                    TrustAction::All => {
+                        self.trust_all = true;
+                        "Trust mode: ON (all non-MCP tools auto-approved)".to_string()
+                    }
+                    TrustAction::Off => {
+                        self.trust_all = false;
+                        self.trusted_tools.clear();
+                        "Trust mode: OFF".to_string()
+                    }
+                };
+                CliTurnOutput {
+                    frames: vec![msg],
+                    control: SessionControl::Continue,
+                }
+            }
             Some(SlashCommandAction::Reset) => {
                 let _ = self.reset_to_ready()?;
                 CliTurnOutput {

--- a/src/config/cli_args.rs
+++ b/src/config/cli_args.rs
@@ -72,4 +72,8 @@ pub struct CliArgs {
     /// Run in offline mode (disable web tools and MCP)
     #[arg(long)]
     pub offline: bool,
+
+    /// Auto-approve built-in tool execution (MCP tools require individual trust)
+    #[arg(long)]
+    pub trust: bool,
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -77,6 +77,9 @@ pub struct ModeConfig {
     pub debug_logging: bool,
     pub log_filter: Option<String>,
     pub offline: bool,
+    /// Trust mode: auto-approve built-in tool execution.
+    /// Set only via `--trust` CLI flag (not from config file deserialization).
+    pub trust_all: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -215,6 +218,7 @@ impl EffectiveConfig {
                 debug_logging: false,
                 log_filter: None,
                 offline: false,
+                trust_all: false,
             },
             paths: PathConfig {
                 mcp_config_file: cwd.join(".anvil").join("mcp.json"),
@@ -374,6 +378,9 @@ impl EffectiveConfig {
 
         if cli.offline {
             self.mode.offline = true;
+        }
+        if cli.trust {
+            self.mode.trust_all = true;
         }
 
         Ok(())

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -5,6 +5,15 @@ use skills::SkillScope;
 use std::fmt::{Display, Formatter};
 use std::path::{Path, PathBuf};
 
+/// Sub-actions for the /trust slash command.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TrustAction {
+    Show,
+    Tool(String),
+    All,
+    Off,
+}
+
 /// Action to perform when a slash command is invoked.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SlashCommandAction {
@@ -31,6 +40,7 @@ pub enum SlashCommandAction {
         content: String,
         skill_dir: PathBuf,
     },
+    Trust(TrustAction),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -137,6 +147,9 @@ impl ExtensionRegistry {
             return Some(parsed);
         }
         if let Some(parsed) = parse_repo_command(command) {
+            return Some(parsed);
+        }
+        if let Some(parsed) = parse_trust_command(command) {
             return Some(parsed);
         }
         if let found @ Some(_) = self
@@ -259,6 +272,12 @@ pub fn builtin_slash_commands() -> Vec<SlashCommandSpec> {
             scope: None,
         },
         SlashCommandSpec {
+            name: "/trust".to_string(),
+            description: "show or manage trust settings (/trust [all|off|<tool>])".to_string(),
+            action: SlashCommandAction::Trust(TrustAction::Show),
+            scope: None,
+        },
+        SlashCommandSpec {
             name: "/exit".to_string(),
             description: "exit the session".to_string(),
             action: SlashCommandAction::Exit,
@@ -363,4 +382,90 @@ fn parse_repo_command(command: &str) -> Option<SlashCommandSpec> {
         action: SlashCommandAction::RepoFind(query.to_string()),
         scope: None,
     })
+}
+
+fn parse_trust_command(command: &str) -> Option<SlashCommandSpec> {
+    if command == "/trust" {
+        return Some(SlashCommandSpec {
+            name: "/trust".to_string(),
+            description: "show current trust settings".to_string(),
+            action: SlashCommandAction::Trust(TrustAction::Show),
+            scope: None,
+        });
+    }
+
+    let rest = command.strip_prefix("/trust ")?.trim();
+    if rest.is_empty() {
+        return Some(SlashCommandSpec {
+            name: "/trust".to_string(),
+            description: "show current trust settings".to_string(),
+            action: SlashCommandAction::Trust(TrustAction::Show),
+            scope: None,
+        });
+    }
+
+    let action = match rest {
+        "all" => TrustAction::All,
+        "off" => TrustAction::Off,
+        tool_name => TrustAction::Tool(tool_name.to_string()),
+    };
+
+    Some(SlashCommandSpec {
+        name: "/trust".to_string(),
+        description: "manage trust settings".to_string(),
+        action: SlashCommandAction::Trust(action),
+        scope: None,
+    })
+}
+
+#[cfg(test)]
+mod trust_parse_tests {
+    use super::*;
+
+    #[test]
+    fn parse_trust_show() {
+        let result = parse_trust_command("/trust").unwrap();
+        assert_eq!(result.action, SlashCommandAction::Trust(TrustAction::Show));
+    }
+
+    #[test]
+    fn parse_trust_show_with_trailing_space() {
+        let result = parse_trust_command("/trust ").unwrap();
+        assert_eq!(result.action, SlashCommandAction::Trust(TrustAction::Show));
+    }
+
+    #[test]
+    fn parse_trust_all() {
+        let result = parse_trust_command("/trust all").unwrap();
+        assert_eq!(result.action, SlashCommandAction::Trust(TrustAction::All));
+    }
+
+    #[test]
+    fn parse_trust_off() {
+        let result = parse_trust_command("/trust off").unwrap();
+        assert_eq!(result.action, SlashCommandAction::Trust(TrustAction::Off));
+    }
+
+    #[test]
+    fn parse_trust_tool() {
+        let result = parse_trust_command("/trust file.edit").unwrap();
+        assert_eq!(
+            result.action,
+            SlashCommandAction::Trust(TrustAction::Tool("file.edit".to_string()))
+        );
+    }
+
+    #[test]
+    fn parse_trust_mcp_tool() {
+        let result = parse_trust_command("/trust mcp__github__create_issue").unwrap();
+        assert_eq!(
+            result.action,
+            SlashCommandAction::Trust(TrustAction::Tool("mcp__github__create_issue".to_string()))
+        );
+    }
+
+    #[test]
+    fn parse_non_trust_command_returns_none() {
+        assert!(parse_trust_command("/help").is_none());
+    }
 }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -24,10 +24,12 @@ impl Tui {
     }
 
     pub fn render_startup(&self, config: &EffectiveConfig, snapshot: &AppStateSnapshot) -> String {
-        let mode = if config.mode.approval_required {
-            "local / confirm"
-        } else {
+        let mode = if !config.mode.approval_required {
             "local / auto"
+        } else if config.mode.trust_all {
+            "local / trust"
+        } else {
+            "local / confirm"
         };
 
         let mut lines = vec![


### PR DESCRIPTION
## Summary
- `--trust`フラグで全ツール自動承認
- `/trust`コマンドで特定ツールの承認制御

Closes #70
🤖 Generated with [Claude Code](https://claude.com/claude-code)