### PR TITLE
feat: Wave 5 - shell execution policy split and offline hardening (#131)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,7 +135,8 @@ src/
 ├── state/mod.rs         # 状態マシン
 ├── tooling/
 │   ├── mod.rs           # ツール実行・検証・CheckpointStack（undo用チェックポイント管理）
-│   └── diff.rs          # 差分プレビュー生成（file.write/file.edit承認時）
+│   ├── diff.rs          # 差分プレビュー生成（file.write/file.edit承認時）
+│   └── shell_policy.rs  # ShellPolicy分類（ReadOnly/BuildTest/General）・offline用ネットワークコマンド検出
 ├── tui/mod.rs           # TUI描画
 └── walk.rs              # 共通ディレクトリウォーカー（.gitignore対応・統一スキップ/バイナリ除外）
 tests/

--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -20,7 +20,7 @@ use crate::tui::Tui;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use crate::tooling::PermissionClass;
+use crate::tooling::{PermissionClass, effective_permission_class};
 use std::collections::HashSet;
 
 use super::policy::{OFFLINE_BLOCK_PAYLOAD, check_offline_blocked};
@@ -512,10 +512,11 @@ impl App {
             }
 
             if self.config.mode.approval_required && validated.approval_required(true).is_some() {
+                let effective_perm = effective_permission_class(&call.input, &validated.spec);
                 if is_trusted(
                     &call.tool_name,
                     validated.spec.kind,
-                    validated.spec.permission_class,
+                    effective_perm,
                     self.trust_all,
                     &self.trusted_tools,
                 ) {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -372,7 +372,7 @@ impl App {
         // Offline mode: warn about shell.exec network access
         if config.mode.offline {
             eprintln!(
-                "Warning: shell.exec can still access the network in offline mode. For full network isolation, use OS/firewall-level controls."
+                "Warning: shell.exec のネットワークコマンド（curl, wget等）は offline mode でブロックされます。エイリアスやスクリプト経由のアクセスは検出されない場合があります。完全なネットワーク遮断には OS/ファイアウォールレベルの制御を使用してください。"
             );
         }
 

--- a/src/app/policy.rs
+++ b/src/app/policy.rs
@@ -5,7 +5,7 @@
 //! to enforce offline mode restrictions.
 
 use crate::config::EffectiveConfig;
-use crate::tooling::{ToolCallRequest, ToolInput};
+use crate::tooling::{ToolCallRequest, ToolInput, is_network_command};
 
 /// Suffix appended to tool name when generating block summary messages.
 pub const OFFLINE_BLOCK_SUMMARY_SUFFIX: &str = "is unavailable in offline mode";
@@ -23,12 +23,17 @@ pub fn check_offline_blocked(config: &EffectiveConfig, call: &ToolCallRequest) -
     if !config.mode.offline {
         return None;
     }
-    match call.input {
+    match &call.input {
         ToolInput::WebFetch { .. }
         | ToolInput::WebSearch { .. }
         // Defense in Depth: MCP tools are normally unreachable in offline mode
         // (MCP initialization is skipped), but block explicitly as a safety net.
         | ToolInput::Mcp { .. } => Some(format!(
+            "{} {}",
+            call.tool_name, OFFLINE_BLOCK_SUMMARY_SUFFIX
+        )),
+        // Block shell commands that perform network access
+        ToolInput::ShellExec { command } if is_network_command(command) => Some(format!(
             "{} {}",
             call.tool_name, OFFLINE_BLOCK_SUMMARY_SUFFIX
         )),
@@ -149,6 +154,47 @@ mod tests {
             },
         );
         assert!(check_offline_blocked(&config, &call).is_none());
+    }
+
+    #[test]
+    fn offline_blocks_network_shell_commands() {
+        let config = make_config(true);
+        for cmd in &[
+            "curl https://example.com",
+            "wget https://example.com",
+            "ssh user@host",
+            "ping 8.8.8.8",
+        ] {
+            let call = make_call(
+                "shell.exec",
+                ToolInput::ShellExec {
+                    command: cmd.to_string(),
+                },
+            );
+            let result = check_offline_blocked(&config, &call);
+            assert!(
+                result.is_some(),
+                "Expected {cmd} to be blocked in offline mode"
+            );
+            assert!(result.unwrap().contains("shell.exec"));
+        }
+    }
+
+    #[test]
+    fn offline_allows_non_network_shell() {
+        let config = make_config(true);
+        for cmd in &["ls -la", "git log", "cargo test", "cat file.txt"] {
+            let call = make_call(
+                "shell.exec",
+                ToolInput::ShellExec {
+                    command: cmd.to_string(),
+                },
+            );
+            assert!(
+                check_offline_blocked(&config, &call).is_none(),
+                "Expected {cmd} to be allowed in offline mode"
+            );
+        }
     }
 
     #[test]

--- a/src/tooling/mod.rs
+++ b/src/tooling/mod.rs
@@ -5,6 +5,9 @@
 //! [`LocalToolExecutor`] within a sandboxed workspace root.
 
 pub mod diff;
+pub mod shell_policy;
+
+pub use shell_policy::{ShellPolicy, classify_shell_policy, is_network_command};
 
 use crate::config::{RuntimeConfig, WebSearchProvider};
 use crate::contracts::ToolLogView;
@@ -1662,10 +1665,12 @@ impl ParallelExecutionPlan {
         policy: ToolExecutionPolicy,
     ) -> Result<Self, ParallelExecutionPlanError> {
         for call in &calls {
-            if policy.approval_required
-                && call.spec.permission_class != PermissionClass::Safe
-                && !call.approved
-            {
+            // Use effective_permission_class (not spec.permission_class) so that
+            // safe shell commands (e.g. git log) are correctly recognised as Safe.
+            // Currently shell.exec is SequentialOnly so it never reaches this path,
+            // but we use the effective class defensively for future-proofing.
+            let effective = effective_permission_class(&call.request.input, &call.spec);
+            if policy.approval_required && effective != PermissionClass::Safe && !call.approved {
                 return Err(ParallelExecutionPlanError::ApprovalRequired(
                     call.request.tool_call_id.clone(),
                 ));
@@ -1940,149 +1945,25 @@ fn validate_shell_command_safety(command: &str) -> Result<(), ToolValidationErro
 ///
 /// Commands that pass this check are promoted from `Confirm` to `Safe`
 /// by [`effective_permission_class`], skipping the approval prompt.
+///
+/// This is a backward-compatible wrapper around [`classify_shell_policy`].
 pub fn is_safe_shell_command(command: &str) -> bool {
-    let trimmed = command.trim();
-
-    // Reject command chaining / injection vectors
-    if trimmed.contains('|')
-        || trimmed.contains(';')
-        || trimmed.contains('`')
-        || trimmed.contains("$(")
-        || trimmed.contains("${")
-        || trimmed.contains('\n')
-        || trimmed.contains("&&")
-        || trimmed.contains('>')
-        || trimmed.contains('<')
-    {
-        return false;
-    }
-
-    // gh api: GET-only is safe (token-split based flag detection)
-    if trimmed.starts_with("gh api ") {
-        let tokens: Vec<&str> = trimmed.split_whitespace().collect();
-
-        // Flags that imply a mutating request by their mere presence.
-        const BODY_FLAGS: &[&str] = &["-f", "--field", "-F", "--raw-field", "--input"];
-
-        // Combined flag=value forms that imply mutation.
-        const MUTATION_COMBINED: &[&str] = &[
-            "-XPOST",
-            "-XPUT",
-            "-XPATCH",
-            "-XDELETE",
-            "--method=POST",
-            "--method=PUT",
-            "--method=PATCH",
-            "--method=DELETE",
-            "--input=",
-            "-f=",
-            "--field=",
-            "-F=",
-            "--raw-field=",
-        ];
-
-        for (i, token) in tokens.iter().enumerate() {
-            // Body/field flags always imply mutation (POST is the gh default).
-            if BODY_FLAGS.iter().any(|f| token == f) {
-                return false;
-            }
-
-            // --method / -X followed by a mutating HTTP verb.
-            if (*token == "--method" || *token == "-X")
-                && let Some(next) = tokens.get(i + 1)
-            {
-                let upper = next.to_uppercase();
-                if ["POST", "PUT", "PATCH", "DELETE"].contains(&upper.as_str()) {
-                    return false;
-                }
-            }
-
-            // Combined forms (e.g. -XPOST, --method=POST, --input=file)
-            if MUTATION_COMBINED.iter().any(|f| token.starts_with(f)) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    // Auto-approved command prefixes, grouped by category for readability.
-    const SAFE_PREFIXES: &[&str] = &[
-        // Git read-only
-        "git log",
-        "git status",
-        "git diff",
-        "git branch",
-        "git show ", // trailing space requires an argument (ref)
-        "git remote -v",
-        "git rev-parse",
-        // GitHub CLI read-only
-        "gh repo view",
-        "gh pr list",
-        "gh issue list",
-        "gh pr view",
-        "gh issue view",
-        "gh auth status",
-        // Rust build/test/lint
-        "cargo clippy",
-        "cargo fmt --check",
-        "cargo test",
-        "cargo check",
-        "cargo build",
-        // Node.js build/test/lint
-        "npm test",
-        "npx jest ",
-        "npx eslint ",
-        "npx prettier --check",
-        // Python test/lint
-        "pytest",
-        "ruff check ",
-        "flake8",
-        // Go build/test/lint
-        "go test",
-        "go vet",
-        "golangci-lint",
-        // Make build/test
-        "make test",
-        "make check",
-        // Environment inspection
-        "which ",
-        "uname",
-        "node -v",
-        "node --version",
-        "rustc --version",
-        "cargo --version",
-        "python --version",
-        "go version",
-        // Process inspection
-        "lsof -i",
-    ];
-
-    if !SAFE_PREFIXES
-        .iter()
-        .any(|prefix| trimmed.starts_with(prefix))
-    {
-        return false;
-    }
-
-    // Block dangerous options that may launch external processes
-    let dangerous_options = ["--web", "--browse"];
-    let tokens: Vec<&str> = trimmed.split_whitespace().collect();
-    for token in &tokens {
-        if dangerous_options.iter().any(|opt| token == opt) {
-            return false;
-        }
-    }
-    true
+    classify_shell_policy(command) != ShellPolicy::General
 }
 
 /// Compute the effective permission class for a tool call.
 ///
-/// Safe shell commands (as determined by [`is_safe_shell_command`]) are
-/// promoted from `Confirm` to `Safe`, skipping the approval prompt.
+/// Shell commands are classified via [`classify_shell_policy`]:
+/// - `ReadOnly` / `BuildTest` → `Safe` (auto-approved)
+/// - `General` → uses spec's permission class (typically `Confirm`)
+///
 /// All other tools (including MCP) use their spec's permission class directly.
 pub fn effective_permission_class(input: &ToolInput, spec: &ToolSpec) -> PermissionClass {
     match input {
-        ToolInput::ShellExec { command } if is_safe_shell_command(command) => PermissionClass::Safe,
+        ToolInput::ShellExec { command } => match classify_shell_policy(command) {
+            ShellPolicy::ReadOnly | ShellPolicy::BuildTest => PermissionClass::Safe,
+            ShellPolicy::General => spec.permission_class,
+        },
         _ => spec.permission_class,
     }
 }

--- a/src/tooling/shell_policy.rs
+++ b/src/tooling/shell_policy.rs
@@ -1,0 +1,605 @@
+//! Shell command policy classification.
+//!
+//! Provides [`ShellPolicy`] enum and [`classify_shell_policy`] to split
+//! shell.exec commands into ReadOnly / BuildTest / General categories.
+//! Also provides [`is_network_command`] for offline mode enforcement.
+
+/// Shell command execution policy classification.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ShellPolicy {
+    /// Read-only commands (git log, ls, cat, etc.)
+    /// PermissionClass: Safe (auto-approved)
+    ReadOnly,
+    /// Build/test commands (cargo test, cargo build, etc.)
+    /// PermissionClass: Safe (auto-approved, maintains current UX)
+    BuildTest,
+    /// General commands (everything else)
+    /// PermissionClass: Confirm (requires approval)
+    General,
+}
+
+/// Read-only command prefixes (split from former SAFE_PREFIXES).
+const READ_ONLY_PREFIXES: &[&str] = &[
+    // Git read-only
+    "git log",
+    "git status",
+    "git diff",
+    "git branch",
+    "git show ", // trailing space requires an argument (ref)
+    "git remote -v",
+    "git rev-parse",
+    // GitHub CLI read-only
+    "gh repo view",
+    "gh pr list",
+    "gh issue list",
+    "gh pr view",
+    "gh issue view",
+    "gh auth status",
+    // Environment inspection
+    "which ",
+    "uname",
+    "node -v",
+    "node --version",
+    "rustc --version",
+    "cargo --version",
+    "python --version",
+    "go version",
+    // Process inspection
+    "lsof -i",
+];
+
+/// Build/test command prefixes (split from former SAFE_PREFIXES).
+const BUILD_TEST_PREFIXES: &[&str] = &[
+    // Rust build/test/lint
+    "cargo clippy",
+    "cargo fmt --check",
+    "cargo test",
+    "cargo check",
+    "cargo build",
+    // Node.js build/test/lint
+    "npm test",
+    "npx jest ",
+    "npx eslint ",
+    "npx prettier --check",
+    // Python test/lint
+    "pytest",
+    "ruff check ",
+    "flake8",
+    // Go build/test/lint
+    "go test",
+    "go vet",
+    "golangci-lint",
+    // Make build/test
+    "make test",
+    "make check",
+];
+
+/// Network command prefixes blocked in offline mode.
+///
+/// Scope (DR1-010): Only commands that establish network connections and
+/// send/receive data. Local network state inspection commands (lsof -i, ss,
+/// netstat) are NOT included.
+///
+/// Note: `git push`, `git fetch`, `git pull`, and `git clone` perform network
+/// I/O but are NOT listed here. They are already classified as `General`
+/// (not in `READ_ONLY_PREFIXES` or `BUILD_TEST_PREFIXES`), so they require
+/// user confirmation before execution. Adding `git` sub-commands here would
+/// require per-sub-command matching (simple prefix `"git"` would block
+/// read-only git commands). This may be addressed in a future issue.
+const NETWORK_COMMAND_PREFIXES: &[&str] = &[
+    "curl",
+    "wget",
+    "nc",
+    "ncat",
+    "netcat",
+    "ssh",
+    "scp",
+    "sftp",
+    "rsync",
+    "nslookup",
+    "dig",
+    "host",
+    "ping",
+    "traceroute",
+    "telnet",
+    "ftp",
+];
+
+/// Classify a shell command into a [`ShellPolicy`] category.
+///
+/// DR4-002: Prefix matching is case-insensitive (uses `to_ascii_lowercase()`).
+///
+/// Note: Unlike [`is_network_command`], this function intentionally does NOT
+/// strip `sudo`/`env` prefixes via `extract_first_command()`. Commands like
+/// `sudo git log` or `env cargo test` fall through to `General` (Confirm
+/// required), which is a safe-side fallback. The prefix lists already contain
+/// bare command names, so stripping wrappers is unnecessary for the common
+/// case and would require a separate security review before adoption.
+pub fn classify_shell_policy(command: &str) -> ShellPolicy {
+    let trimmed = command.trim();
+    let lower = trimmed.to_ascii_lowercase();
+
+    // Reject command chaining / injection vectors → General
+    if contains_injection_vectors(trimmed) {
+        return ShellPolicy::General;
+    }
+
+    // gh api: GET-only is ReadOnly (DR2-010: preserve evaluation order)
+    if is_safe_gh_api(&lower) {
+        return ShellPolicy::ReadOnly;
+    }
+
+    // Category-based prefix matching (DR4-002: case-insensitive via lower)
+    if matches_read_only_prefixes(&lower) {
+        if has_dangerous_options(&lower) {
+            return ShellPolicy::General;
+        }
+        return ShellPolicy::ReadOnly;
+    }
+    if matches_build_test_prefixes(&lower) {
+        if has_dangerous_options(&lower) {
+            return ShellPolicy::General;
+        }
+        return ShellPolicy::BuildTest;
+    }
+
+    ShellPolicy::General
+}
+
+/// Determine whether a shell command targets a network endpoint.
+///
+/// DR4-002: Case-insensitive (handles CURL, Wget, etc.)
+pub fn is_network_command(command: &str) -> bool {
+    let trimmed = command.trim();
+    let lower = trimmed.to_ascii_lowercase();
+    let first_cmd = extract_first_command(&lower);
+    NETWORK_COMMAND_PREFIXES
+        .iter()
+        .any(|prefix| first_cmd == *prefix || first_cmd.ends_with(&format!("/{prefix}")))
+}
+
+/// Detect pipe / chain / injection vectors (shared function).
+///
+/// DR1-002: Extracted from the former inline checks in `is_safe_shell_command()`.
+fn contains_injection_vectors(command: &str) -> bool {
+    command.contains('|')
+        || command.contains(';')
+        || command.contains('`')
+        || command.contains("$(")
+        || command.contains("${")
+        || command.contains('\n')
+        || command.contains("&&")
+        || command.contains('>')
+        || command.contains('<')
+}
+
+/// Detect dangerous options that may launch external processes (DR2-009).
+///
+/// Moved from the former inline check in `is_safe_shell_command()`.
+fn has_dangerous_options(command: &str) -> bool {
+    let dangerous_options = ["--web", "--browse"];
+    command
+        .split_whitespace()
+        .any(|token| dangerous_options.contains(&token))
+}
+
+/// Check if a command matches read-only prefixes.
+fn matches_read_only_prefixes(lower_command: &str) -> bool {
+    READ_ONLY_PREFIXES
+        .iter()
+        .any(|prefix| lower_command.starts_with(prefix))
+}
+
+/// Check if a command matches build/test prefixes.
+fn matches_build_test_prefixes(lower_command: &str) -> bool {
+    BUILD_TEST_PREFIXES
+        .iter()
+        .any(|prefix| lower_command.starts_with(prefix))
+}
+
+/// Check if a `gh api` command is safe (GET-only).
+///
+/// Moved from the former inline logic in `is_safe_shell_command()`.
+fn is_safe_gh_api(lower_command: &str) -> bool {
+    if !lower_command.starts_with("gh api ") {
+        return false;
+    }
+
+    let tokens: Vec<&str> = lower_command.split_whitespace().collect();
+
+    // Flags that imply a mutating request by their mere presence.
+    // Input is already lowercased, so `-F` becomes `-f` (no separate entry needed).
+    const BODY_FLAGS: &[&str] = &["-f", "--field", "--raw-field", "--input"];
+
+    // Combined flag=value forms that imply mutation.
+    const MUTATION_COMBINED: &[&str] = &[
+        "-xpost",
+        "-xput",
+        "-xpatch",
+        "-xdelete",
+        "--method=post",
+        "--method=put",
+        "--method=patch",
+        "--method=delete",
+        "--input=",
+        "-f=",
+        "--field=",
+        "--raw-field=",
+    ];
+
+    for (i, token) in tokens.iter().enumerate() {
+        // Body/field flags always imply mutation.
+        if BODY_FLAGS.iter().any(|f| token == f) {
+            return false;
+        }
+
+        // --method / -x followed by a mutating HTTP verb.
+        if (*token == "--method" || *token == "-x")
+            && let Some(next) = tokens.get(i + 1)
+            && ["post", "put", "patch", "delete"].contains(next)
+        {
+            return false;
+        }
+
+        // Combined forms (e.g. -xpost, --method=post, --input=file)
+        if MUTATION_COMBINED.iter().any(|f| token.starts_with(f)) {
+            return false;
+        }
+    }
+    true
+}
+
+/// Extract the first actual command name from a command string (DR1-007).
+///
+/// Handles:
+/// 1. VAR=value environment variable prefixes (e.g. `FOO=bar curl` -> `curl`)
+/// 2. `sudo` / `env` command prefixes (e.g. `sudo curl` -> `curl`)
+/// 3. `env` option arguments (`-i`, `-u`, etc.) skipping (DR4-001)
+/// 4. Absolute path basename extraction (e.g. `/usr/bin/curl` -> `curl`)
+fn extract_first_command(command: &str) -> &str {
+    let mut words = command.split_whitespace();
+    let mut after_env = false;
+    loop {
+        match words.next() {
+            None => return "",
+            Some(word) => {
+                // Skip VAR=value patterns
+                if word.contains('=') && !word.starts_with('-') {
+                    continue;
+                }
+                // Skip env option arguments (DR4-001)
+                if after_env && word.starts_with('-') {
+                    continue;
+                }
+                // Skip sudo / env
+                let base = word.rsplit('/').next().unwrap_or(word);
+                if base == "sudo" {
+                    continue;
+                }
+                if base == "env" {
+                    after_env = true;
+                    continue;
+                }
+                // Return basename
+                return base;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- classify_shell_policy tests ---
+
+    #[test]
+    fn classify_read_only_git_log() {
+        assert_eq!(
+            classify_shell_policy("git log --oneline"),
+            ShellPolicy::ReadOnly
+        );
+    }
+
+    #[test]
+    fn classify_read_only_git_status() {
+        assert_eq!(classify_shell_policy("git status"), ShellPolicy::ReadOnly);
+    }
+
+    #[test]
+    fn classify_read_only_gh_api_get() {
+        assert_eq!(
+            classify_shell_policy("gh api repos/o/r/stats"),
+            ShellPolicy::ReadOnly
+        );
+    }
+
+    #[test]
+    fn classify_build_test_cargo_test() {
+        assert_eq!(classify_shell_policy("cargo test"), ShellPolicy::BuildTest);
+    }
+
+    #[test]
+    fn classify_build_test_cargo_build() {
+        assert_eq!(classify_shell_policy("cargo build"), ShellPolicy::BuildTest);
+    }
+
+    #[test]
+    fn classify_build_test_npm_test() {
+        assert_eq!(classify_shell_policy("npm test"), ShellPolicy::BuildTest);
+    }
+
+    #[test]
+    fn classify_general_curl() {
+        assert_eq!(
+            classify_shell_policy("curl https://example.com"),
+            ShellPolicy::General
+        );
+    }
+
+    #[test]
+    fn classify_general_unknown() {
+        assert_eq!(
+            classify_shell_policy("some-unknown-command"),
+            ShellPolicy::General
+        );
+    }
+
+    #[test]
+    fn classify_pipe_fallback() {
+        assert_eq!(
+            classify_shell_policy("git log | head -5"),
+            ShellPolicy::General
+        );
+    }
+
+    #[test]
+    fn classify_chain_fallback() {
+        assert_eq!(
+            classify_shell_policy("cargo test && rm -rf /"),
+            ShellPolicy::General
+        );
+    }
+
+    #[test]
+    fn classify_case_insensitive_git() {
+        assert_eq!(
+            classify_shell_policy("GIT LOG --oneline"),
+            ShellPolicy::ReadOnly
+        );
+    }
+
+    #[test]
+    fn classify_case_insensitive_cargo() {
+        assert_eq!(classify_shell_policy("Cargo Test"), ShellPolicy::BuildTest);
+    }
+
+    #[test]
+    fn classify_dangerous_options_web() {
+        assert_eq!(
+            classify_shell_policy("gh repo view --web"),
+            ShellPolicy::General
+        );
+    }
+
+    #[test]
+    fn classify_dangerous_options_browse() {
+        assert_eq!(
+            classify_shell_policy("gh issue list --browse"),
+            ShellPolicy::General
+        );
+    }
+
+    #[test]
+    fn classify_gh_api_post_is_general() {
+        assert_eq!(
+            classify_shell_policy("gh api --method POST repos/o/r/issues"),
+            ShellPolicy::General
+        );
+    }
+
+    // --- is_network_command tests ---
+
+    #[test]
+    fn network_curl() {
+        assert!(is_network_command("curl https://example.com"));
+    }
+
+    #[test]
+    fn network_wget() {
+        assert!(is_network_command("wget https://example.com"));
+    }
+
+    #[test]
+    fn network_ssh() {
+        assert!(is_network_command("ssh user@host"));
+    }
+
+    #[test]
+    fn network_ping() {
+        assert!(is_network_command("ping 8.8.8.8"));
+    }
+
+    #[test]
+    fn not_network_ls() {
+        assert!(!is_network_command("ls -la"));
+    }
+
+    #[test]
+    fn not_network_git() {
+        assert!(!is_network_command("git log"));
+    }
+
+    #[test]
+    fn not_network_cargo() {
+        assert!(!is_network_command("cargo test"));
+    }
+
+    #[test]
+    fn network_case_insensitive_curl() {
+        assert!(is_network_command("CURL https://example.com"));
+    }
+
+    #[test]
+    fn network_case_insensitive_wget() {
+        assert!(is_network_command("Wget https://example.com"));
+    }
+
+    // --- extract_first_command tests ---
+
+    #[test]
+    fn extract_simple() {
+        assert_eq!(extract_first_command("curl https://example.com"), "curl");
+    }
+
+    #[test]
+    fn extract_env_prefix() {
+        assert_eq!(
+            extract_first_command("FOO=bar curl https://example.com"),
+            "curl"
+        );
+    }
+
+    #[test]
+    fn extract_sudo() {
+        assert_eq!(
+            extract_first_command("sudo curl https://example.com"),
+            "curl"
+        );
+    }
+
+    #[test]
+    fn extract_env_command() {
+        assert_eq!(
+            extract_first_command("env curl https://example.com"),
+            "curl"
+        );
+    }
+
+    #[test]
+    fn extract_env_options() {
+        assert_eq!(
+            extract_first_command("env -i curl https://example.com"),
+            "curl"
+        );
+    }
+
+    #[test]
+    fn extract_env_u_option() {
+        // Known limitation (DR4-001): `-u VAR` is an option with argument.
+        // Only the `-u` token (starting with `-`) is skipped; `VAR` is returned
+        // as the command. This is a false extraction but safe: the command won't
+        // match any prefix list and will fall to General (Confirm required).
+        assert_eq!(
+            extract_first_command("env -u VAR curl https://example.com"),
+            "VAR"
+        );
+    }
+
+    #[test]
+    fn extract_absolute_path() {
+        assert_eq!(
+            extract_first_command("/usr/bin/curl https://example.com"),
+            "curl"
+        );
+    }
+
+    #[test]
+    fn extract_empty() {
+        assert_eq!(extract_first_command(""), "");
+    }
+
+    #[test]
+    fn extract_sudo_env_combined() {
+        assert_eq!(
+            extract_first_command("sudo env -i curl https://example.com"),
+            "curl"
+        );
+    }
+
+    // --- contains_injection_vectors tests ---
+
+    #[test]
+    fn injection_pipe() {
+        assert!(contains_injection_vectors("ls | grep foo"));
+    }
+
+    #[test]
+    fn injection_semicolon() {
+        assert!(contains_injection_vectors("ls; rm -rf /"));
+    }
+
+    #[test]
+    fn injection_backtick() {
+        assert!(contains_injection_vectors("echo `whoami`"));
+    }
+
+    #[test]
+    fn injection_dollar_paren() {
+        assert!(contains_injection_vectors("echo $(whoami)"));
+    }
+
+    #[test]
+    fn injection_dollar_brace() {
+        assert!(contains_injection_vectors("echo ${HOME}"));
+    }
+
+    #[test]
+    fn injection_newline() {
+        assert!(contains_injection_vectors("ls\nrm -rf /"));
+    }
+
+    #[test]
+    fn injection_and_chain() {
+        assert!(contains_injection_vectors("ls && rm -rf /"));
+    }
+
+    #[test]
+    fn injection_redirect_out() {
+        assert!(contains_injection_vectors("echo foo > file"));
+    }
+
+    #[test]
+    fn injection_redirect_in() {
+        assert!(contains_injection_vectors("cat < file"));
+    }
+
+    #[test]
+    fn no_injection_simple() {
+        assert!(!contains_injection_vectors("git log --oneline"));
+    }
+
+    // --- has_dangerous_options tests ---
+
+    #[test]
+    fn dangerous_web() {
+        assert!(has_dangerous_options("gh repo view --web"));
+    }
+
+    #[test]
+    fn dangerous_browse() {
+        assert!(has_dangerous_options("gh issue list --browse"));
+    }
+
+    #[test]
+    fn not_dangerous_json() {
+        assert!(!has_dangerous_options("gh repo view --json owner"));
+    }
+
+    // --- network command with sudo/env ---
+
+    #[test]
+    fn network_sudo_curl() {
+        assert!(is_network_command("sudo curl https://example.com"));
+    }
+
+    #[test]
+    fn network_env_wget() {
+        assert!(is_network_command("env wget https://example.com"));
+    }
+
+    #[test]
+    fn network_absolute_path_curl() {
+        assert!(is_network_command("/usr/bin/curl https://example.com"));
+    }
+}

--- a/tests/tooling_system.rs
+++ b/tests/tooling_system.rs
@@ -667,6 +667,283 @@ fn web_search_serde_round_trip() {
     assert_eq!(input, deserialized);
 }
 
+// --- classify_shell_policy tests ---
+
+mod classify_shell_policy_tests {
+    use anvil::tooling::{ShellPolicy, classify_shell_policy};
+
+    #[test]
+    fn read_only_git_log() {
+        assert_eq!(
+            classify_shell_policy("git log --oneline"),
+            ShellPolicy::ReadOnly
+        );
+    }
+
+    #[test]
+    fn read_only_git_status() {
+        assert_eq!(classify_shell_policy("git status"), ShellPolicy::ReadOnly);
+    }
+
+    #[test]
+    fn read_only_git_diff() {
+        assert_eq!(classify_shell_policy("git diff"), ShellPolicy::ReadOnly);
+    }
+
+    #[test]
+    fn read_only_git_branch() {
+        assert_eq!(classify_shell_policy("git branch"), ShellPolicy::ReadOnly);
+    }
+
+    #[test]
+    fn read_only_git_show_with_ref() {
+        assert_eq!(
+            classify_shell_policy("git show HEAD"),
+            ShellPolicy::ReadOnly
+        );
+    }
+
+    #[test]
+    fn read_only_gh_api_get() {
+        assert_eq!(
+            classify_shell_policy("gh api repos/o/r/stats"),
+            ShellPolicy::ReadOnly
+        );
+    }
+
+    #[test]
+    fn read_only_which() {
+        assert_eq!(classify_shell_policy("which rustc"), ShellPolicy::ReadOnly);
+    }
+
+    #[test]
+    fn read_only_uname() {
+        assert_eq!(classify_shell_policy("uname"), ShellPolicy::ReadOnly);
+    }
+
+    #[test]
+    fn read_only_lsof_i() {
+        assert_eq!(classify_shell_policy("lsof -i"), ShellPolicy::ReadOnly);
+    }
+
+    #[test]
+    fn build_test_cargo_test() {
+        assert_eq!(classify_shell_policy("cargo test"), ShellPolicy::BuildTest);
+    }
+
+    #[test]
+    fn build_test_cargo_build() {
+        assert_eq!(classify_shell_policy("cargo build"), ShellPolicy::BuildTest);
+    }
+
+    #[test]
+    fn build_test_cargo_clippy() {
+        assert_eq!(
+            classify_shell_policy("cargo clippy --all-targets"),
+            ShellPolicy::BuildTest
+        );
+    }
+
+    #[test]
+    fn build_test_npm_test() {
+        assert_eq!(classify_shell_policy("npm test"), ShellPolicy::BuildTest);
+    }
+
+    #[test]
+    fn build_test_pytest() {
+        assert_eq!(
+            classify_shell_policy("pytest tests/"),
+            ShellPolicy::BuildTest
+        );
+    }
+
+    #[test]
+    fn build_test_go_test() {
+        assert_eq!(
+            classify_shell_policy("go test ./..."),
+            ShellPolicy::BuildTest
+        );
+    }
+
+    #[test]
+    fn build_test_make_test() {
+        assert_eq!(classify_shell_policy("make test"), ShellPolicy::BuildTest);
+    }
+
+    #[test]
+    fn general_curl() {
+        assert_eq!(
+            classify_shell_policy("curl https://example.com"),
+            ShellPolicy::General
+        );
+    }
+
+    #[test]
+    fn general_unknown_command() {
+        assert_eq!(
+            classify_shell_policy("some-unknown-command"),
+            ShellPolicy::General
+        );
+    }
+
+    #[test]
+    fn pipe_fallback_to_general() {
+        assert_eq!(
+            classify_shell_policy("git log | head -5"),
+            ShellPolicy::General
+        );
+    }
+
+    #[test]
+    fn chain_fallback_to_general() {
+        assert_eq!(
+            classify_shell_policy("cargo test && rm -rf /"),
+            ShellPolicy::General
+        );
+    }
+
+    #[test]
+    fn case_insensitive_git_log() {
+        assert_eq!(
+            classify_shell_policy("GIT LOG --oneline"),
+            ShellPolicy::ReadOnly
+        );
+    }
+
+    #[test]
+    fn case_insensitive_cargo_test() {
+        assert_eq!(classify_shell_policy("Cargo Test"), ShellPolicy::BuildTest);
+    }
+
+    #[test]
+    fn dangerous_options_web_general() {
+        assert_eq!(
+            classify_shell_policy("gh repo view --web"),
+            ShellPolicy::General
+        );
+    }
+
+    #[test]
+    fn dangerous_options_browse_general() {
+        assert_eq!(
+            classify_shell_policy("gh issue list --browse"),
+            ShellPolicy::General
+        );
+    }
+
+    #[test]
+    fn gh_api_post_is_general() {
+        assert_eq!(
+            classify_shell_policy("gh api --method POST repos/o/r/issues"),
+            ShellPolicy::General
+        );
+    }
+
+    #[test]
+    fn gh_api_xdelete_is_general() {
+        assert_eq!(
+            classify_shell_policy("gh api -XDELETE repos/o/r/issues/1"),
+            ShellPolicy::General
+        );
+    }
+
+    #[test]
+    fn gh_api_field_flag_is_general() {
+        assert_eq!(
+            classify_shell_policy("gh api -f title=hacked repos/o/r/issues"),
+            ShellPolicy::General
+        );
+    }
+}
+
+// --- is_network_command tests ---
+
+mod is_network_command_tests {
+    use anvil::tooling::is_network_command;
+
+    #[test]
+    fn curl_is_network() {
+        assert!(is_network_command("curl https://example.com"));
+    }
+
+    #[test]
+    fn wget_is_network() {
+        assert!(is_network_command("wget https://example.com"));
+    }
+
+    #[test]
+    fn ssh_is_network() {
+        assert!(is_network_command("ssh user@host"));
+    }
+
+    #[test]
+    fn ping_is_network() {
+        assert!(is_network_command("ping 8.8.8.8"));
+    }
+
+    #[test]
+    fn scp_is_network() {
+        assert!(is_network_command("scp file user@host:/tmp/"));
+    }
+
+    #[test]
+    fn dig_is_network() {
+        assert!(is_network_command("dig example.com"));
+    }
+
+    #[test]
+    fn ls_is_not_network() {
+        assert!(!is_network_command("ls -la"));
+    }
+
+    #[test]
+    fn git_is_not_network() {
+        assert!(!is_network_command("git log"));
+    }
+
+    #[test]
+    fn cargo_is_not_network() {
+        assert!(!is_network_command("cargo test"));
+    }
+
+    #[test]
+    fn case_insensitive_curl() {
+        assert!(is_network_command("CURL https://example.com"));
+    }
+
+    #[test]
+    fn case_insensitive_wget() {
+        assert!(is_network_command("Wget https://example.com"));
+    }
+
+    #[test]
+    fn sudo_curl_is_network() {
+        assert!(is_network_command("sudo curl https://example.com"));
+    }
+
+    #[test]
+    fn env_wget_is_network() {
+        assert!(is_network_command("env wget https://example.com"));
+    }
+
+    #[test]
+    fn absolute_path_curl_is_network() {
+        assert!(is_network_command("/usr/bin/curl https://example.com"));
+    }
+
+    #[test]
+    fn env_var_prefix_curl_is_network() {
+        assert!(is_network_command(
+            "HTTPS_PROXY=proxy curl https://example.com"
+        ));
+    }
+
+    #[test]
+    fn env_i_curl_is_network() {
+        assert!(is_network_command("env -i curl https://example.com"));
+    }
+}
+
 // --- is_safe_shell_command: gh api tests ---
 
 mod safe_shell_gh_api {


### PR DESCRIPTION
## Summary
- `shell.exec`をread-only / build-test / generalに分類するShellPolicyを追加
- offline modeでのネットワークコマンド遮断を強化
- 実行ポリシーの責務分離を整理

Closes #131
Parent: #127

## Test plan
- [ ] cargo fmt --check: 差分なし
- [ ] cargo clippy --all-targets: 警告0件
- [ ] cargo test: 全テストパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)