### PR TITLE
feat: セッション管理改善 (#71)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,7 +129,7 @@ src/
 │   ├── openai.rs        # OpenAI互換クライアント
 │   └── transport.rs     # HTTPトランスポート
 ├── retrieval/mod.rs     # リポジトリ検索
-├── session/mod.rs       # セッション永続化
+├── session/mod.rs       # セッション永続化（名前付きセッション・一覧・切替・削除・マイグレーション）
 ├── spinner.rs           # スピナーUI
 ├── state/mod.rs         # 状態マシン
 ├── tooling/

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -120,6 +120,8 @@ pub struct App {
     /// MCP server manager. `None` when mcp.json is absent or initialization failed.
     /// [D2-010] Declared last so it is dropped last (Drop order = declaration order).
     mcp_manager: Option<crate::mcp::McpManager>,
+    /// Current session name (derived from session file stem).
+    current_session_name: String,
 }
 
 /// Whether the session loop should continue or exit.
@@ -335,6 +337,14 @@ impl App {
             );
         }
 
+        let current_session_name = config
+            .paths
+            .session_file
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("default")
+            .to_string();
+
         Ok(Self {
             tools,
             config,
@@ -348,6 +358,7 @@ impl App {
             warning_tracker: ContextWarningTracker::new(),
             hooks_engine,
             mcp_manager,
+            current_session_name,
         })
     }
 
@@ -472,6 +483,50 @@ impl App {
         &mut self.session
     }
 
+    pub fn current_session_name(&self) -> &str {
+        &self.current_session_name
+    }
+
+    /// Switch to a different named session.
+    ///
+    /// Validates the name, saves the current session, builds a new
+    /// `SessionStore`, loads or creates the target session, and resets
+    /// internal state.
+    fn switch_session(&mut self, name: &str) -> Result<Vec<String>, AppError> {
+        crate::session::validate_session_name(name)?;
+
+        if self.session.has_pending_turn() {
+            return Err(AppError::PendingApprovalRequired);
+        }
+
+        // Save current session
+        self.flush_session()?;
+
+        // Build new SessionStore
+        let new_path = self.config.paths.session_dir.join(format!("{name}.json"));
+        let new_store = SessionStore::new(new_path.clone(), self.config.paths.session_dir.clone());
+
+        // Load or create
+        let new_session = if new_path.exists() {
+            new_store.load()?
+        } else {
+            SessionRecord::new_named(name, self.config.paths.cwd.clone())?
+        };
+
+        // Reset fields
+        self.session_store = new_store;
+        self.session = new_session;
+        self.session.auto_compact_threshold = self.config.runtime.auto_compact_threshold;
+        self.state_machine =
+            StateMachine::from_snapshot(AppStateSnapshot::new(RuntimeState::Ready));
+        self.warning_tracker = ContextWarningTracker::new();
+        self.current_session_name = name.to_string();
+
+        tracing::info!(session_name = name, "Session switched");
+
+        Ok(vec![format!("Switched to session: {name}")])
+    }
+
     pub fn render_console(&self, tui: &Tui) -> Result<String, AppError> {
         Ok(tui.render_console(&self.build_console_render_context()))
     }
@@ -484,7 +539,7 @@ impl App {
 
         Ok(format!(
             "{}\n{}",
-            render::render_resume_header(&self.config),
+            render::render_resume_header(&self.config, &self.current_session_name),
             tui.render_console(&self.build_startup_render_context())
         ))
     }
@@ -1289,6 +1344,61 @@ impl App {
                     crate::extensions::skills::expand_variables(&content, &args, &skill_dir);
                 self.run_turn_to_output(prompt, provider_client, tui)?
             }
+            Some(SlashCommandAction::SessionList) => {
+                let sessions = self.session_store.list_sessions()?;
+                let output = if sessions.is_empty() {
+                    "[A] anvil > no sessions found".to_string()
+                } else {
+                    let mut lines = vec![format!("[A] anvil > {} session(s)", sessions.len())];
+                    for info in &sessions {
+                        let marker = if info.name == self.current_session_name {
+                            " *"
+                        } else {
+                            ""
+                        };
+                        lines.push(format!(
+                            "  {}{} ({} messages)",
+                            info.name, marker, info.message_count
+                        ));
+                    }
+                    lines.join("\n")
+                };
+                CliTurnOutput {
+                    frames: vec![output],
+                    control: SessionControl::Continue,
+                }
+            }
+            Some(SlashCommandAction::SessionDelete(name)) => {
+                if name == self.current_session_name {
+                    CliTurnOutput {
+                        frames: vec![format!(
+                            "[A] anvil > cannot delete the active session: {name}"
+                        )],
+                        control: SessionControl::Continue,
+                    }
+                } else {
+                    match self.session_store.delete_session(&name) {
+                        Ok(()) => CliTurnOutput {
+                            frames: vec![format!("[A] anvil > deleted session: {name}")],
+                            control: SessionControl::Continue,
+                        },
+                        Err(e) => CliTurnOutput {
+                            frames: vec![format!("[A] anvil > {e}")],
+                            control: SessionControl::Continue,
+                        },
+                    }
+                }
+            }
+            Some(SlashCommandAction::SessionSwitch(name)) => match self.switch_session(&name) {
+                Ok(frames) => CliTurnOutput {
+                    frames,
+                    control: SessionControl::Continue,
+                },
+                Err(e) => CliTurnOutput {
+                    frames: vec![format!("[A] anvil > {e}")],
+                    control: SessionControl::Continue,
+                },
+            },
             _ => {
                 let suggestion = self.extensions.suggest_command(command);
                 let msg = if let Some(suggested) = suggestion {

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -86,10 +86,11 @@ pub fn render_provider_frame(
     )
 }
 
-pub fn render_resume_header(config: &EffectiveConfig) -> String {
+pub fn render_resume_header(config: &EffectiveConfig, session_name: &str) -> String {
     let mut lines = vec![
         "  --------------------------------------------------------------".to_string(),
         "  Resuming existing session".to_string(),
+        format!("  Session : {session_name}"),
         format!("  Model   : {}", config.runtime.model),
         format!("  Context : {}k", config.runtime.context_window / 1_000),
         format!("  Project : {}", config.paths.cwd.display()),

--- a/src/config/cli_args.rs
+++ b/src/config/cli_args.rs
@@ -72,4 +72,8 @@ pub struct CliArgs {
     /// Run in offline mode (disable web tools and MCP)
     #[arg(long)]
     pub offline: bool,
+
+    /// Named session to use
+    #[arg(long)]
+    pub session: Option<String>,
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -9,8 +9,6 @@ pub use cli_args::CliArgs;
 
 use clap::Parser;
 use std::collections::HashMap;
-use std::collections::hash_map::DefaultHasher;
-use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
 use std::{
     error::Error,
@@ -186,7 +184,7 @@ impl EffectiveConfig {
     fn default_for_paths(cwd: PathBuf, workspace_dir: PathBuf, config_file: PathBuf) -> Self {
         let state_dir = cwd.join(".anvil").join("state");
         let session_dir = cwd.join(".anvil").join("sessions");
-        let session_file = session_dir.join(format!("{}.json", session_key_for_cwd(&cwd)));
+        let session_file = session_dir.join("default.json");
         let logs_dir = cwd.join(".anvil").join("logs");
         Self {
             runtime: RuntimeConfig {
@@ -374,6 +372,13 @@ impl EffectiveConfig {
 
         if cli.offline {
             self.mode.offline = true;
+        }
+
+        // --session flag: override session file path
+        if let Some(ref name) = cli.session {
+            crate::session::validate_session_name(name)
+                .map_err(|e| ConfigError::ValidationError(e.to_string()))?;
+            self.paths.session_file = self.paths.session_dir.join(format!("{name}.json"));
         }
 
         Ok(())
@@ -772,10 +777,11 @@ pub fn sanitize_markers(content: &str) -> (String, bool) {
     (sanitized, found)
 }
 
+/// Wrapper around `session::session_id_for_cwd()` kept for backward compatibility.
+/// Used by `session_key()` for log file naming. May be removed in a future refactor.
+#[allow(dead_code)]
 fn session_key_for_cwd(cwd: &std::path::Path) -> String {
-    let mut hasher = DefaultHasher::new();
-    cwd.hash(&mut hasher);
-    format!("session_{:x}", hasher.finish())
+    crate::session::session_id_for_cwd(cwd)
 }
 
 fn parse_bool(value: &str) -> bool {

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -31,6 +31,9 @@ pub enum SlashCommandAction {
         content: String,
         skill_dir: PathBuf,
     },
+    SessionList,
+    SessionSwitch(String),
+    SessionDelete(String),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -137,6 +140,9 @@ impl ExtensionRegistry {
             return Some(parsed);
         }
         if let Some(parsed) = parse_repo_command(command) {
+            return Some(parsed);
+        }
+        if let Some(parsed) = parse_session_command(command) {
             return Some(parsed);
         }
         if let found @ Some(_) = self
@@ -264,6 +270,12 @@ pub fn builtin_slash_commands() -> Vec<SlashCommandSpec> {
             action: SlashCommandAction::Exit,
             scope: None,
         },
+        SlashCommandSpec {
+            name: "/session".to_string(),
+            description: "manage sessions (list/switch/delete)".to_string(),
+            action: SlashCommandAction::SessionList,
+            scope: None,
+        },
     ]
 }
 
@@ -349,6 +361,35 @@ fn edit_distance(a: &str, b: &str) -> usize {
         std::mem::swap(&mut prev, &mut curr);
     }
     prev[n]
+}
+
+fn parse_session_command(command: &str) -> Option<SlashCommandSpec> {
+    let rest = command.strip_prefix("/session")?.trim();
+
+    let action = if rest.is_empty() || rest == "list" {
+        SlashCommandAction::SessionList
+    } else if let Some(name) = rest.strip_prefix("switch ") {
+        let name = name.trim();
+        if name.is_empty() {
+            return None;
+        }
+        SlashCommandAction::SessionSwitch(name.to_string())
+    } else if let Some(name) = rest.strip_prefix("delete ") {
+        let name = name.trim();
+        if name.is_empty() {
+            return None;
+        }
+        SlashCommandAction::SessionDelete(name.to_string())
+    } else {
+        return None;
+    };
+
+    Some(SlashCommandSpec {
+        name: "/session".to_string(),
+        description: "manage sessions (list/switch/delete)".to_string(),
+        action,
+        scope: None,
+    })
 }
 
 fn parse_repo_command(command: &str) -> Option<SlashCommandSpec> {

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -123,11 +123,23 @@ pub struct SessionRecord {
 }
 
 impl SessionRecord {
+    /// Create a new session with a hash-based ID derived from the working directory.
     pub fn new(cwd: PathBuf) -> Self {
+        Self::with_id(session_id_for_cwd(&cwd), cwd)
+    }
+
+    /// Create a new session with an explicit name after validation.
+    pub fn new_named(name: &str, cwd: PathBuf) -> Result<Self, SessionError> {
+        validate_session_name(name)?;
+        Ok(Self::with_id(name.to_string(), cwd))
+    }
+
+    /// Internal constructor shared by `new` and `new_named`.
+    fn with_id(session_id: String, cwd: PathBuf) -> Self {
         let now = now_ms();
         Self {
             metadata: SessionMetadata {
-                session_id: session_id_for_cwd(&cwd),
+                session_id,
                 cwd,
                 created_at_ms: now,
                 updated_at_ms: now,
@@ -419,22 +431,49 @@ impl SessionRecord {
     }
 }
 
+/// Information about a session for listing purposes.
+#[derive(Debug, Clone)]
+pub struct SessionInfo {
+    pub name: String,
+    pub updated_at_ms: u128,
+    pub message_count: usize,
+}
+
 #[derive(Debug, Clone)]
 pub struct SessionStore {
     file_path: PathBuf,
+    session_dir: PathBuf,
 }
 
 impl SessionStore {
-    pub fn new(file_path: PathBuf) -> Self {
-        Self { file_path }
+    pub fn new(file_path: PathBuf, session_dir: PathBuf) -> Self {
+        Self {
+            file_path,
+            session_dir,
+        }
     }
 
     pub fn from_config(config: &EffectiveConfig) -> Self {
-        Self::new(config.paths.session_file.clone())
+        Self::new(
+            config.paths.session_file.clone(),
+            config.paths.session_dir.clone(),
+        )
     }
 
     pub fn file_path(&self) -> &Path {
         &self.file_path
+    }
+
+    pub fn session_dir(&self) -> &Path {
+        &self.session_dir
+    }
+
+    /// Extract the session name from the file path stem (e.g. "default" from "default.json").
+    fn session_name(&self) -> &str {
+        self.file_path
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("default")
     }
 
     pub fn load_or_create(&self, cwd: &Path) -> Result<SessionRecord, SessionError> {
@@ -456,11 +495,98 @@ impl SessionStore {
             }
         }
 
+        // Migration: look for old hash-based session file
+        let old_key = session_id_for_cwd(cwd);
+        let old_path = self.session_dir.join(format!("{old_key}.json"));
+        let session_name = self.session_name();
+        if old_path.exists() {
+            tracing::debug!(old = %old_path.display(), new = %self.file_path.display(), "migrating old session file");
+            std::fs::rename(&old_path, &self.file_path)
+                .map_err(SessionError::SessionWriteFailed)?;
+            let mut session = self.load()?;
+            session.metadata.session_id = session_name.to_string();
+            session.record_event(AppEvent::SessionLoaded);
+            self.save(&session)?;
+            return Ok(session);
+        }
+
+        // New session creation using named constructor
         tracing::debug!("creating new session");
-        let mut record = SessionRecord::new(cwd.to_path_buf());
+        let mut record = if validate_session_name(session_name).is_ok() {
+            SessionRecord::new_named(session_name, cwd.to_path_buf())?
+        } else {
+            // Fallback for non-conforming file names (e.g. hash-based)
+            SessionRecord::new(cwd.to_path_buf())
+        };
         record.record_event(AppEvent::SessionLoaded);
         self.save(&record)?;
         Ok(record)
+    }
+
+    /// List all sessions in the session directory.
+    /// Skips symlinks and non-JSON files.
+    pub fn list_sessions(&self) -> Result<Vec<SessionInfo>, SessionError> {
+        let entries = match std::fs::read_dir(&self.session_dir) {
+            Ok(entries) => entries,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                return Ok(Vec::new());
+            }
+            Err(err) => return Err(SessionError::SessionReadFailed(err)),
+        };
+
+        let mut sessions = Vec::new();
+        for entry in entries {
+            let entry = match entry {
+                Ok(e) => e,
+                Err(_) => continue,
+            };
+
+            let path = entry.path();
+
+            // Skip symlinks
+            if path.symlink_metadata().map_or(true, |m| m.is_symlink()) {
+                continue;
+            }
+
+            // Only process .json files (skip .json.tmp and others)
+            if path.extension().and_then(|e| e.to_str()) != Some("json") {
+                continue;
+            }
+
+            let name = match path.file_stem().and_then(|s| s.to_str()) {
+                Some(n) => n.to_string(),
+                None => continue,
+            };
+
+            // Try to read and deserialize the session
+            let contents = match std::fs::read_to_string(&path) {
+                Ok(c) => c,
+                Err(_) => continue,
+            };
+            let record: SessionRecord = match serde_json::from_str(&contents) {
+                Ok(r) => r,
+                Err(_) => continue,
+            };
+
+            sessions.push(SessionInfo {
+                name,
+                updated_at_ms: record.metadata.updated_at_ms,
+                message_count: record.messages.len(),
+            });
+        }
+
+        Ok(sessions)
+    }
+
+    /// Delete a session by name. Validates the name and checks existence.
+    pub fn delete_session(&self, name: &str) -> Result<(), SessionError> {
+        validate_session_name(name)?;
+        let path = self.session_dir.join(format!("{name}.json"));
+        if !path.exists() {
+            return Err(SessionError::SessionNotFound(name.to_string()));
+        }
+        std::fs::remove_file(&path).map_err(SessionError::SessionWriteFailed)?;
+        Ok(())
     }
 
     pub fn load(&self) -> Result<SessionRecord, SessionError> {
@@ -517,6 +643,9 @@ pub enum SessionError {
     SessionWriteFailed(std::io::Error),
     SessionSerializeFailed(serde_json::Error),
     SessionDeserializeFailed(serde_json::Error),
+    InvalidSessionName(String),
+    SessionNotFound(String),
+    ActiveSessionCannotBeDeleted,
 }
 
 impl Display for SessionError {
@@ -532,6 +661,18 @@ impl Display for SessionError {
             }
             Self::SessionDeserializeFailed(err) => {
                 write!(f, "failed to deserialize session: {err}")
+            }
+            Self::InvalidSessionName(name) => {
+                write!(
+                    f,
+                    "invalid session name: '{name}' (allowed: alphanumeric, hyphen, underscore, 1-64 chars)"
+                )
+            }
+            Self::SessionNotFound(name) => {
+                write!(f, "session not found: '{name}'")
+            }
+            Self::ActiveSessionCannotBeDeleted => {
+                write!(f, "cannot delete the active session")
             }
         }
     }
@@ -560,10 +701,27 @@ fn now_ms() -> u128 {
         .as_millis()
 }
 
-fn session_id_for_cwd(cwd: &Path) -> String {
+pub(crate) fn session_id_for_cwd(cwd: &Path) -> String {
     let mut hasher = DefaultHasher::new();
     cwd.hash(&mut hasher);
     format!("session_{:x}", hasher.finish())
+}
+
+/// Validate a session name: alphanumeric, hyphen, underscore only, 1-64 chars.
+/// Rejects `.`, `..`, NUL bytes, and any other special characters.
+pub fn validate_session_name(name: &str) -> Result<(), SessionError> {
+    // The alphanumeric + hyphen + underscore check below already rejects
+    // '.', '..', NUL bytes, and all other special characters, so no
+    // separate guards are needed.
+    let valid = !name.is_empty()
+        && name.len() <= 64
+        && name
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_');
+    if !valid {
+        return Err(SessionError::InvalidSessionName(name.to_string()));
+    }
+    Ok(())
 }
 
 fn compact_preview(content: &str, max_chars: usize) -> String {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -26,7 +26,7 @@ pub fn build_config_in(root: PathBuf) -> EffectiveConfig {
     config.paths.config_file = root.join(".anvil").join("config");
     config.paths.state_dir = root.join(".anvil").join("state");
     config.paths.session_dir = root.join(".anvil").join("sessions");
-    config.paths.session_file = config.paths.session_dir.join("session.json");
+    config.paths.session_file = config.paths.session_dir.join("default.json");
     config.paths.logs_dir = root.join(".anvil").join("logs");
     config.paths.mcp_config_file = root.join(".anvil").join("mcp.json");
     config.paths.hooks_config_file = root.join(".anvil").join("hooks.json");

--- a/tests/state_session.rs
+++ b/tests/state_session.rs
@@ -3,7 +3,7 @@ mod common;
 use anvil::contracts::{AppEvent, AppStateSnapshot, RuntimeState};
 use anvil::session::{
     MessageRole, MessageStatus, SessionMessage, SessionRecord, SessionStore, new_assistant_message,
-    new_user_message,
+    new_user_message, validate_session_name,
 };
 use anvil::state::{StateMachine, StateTransition};
 use std::path::PathBuf;
@@ -625,4 +625,499 @@ fn estimated_token_count_accounts_for_images_on_recalc() {
     );
     // After compact, image message was replaced with summary (no images), so count_after may differ
     // The important thing is the count_before properly included image tokens
+}
+
+// ── Task 1.1: validate_session_name tests ──────────────────────────────
+
+#[test]
+fn validate_session_name_accepts_valid_names() {
+    for name in &["default", "my-session", "bugfix_123", "A", "a1-b2_c3"] {
+        assert!(
+            validate_session_name(name).is_ok(),
+            "expected '{name}' to be valid"
+        );
+    }
+}
+
+#[test]
+fn validate_session_name_accepts_max_length_name() {
+    let name: String = "a".repeat(64);
+    assert!(validate_session_name(&name).is_ok());
+}
+
+#[test]
+fn validate_session_name_rejects_empty_name() {
+    assert!(validate_session_name("").is_err());
+}
+
+#[test]
+fn validate_session_name_rejects_too_long_name() {
+    let name: String = "a".repeat(65);
+    assert!(validate_session_name(&name).is_err());
+}
+
+#[test]
+fn validate_session_name_rejects_special_characters() {
+    for name in &["foo/bar", "foo\\bar", "foo bar", "hello!", "a@b", "a.b"] {
+        assert!(
+            validate_session_name(name).is_err(),
+            "expected '{name}' to be rejected"
+        );
+    }
+}
+
+#[test]
+fn validate_session_name_rejects_dot_and_dotdot() {
+    assert!(validate_session_name(".").is_err());
+    assert!(validate_session_name("..").is_err());
+}
+
+#[test]
+fn validate_session_name_rejects_nul_byte() {
+    assert!(validate_session_name("foo\0bar").is_err());
+}
+
+// ── Task 1.2: SessionRecord::new_named tests ──────────────────────────
+
+#[test]
+fn session_record_new_named_sets_session_id_to_name() {
+    let record = SessionRecord::new_named("my-session", PathBuf::from("/tmp/test"))
+        .expect("should create named session");
+    assert_eq!(record.metadata.session_id, "my-session");
+    assert_eq!(record.metadata.cwd, PathBuf::from("/tmp/test"));
+    assert!(record.messages.is_empty());
+}
+
+#[test]
+fn session_record_new_named_rejects_invalid_name() {
+    let result = SessionRecord::new_named("invalid name!", PathBuf::from("/tmp/test"));
+    assert!(result.is_err());
+}
+
+// ── Task 1.3: SessionStore list/delete tests ───────────────────────────
+
+#[test]
+fn session_store_list_sessions_empty_dir() {
+    let root = unique_test_dir("list_empty");
+    let session_dir = root.join(".anvil").join("sessions");
+    std::fs::create_dir_all(&session_dir).expect("should create dir");
+    let store = SessionStore::new(session_dir.join("default.json"), session_dir.clone());
+    let sessions = store.list_sessions().expect("should list");
+    assert!(sessions.is_empty());
+}
+
+#[test]
+fn session_store_list_sessions_returns_session_info() {
+    let root = unique_test_dir("list_sessions");
+    let session_dir = root.join(".anvil").join("sessions");
+    std::fs::create_dir_all(&session_dir).expect("should create dir");
+
+    // Create two sessions
+    let store1 = SessionStore::new(session_dir.join("alpha.json"), session_dir.clone());
+    let mut s1 = SessionRecord::new_named("alpha", root.clone()).expect("named session");
+    s1.push_message(new_user_message("m1", "hello"));
+    store1.save(&s1).expect("save alpha");
+
+    let store2 = SessionStore::new(session_dir.join("beta.json"), session_dir.clone());
+    let s2 = SessionRecord::new_named("beta", root.clone()).expect("named session");
+    store2.save(&s2).expect("save beta");
+
+    let store = SessionStore::new(session_dir.join("default.json"), session_dir.clone());
+    let mut sessions = store.list_sessions().expect("should list");
+    sessions.sort_by(|a, b| a.name.cmp(&b.name));
+    assert_eq!(sessions.len(), 2);
+    assert_eq!(sessions[0].name, "alpha");
+    assert_eq!(sessions[0].message_count, 1);
+    assert_eq!(sessions[1].name, "beta");
+    assert_eq!(sessions[1].message_count, 0);
+}
+
+#[test]
+fn session_store_list_sessions_ignores_non_json_files() {
+    let root = unique_test_dir("list_nonjson");
+    let session_dir = root.join(".anvil").join("sessions");
+    std::fs::create_dir_all(&session_dir).expect("should create dir");
+
+    // Create a valid session
+    let store = SessionStore::new(session_dir.join("valid.json"), session_dir.clone());
+    let s = SessionRecord::new_named("valid", root.clone()).expect("named session");
+    store.save(&s).expect("save");
+
+    // Create a non-json file
+    std::fs::write(session_dir.join("notes.txt"), "not a session").expect("write txt");
+
+    let sessions = store.list_sessions().expect("should list");
+    assert_eq!(sessions.len(), 1);
+    assert_eq!(sessions[0].name, "valid");
+}
+
+#[test]
+fn session_store_delete_session_removes_file() {
+    let root = unique_test_dir("delete_session");
+    let session_dir = root.join(".anvil").join("sessions");
+    std::fs::create_dir_all(&session_dir).expect("should create dir");
+
+    let store = SessionStore::new(session_dir.join("default.json"), session_dir.clone());
+    let target = session_dir.join("target.json");
+    let s = SessionRecord::new_named("target", root.clone()).expect("named session");
+    let target_store = SessionStore::new(target.clone(), session_dir.clone());
+    target_store.save(&s).expect("save target");
+    assert!(target.exists());
+
+    store.delete_session("target").expect("should delete");
+    assert!(!target.exists());
+}
+
+#[test]
+fn session_store_delete_session_not_found() {
+    let root = unique_test_dir("delete_notfound");
+    let session_dir = root.join(".anvil").join("sessions");
+    std::fs::create_dir_all(&session_dir).expect("should create dir");
+
+    let store = SessionStore::new(session_dir.join("default.json"), session_dir.clone());
+    let result = store.delete_session("nonexistent");
+    assert!(result.is_err());
+}
+
+#[test]
+fn session_store_delete_session_rejects_invalid_name() {
+    let root = unique_test_dir("delete_invalid");
+    let session_dir = root.join(".anvil").join("sessions");
+    std::fs::create_dir_all(&session_dir).expect("should create dir");
+
+    let store = SessionStore::new(session_dir.join("default.json"), session_dir.clone());
+    let result = store.delete_session("../escape");
+    assert!(result.is_err());
+}
+
+// ── Task 1.4: Migration tests ──────────────────────────────────────────
+
+#[test]
+fn session_store_migrates_old_hash_file_to_named() {
+    let root = unique_test_dir("migration");
+    let session_dir = root.join(".anvil").join("sessions");
+    std::fs::create_dir_all(&session_dir).expect("should create dir");
+
+    // Create an old-style session file using hash-based name
+    let old_session = SessionRecord::new(root.clone());
+    let old_key = &old_session.metadata.session_id; // session_<hash>
+    let old_path = session_dir.join(format!("{old_key}.json"));
+    let old_store = SessionStore::new(old_path.clone(), session_dir.clone());
+    old_store.save(&old_session).expect("save old session");
+    assert!(old_path.exists());
+
+    // Now load with new-style default.json path
+    let new_path = session_dir.join("default.json");
+    let new_store = SessionStore::new(new_path.clone(), session_dir.clone());
+    let migrated = new_store.load_or_create(&root).expect("should migrate");
+
+    // Old file should be gone, new file should exist
+    assert!(!old_path.exists());
+    assert!(new_path.exists());
+    // session_id should be updated to name-based
+    assert_eq!(migrated.metadata.session_id, "default");
+}
+
+#[test]
+fn session_store_skips_migration_when_new_file_exists() {
+    let root = unique_test_dir("migration_skip");
+    let session_dir = root.join(".anvil").join("sessions");
+    std::fs::create_dir_all(&session_dir).expect("should create dir");
+
+    // Create the new-style file
+    let new_path = session_dir.join("default.json");
+    let new_store = SessionStore::new(new_path.clone(), session_dir.clone());
+    let session = SessionRecord::new_named("default", root.clone()).expect("named");
+    new_store.save(&session).expect("save new");
+
+    // load_or_create should load it directly, not migrate
+    let loaded = new_store.load_or_create(&root).expect("should load");
+    assert_eq!(loaded.metadata.session_id, "default");
+}
+
+#[test]
+fn session_store_creates_new_named_session_when_no_old_file() {
+    let root = unique_test_dir("migration_new");
+    let session_dir = root.join(".anvil").join("sessions");
+    std::fs::create_dir_all(&session_dir).expect("should create dir");
+
+    let new_path = session_dir.join("my-project.json");
+    let new_store = SessionStore::new(new_path.clone(), session_dir.clone());
+    let created = new_store.load_or_create(&root).expect("should create new");
+
+    assert!(new_path.exists());
+    assert_eq!(created.metadata.session_id, "my-project");
+}
+
+// ── Task 6.2: Named session integration tests ───────────────────────────
+
+#[test]
+fn named_session_create_save_and_reload() {
+    let root = unique_test_dir("named_roundtrip");
+    let session_dir = root.join(".anvil").join("sessions");
+    std::fs::create_dir_all(&session_dir).expect("should create dir");
+
+    let store = SessionStore::new(session_dir.join("bugfix-42.json"), session_dir.clone());
+    let mut session =
+        SessionRecord::new_named("bugfix-42", root.clone()).expect("should create named session");
+    session.push_message(new_user_message("m1", "fix the bug"));
+    session.push_message(new_assistant_message(
+        "m2",
+        "investigating",
+        MessageStatus::Committed,
+    ));
+    store.save(&session).expect("save should succeed");
+
+    let reloaded = store.load().expect("reload should succeed");
+    assert_eq!(reloaded.metadata.session_id, "bugfix-42");
+    assert_eq!(reloaded.message_count(), 2);
+    assert_eq!(reloaded.messages[0].content, "fix the bug");
+}
+
+#[test]
+fn session_flag_config_sets_session_file() {
+    use anvil::config::{CliArgs, EffectiveConfig};
+
+    let mut config = EffectiveConfig::default_for_test().expect("config should load");
+    let cli = CliArgs {
+        session: Some("my-feature".to_string()),
+        ..Default::default()
+    };
+    config.apply_cli_args(&cli).expect("apply should succeed");
+
+    assert!(
+        config.paths.session_file.ends_with("my-feature.json"),
+        "session_file should end with my-feature.json, got: {:?}",
+        config.paths.session_file
+    );
+}
+
+#[test]
+fn session_flag_config_rejects_invalid_name() {
+    use anvil::config::{CliArgs, EffectiveConfig};
+
+    let mut config = EffectiveConfig::default_for_test().expect("config should load");
+    let cli = CliArgs {
+        session: Some("../escape".to_string()),
+        ..Default::default()
+    };
+    let result = config.apply_cli_args(&cli);
+    assert!(result.is_err(), "invalid session name should be rejected");
+}
+
+// ── Task 3.1: parse_session_command tests ───────────────────────────────
+
+#[test]
+fn parse_session_command_list() {
+    use anvil::extensions::{ExtensionRegistry, SlashCommandAction};
+
+    let registry = ExtensionRegistry::new();
+    let spec = registry
+        .find_slash_command("/session")
+        .expect("should find /session");
+    assert_eq!(spec.action, SlashCommandAction::SessionList);
+
+    let spec2 = registry
+        .find_slash_command("/session list")
+        .expect("should find /session list");
+    assert_eq!(spec2.action, SlashCommandAction::SessionList);
+}
+
+#[test]
+fn parse_session_command_switch() {
+    use anvil::extensions::{ExtensionRegistry, SlashCommandAction};
+
+    let registry = ExtensionRegistry::new();
+    let spec = registry
+        .find_slash_command("/session switch my-feature")
+        .expect("should find /session switch");
+    assert_eq!(
+        spec.action,
+        SlashCommandAction::SessionSwitch("my-feature".to_string())
+    );
+}
+
+#[test]
+fn parse_session_command_delete() {
+    use anvil::extensions::{ExtensionRegistry, SlashCommandAction};
+
+    let registry = ExtensionRegistry::new();
+    let spec = registry
+        .find_slash_command("/session delete old-work")
+        .expect("should find /session delete");
+    assert_eq!(
+        spec.action,
+        SlashCommandAction::SessionDelete("old-work".to_string())
+    );
+}
+
+#[test]
+fn parse_session_command_unknown_subcommand_returns_none() {
+    use anvil::extensions::ExtensionRegistry;
+
+    let registry = ExtensionRegistry::new();
+    // Unknown subcommand should not match parse_session_command
+    let result = registry.find_slash_command("/session foobar");
+    assert!(result.is_none(), "unknown subcommand should not be matched");
+}
+
+// ── Task 5.1: render_resume_header session name test ────────────────────
+
+#[test]
+fn render_resume_header_includes_session_name() {
+    use anvil::app::render::render_resume_header;
+    use anvil::config::EffectiveConfig;
+
+    let config = EffectiveConfig::default_for_test().expect("config should load");
+    let output = render_resume_header(&config, "my-feature");
+    assert!(
+        output.contains("my-feature"),
+        "resume header should include session name"
+    );
+    assert!(output.contains("Session"));
+}
+
+// ── Task 4.1: App current_session_name test ─────────────────────────────
+
+#[test]
+fn app_current_session_name_from_default() {
+    let app = common::build_app();
+    assert_eq!(app.current_session_name(), "default");
+}
+
+#[test]
+fn app_current_session_name_from_custom_config() {
+    let root = common::unique_test_dir("custom_session_name");
+    let mut config = common::build_config_in(root);
+    config.paths.session_file = config.paths.session_dir.join("my-work.json");
+
+    let provider =
+        anvil::provider::ProviderRuntimeContext::bootstrap(&config).expect("provider bootstrap");
+    let shutdown_flag = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let app = anvil::app::App::new(config, provider, shutdown_flag).expect("app should init");
+    assert_eq!(app.current_session_name(), "my-work");
+}
+
+// ── Task 6.3: /session switch creates new session if non-existent ───────
+
+#[test]
+fn session_switch_to_nonexistent_creates_new_session() {
+    let root = unique_test_dir("switch_new");
+    let session_dir = root.join(".anvil").join("sessions");
+    std::fs::create_dir_all(&session_dir).expect("should create dir");
+
+    // Create an existing "default" session
+    let store = SessionStore::new(session_dir.join("default.json"), session_dir.clone());
+    let mut s = SessionRecord::new_named("default", root.clone()).expect("named");
+    s.push_message(new_user_message("m1", "hello"));
+    store.save(&s).expect("save default");
+
+    // Verify "brand-new" does not yet exist
+    let new_path = session_dir.join("brand-new.json");
+    assert!(!new_path.exists());
+
+    // Simulate what switch_session does for a non-existent name:
+    // load_or_create or new_named when the file doesn't exist
+    let new_store = SessionStore::new(new_path.clone(), session_dir.clone());
+    let new_session =
+        SessionRecord::new_named("brand-new", root.clone()).expect("should create new session");
+    new_store.save(&new_session).expect("save new");
+
+    assert!(new_path.exists());
+    assert_eq!(new_session.metadata.session_id, "brand-new");
+    assert_eq!(new_session.message_count(), 0);
+}
+
+// ── Task 6.4: /session switch rejected during PendingTurn ────────────────
+// Verified at the SessionRecord level: has_pending_turn() returns true after
+// set_pending_turn(). The App::switch_session() method checks this and returns
+// Err(AppError::PendingApprovalRequired). switch_session() is pub(crate),
+// so we test the invariant at the session level.
+
+#[test]
+fn session_record_has_pending_turn_blocks_conceptual_switch() {
+    use anvil::agent::PendingTurnState;
+
+    let mut session = SessionRecord::new(PathBuf::from("/tmp/anvil-pending-test"));
+    assert!(!session.has_pending_turn());
+
+    session.set_pending_turn(PendingTurnState {
+        waiting_tool_call_id: "call_test".to_string(),
+        remaining_events: vec![],
+        pending_tool_calls: vec![],
+    });
+    assert!(
+        session.has_pending_turn(),
+        "has_pending_turn should be true after set_pending_turn"
+    );
+
+    // After clearing, switch would be allowed
+    session.clear_pending_turn();
+    assert!(
+        !session.has_pending_turn(),
+        "has_pending_turn should be false after clear_pending_turn"
+    );
+}
+
+// ── Task 6.5: --session + --fresh-session creates new session ────────────
+
+#[test]
+fn session_and_fresh_session_flags_create_new_session() {
+    use anvil::config::{CliArgs, EffectiveConfig};
+
+    let mut config = EffectiveConfig::default_for_test().expect("config should load");
+    let cli = CliArgs {
+        session: Some("fresh-feature".to_string()),
+        fresh_session: true,
+        ..Default::default()
+    };
+    config.apply_cli_args(&cli).expect("apply should succeed");
+
+    // session_file should point to fresh-feature.json
+    assert!(
+        config.paths.session_file.ends_with("fresh-feature.json"),
+        "session_file should end with fresh-feature.json, got: {:?}",
+        config.paths.session_file
+    );
+    // fresh_session flag should be set
+    assert!(config.mode.fresh_session);
+}
+
+// ── Task 6.6: default session name when --session omitted ────────────────
+
+#[test]
+fn default_session_file_is_default_json() {
+    use anvil::config::EffectiveConfig;
+
+    let config = EffectiveConfig::default_for_test().expect("config should load");
+    assert!(
+        config.paths.session_file.ends_with("default.json"),
+        "default session_file should end with default.json, got: {:?}",
+        config.paths.session_file
+    );
+}
+
+// ── Task 6.7: session list shows name, message count ─────────────────────
+
+#[test]
+fn session_list_shows_updated_at_ms() {
+    let root = unique_test_dir("list_updated_at");
+    let session_dir = root.join(".anvil").join("sessions");
+    std::fs::create_dir_all(&session_dir).expect("should create dir");
+
+    let store = SessionStore::new(session_dir.join("test-session.json"), session_dir.clone());
+    let mut s = SessionRecord::new_named("test-session", root.clone()).expect("named");
+    s.push_message(new_user_message("m1", "hello"));
+    s.push_message(new_user_message("m2", "world"));
+    store.save(&s).expect("save");
+
+    let listing_store = SessionStore::new(session_dir.join("default.json"), session_dir.clone());
+    let sessions = listing_store.list_sessions().expect("should list");
+    assert_eq!(sessions.len(), 1);
+    assert_eq!(sessions[0].name, "test-session");
+    assert_eq!(sessions[0].message_count, 2);
+    assert!(
+        sessions[0].updated_at_ms > 0,
+        "updated_at_ms should be non-zero"
+    );
 }


### PR DESCRIPTION
## Summary
- `--session <name>`で名前付きセッション
- `/session list/switch/delete`コマンド

Closes #71
🤖 Generated with [Claude Code](https://claude.com/claude-code)