### PR TITLE
chore: release v0.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## [Unreleased]
 
+## [0.0.5] - 2026-03-21
+
+### Added
+- Repository search improvement with gitignore support and ranking (#116)
+- Tool result handling improvement for long outputs (#117)
+- Optional tools exposure in system prompt before first use (#115)
+- Cache invalidation strengthening with per-entry manifest hashing (#118)
+- Release skill update to use git worktree + commandmatedev
+
+### Fixed
+- Web search/fetch inclusion in system prompt for fresh sessions (#114)
+- Clippy map_or → is_some_and style fix
+
 ## [0.0.4] - 2026-03-20
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,7 +72,7 @@ dependencies = [
 
 [[package]]
 name = "anvil"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "base64",
  "chrono",
@@ -1217,9 +1217,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anvil"
-version = "0.0.4"
+version = "0.0.5"
 edition = "2024"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ```bash
 # macOS (Apple Silicon)
-curl -L https://github.com/Kewton/Anvil/releases/download/v0.0.4/anvil-darwin-arm64.gz -o anvil.gz
+curl -L https://github.com/Kewton/Anvil/releases/download/v0.0.5/anvil-darwin-arm64.gz -o anvil.gz
 gunzip anvil.gz
 chmod +x anvil
 sudo mv anvil /usr/local/bin/


### PR DESCRIPTION
## Release v0.0.5

### Added
- Repository search improvement with gitignore support and ranking (#116)
- Tool result handling improvement for long outputs (#117)
- Optional tools exposure in system prompt before first use (#115)
- Cache invalidation strengthening with per-entry manifest hashing (#118)
- Release skill update to use git worktree + commandmatedev

### Fixed
- Web search/fetch inclusion in system prompt for fresh sessions (#114)
- Clippy map_or → is_some_and style fix

## Checklist
- [x] `cargo build` — エラー0件
- [x] `cargo test` — 170テスト全パス
- [x] `cargo clippy --all-targets` — 警告0件
- [x] Cargo.toml version updated to 0.0.5
- [x] Cargo.lock regenerated
- [x] README.md download URLs updated
- [x] CHANGELOG.md updated with v0.0.5 section

🤖 Generated with [Claude Code](https://claude.com/claude-code)