### PR TITLE
feat: prevent duplicate confirmation loops for confirm-class tools

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -574,6 +574,19 @@ const PROMPT_TOOL_RULES: &str = concat!(
     "- GitHub stats endpoints (contributors, commit_activity) may return {} on first request. If you get an empty response, wait 3 seconds with shell.exec sleep 3 and retry the same API call.",
 );
 
+/// Guidance for LLMs on confirm-class tool behavior.
+///
+/// Prevents models from asking for permission in natural language
+/// when a tool requires user approval. Anvil handles approval inline.
+const PROMPT_CONFIRM_CLASS_GUIDANCE: &str = concat!(
+    "\n## Tool approval\n",
+    "Some tools require user approval before execution.\n",
+    "Anvil automatically shows an approval prompt when you call these tools.\n",
+    "Do NOT ask the user for permission in natural language.\n",
+    "Always emit the tool call directly using ANVIL_TOOL blocks — Anvil handles the rest.\n",
+    "If a tool call is denied, you will receive \"denied by user\" as the result.\n",
+);
+
 const PROMPT_GIT_GUIDE: &str = concat!(
     "\n\n## Git operations\n",
     "When working with Git, follow these safety categories:\n",
@@ -658,6 +671,9 @@ pub(crate) fn tool_protocol_system_prompt(
 
     // Tool rules and GitHub Insights (static)
     prompt.push_str(PROMPT_TOOL_RULES);
+
+    // Confirm-class tool approval guidance (static)
+    prompt.push_str(PROMPT_CONFIRM_CLASS_GUIDANCE);
 
     // Append MCP tool descriptions dynamically
     // [D4-010] mcp_tool_descriptions is sanitized by generate_mcp_tool_descriptions()

--- a/tests/runtime_flow.rs
+++ b/tests/runtime_flow.rs
@@ -538,6 +538,24 @@ fn system_prompt_includes_agent_explore_and_plan_descriptions() {
 }
 
 #[test]
+fn system_prompt_includes_confirm_class_guidance() {
+    use anvil::agent::{ProjectLanguage, tool_protocol_system_prompt_all_tools};
+    let prompt = tool_protocol_system_prompt_all_tools(&[ProjectLanguage::Rust], None);
+    assert!(
+        prompt.contains("Tool approval"),
+        "system prompt must include confirm-class guidance section"
+    );
+    assert!(
+        prompt.contains("Do NOT ask the user for permission in natural language"),
+        "system prompt must instruct LLM not to double-confirm"
+    );
+    assert!(
+        prompt.contains("denied by user"),
+        "system prompt must explain denial handling"
+    );
+}
+
+#[test]
 fn build_subagent_system_prompt_explore_contains_expected_tools() {
     use anvil::agent::subagent::{SubAgentKind, build_subagent_system_prompt};
     let prompt = build_subagent_system_prompt(&SubAgentKind::Explore, false);


### PR DESCRIPTION
## Summary

- System prompt に confirm-class ツール（file.write, file.edit, shell.exec, web.search）の承認ポリシーガイダンスを追加
- LLM が自然文で「実行しますか？」と二重確認して停止する挙動を防止
- Anvil 側のインライン承認フローは変更なし

## Changes

- `src/agent/mod.rs`: `PROMPT_CONFIRM_CLASS_GUIDANCE` 定数追加 + `tool_protocol_system_prompt()` に push_str 1行追加
- `tests/runtime_flow.rs`: `system_prompt_includes_confirm_class_guidance` テスト追加

## Test plan

- [x] `cargo build` エラー0件
- [x] `cargo clippy --all-targets` 警告0件
- [x] `cargo test` 全テストパス
- [x] `cargo fmt --check` 差分なし
- [x] 新規テスト `system_prompt_includes_confirm_class_guidance` パス
- [ ] 実機テスト: `cloc を使用して実コード数を計測して` で二重確認が発生しないことを確認

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)