### PR TITLE
feat: Wave 1 - multi-tier tool protocol and resilient editing (#128)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,10 @@ src/
 ├── lib.rs               # モジュール宣言
 ├── agent/
 │   ├── mod.rs           # エージェントループ・プロトコル
-│   └── subagent.rs      # サブエージェント実行ループ（Explore/Plan）
+│   ├── model_classifier.rs # モデル分類・ToolProtocolMode判定
+│   ├── subagent.rs      # サブエージェント実行ループ（Explore/Plan）
+│   ├── tag_parser.rs    # タグベースツール呼び出しパーサー（多層プロトコル対応）
+│   └── tag_spec.rs      # ツールタグ仕様テーブル（TOOL_TAG_SPECS）
 ├── app/
 │   ├── mod.rs           # アプリケーションオーケストレータ
 │   ├── agentic.rs       # agenticツール実行ループ

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -5,6 +5,7 @@
 
 pub mod model_classifier;
 pub mod subagent;
+pub mod tag_parser;
 pub mod tag_spec;
 
 pub use model_classifier::ToolProtocolMode;
@@ -242,7 +243,7 @@ impl BasicAgentLoop {
 
         let mut tool_calls = Vec::new();
         for block in tool_blocks {
-            tool_calls.push(parse_tool_call_block(&block)?);
+            tool_calls.push(parse_tool_call_block_multi_tier(&block)?);
         }
 
         let final_response = final_block
@@ -260,13 +261,38 @@ impl BasicAgentLoop {
     }
 }
 
-fn parse_tool_call_block(block: &str) -> Result<ToolCallRequest, String> {
-    match serde_json::from_str::<Value>(block) {
-        Ok(value) => parse_tool_call_value(&value),
-        Err(err) => {
-            repair_tool_call_block(block).ok_or_else(|| format!("invalid ANVIL_TOOL JSON: {err}"))
+/// Multi-tier tool call parser.
+///
+/// Tier 1: Strict JSON (existing parse path)
+/// Tier 2: Tag-based (XML-like) format via tag_parser
+/// Tier 3: Repair fallback (existing repair path)
+fn parse_tool_call_block_multi_tier(block: &str) -> Result<ToolCallRequest, String> {
+    // Tier 1: strict JSON
+    if let Ok(value) = serde_json::from_str::<Value>(block) {
+        match parse_tool_call_value(&value) {
+            Ok(call) => return Ok(call),
+            Err(json_err) => {
+                // JSON parsed but field extraction failed — this is a definitive error
+                // (the tool name was recognized but required fields are missing).
+                // Only fall through if the JSON didn't even have a "tool" field.
+                if value.get("tool").and_then(Value::as_str).is_some() {
+                    return Err(json_err);
+                }
+            }
         }
     }
+
+    // Tier 2: tag-based
+    if tag_parser::is_tag_format(block)
+        && let Ok((tool_name, input)) = tag_parser::parse_tag_tool_block(block)
+    {
+        let id = format!("tag_{}", tool_name.replace('.', "_"));
+        return Ok(ToolCallRequest::new(id, tool_name, input));
+    }
+
+    // Tier 3: repair fallback
+    repair_tool_call_block(block)
+        .ok_or_else(|| "Failed to parse tool call in any format".to_string())
 }
 
 fn parse_tool_call_value(value: &Value) -> Result<ToolCallRequest, String> {
@@ -717,6 +743,40 @@ pub(crate) fn tool_protocol_system_prompt(
     used_tools: &std::collections::HashSet<String>,
     offline: bool,
 ) -> String {
+    tool_protocol_system_prompt_with_mode(
+        languages,
+        mcp_tool_descriptions,
+        used_tools,
+        offline,
+        ToolProtocolMode::Json,
+    )
+}
+
+/// Generate the system prompt with dynamic tool selection and protocol mode.
+pub(crate) fn tool_protocol_system_prompt_with_mode(
+    languages: &[ProjectLanguage],
+    mcp_tool_descriptions: Option<&str>,
+    used_tools: &std::collections::HashSet<String>,
+    offline: bool,
+    protocol: ToolProtocolMode,
+) -> String {
+    match protocol {
+        ToolProtocolMode::Json => {
+            build_json_protocol_prompt(languages, mcp_tool_descriptions, used_tools, offline)
+        }
+        ToolProtocolMode::TagBased => {
+            build_tag_protocol_prompt(languages, mcp_tool_descriptions, used_tools, offline)
+        }
+    }
+}
+
+/// JSON format system prompt (existing behavior).
+fn build_json_protocol_prompt(
+    languages: &[ProjectLanguage],
+    mcp_tool_descriptions: Option<&str>,
+    used_tools: &std::collections::HashSet<String>,
+    offline: bool,
+) -> String {
     let mut prompt = String::with_capacity(8192);
 
     // Work approach (static)
@@ -764,6 +824,49 @@ pub(crate) fn tool_protocol_system_prompt(
     // Confirm-class tool approval guidance (static)
     prompt.push_str(PROMPT_CONFIRM_CLASS_GUIDANCE);
 
+    append_common_prompt_sections(&mut prompt, languages, mcp_tool_descriptions);
+
+    prompt
+}
+
+/// Tag-based format system prompt (for smaller models).
+fn build_tag_protocol_prompt(
+    languages: &[ProjectLanguage],
+    mcp_tool_descriptions: Option<&str>,
+    _used_tools: &std::collections::HashSet<String>,
+    _offline: bool,
+) -> String {
+    use crate::agent::tag_spec::TOOL_TAG_SPECS;
+
+    let mut prompt = String::with_capacity(8192);
+
+    prompt.push_str(PROMPT_WORK_APPROACH);
+
+    // Generate tag-based tool descriptions from TOOL_TAG_SPECS
+    for (i, spec) in TOOL_TAG_SPECS.iter().enumerate() {
+        prompt.push_str(&format!(
+            "{}. {} — use tag format:\n```ANVIL_TOOL\n{}\n```\n\n",
+            i + 1,
+            spec.name,
+            spec.example
+        ));
+    }
+
+    // Tool rules (same as JSON but with tag format note)
+    prompt.push_str(PROMPT_TOOL_RULES);
+    prompt.push_str(PROMPT_CONFIRM_CLASS_GUIDANCE);
+
+    append_common_prompt_sections(&mut prompt, languages, mcp_tool_descriptions);
+
+    prompt
+}
+
+/// Append sections common to both JSON and tag-based prompts.
+fn append_common_prompt_sections(
+    prompt: &mut String,
+    languages: &[ProjectLanguage],
+    mcp_tool_descriptions: Option<&str>,
+) {
     // Append MCP tool descriptions dynamically
     // [D4-010] mcp_tool_descriptions is sanitized by generate_mcp_tool_descriptions()
     if let Some(mcp_desc) = mcp_tool_descriptions {
@@ -789,8 +892,6 @@ pub(crate) fn tool_protocol_system_prompt(
     if languages.contains(&ProjectLanguage::NodeJs) {
         prompt.push_str(PROMPT_NODEJS_GUIDE);
     }
-
-    prompt
 }
 
 /// Generate a system prompt with no optional tools (basic tools only).
@@ -813,6 +914,21 @@ pub fn tool_protocol_system_prompt_all_tools(
     let all_tools: std::collections::HashSet<String> =
         optional_tool_names().map(|s| s.to_string()).collect();
     tool_protocol_system_prompt(languages, mcp_tool_descriptions, &all_tools, false)
+}
+
+/// Generate a system prompt with tag-based protocol (for small model testing).
+pub fn tool_protocol_system_prompt_tag_based(
+    languages: &[ProjectLanguage],
+    mcp_tool_descriptions: Option<&str>,
+) -> String {
+    let empty = std::collections::HashSet::new();
+    tool_protocol_system_prompt_with_mode(
+        languages,
+        mcp_tool_descriptions,
+        &empty,
+        false,
+        ToolProtocolMode::TagBased,
+    )
 }
 
 fn extract_fenced_blocks(content: &str, label: &str) -> Vec<String> {

--- a/src/agent/model_classifier.rs
+++ b/src/agent/model_classifier.rs
@@ -6,9 +6,10 @@
 use regex::Regex;
 
 /// Tool protocol mode for agent-model communication.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum ToolProtocolMode {
     /// JSON format (default, for large models).
+    #[default]
     Json,
     /// Tag-based format (for small models, <= 13B).
     TagBased,

--- a/src/agent/tag_parser.rs
+++ b/src/agent/tag_parser.rs
@@ -1,0 +1,414 @@
+//! Tag-based tool call parser.
+//!
+//! Parses XML-like tag syntax into [`ToolInput`] variants using the
+//! [`tag_spec`] table as the source of truth for tool names, attributes,
+//! and child elements.
+
+use crate::agent::tag_spec::{TOOL_TAG_SPECS, find_spec};
+use crate::tooling::{AnchorEditParams, ToolInput};
+
+/// Check whether a block appears to use tag-based tool call syntax.
+///
+/// Returns `true` if the block starts with `<tool ` or with a known tool
+/// name tag (e.g., `<file.read`).
+pub fn is_tag_format(block: &str) -> bool {
+    let trimmed = block.trim();
+    if trimmed.starts_with("<tool ") || trimmed.starts_with("<tool>") {
+        return true;
+    }
+    // Check for direct tool name tags (exact boundary match to avoid false positives)
+    for spec in TOOL_TAG_SPECS {
+        let prefix = format!("<{}", spec.name);
+        if trimmed.starts_with(&prefix) {
+            // Ensure the next char after the tool name is a valid boundary
+            let rest = &trimmed[prefix.len()..];
+            if rest.is_empty()
+                || rest.starts_with(' ')
+                || rest.starts_with('>')
+                || rest.starts_with('/')
+            {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Parse a tag-based tool call block into a tool name and [`ToolInput`].
+///
+/// Supports two syntaxes:
+/// 1. `<tool name="tool_name" attr="value">children</tool>`
+/// 2. `<tool_name attr="value">children</tool_name>` (direct name tag)
+///
+/// Self-closing tags (`<tool ... />`) are also supported.
+pub fn parse_tag_tool_block(block: &str) -> Result<(String, ToolInput), String> {
+    let trimmed = block.trim();
+
+    // Determine tool name and the rest of the tag content
+    let (tool_name, tag_body, children) = extract_tag_structure(trimmed)?;
+
+    // Validate against tag_spec
+    let spec =
+        find_spec(&tool_name).ok_or_else(|| format!("unknown tool in tag format: {tool_name}"))?;
+
+    // Extract attributes from the opening tag
+    let attrs = extract_attributes(&tag_body);
+
+    // Extract child elements
+    let child_contents = extract_child_elements(&children, spec.child_elements);
+
+    // Build ToolInput from attributes and children
+    build_tool_input(&tool_name, &attrs, &child_contents)
+}
+
+/// Extract the tag structure: (tool_name, opening_tag_body, inner_content).
+fn extract_tag_structure(block: &str) -> Result<(String, String, String), String> {
+    // Pattern 1: <tool name="xxx" ...>...</tool> or <tool name="xxx" .../>
+    if block.starts_with("<tool ") || block.starts_with("<tool>") {
+        let (tag_body, rest) = split_opening_tag(block, "tool")?;
+
+        // Extract tool name from name="..." attribute
+        let tool_name = extract_attribute_value(&tag_body, "name")
+            .ok_or_else(|| "missing name attribute in <tool> tag".to_string())?;
+
+        // For self-closing tags, rest is empty
+        return Ok((tool_name, tag_body, rest));
+    }
+
+    // Pattern 2: <tool_name attr="value">...</tool_name>
+    for spec in TOOL_TAG_SPECS {
+        let open_prefix = format!("<{}", spec.name);
+        if block.starts_with(&open_prefix) {
+            let (tag_body, rest) = split_opening_tag(block, spec.name)?;
+            return Ok((spec.name.to_string(), tag_body, rest));
+        }
+    }
+
+    Err("block does not start with a recognized tool tag".to_string())
+}
+
+/// Split an opening tag from the rest of the block.
+///
+/// Returns (opening_tag_attributes, inner_content).
+/// Handles both `<tag ...>content</tag>` and `<tag .../>`
+fn split_opening_tag(block: &str, tag_name: &str) -> Result<(String, String), String> {
+    // Find the end of the opening tag
+    let after_name = &block[tag_name.len() + 1..]; // skip `<tag_name`
+
+    // Check for self-closing tag
+    if let Some(close_pos) = after_name.find("/>") {
+        let attrs = after_name[..close_pos].to_string();
+        return Ok((attrs, String::new()));
+    }
+
+    // Find the closing `>`
+    let gt_pos = after_name
+        .find('>')
+        .ok_or_else(|| format!("unclosed opening tag: <{tag_name}"))?;
+
+    let attrs = after_name[..gt_pos].to_string();
+    let after_gt = &after_name[gt_pos + 1..];
+
+    // Find the closing tag
+    let close_tag = format!("</{tag_name}>");
+    if let Some(close_pos) = after_gt.rfind(&close_tag) {
+        let inner = after_gt[..close_pos].to_string();
+        Ok((attrs, inner))
+    } else {
+        // No closing tag — treat entire remainder as inner content
+        Ok((attrs, after_gt.to_string()))
+    }
+}
+
+/// Extract attribute values from a tag's attribute string.
+///
+/// Parses `key="value"` pairs, returning them as a Vec of (key, value).
+fn extract_attributes(attrs_str: &str) -> Vec<(String, String)> {
+    let mut result = Vec::new();
+    let mut remaining = attrs_str.trim();
+
+    while !remaining.is_empty() {
+        // Skip whitespace
+        remaining = remaining.trim_start();
+        if remaining.is_empty() {
+            break;
+        }
+
+        // Find key=
+        let eq_pos = match remaining.find('=') {
+            Some(pos) => pos,
+            None => break,
+        };
+
+        let key = remaining[..eq_pos].trim().to_string();
+        remaining = &remaining[eq_pos + 1..];
+        remaining = remaining.trim_start();
+
+        // Extract quoted value
+        if remaining.starts_with('"') {
+            remaining = &remaining[1..];
+            let end_quote = match remaining.find('"') {
+                Some(pos) => pos,
+                None => break,
+            };
+            let value = remaining[..end_quote].to_string();
+            remaining = &remaining[end_quote + 1..];
+            result.push((key, value));
+        } else if remaining.starts_with('\'') {
+            remaining = &remaining[1..];
+            let end_quote = match remaining.find('\'') {
+                Some(pos) => pos,
+                None => break,
+            };
+            let value = remaining[..end_quote].to_string();
+            remaining = &remaining[end_quote + 1..];
+            result.push((key, value));
+        } else {
+            // Unquoted value — take until whitespace
+            let end = remaining
+                .find(char::is_whitespace)
+                .unwrap_or(remaining.len());
+            let value = remaining[..end].to_string();
+            remaining = &remaining[end..];
+            result.push((key, value));
+        }
+    }
+
+    result
+}
+
+/// Extract the text content of child elements.
+fn extract_child_elements(inner: &str, element_names: &[&str]) -> Vec<(String, String)> {
+    let mut result = Vec::new();
+
+    for &name in element_names {
+        let open_tag = format!("<{name}>");
+        let close_tag = format!("</{name}>");
+
+        if let Some(start) = inner.find(&open_tag) {
+            let content_start = start + open_tag.len();
+            if let Some(end) = inner[content_start..].find(&close_tag) {
+                let content = inner[content_start..content_start + end].to_string();
+                result.push((name.to_string(), content));
+            }
+        }
+    }
+
+    result
+}
+
+/// Extract a specific attribute value from an attribute string.
+fn extract_attribute_value(attrs_str: &str, key: &str) -> Option<String> {
+    let attrs = extract_attributes(attrs_str);
+    attrs.into_iter().find(|(k, _)| k == key).map(|(_, v)| v)
+}
+
+/// Build a [`ToolInput`] from parsed attributes and child elements.
+fn build_tool_input(
+    tool_name: &str,
+    attrs: &[(String, String)],
+    children: &[(String, String)],
+) -> Result<(String, ToolInput), String> {
+    let get_attr = |key: &str| -> Option<String> {
+        attrs.iter().find(|(k, _)| k == key).map(|(_, v)| v.clone())
+    };
+    let get_child = |key: &str| -> Option<String> {
+        children
+            .iter()
+            .find(|(k, _)| k == key)
+            .map(|(_, v)| v.clone())
+    };
+
+    let input = match tool_name {
+        "file.read" => ToolInput::FileRead {
+            path: get_attr("path")
+                .ok_or_else(|| "missing path attribute for file.read".to_string())?,
+        },
+        "file.write" => ToolInput::FileWrite {
+            path: get_attr("path")
+                .ok_or_else(|| "missing path attribute for file.write".to_string())?,
+            content: get_child("content")
+                .ok_or_else(|| "missing content element for file.write".to_string())?,
+        },
+        "file.edit" => {
+            let path = get_attr("path")
+                .ok_or_else(|| "missing path attribute for file.edit".to_string())?;
+            let old_string = get_child("old_string")
+                .ok_or_else(|| "missing old_string element for file.edit".to_string())?;
+            let new_string = get_child("new_string").unwrap_or_default();
+            ToolInput::FileEdit {
+                path,
+                old_string,
+                new_string,
+            }
+        }
+        "file.edit_anchor" => {
+            let path = get_attr("path")
+                .ok_or_else(|| "missing path attribute for file.edit_anchor".to_string())?;
+            let old_content = get_child("old_content")
+                .ok_or_else(|| "missing old_content element for file.edit_anchor".to_string())?;
+            let new_content = get_child("new_content").unwrap_or_default();
+            ToolInput::FileEditAnchor {
+                path,
+                params: AnchorEditParams {
+                    old_content,
+                    new_content,
+                },
+            }
+        }
+        "file.search" => ToolInput::FileSearch {
+            root: get_attr("root")
+                .ok_or_else(|| "missing root attribute for file.search".to_string())?,
+            pattern: get_attr("pattern")
+                .ok_or_else(|| "missing pattern attribute for file.search".to_string())?,
+            regex: false,
+            context_lines: 0,
+        },
+        "shell.exec" => ToolInput::ShellExec {
+            command: get_attr("command")
+                .ok_or_else(|| "missing command attribute for shell.exec".to_string())?,
+        },
+        "web.fetch" => ToolInput::WebFetch {
+            url: get_attr("url")
+                .ok_or_else(|| "missing url attribute for web.fetch".to_string())?,
+        },
+        "web.search" => ToolInput::WebSearch {
+            query: get_attr("query")
+                .ok_or_else(|| "missing query attribute for web.search".to_string())?,
+        },
+        "agent.explore" => ToolInput::AgentExplore {
+            prompt: get_child("prompt")
+                .ok_or_else(|| "missing prompt element for agent.explore".to_string())?,
+            scope: get_attr("scope"),
+        },
+        "agent.plan" => ToolInput::AgentPlan {
+            prompt: get_child("prompt")
+                .ok_or_else(|| "missing prompt element for agent.plan".to_string())?,
+            scope: get_attr("scope"),
+        },
+        _ => return Err(format!("unsupported tool in tag format: {tool_name}")),
+    };
+
+    Ok((tool_name.to_string(), input))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_tag_format_detects_tool_tag() {
+        assert!(is_tag_format(r#"<tool name="file.read" path="./src"/>"#));
+        assert!(is_tag_format(r#"<file.read path="./src"/>"#));
+        assert!(is_tag_format(
+            r#"<tool name="file.edit" path="./a.rs"><old_string>x</old_string><new_string>y</new_string></tool>"#
+        ));
+    }
+
+    #[test]
+    fn is_tag_format_rejects_non_tag() {
+        assert!(!is_tag_format(r#"{"tool":"file.read","path":"./src"}"#));
+        assert!(!is_tag_format("plain text"));
+        assert!(!is_tag_format("<div>html</div>"));
+    }
+
+    #[test]
+    fn parse_self_closing_file_read() {
+        let block = r#"<tool name="file.read" path="./src/main.rs"/>"#;
+        let (name, input) = parse_tag_tool_block(block).unwrap();
+        assert_eq!(name, "file.read");
+        assert_eq!(
+            input,
+            ToolInput::FileRead {
+                path: "./src/main.rs".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn parse_direct_name_tag_file_read() {
+        let block = r#"<file.read path="./src/main.rs"/>"#;
+        let (name, input) = parse_tag_tool_block(block).unwrap();
+        assert_eq!(name, "file.read");
+        assert_eq!(
+            input,
+            ToolInput::FileRead {
+                path: "./src/main.rs".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn parse_file_edit_with_children() {
+        let block = r#"<tool name="file.edit" path="./src/main.rs"><old_string>fn old()</old_string><new_string>fn new()</new_string></tool>"#;
+        let (name, input) = parse_tag_tool_block(block).unwrap();
+        assert_eq!(name, "file.edit");
+        assert_eq!(
+            input,
+            ToolInput::FileEdit {
+                path: "./src/main.rs".to_string(),
+                old_string: "fn old()".to_string(),
+                new_string: "fn new()".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn parse_file_edit_anchor_with_children() {
+        let block = r#"<tool name="file.edit_anchor" path="./src/main.rs"><old_content>fn old()</old_content><new_content>fn new()</new_content></tool>"#;
+        let (name, input) = parse_tag_tool_block(block).unwrap();
+        assert_eq!(name, "file.edit_anchor");
+        assert_eq!(
+            input,
+            ToolInput::FileEditAnchor {
+                path: "./src/main.rs".to_string(),
+                params: AnchorEditParams {
+                    old_content: "fn old()".to_string(),
+                    new_content: "fn new()".to_string(),
+                },
+            }
+        );
+    }
+
+    #[test]
+    fn parse_shell_exec() {
+        let block = r#"<tool name="shell.exec" command="ls -la"/>"#;
+        let (name, input) = parse_tag_tool_block(block).unwrap();
+        assert_eq!(name, "shell.exec");
+        assert_eq!(
+            input,
+            ToolInput::ShellExec {
+                command: "ls -la".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn parse_unknown_tool_rejected() {
+        let block = r#"<tool name="unknown.tool" arg="val"/>"#;
+        let result = parse_tag_tool_block(block);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_malformed_tag_rejected() {
+        let block = "<tool";
+        let result = parse_tag_tool_block(block);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_file_write_with_content() {
+        let block =
+            r#"<tool name="file.write" path="./out.txt"><content>hello world</content></tool>"#;
+        let (name, input) = parse_tag_tool_block(block).unwrap();
+        assert_eq!(name, "file.write");
+        assert_eq!(
+            input,
+            ToolInput::FileWrite {
+                path: "./out.txt".to_string(),
+                content: "hello world".to_string(),
+            }
+        );
+    }
+}

--- a/src/agent/tag_spec.rs
+++ b/src/agent/tag_spec.rs
@@ -60,6 +60,12 @@ pub const TOOL_TAG_SPECS: &[ToolTagSpec] = &[
         example: r#"<tool name="web.search" query="search keywords"/>"#,
     },
     ToolTagSpec {
+        name: "file.edit_anchor",
+        attributes: &["path"],
+        child_elements: &["old_content", "new_content"],
+        example: r#"<tool name="file.edit_anchor" path="./src/main.rs"><old_content>fn old_code()</old_content><new_content>fn new_code()</new_content></tool>"#,
+    },
+    ToolTagSpec {
         name: "agent.explore",
         attributes: &["scope"],
         child_elements: &["prompt"],

--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -801,9 +801,12 @@ impl App {
 
         // Helper: check whether a tool_call_id refers to a file-mutating tool.
         let is_file_mutation = |tool_call_id: &str| -> bool {
-            tool_kind_map
-                .get(tool_call_id)
-                .is_some_and(|kind| matches!(kind, ToolKind::FileWrite | ToolKind::FileEdit))
+            tool_kind_map.get(tool_call_id).is_some_and(|kind| {
+                matches!(
+                    kind,
+                    ToolKind::FileWrite | ToolKind::FileEdit | ToolKind::FileEditAnchor
+                )
+            })
         };
 
         // Transaction check: determine if any file-mutating tool failed.
@@ -1026,6 +1029,9 @@ pub(crate) fn infer_plan_from_structured_response(
                 } else {
                     format!("git log -{count_str}")
                 }
+            }
+            crate::tooling::ToolInput::FileEditAnchor { path, .. } => {
+                format!("edit (anchor) {path}")
             }
         };
         plan.push(item);

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -458,7 +458,7 @@ impl App {
     /// Called each turn to include only relevant tool descriptions.
     /// Offline mode filters out web.* tools from the effective used_tools set.
     fn build_dynamic_system_prompt(&self) -> String {
-        use crate::agent::tool_protocol_system_prompt;
+        use crate::agent::tool_protocol_system_prompt_with_mode;
 
         // Offline mode: exclude web.* tools from used_tools.
         // Non-offline: pass a reference directly to avoid cloning.
@@ -476,11 +476,14 @@ impl App {
             &self.session.used_tools
         };
 
-        let mut prompt = tool_protocol_system_prompt(
+        let protocol = self.provider.capabilities.tool_protocol;
+
+        let mut prompt = tool_protocol_system_prompt_with_mode(
             &self.detected_languages,
             self.mcp_descriptions.as_deref(),
             effective_used_tools,
             self.config.mode.offline,
+            protocol,
         );
 
         // Current date and timezone (dynamic, re-evaluated per turn)
@@ -1799,7 +1802,9 @@ impl App {
         }
 
         let rel_path = match &request.input {
-            ToolInput::FileWrite { path, .. } | ToolInput::FileEdit { path, .. } => path,
+            ToolInput::FileWrite { path, .. }
+            | ToolInput::FileEdit { path, .. }
+            | ToolInput::FileEditAnchor { path, .. } => path,
             _ => return None,
         };
 

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -8,6 +8,7 @@ pub mod openai;
 pub mod transport;
 
 use crate::agent::AgentEvent;
+use crate::agent::model_classifier::{ToolProtocolMode, determine_protocol_mode};
 use crate::config::EffectiveConfig;
 use crate::contracts::InferencePerformanceView;
 use serde::{Deserialize, Serialize};
@@ -48,6 +49,7 @@ pub enum LocalProviderClient {
 pub struct ProviderCapabilities {
     pub streaming: bool,
     pub tool_calling: bool,
+    pub tool_protocol: ToolProtocolMode,
 }
 
 /// Bootstrapped provider context available for the lifetime of a session.
@@ -351,15 +353,14 @@ impl ProviderRuntimeContext {
             }
         };
 
-        let capabilities = match backend {
-            ProviderBackend::Ollama => ProviderCapabilities {
-                streaming: true,
-                tool_calling: true,
-            },
-            ProviderBackend::OpenAi => ProviderCapabilities {
-                streaming: true,
-                tool_calling: true,
-            },
+        let tool_protocol =
+            determine_protocol_mode(&config.runtime.model, config.runtime.tag_protocol);
+
+        // Both backends currently share identical capability defaults.
+        let capabilities = ProviderCapabilities {
+            streaming: true,
+            tool_calling: true,
+            tool_protocol,
         };
 
         Ok(Self {

--- a/src/tooling/diff.rs
+++ b/src/tooling/diff.rs
@@ -34,6 +34,9 @@ pub fn generate_diff_preview(workspace_root: &Path, tool_input: &ToolInput) -> O
             new_string,
             ..
         } => generate_file_edit_diff(old_string, new_string),
+        ToolInput::FileEditAnchor { params, .. } => {
+            generate_file_edit_diff(&params.old_content, &params.new_content)
+        }
         // MCP tools do not have diff previews
         ToolInput::Mcp { .. } => None,
         // Agent tools do not have diff previews

--- a/src/tooling/mod.rs
+++ b/src/tooling/mod.rs
@@ -76,6 +76,7 @@ pub enum ToolKind {
     FileRead,
     FileWrite,
     FileEdit,
+    FileEditAnchor,
     FileSearch,
     ShellExec,
     WebFetch,
@@ -97,6 +98,13 @@ impl ToolKind {
             ToolKind::ShellExec | ToolKind::GitStatus | ToolKind::GitDiff | ToolKind::GitLog
         )
     }
+}
+
+/// Anchor-based edit parameters (Wave 1: indent normalization only).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AnchorEditParams {
+    pub old_content: String,
+    pub new_content: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -153,6 +161,10 @@ pub enum ToolInput {
         count: Option<u32>,
         path: Option<String>,
     },
+    FileEditAnchor {
+        path: String,
+        params: AnchorEditParams,
+    },
 }
 
 impl ToolInput {
@@ -171,6 +183,7 @@ impl ToolInput {
             Self::GitStatus { .. } => ToolKind::GitStatus,
             Self::GitDiff { .. } => ToolKind::GitDiff,
             Self::GitLog { .. } => ToolKind::GitLog,
+            Self::FileEditAnchor { .. } => ToolKind::FileEditAnchor,
         }
     }
 
@@ -309,6 +322,32 @@ impl ToolInput {
                     .and_then(serde_json::Value::as_str)
                     .map(String::from),
             }),
+            "file.edit_anchor" => {
+                let path = value
+                    .get("path")
+                    .and_then(serde_json::Value::as_str)
+                    .map(String::from)
+                    .ok_or_else(|| "missing path in file.edit_anchor tool block".to_string())?;
+                let old_content = value
+                    .get("old_content")
+                    .and_then(serde_json::Value::as_str)
+                    .map(String::from)
+                    .ok_or_else(|| {
+                        "missing old_content in file.edit_anchor tool block".to_string()
+                    })?;
+                let new_content = value
+                    .get("new_content")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or_default()
+                    .to_string();
+                Ok(ToolInput::FileEditAnchor {
+                    path,
+                    params: AnchorEditParams {
+                        old_content,
+                        new_content,
+                    },
+                })
+            }
             other => {
                 // mcp__<server>__<tool> pattern detection
                 if let Some((server, tool)) = parse_mcp_tool_name(other) {
@@ -390,6 +429,18 @@ impl ToolInput {
                 count: extract_simple(block, "count").and_then(|s| s.parse::<u32>().ok()),
                 path: extract_simple(block, "path"),
             }),
+            "file.edit_anchor" => {
+                let path = extract_simple(block, "path")?;
+                let old_content = extract_simple(block, "old_content")?;
+                let new_content = extract_trailing(block, "new_content").unwrap_or_default();
+                Some(ToolInput::FileEditAnchor {
+                    path,
+                    params: AnchorEditParams {
+                        old_content,
+                        new_content,
+                    },
+                })
+            }
             _ => None,
         }
     }
@@ -648,6 +699,19 @@ impl ToolRegistry {
         });
     }
 
+    pub fn register_file_edit_anchor(&mut self) {
+        self.register(ToolSpec {
+            version: 1,
+            name: "file.edit_anchor".to_string(),
+            kind: ToolKind::FileEditAnchor,
+            execution_class: ExecutionClass::Mutating,
+            permission_class: PermissionClass::Confirm,
+            execution_mode: ExecutionMode::SequentialOnly,
+            plan_mode: PlanModePolicy::Allowed,
+            rollback_policy: RollbackPolicy::CheckpointBeforeWrite,
+        });
+    }
+
     pub fn register_file_search(&mut self) {
         self.register(ToolSpec {
             version: 1,
@@ -786,6 +850,7 @@ impl ToolRegistry {
         self.register_file_read();
         self.register_file_write();
         self.register_file_edit();
+        self.register_file_edit_anchor();
         self.register_file_search();
         self.register_shell_exec();
         self.register_web_fetch();
@@ -847,6 +912,13 @@ pub enum ToolRuntimeError {
     InvalidPath(String),
     Io(String),
     CaptchaBlocked { query: String },
+    EditNotFound(String),
+}
+
+impl ToolRuntimeError {
+    pub fn is_edit_not_found(&self) -> bool {
+        matches!(self, Self::EditNotFound(_))
+    }
 }
 
 impl Display for ToolRuntimeError {
@@ -860,6 +932,7 @@ impl Display for ToolRuntimeError {
                  Consider setting SERPER_API_KEY for automatic fallback, \
                  or use web.fetch to access specific URLs directly."
             ),
+            Self::EditNotFound(message) => write!(f, "{message}"),
         }
     }
 }
@@ -936,7 +1009,8 @@ impl LocalToolExecutor {
                 ref path,
                 ref old_string,
                 ref new_string,
-            } => self.execute_file_edit(&request, path, old_string, new_string, started),
+            } => self
+                .execute_file_edit_with_fallback(&request, path, old_string, new_string, started),
             ToolInput::FileSearch {
                 ref root,
                 ref pattern,
@@ -958,6 +1032,10 @@ impl LocalToolExecutor {
                 ref count,
                 ref path,
             } => self.execute_git_log(&request, count, path, started),
+            ToolInput::FileEditAnchor {
+                ref path,
+                ref params,
+            } => self.execute_file_edit_anchor(&request, path, params, started),
             ToolInput::Mcp { .. } => unreachable!("MCP tools are dispatched in agentic.rs"),
             ToolInput::AgentExplore { .. } | ToolInput::AgentPlan { .. } => {
                 unreachable!("agent tools are dispatched in agentic.rs")
@@ -1102,14 +1180,14 @@ impl LocalToolExecutor {
         }
         let count = content.matches(old_string).count();
         if count == 0 {
-            return Err(ToolRuntimeError::Io(format!(
+            return Err(ToolRuntimeError::EditNotFound(format!(
                 "file.edit: old_string not found in {path}. \
                  Ensure the string exactly matches the file content, \
                  including whitespace and indentation."
             )));
         }
         if count > 1 {
-            return Err(ToolRuntimeError::Io(format!(
+            return Err(ToolRuntimeError::EditNotFound(format!(
                 "file.edit: old_string found {count} times in {path}. \
                  Include more surrounding context to make the match unique."
             )));
@@ -1128,6 +1206,89 @@ impl LocalToolExecutor {
             vec![resolved.display().to_string()],
             started,
         ))
+    }
+
+    fn execute_file_edit_anchor(
+        &self,
+        request: &ToolExecutionRequest,
+        path: &str,
+        params: &AnchorEditParams,
+        started: Instant,
+    ) -> Result<ToolExecutionResult, ToolRuntimeError> {
+        let resolved = self.resolve_path(path)?;
+        let content = fs::read_to_string(&resolved).map_err(|err| {
+            ToolRuntimeError::Io(format!(
+                "file.edit_anchor failed to read {}: {err}",
+                resolved.display()
+            ))
+        })?;
+
+        if params.old_content == params.new_content {
+            return Ok(build_completed_result(
+                request,
+                format!("{path} (no changes)"),
+                ToolExecutionPayload::None,
+                vec![],
+                started,
+            ));
+        }
+
+        let normalized_matches = find_indent_normalized_matches(&content, &params.old_content);
+
+        match normalized_matches.len() {
+            1 => {
+                let new_content =
+                    apply_normalized_edit(&content, &normalized_matches[0], &params.new_content);
+                fs::write(&resolved, &new_content).map_err(|err| {
+                    ToolRuntimeError::Io(format!(
+                        "file.edit_anchor failed to write {}: {err}",
+                        resolved.display()
+                    ))
+                })?;
+                Ok(build_completed_result(
+                    request,
+                    path.to_string(),
+                    ToolExecutionPayload::None,
+                    vec![resolved.display().to_string()],
+                    started,
+                ))
+            }
+            0 => Err(ToolRuntimeError::EditNotFound(format!(
+                "anchor: normalized old_content not found in {path}"
+            ))),
+            n => Err(ToolRuntimeError::EditNotFound(format!(
+                "anchor: old_content matched {n} locations in {path}, need unique match"
+            ))),
+        }
+    }
+
+    /// Try file.edit first, fall back to anchor-based edit on EditNotFound.
+    fn execute_file_edit_with_fallback(
+        &self,
+        request: &ToolExecutionRequest,
+        path: &str,
+        old_string: &str,
+        new_string: &str,
+        started: Instant,
+    ) -> Result<ToolExecutionResult, ToolRuntimeError> {
+        match self.execute_file_edit(request, path, old_string, new_string, started) {
+            Ok(result) => Ok(result),
+            Err(original_err) if original_err.is_edit_not_found() => {
+                let params = AnchorEditParams {
+                    old_content: old_string.to_string(),
+                    new_content: new_string.to_string(),
+                };
+                match self.execute_file_edit_anchor(request, path, &params, started) {
+                    Ok(mut result) => {
+                        result.summary = format!("{} (anchor fallback)", result.summary);
+                        Ok(result)
+                    }
+                    // Anchor also failed — return the original error for better diagnostics
+                    Err(_) => Err(original_err),
+                }
+            }
+            Err(err) => Err(err),
+        }
     }
 
     fn execute_file_search(
@@ -1587,6 +1748,137 @@ impl LocalToolExecutor {
     }
 }
 
+/// A matched region in file content for indent-normalized editing.
+#[derive(Debug, Clone)]
+struct NormalizedMatch {
+    /// Byte offset of the matched region start in the original file content.
+    start: usize,
+    /// Byte offset of the matched region end in the original file content.
+    end: usize,
+    /// The leading whitespace prefix of the first line of the matched region.
+    indent_prefix: String,
+}
+
+/// Compute the byte offset of the start of `line_idx` in `content`.
+fn byte_offset_of_line(content: &str, lines: &[&str], line_idx: usize) -> usize {
+    let mut pos = 0;
+    for (idx, line) in lines.iter().enumerate() {
+        if idx == line_idx {
+            return pos;
+        }
+        pos += line.len();
+        pos += line_terminator_len(&content[pos..]);
+    }
+    pos
+}
+
+/// Compute the byte offset just after the end of `line_idx` in `content`
+/// (i.e., after the line's text but before its terminator).
+fn byte_offset_after_line(content: &str, lines: &[&str], line_idx: usize) -> usize {
+    let mut pos = 0;
+    for (idx, line) in lines.iter().enumerate() {
+        pos += line.len();
+        if idx == line_idx {
+            return pos;
+        }
+        pos += line_terminator_len(&content[pos..]);
+    }
+    pos
+}
+
+/// Return the byte length of the line terminator at the start of `s` (0, 1, or 2).
+fn line_terminator_len(s: &str) -> usize {
+    if s.starts_with("\r\n") {
+        2
+    } else if s.starts_with('\n') {
+        1
+    } else {
+        0
+    }
+}
+
+/// Find regions in `content` that match `pattern` after stripping leading whitespace
+/// from each line of both pattern and content.
+fn find_indent_normalized_matches(content: &str, pattern: &str) -> Vec<NormalizedMatch> {
+    let pattern_lines: Vec<&str> = pattern.lines().collect();
+    if pattern_lines.is_empty() {
+        return Vec::new();
+    }
+
+    let normalized_pattern: Vec<String> = pattern_lines
+        .iter()
+        .map(|line| line.trim_start().to_string())
+        .collect();
+
+    // Skip all-empty patterns
+    if normalized_pattern.iter().all(|l| l.is_empty()) {
+        return Vec::new();
+    }
+
+    let content_lines: Vec<&str> = content.lines().collect();
+    let mut matches = Vec::new();
+
+    'outer: for i in 0..content_lines.len() {
+        if i + pattern_lines.len() > content_lines.len() {
+            break;
+        }
+
+        // Check if lines match after trimming leading whitespace
+        for (j, norm_pat) in normalized_pattern.iter().enumerate() {
+            let content_line_trimmed = content_lines[i + j].trim_start();
+            if content_line_trimmed != norm_pat.as_str() {
+                continue 'outer;
+            }
+        }
+
+        // Compute byte offsets using actual content positions
+        // (handles CRLF and missing trailing newline).
+        let start_byte = byte_offset_of_line(content, &content_lines, i);
+        let end_line = i + pattern_lines.len() - 1;
+        let end_byte = byte_offset_after_line(content, &content_lines, end_line);
+
+        // Extract indent prefix from first matched line
+        let first_line = content_lines[i];
+        let trimmed_len = first_line.trim_start().len();
+        let indent_prefix = first_line[..first_line.len() - trimmed_len].to_string();
+
+        matches.push(NormalizedMatch {
+            start: start_byte,
+            end: end_byte,
+            indent_prefix,
+        });
+    }
+
+    matches
+}
+
+/// Apply a normalized edit by replacing the matched region with new content,
+/// preserving the original indentation.
+fn apply_normalized_edit(content: &str, matched: &NormalizedMatch, new_content: &str) -> String {
+    // Re-indent new_content to match the indentation of the matched region.
+    // Wave 1: all non-empty lines use the same indent prefix as the first matched line.
+    let new_lines: Vec<&str> = new_content.lines().collect();
+    let reindented: Vec<String> = new_lines
+        .iter()
+        .map(|line| {
+            if line.trim().is_empty() {
+                String::new()
+            } else {
+                format!("{}{}", matched.indent_prefix, line.trim_start())
+            }
+        })
+        .collect();
+
+    let replacement = reindented.join("\n");
+
+    format!(
+        "{}{}{}",
+        &content[..matched.start],
+        replacement,
+        &content[matched.end..]
+    )
+}
+
 /// Resolve a relative path within a sandbox root directory.
 ///
 /// Rejects absolute paths, parent-directory traversal (`..`), and symlinks
@@ -1802,6 +2094,18 @@ fn validate_required_fields(input: &ToolInput) -> Result<(), ToolValidationError
                         MAX_PROMPT_LENGTH
                     ),
                 });
+            }
+        }
+        ToolInput::FileEditAnchor { path, params } => {
+            if path.trim().is_empty() {
+                return Err(ToolValidationError::MissingRequiredField(
+                    "path".to_string(),
+                ));
+            }
+            if params.old_content.is_empty() {
+                return Err(ToolValidationError::MissingRequiredField(
+                    "old_content".to_string(),
+                ));
             }
         }
         // [D3-001] MCP tool input validation is handled by the MCP server side

--- a/tests/runtime_flow.rs
+++ b/tests/runtime_flow.rs
@@ -625,3 +625,104 @@ fn system_prompt_includes_web_tools_even_with_empty_used_tools() {
         "fresh session system prompt must include web.fetch description (Issue #114)"
     );
 }
+
+// --- Issue #128: Multi-tier parsing tests ---
+
+#[test]
+fn parse_json_tool_call_unchanged() {
+    let response = anvil::agent::BasicAgentLoop::parse_structured_response(concat!(
+        "```ANVIL_TOOL\n",
+        "{\"id\":\"call_001\",\"tool\":\"file.read\",\"path\":\"./src/main.rs\"}\n",
+        "```\n",
+        "```ANVIL_FINAL\n",
+        "Read the file.\n",
+        "```\n"
+    ))
+    .expect("JSON parsing should work");
+
+    assert_eq!(response.tool_calls.len(), 1);
+    assert_eq!(response.tool_calls[0].tool_name, "file.read");
+}
+
+#[test]
+fn parse_tag_based_tool_call() {
+    let response = anvil::agent::BasicAgentLoop::parse_structured_response(concat!(
+        "```ANVIL_TOOL\n",
+        "<tool name=\"file.read\" path=\"./src/main.rs\"/>\n",
+        "```\n",
+        "```ANVIL_FINAL\n",
+        "Read the file.\n",
+        "```\n"
+    ))
+    .expect("Tag-based parsing should work");
+
+    assert_eq!(response.tool_calls.len(), 1);
+    assert_eq!(response.tool_calls[0].tool_name, "file.read");
+    assert_eq!(
+        response.tool_calls[0].tool_call_id, "tag_file_read",
+        "tag-based tool calls should have tag_ prefixed id"
+    );
+}
+
+#[test]
+fn parse_tag_based_file_edit() {
+    let response = anvil::agent::BasicAgentLoop::parse_structured_response(concat!(
+        "```ANVIL_TOOL\n",
+        "<tool name=\"file.edit\" path=\"./src/main.rs\"><old_string>fn old()</old_string><new_string>fn new()</new_string></tool>\n",
+        "```\n",
+        "```ANVIL_FINAL\n",
+        "Edited the file.\n",
+        "```\n"
+    ))
+    .expect("Tag-based file.edit parsing should work");
+
+    assert_eq!(response.tool_calls.len(), 1);
+    assert_eq!(response.tool_calls[0].tool_name, "file.edit");
+}
+
+#[test]
+fn parse_tag_based_file_edit_anchor() {
+    let response = anvil::agent::BasicAgentLoop::parse_structured_response(concat!(
+        "```ANVIL_TOOL\n",
+        "<tool name=\"file.edit_anchor\" path=\"./src/main.rs\"><old_content>fn old()</old_content><new_content>fn new()</new_content></tool>\n",
+        "```\n",
+        "```ANVIL_FINAL\n",
+        "Edited the file with anchor.\n",
+        "```\n"
+    ))
+    .expect("Tag-based file.edit_anchor parsing should work");
+
+    assert_eq!(response.tool_calls.len(), 1);
+    assert_eq!(response.tool_calls[0].tool_name, "file.edit_anchor");
+}
+
+#[test]
+fn parse_malformed_rejected() {
+    let result = anvil::agent::BasicAgentLoop::parse_structured_response(concat!(
+        "```ANVIL_TOOL\n",
+        "this is not valid json or tag format\n",
+        "```\n",
+        "```ANVIL_FINAL\n",
+        "Done.\n",
+        "```\n"
+    ));
+
+    assert!(result.is_err(), "malformed tool block should be rejected");
+}
+
+#[test]
+fn tag_protocol_prompt_contains_tag_examples() {
+    let prompt = anvil::agent::tool_protocol_system_prompt_tag_based(&[], None);
+    assert!(
+        prompt.contains("<tool name="),
+        "tag-based prompt should contain tag examples"
+    );
+    assert!(
+        prompt.contains("file.read"),
+        "tag-based prompt should mention file.read"
+    );
+    assert!(
+        prompt.contains("file.edit_anchor"),
+        "tag-based prompt should mention file.edit_anchor"
+    );
+}

--- a/tests/tag_spec_system.rs
+++ b/tests/tag_spec_system.rs
@@ -3,8 +3,8 @@
 use anvil::agent::tag_spec::{TOOL_TAG_SPECS, find_spec};
 
 #[test]
-fn tool_tag_specs_has_nine_entries() {
-    assert_eq!(TOOL_TAG_SPECS.len(), 9);
+fn tool_tag_specs_has_ten_entries() {
+    assert_eq!(TOOL_TAG_SPECS.len(), 10);
 }
 
 #[test]
@@ -72,6 +72,15 @@ fn find_spec_agent_plan() {
     let spec = find_spec("agent.plan").expect("agent.plan should exist");
     assert_eq!(spec.attributes, &["scope"]);
     assert_eq!(spec.child_elements, &["prompt"]);
+}
+
+#[test]
+fn find_spec_file_edit_anchor() {
+    let spec = find_spec("file.edit_anchor").expect("file.edit_anchor should exist");
+    assert_eq!(spec.name, "file.edit_anchor");
+    assert_eq!(spec.attributes, &["path"]);
+    assert_eq!(spec.child_elements, &["old_content", "new_content"]);
+    assert!(!spec.example.is_empty());
 }
 
 #[test]

--- a/tests/tooling_system.rs
+++ b/tests/tooling_system.rs
@@ -4234,3 +4234,186 @@ mod captcha_blocked_error {
         );
     }
 }
+
+// --- Issue #128: file.edit_anchor and fallback tests ---
+
+use anvil::tooling::AnchorEditParams;
+
+#[test]
+fn file_edit_anchor_registered_in_registry() {
+    let registry = build_registry();
+    let spec = registry
+        .get("file.edit_anchor")
+        .expect("file.edit_anchor should be registered");
+    assert_eq!(spec.kind, ToolKind::FileEditAnchor);
+    assert_eq!(spec.execution_class, ExecutionClass::Mutating);
+    assert_eq!(spec.permission_class, PermissionClass::Confirm);
+    assert_eq!(spec.execution_mode, ExecutionMode::SequentialOnly);
+    assert_eq!(spec.plan_mode, PlanModePolicy::Allowed);
+    assert_eq!(spec.rollback_policy, RollbackPolicy::CheckpointBeforeWrite);
+}
+
+#[test]
+fn file_edit_anchor_validates_typed_tool_input() {
+    let registry = build_registry();
+    let valid = ToolCallRequest::new(
+        "call_anchor_001",
+        "file.edit_anchor",
+        ToolInput::FileEditAnchor {
+            path: "./src/main.rs".to_string(),
+            params: AnchorEditParams {
+                old_content: "fn old()".to_string(),
+                new_content: "fn new()".to_string(),
+            },
+        },
+    );
+    assert!(registry.validate(valid).is_ok());
+}
+
+#[test]
+fn file_edit_anchor_execution_indent_normalized_match() {
+    let root = std::env::temp_dir().join("anvil_anchor_indent_match");
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(&root).expect("dir should exist");
+    // File has 4-space indentation
+    let file_content = "fn main() {\n    let x = 1;\n    let y = 2;\n}\n";
+    fs::write(root.join("test.rs"), file_content).expect("write should succeed");
+
+    let mut executor = LocalToolExecutor::new_without_rate_limit(root.clone());
+    // Pattern has no indentation — should match via normalization
+    let result = executor
+        .execute(ToolExecutionRequest {
+            tool_call_id: "call_anchor_exec_001".to_string(),
+            spec: build_registry()
+                .get("file.edit_anchor")
+                .expect("file.edit_anchor spec")
+                .clone(),
+            input: ToolInput::FileEditAnchor {
+                path: "./test.rs".to_string(),
+                params: AnchorEditParams {
+                    old_content: "let x = 1;\nlet y = 2;".to_string(),
+                    new_content: "let x = 10;\nlet y = 20;".to_string(),
+                },
+            },
+        })
+        .expect("anchor edit should succeed");
+
+    assert_eq!(result.status, ToolExecutionStatus::Completed);
+    let content = fs::read_to_string(root.join("test.rs")).expect("read should succeed");
+    assert!(
+        content.contains("let x = 10;"),
+        "edited content should contain new values, got: {content}"
+    );
+    assert!(
+        content.contains("let y = 20;"),
+        "edited content should contain new values, got: {content}"
+    );
+}
+
+#[test]
+fn file_edit_anchor_execution_no_match_error() {
+    let root = std::env::temp_dir().join("anvil_anchor_no_match");
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(&root).expect("dir should exist");
+    fs::write(root.join("test.rs"), "fn main() {}\n").expect("write should succeed");
+
+    let mut executor = LocalToolExecutor::new_without_rate_limit(root.clone());
+    let err = executor
+        .execute(ToolExecutionRequest {
+            tool_call_id: "call_anchor_nm_001".to_string(),
+            spec: build_registry()
+                .get("file.edit_anchor")
+                .expect("file.edit_anchor spec")
+                .clone(),
+            input: ToolInput::FileEditAnchor {
+                path: "./test.rs".to_string(),
+                params: AnchorEditParams {
+                    old_content: "nonexistent code".to_string(),
+                    new_content: "replacement".to_string(),
+                },
+            },
+        })
+        .expect_err("should fail when old_content not found");
+
+    assert!(err.to_string().contains("not found"));
+}
+
+#[test]
+fn file_edit_anchor_execution_multiple_matches_error() {
+    let root = std::env::temp_dir().join("anvil_anchor_multi_match");
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(&root).expect("dir should exist");
+    let file_content = "let x = 1;\nlet x = 1;\n";
+    fs::write(root.join("test.rs"), file_content).expect("write should succeed");
+
+    let mut executor = LocalToolExecutor::new_without_rate_limit(root.clone());
+    let err = executor
+        .execute(ToolExecutionRequest {
+            tool_call_id: "call_anchor_mm_001".to_string(),
+            spec: build_registry()
+                .get("file.edit_anchor")
+                .expect("file.edit_anchor spec")
+                .clone(),
+            input: ToolInput::FileEditAnchor {
+                path: "./test.rs".to_string(),
+                params: AnchorEditParams {
+                    old_content: "let x = 1;".to_string(),
+                    new_content: "let x = 2;".to_string(),
+                },
+            },
+        })
+        .expect_err("should fail when old_content matches multiple times");
+
+    assert!(
+        err.to_string().contains("matched 2 locations"),
+        "error should mention multiple matches, got: {}",
+        err
+    );
+}
+
+#[test]
+fn file_edit_fallback_indent_mismatch() {
+    let root = std::env::temp_dir().join("anvil_fallback_indent");
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(&root).expect("dir should exist");
+    // File has 4-space indentation
+    let file_content = "fn main() {\n    let x = 1;\n}\n";
+    fs::write(root.join("test.rs"), file_content).expect("write should succeed");
+
+    let mut executor = LocalToolExecutor::new_without_rate_limit(root.clone());
+    // Use file.edit with 8-space indent instead of 4-space — cannot be a substring match
+    let result = executor
+        .execute(ToolExecutionRequest {
+            tool_call_id: "call_fallback_001".to_string(),
+            spec: build_registry()
+                .get("file.edit")
+                .expect("file.edit spec")
+                .clone(),
+            input: ToolInput::FileEdit {
+                path: "./test.rs".to_string(),
+                old_string: "        let x = 1;".to_string(), // 8-space indent
+                new_string: "        let x = 2;".to_string(),
+            },
+        })
+        .expect("fallback should succeed");
+
+    assert_eq!(result.status, ToolExecutionStatus::Completed);
+    assert!(
+        result.summary.contains("anchor fallback"),
+        "summary should mention anchor fallback, got: {}",
+        result.summary
+    );
+    let content = fs::read_to_string(root.join("test.rs")).expect("read should succeed");
+    assert!(
+        content.contains("let x = 2;"),
+        "content should be edited, got: {content}"
+    );
+}
+
+#[test]
+fn edit_not_found_error_is_distinguishable() {
+    let err = anvil::tooling::ToolRuntimeError::EditNotFound("test".to_string());
+    assert!(err.is_edit_not_found());
+    let io_err = anvil::tooling::ToolRuntimeError::Io("test".to_string());
+    assert!(!io_err.is_edit_not_found());
+}


### PR DESCRIPTION
## Summary
- ツール呼び出しを `native tool calling > structured JSON/tag > repair fallback` の多層処理に対応
- provider capabilityを拡張し、native tool calling利用可否をruntimeが判断可能に
- `file.edit`の代替としてpatch/anchorベースの編集方式を追加

Closes #128
Parent: #127

## Test plan
- [ ] cargo fmt --check: 差分なし
- [ ] cargo clippy --all-targets: 警告0件
- [ ] cargo test: 全テストパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)