### PR TITLE
feat: Wave 2 - prompt tiering and model adaptation (#132)

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -7,7 +7,7 @@ pub mod model_classifier;
 pub mod subagent;
 pub mod tag_spec;
 
-pub use model_classifier::ToolProtocolMode;
+pub use model_classifier::{ModelCapability, ModelSizeClass, PromptTier, ToolProtocolMode};
 
 use crate::contracts::InferencePerformanceView;
 use crate::contracts::tokens::{ContentKind, NO_CALIBRATION, estimate_tokens_calibrated};
@@ -716,6 +716,25 @@ pub(crate) fn tool_protocol_system_prompt(
     mcp_tool_descriptions: Option<&str>,
     used_tools: &std::collections::HashSet<String>,
     offline: bool,
+    tier: PromptTier,
+) -> String {
+    match tier {
+        PromptTier::Full => {
+            tool_protocol_system_prompt_full(languages, mcp_tool_descriptions, used_tools, offline)
+        }
+        PromptTier::Compact => {
+            tool_protocol_system_prompt_compact(mcp_tool_descriptions, used_tools, offline)
+        }
+        PromptTier::Tiny => tool_protocol_system_prompt_tiny(),
+    }
+}
+
+/// Full tier: all sections included (original behaviour).
+fn tool_protocol_system_prompt_full(
+    languages: &[ProjectLanguage],
+    mcp_tool_descriptions: Option<&str>,
+    used_tools: &std::collections::HashSet<String>,
+    offline: bool,
 ) -> String {
     let mut prompt = String::with_capacity(8192);
 
@@ -793,26 +812,111 @@ pub(crate) fn tool_protocol_system_prompt(
     prompt
 }
 
+/// Compact tier: basic tools + rules, guides omitted.
+fn tool_protocol_system_prompt_compact(
+    mcp_tool_descriptions: Option<&str>,
+    used_tools: &std::collections::HashSet<String>,
+    offline: bool,
+) -> String {
+    let mut prompt = String::with_capacity(4096);
+
+    // Work approach (static)
+    prompt.push_str(PROMPT_WORK_APPROACH);
+
+    // All basic tools
+    prompt.push_str(TOOL_DESC_FILE_READ);
+    prompt.push_str(TOOL_DESC_FILE_WRITE);
+    prompt.push_str(TOOL_DESC_FILE_EDIT);
+    prompt.push_str(TOOL_DESC_FILE_SEARCH);
+    prompt.push_str(TOOL_DESC_SHELL_EXEC);
+    prompt.push_str(TOOL_DESC_WEB_FETCH);
+    prompt.push_str(TOOL_DESC_WEB_SEARCH);
+
+    // Detailed descriptions for used optional tools (no catalog header)
+    for (tool_name, tool_desc, _) in OPTIONAL_TOOLS {
+        if used_tools.contains(*tool_name) {
+            if offline && tool_name.starts_with("web.") {
+                continue;
+            }
+            prompt.push_str(tool_desc);
+        }
+    }
+
+    // Tool rules (static)
+    prompt.push_str(PROMPT_TOOL_RULES);
+
+    // MCP tool descriptions (with reduced limit)
+    if let Some(mcp_desc) = mcp_tool_descriptions {
+        let truncated = if mcp_desc.len() > 4000 {
+            &mcp_desc[..4000]
+        } else {
+            mcp_desc
+        };
+        prompt.push_str("\n\n## MCP External Tools\n\n");
+        prompt.push_str(truncated);
+    }
+
+    // Omitted: CONFIRM_CLASS_GUIDANCE, GIT_GUIDE, ENV_GUIDE, PROCESS_GUIDE, language guides
+
+    prompt
+}
+
+/// Tiny tier: minimal tool syntax for very small models (<7B).
+fn tool_protocol_system_prompt_tiny() -> String {
+    let mut prompt = String::with_capacity(2048);
+
+    prompt.push_str("You are Anvil, a coding agent.\n\n");
+    prompt.push_str("Use ANVIL_TOOL blocks for tool calls. Available tools:\n\n");
+
+    // Only core 4 tools + shell
+    prompt.push_str(TOOL_DESC_FILE_READ);
+    prompt.push_str(TOOL_DESC_FILE_WRITE);
+    prompt.push_str(TOOL_DESC_FILE_EDIT);
+    prompt.push_str(TOOL_DESC_SHELL_EXEC);
+
+    prompt.push_str(concat!(
+        "Rules:\n",
+        "- All paths must be relative.\n",
+        "- Include ANVIL_FINAL block after tool blocks.\n",
+    ));
+
+    prompt
+}
+
 /// Generate a system prompt with no optional tools (basic tools only).
 ///
 /// Useful for testing that optional tools are excluded when unused.
+/// Always uses [`PromptTier::Full`] for backward compatibility.
 pub fn tool_protocol_system_prompt_basic_only(
     languages: &[ProjectLanguage],
     mcp_tool_descriptions: Option<&str>,
 ) -> String {
     let empty = std::collections::HashSet::new();
-    tool_protocol_system_prompt(languages, mcp_tool_descriptions, &empty, false)
+    tool_protocol_system_prompt(
+        languages,
+        mcp_tool_descriptions,
+        &empty,
+        false,
+        PromptTier::Full,
+    )
 }
 
 /// Generate a system prompt with all tools included (for test compatibility
 /// and contexts where all tools should be available).
+/// Always uses [`PromptTier::Full`] for backward compatibility.
 pub fn tool_protocol_system_prompt_all_tools(
     languages: &[ProjectLanguage],
     mcp_tool_descriptions: Option<&str>,
 ) -> String {
     let all_tools: std::collections::HashSet<String> =
         optional_tool_names().map(|s| s.to_string()).collect();
-    tool_protocol_system_prompt(languages, mcp_tool_descriptions, &all_tools, false)
+    tool_protocol_system_prompt(
+        languages,
+        mcp_tool_descriptions,
+        &all_tools,
+        false,
+        PromptTier::Full,
+    )
 }
 
 fn extract_fenced_blocks(content: &str, label: &str) -> Vec<String> {
@@ -927,7 +1031,8 @@ mod tests {
 
     #[test]
     fn catalog_hides_web_tools_offline() {
-        let prompt = tool_protocol_system_prompt(&[], None, &HashSet::new(), true);
+        let prompt =
+            tool_protocol_system_prompt(&[], None, &HashSet::new(), true, PromptTier::Full);
         assert!(
             !prompt.contains("- web.fetch:"),
             "offline prompt should not contain web.fetch catalog entry"
@@ -950,7 +1055,7 @@ mod tests {
     fn catalog_offline_with_restored_session() {
         let mut used_tools = HashSet::new();
         used_tools.insert("web.fetch".to_string());
-        let prompt = tool_protocol_system_prompt(&[], None, &used_tools, true);
+        let prompt = tool_protocol_system_prompt(&[], None, &used_tools, true, PromptTier::Full);
         // web.fetch is now a basic tool (always included per Issue #114),
         // so the catalog entry should not exist but the basic description should.
         assert!(

--- a/src/agent/model_classifier.rs
+++ b/src/agent/model_classifier.rs
@@ -1,7 +1,8 @@
-//! Model size classification for tool protocol mode selection.
+//! Model size classification for tool protocol mode and prompt tier selection.
 //!
 //! Determines whether a model should use JSON or tag-based tool protocol
-//! based on configuration overrides and model name heuristics.
+//! and which prompt tier (Full/Compact/Tiny) to use, based on configuration
+//! overrides and model name heuristics.
 
 use regex::Regex;
 
@@ -12,6 +13,43 @@ pub enum ToolProtocolMode {
     Json,
     /// Tag-based format (for small models, <= 13B).
     TagBased,
+}
+
+/// System prompt verbosity tier.
+///
+/// Controls how much of the system prompt is included, allowing smaller
+/// models to receive a more concise prompt that fits their context window.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum PromptTier {
+    /// Full prompt with all sections (default, for large models >13B).
+    #[default]
+    Full,
+    /// Compact prompt: basic tools + rules, guides omitted (for 7B-13B models).
+    Compact,
+    /// Tiny prompt: minimal tool syntax only (for <7B models).
+    Tiny,
+}
+
+/// Model size classification.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ModelSizeClass {
+    /// Small model (<7B parameters).
+    Small,
+    /// Medium model (7B-13B parameters).
+    Medium,
+    /// Large model (>13B parameters or unknown).
+    Large,
+}
+
+/// Combined model capability assessment.
+///
+/// Produced by [`classify_model_capability`] and used to drive prompt tier
+/// selection and protocol mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ModelCapability {
+    pub size_class: ModelSizeClass,
+    pub protocol_mode: ToolProtocolMode,
+    pub prompt_tier: PromptTier,
 }
 
 /// Determine the tool protocol mode from config override and model name.
@@ -31,6 +69,56 @@ pub fn determine_protocol_mode(
     classify_model_size(model_name)
 }
 
+/// Classify a model's capabilities from its name and config overrides.
+///
+/// Priority: `config_prompt_tier` > model name heuristic.
+/// The `config_tag_protocol` override is forwarded to [`determine_protocol_mode`].
+pub fn classify_model_capability(
+    model_name: &str,
+    config_tag_protocol: Option<bool>,
+    config_prompt_tier: Option<&str>,
+) -> ModelCapability {
+    let protocol_mode = determine_protocol_mode(model_name, config_tag_protocol);
+
+    // Config override for prompt tier takes priority
+    if let Some(tier_str) = config_prompt_tier
+        && let Some(tier) = parse_prompt_tier(tier_str)
+    {
+        return ModelCapability {
+            size_class: classify_size_class(model_name),
+            protocol_mode,
+            prompt_tier: tier,
+        };
+    }
+
+    // Auto-detect from model name
+    let size_class = classify_size_class(model_name);
+    let prompt_tier = match size_class {
+        ModelSizeClass::Small => PromptTier::Tiny,
+        ModelSizeClass::Medium => PromptTier::Compact,
+        ModelSizeClass::Large => PromptTier::Full,
+    };
+
+    ModelCapability {
+        size_class,
+        protocol_mode,
+        prompt_tier,
+    }
+}
+
+/// Parse a prompt tier string into a [`PromptTier`].
+///
+/// Accepts "full", "compact", "tiny" (case-insensitive). Returns `None` for
+/// unrecognised values (caller falls back to auto-detect).
+pub fn parse_prompt_tier(s: &str) -> Option<PromptTier> {
+    match s.to_lowercase().as_str() {
+        "full" => Some(PromptTier::Full),
+        "compact" => Some(PromptTier::Compact),
+        "tiny" => Some(PromptTier::Tiny),
+        _ => None,
+    }
+}
+
 /// Small-model family names that default to tag-based protocol.
 const SMALL_MODEL_FAMILIES: &[&str] = &[
     "gemma",
@@ -41,34 +129,44 @@ const SMALL_MODEL_FAMILIES: &[&str] = &[
     "codegemma",
 ];
 
-/// Classify model size from its name and return the appropriate protocol mode.
+/// Classify model size class from its name.
 ///
-/// 1. Extract parameter count from `:NNb` suffix — <= 13 means TagBased.
+/// 1. Extract parameter count from `:NNb` suffix.
 /// 2. Fall back to family name dictionary.
-/// 3. Unknown models default to Json (safe side).
-fn classify_model_size(model_name: &str) -> ToolProtocolMode {
-    // Try to extract parameter count from suffix like ":8b", ":70b"
+/// 3. Unknown models default to Large (safe side).
+fn classify_size_class(model_name: &str) -> ModelSizeClass {
     let re = Regex::new(r":([0-9]+)[bB]").expect("valid regex");
     if let Some(caps) = re.captures(model_name)
         && let Ok(size) = caps[1].parse::<u64>()
     {
-        return if size <= 13 {
-            ToolProtocolMode::TagBased
-        } else {
-            ToolProtocolMode::Json
+        return match size {
+            0..7 => ModelSizeClass::Small,
+            7..=13 => ModelSizeClass::Medium,
+            _ => ModelSizeClass::Large,
         };
     }
 
-    // Check model family name dictionary
+    // Check model family name dictionary — these are all small/medium
     let lower = model_name.to_lowercase();
     for family in SMALL_MODEL_FAMILIES {
         if lower.contains(family) {
-            return ToolProtocolMode::TagBased;
+            return ModelSizeClass::Medium;
         }
     }
 
-    // Unknown model — default to Json (safe side)
-    ToolProtocolMode::Json
+    // Unknown model — default to Large (safe side)
+    ModelSizeClass::Large
+}
+
+/// Classify model size from its name and return the appropriate protocol mode.
+///
+/// Delegates to [`classify_size_class`] for the size determination, then maps
+/// Small/Medium → TagBased, Large → Json.
+fn classify_model_size(model_name: &str) -> ToolProtocolMode {
+    match classify_size_class(model_name) {
+        ModelSizeClass::Small | ModelSizeClass::Medium => ToolProtocolMode::TagBased,
+        ModelSizeClass::Large => ToolProtocolMode::Json,
+    }
 }
 
 #[cfg(test)]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -12,7 +12,7 @@ pub mod policy;
 pub mod render;
 
 use crate::agent::BasicAgentLoop;
-use crate::agent::{AgentEvent, AgentRuntime, PendingTurnState, ProjectLanguage};
+use crate::agent::{AgentEvent, AgentRuntime, PendingTurnState, ProjectLanguage, PromptTier};
 use crate::config::EffectiveConfig;
 use crate::contracts::tokens::TokenCalibrationStore;
 use crate::contracts::{
@@ -142,6 +142,8 @@ pub struct App {
     /// Last estimated prompt tokens from build_turn_request_calibrated.
     /// Consumed by apply_agent_event Done handler via Option::take.
     last_estimated_prompt_tokens: Option<usize>,
+    /// System prompt verbosity tier, determined at session start.
+    prompt_tier: PromptTier,
 }
 
 /// Whether the session loop should continue or exit.
@@ -386,6 +388,17 @@ impl App {
 
         let trust_all = config.mode.trust_all;
 
+        // Determine prompt tier from config override or model name heuristic
+        let prompt_tier = {
+            use crate::agent::model_classifier::classify_model_capability;
+            let capability = classify_model_capability(
+                &config.runtime.model,
+                config.runtime.tag_protocol,
+                config.runtime.prompt_tier.as_deref(),
+            );
+            capability.prompt_tier
+        };
+
         Ok(Self {
             tools,
             config,
@@ -409,6 +422,7 @@ impl App {
             active_context_window: None,
             calibration_store: TokenCalibrationStore::new(),
             last_estimated_prompt_tokens: None,
+            prompt_tier,
         })
     }
 
@@ -481,6 +495,7 @@ impl App {
             self.mcp_descriptions.as_deref(),
             effective_used_tools,
             self.config.mode.offline,
+            self.prompt_tier,
         );
 
         // Current date and timezone (dynamic, re-evaluated per turn)

--- a/src/config/cli_args.rs
+++ b/src/config/cli_args.rs
@@ -81,6 +81,10 @@ pub struct CliArgs {
     #[arg(long)]
     pub trust: bool,
 
+    /// Prompt tier override (full|compact|tiny)
+    #[arg(long = "prompt-tier")]
+    pub prompt_tier: Option<String>,
+
     /// Enable tag-based tool protocol (--tag-protocol).
     #[doc(hidden)]
     #[arg(long = "tag-protocol")]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -66,6 +66,9 @@ pub struct RuntimeConfig {
     /// Tag-based tool protocol mode override.
     /// `Some(true)` = force tag-based, `Some(false)` = force JSON, `None` = auto-detect from model name.
     pub tag_protocol: Option<bool>,
+    /// Prompt tier override: "full", "compact", or "tiny".
+    /// `None` = auto-detect from model name.
+    pub prompt_tier: Option<String>,
     /// Smart compact threshold ratio (0.1..=0.95, default 0.75).
     /// When estimated tokens exceed context_window * ratio, token-based compaction triggers.
     pub smart_compact_threshold_ratio: f64,
@@ -216,6 +219,7 @@ impl EffectiveConfig {
                 serper_api_key: None,
                 context_window_explicitly_set: false,
                 tag_protocol: None,
+                prompt_tier: None,
                 smart_compact_threshold_ratio: 0.75,
             },
             mode: ModeConfig {
@@ -310,6 +314,7 @@ impl EffectiveConfig {
             "ANVIL_LOG",
             "ANVIL_OFFLINE",
             "ANVIL_TAG_PROTOCOL",
+            "ANVIL_PROMPT_TIER",
             "ANVIL_SMART_COMPACT_THRESHOLD_RATIO",
         ] {
             if let Ok(value) = std::env::var(key) {
@@ -397,6 +402,11 @@ impl EffectiveConfig {
         // Tag protocol flag
         if let Some(v) = cli.tag_protocol {
             self.runtime.tag_protocol = Some(v);
+        }
+
+        // Prompt tier override
+        if let Some(ref v) = cli.prompt_tier {
+            self.runtime.prompt_tier = Some(v.clone());
         }
 
         // --session flag: override session file path
@@ -502,6 +512,13 @@ impl EffectiveConfig {
                 }
                 "tag_protocol" | "ANVIL_TAG_PROTOCOL" => {
                     self.runtime.tag_protocol = Some(parse_bool(value));
+                }
+                "prompt_tier" | "ANVIL_PROMPT_TIER" => {
+                    self.runtime.prompt_tier = if value.is_empty() {
+                        None
+                    } else {
+                        Some(value.clone())
+                    };
                 }
                 "smart_compact_threshold_ratio" | "ANVIL_SMART_COMPACT_THRESHOLD_RATIO" => {
                     self.runtime.smart_compact_threshold_ratio = value

--- a/tests/model_classifier.rs
+++ b/tests/model_classifier.rs
@@ -1,4 +1,7 @@
-use anvil::agent::{ToolProtocolMode, model_classifier::determine_protocol_mode};
+use anvil::agent::{
+    ModelSizeClass, PromptTier, ToolProtocolMode,
+    model_classifier::{classify_model_capability, determine_protocol_mode},
+};
 
 #[test]
 fn config_true_forces_tag_based() {
@@ -62,4 +65,106 @@ fn unknown_model_returns_json() {
         determine_protocol_mode("unknown-model", None),
         ToolProtocolMode::Json,
     );
+}
+
+// --- classify_model_capability tests ---
+
+#[test]
+fn capability_small_model_3b_returns_tiny() {
+    let cap = classify_model_capability("phi3:3b", None, None);
+    assert_eq!(cap.size_class, ModelSizeClass::Small);
+    assert_eq!(cap.prompt_tier, PromptTier::Tiny);
+    assert_eq!(cap.protocol_mode, ToolProtocolMode::TagBased);
+}
+
+#[test]
+fn capability_medium_model_8b_returns_compact() {
+    let cap = classify_model_capability("llama3:8b", None, None);
+    assert_eq!(cap.size_class, ModelSizeClass::Medium);
+    assert_eq!(cap.prompt_tier, PromptTier::Compact);
+    assert_eq!(cap.protocol_mode, ToolProtocolMode::TagBased);
+}
+
+#[test]
+fn capability_large_model_70b_returns_full() {
+    let cap = classify_model_capability("llama3:70b", None, None);
+    assert_eq!(cap.size_class, ModelSizeClass::Large);
+    assert_eq!(cap.prompt_tier, PromptTier::Full);
+    assert_eq!(cap.protocol_mode, ToolProtocolMode::Json);
+}
+
+#[test]
+fn capability_unknown_model_defaults_to_full() {
+    let cap = classify_model_capability("unknown-model", None, None);
+    assert_eq!(cap.size_class, ModelSizeClass::Large);
+    assert_eq!(cap.prompt_tier, PromptTier::Full);
+}
+
+#[test]
+fn capability_config_tier_overrides_auto() {
+    // Force tiny tier on a large model
+    let cap = classify_model_capability("llama3:70b", None, Some("tiny"));
+    assert_eq!(cap.prompt_tier, PromptTier::Tiny);
+    // Size class still reflects actual model
+    assert_eq!(cap.size_class, ModelSizeClass::Large);
+}
+
+#[test]
+fn capability_config_tier_compact() {
+    let cap = classify_model_capability("llama3:70b", None, Some("compact"));
+    assert_eq!(cap.prompt_tier, PromptTier::Compact);
+}
+
+#[test]
+fn capability_config_tier_full_on_small_model() {
+    let cap = classify_model_capability("phi3:3b", None, Some("full"));
+    assert_eq!(cap.prompt_tier, PromptTier::Full);
+    assert_eq!(cap.size_class, ModelSizeClass::Small);
+}
+
+#[test]
+fn capability_invalid_tier_falls_back_to_auto() {
+    let cap = classify_model_capability("llama3:8b", None, Some("invalid"));
+    // Should fall back to auto-detect (Medium -> Compact)
+    assert_eq!(cap.prompt_tier, PromptTier::Compact);
+}
+
+#[test]
+fn capability_boundary_7b_is_medium() {
+    let cap = classify_model_capability("model:7b", None, None);
+    assert_eq!(cap.size_class, ModelSizeClass::Medium);
+    assert_eq!(cap.prompt_tier, PromptTier::Compact);
+}
+
+#[test]
+fn capability_boundary_13b_is_medium() {
+    let cap = classify_model_capability("model:13b", None, None);
+    assert_eq!(cap.size_class, ModelSizeClass::Medium);
+    assert_eq!(cap.prompt_tier, PromptTier::Compact);
+}
+
+#[test]
+fn capability_boundary_14b_is_large() {
+    let cap = classify_model_capability("model:14b", None, None);
+    assert_eq!(cap.size_class, ModelSizeClass::Large);
+    assert_eq!(cap.prompt_tier, PromptTier::Full);
+}
+
+#[test]
+fn capability_family_gemma_is_medium() {
+    let cap = classify_model_capability("gemma2", None, None);
+    assert_eq!(cap.size_class, ModelSizeClass::Medium);
+    assert_eq!(cap.prompt_tier, PromptTier::Compact);
+}
+
+#[test]
+fn capability_tag_protocol_override_preserved() {
+    let cap = classify_model_capability("llama3:70b", Some(true), None);
+    assert_eq!(cap.protocol_mode, ToolProtocolMode::TagBased);
+    assert_eq!(cap.prompt_tier, PromptTier::Full);
+}
+
+#[test]
+fn prompt_tier_default_is_full() {
+    assert_eq!(PromptTier::default(), PromptTier::Full);
 }


### PR DESCRIPTION
## Summary
- model classifierを能力ベースに拡張
- system promptに `full / compact / tiny` tierを導入
- モデル特性に応じてprotocol, prompt verbosity, retry方針を調整

Closes #132
Parent: #127

## Test plan
- [ ] cargo fmt --check: 差分なし
- [ ] cargo clippy --all-targets: 警告0件
- [ ] cargo test: 全テストパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)