### PR TITLE
chore: release v0.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## [Unreleased]
 
+## [0.0.6] - 2026-03-21
+
+### Added
+- Prompt tiering and model capability classification (#132)
+- Multi-tier tool protocol and resilient editing (#128)
+- Structured working memory for long-session context retention (#130)
+- Sub-agent redesign for structured exploration payload (#129)
+- ShellPolicy classification and offline network command blocking (#131)
+- Retrieval scoring upgrade with 2-pass, keyword split, and boost for large repos (#133)
+
+### Changed
+- Codex code review phase added between TDD and acceptance test
+- Delegate 2nd-round reviews to Codex via commandmatedev
+
 ## [0.0.5] - 2026-03-21
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,7 +72,7 @@ dependencies = [
 
 [[package]]
 name = "anvil"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anvil"
-version = "0.0.5"
+version = "0.0.6"
 edition = "2024"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ```bash
 # macOS (Apple Silicon)
-curl -L https://github.com/Kewton/Anvil/releases/download/v0.0.5/anvil-darwin-arm64.gz -o anvil.gz
+curl -L https://github.com/Kewton/Anvil/releases/download/v0.0.6/anvil-darwin-arm64.gz -o anvil.gz
 gunzip anvil.gz
 chmod +x anvil
 sudo mv anvil /usr/local/bin/


### PR DESCRIPTION
## Release v0.0.6

### Added
- Prompt tiering and model capability classification (#132)
- Multi-tier tool protocol and resilient editing (#128)
- Structured working memory for long-session context retention (#130)
- Sub-agent redesign for structured exploration payload (#129)
- ShellPolicy classification and offline network command blocking (#131)
- Retrieval scoring upgrade with 2-pass, keyword split, and boost for large repos (#133)

### Changed
- Codex code review phase added between TDD and acceptance test
- Delegate 2nd-round reviews to Codex via commandmatedev

## Checklist
- [x] Cargo.toml version updated to 0.0.6
- [x] Cargo.lock regenerated
- [x] README.md download URLs updated
- [x] CHANGELOG.md updated with v0.0.6 section
- [x] `cargo build` — success
- [x] `cargo test` — all tests pass
- [x] `cargo clippy --all-targets` — 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)