### PR TITLE
feat: --timeout オプションの外部化 (#146)

### DIFF
--- a/src/config/cli_args.rs
+++ b/src/config/cli_args.rs
@@ -81,6 +81,10 @@ pub struct CliArgs {
     #[arg(long)]
     pub trust: bool,
 
+    /// HTTP request timeout in seconds (default: 300)
+    #[arg(long = "timeout")]
+    pub timeout: Option<u64>,
+
     /// Prompt tier override (full|compact|tiny)
     #[arg(long = "prompt-tier")]
     pub prompt_tier: Option<String>,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -7,6 +7,7 @@
 pub mod cli_args;
 pub use cli_args::CliArgs;
 
+use crate::provider::transport::{DEFAULT_HTTP_TIMEOUT_SECS, normalize_http_timeout};
 use clap::Parser;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -76,6 +77,8 @@ pub struct RuntimeConfig {
     pub subagent_max_iterations: u32,
     /// Wall-clock timeout in seconds for the entire sub-agent run (Issue #129).
     pub subagent_timeout_secs: u64,
+    /// HTTP request timeout in seconds (Issue #146).
+    pub http_timeout_secs: u64,
 }
 
 #[derive(Debug, Clone)]
@@ -227,6 +230,7 @@ impl EffectiveConfig {
                 smart_compact_threshold_ratio: 0.75,
                 subagent_max_iterations: 10,
                 subagent_timeout_secs: 120,
+                http_timeout_secs: DEFAULT_HTTP_TIMEOUT_SECS,
             },
             mode: ModeConfig {
                 prompt_source: PromptSource::Interactive,
@@ -324,6 +328,8 @@ impl EffectiveConfig {
             "ANVIL_SMART_COMPACT_THRESHOLD_RATIO",
             "ANVIL_SUBAGENT_MAX_ITERATIONS",
             "ANVIL_SUBAGENT_TIMEOUT",
+            "ANVIL_HTTP_TIMEOUT",
+            "ANVIL_CURL_TIMEOUT",
         ] {
             if let Ok(value) = std::env::var(key) {
                 map.insert(key.to_string(), value);
@@ -410,6 +416,11 @@ impl EffectiveConfig {
         // Tag protocol flag
         if let Some(v) = cli.tag_protocol {
             self.runtime.tag_protocol = Some(v);
+        }
+
+        // HTTP timeout
+        if let Some(timeout) = cli.timeout {
+            self.runtime.http_timeout_secs = timeout;
         }
 
         // Prompt tier override
@@ -543,6 +554,11 @@ impl EffectiveConfig {
                         .parse()
                         .map_err(|_| ConfigError::InvalidNumericValue(value.clone()))?;
                 }
+                "http_timeout_secs" | "ANVIL_HTTP_TIMEOUT" | "ANVIL_CURL_TIMEOUT" => {
+                    self.runtime.http_timeout_secs = value
+                        .parse()
+                        .map_err(|_| ConfigError::InvalidNumericValue(value.clone()))?;
+                }
                 _ => {}
             }
         }
@@ -569,7 +585,17 @@ impl EffectiveConfig {
         self.clamp_agent_iterations();
         self.clamp_smart_compact_ratio();
         self.clamp_subagent_settings();
+        self.clamp_http_timeout();
         Ok(())
+    }
+
+    fn clamp_http_timeout(&mut self) {
+        let old = self.runtime.http_timeout_secs;
+        let normalized = normalize_http_timeout(old);
+        if normalized != old {
+            self.runtime.http_timeout_secs = normalized;
+            eprintln!("Warning: http_timeout_secs={old} adjusted to {normalized}");
+        }
     }
 
     /// Clamp smart_compact_threshold_ratio to [0.1, 0.95].
@@ -925,6 +951,7 @@ impl std::fmt::Debug for RuntimeConfig {
                 "smart_compact_threshold_ratio",
                 &self.smart_compact_threshold_ratio,
             )
+            .field("http_timeout_secs", &self.http_timeout_secs)
             .finish()
     }
 }

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -23,9 +23,9 @@ pub use ollama::{
     parse_model_list_from_tags_response, resolve_ollama_model_alias,
 };
 pub use transport::{
-    HttpResponse, HttpTransport, ReqwestHttpTransport, RetryConfig, RetryTransport,
-    classify_http_error, classify_reqwest_error, http_timeout, redact_secrets,
-    sanitize_error_message,
+    DEFAULT_HTTP_TIMEOUT_SECS, HttpResponse, HttpTransport, ReqwestHttpTransport, RetryConfig,
+    RetryTransport, classify_http_error, classify_reqwest_error, http_timeout,
+    normalize_http_timeout, redact_secrets, sanitize_error_message,
 };
 
 /// Default transport used by provider clients: reqwest with retry wrapper.
@@ -405,7 +405,10 @@ pub fn build_local_provider_client(
     config: &EffectiveConfig,
     shutdown_flag: Arc<AtomicBool>,
 ) -> Result<LocalProviderClient, ProviderBootstrapError> {
-    let reqwest_transport = ReqwestHttpTransport::with_shutdown_flag(Arc::clone(&shutdown_flag));
+    let reqwest_transport = ReqwestHttpTransport::with_timeout_and_shutdown_flag(
+        config.runtime.http_timeout_secs,
+        Arc::clone(&shutdown_flag),
+    );
     let transport = RetryTransport::with_shutdown_flag(
         reqwest_transport,
         RetryConfig::default(),

--- a/src/provider/transport.rs
+++ b/src/provider/transport.rs
@@ -112,19 +112,37 @@ pub fn classify_reqwest_error(err: reqwest::Error) -> ProviderTurnError {
     }
 }
 
+/// Default HTTP request timeout in seconds.
+pub const DEFAULT_HTTP_TIMEOUT_SECS: u64 = 300;
+
+/// Normalize timeout values shared by config validation and env fallback.
+///
+/// - 0 → `DEFAULT_HTTP_TIMEOUT_SECS` (restore default)
+/// - <10 → 10
+/// - >3600 → 3600
+/// - otherwise → unchanged
+pub fn normalize_http_timeout(timeout_secs: u64) -> u64 {
+    const MIN_HTTP_TIMEOUT_SECS: u64 = 10;
+    const MAX_HTTP_TIMEOUT_SECS: u64 = 3600;
+
+    if timeout_secs == 0 {
+        DEFAULT_HTTP_TIMEOUT_SECS
+    } else {
+        timeout_secs.clamp(MIN_HTTP_TIMEOUT_SECS, MAX_HTTP_TIMEOUT_SECS)
+    }
+}
+
 /// Read the HTTP timeout from the environment.
 ///
 /// Checks `ANVIL_HTTP_TIMEOUT` first, then falls back to `ANVIL_CURL_TIMEOUT`
-/// for backward compatibility, defaulting to 300 seconds.
+/// for backward compatibility, defaulting to `DEFAULT_HTTP_TIMEOUT_SECS`.
 pub fn http_timeout() -> u64 {
-    static TIMEOUT: std::sync::OnceLock<u64> = std::sync::OnceLock::new();
-    *TIMEOUT.get_or_init(|| {
-        std::env::var("ANVIL_HTTP_TIMEOUT")
-            .or_else(|_| std::env::var("ANVIL_CURL_TIMEOUT"))
-            .unwrap_or_else(|_| "300".to_string())
-            .parse::<u64>()
-            .unwrap_or(300)
-    })
+    let parsed = std::env::var("ANVIL_HTTP_TIMEOUT")
+        .or_else(|_| std::env::var("ANVIL_CURL_TIMEOUT"))
+        .unwrap_or_else(|_| DEFAULT_HTTP_TIMEOUT_SECS.to_string())
+        .parse::<u64>()
+        .unwrap_or(DEFAULT_HTTP_TIMEOUT_SECS);
+    normalize_http_timeout(parsed)
 }
 
 /// HTTP transport backed by `reqwest::blocking::Client`.
@@ -144,11 +162,10 @@ impl Default for ReqwestHttpTransport {
 }
 
 impl ReqwestHttpTransport {
-    /// Create a new transport without a shutdown flag.
-    pub fn new() -> Self {
-        let timeout = http_timeout();
+    /// Create a new transport with explicit timeout.
+    pub fn with_timeout(timeout_secs: u64) -> Self {
         let client = reqwest::blocking::Client::builder()
-            .timeout(Duration::from_secs(timeout))
+            .timeout(Duration::from_secs(timeout_secs))
             .redirect(reqwest::redirect::Policy::none())
             .build()
             .expect("Failed to build HTTP client");
@@ -164,7 +181,22 @@ impl ReqwestHttpTransport {
         }
     }
 
-    /// Create a new transport with a shutdown flag for graceful shutdown.
+    /// Create a new transport (reads timeout from environment).
+    pub fn new() -> Self {
+        Self::with_timeout(http_timeout())
+    }
+
+    /// Create a new transport with explicit timeout and shutdown flag.
+    pub fn with_timeout_and_shutdown_flag(
+        timeout_secs: u64,
+        shutdown_flag: Arc<AtomicBool>,
+    ) -> Self {
+        let mut transport = Self::with_timeout(timeout_secs);
+        transport.shutdown_flag = Some(shutdown_flag);
+        transport
+    }
+
+    /// Create a new transport with a shutdown flag for graceful shutdown (reads timeout from environment).
     pub fn with_shutdown_flag(shutdown_flag: Arc<AtomicBool>) -> Self {
         let mut transport = Self::new();
         transport.shutdown_flag = Some(shutdown_flag);

--- a/tests/config_bootstrap.rs
+++ b/tests/config_bootstrap.rs
@@ -787,3 +787,115 @@ fn subagent_config_invalid_numeric_value() {
     let result = config.apply_overrides_for_test(&map, &HashMap::new(), &HashMap::new());
     assert!(result.is_err(), "non-numeric value should fail");
 }
+
+// ============================================================
+// HTTP timeout config tests (Issue #146)
+// ============================================================
+
+#[test]
+fn http_timeout_default() {
+    let config = EffectiveConfig::default_for_test().unwrap();
+    assert_eq!(config.runtime.http_timeout_secs, 300);
+}
+
+#[test]
+fn http_timeout_from_map_config_key() {
+    let mut config = EffectiveConfig::default_for_test().unwrap();
+    let mut map = HashMap::new();
+    map.insert("http_timeout_secs".to_string(), "60".to_string());
+    config
+        .apply_overrides_for_test(&map, &HashMap::new(), &HashMap::new())
+        .expect("should apply");
+    assert_eq!(config.runtime.http_timeout_secs, 60);
+}
+
+#[test]
+fn http_timeout_from_map_anvil_http_timeout() {
+    let mut config = EffectiveConfig::default_for_test().unwrap();
+    let mut map = HashMap::new();
+    map.insert("ANVIL_HTTP_TIMEOUT".to_string(), "120".to_string());
+    config
+        .apply_overrides_for_test(&HashMap::new(), &map, &HashMap::new())
+        .expect("should apply");
+    assert_eq!(config.runtime.http_timeout_secs, 120);
+}
+
+#[test]
+fn http_timeout_from_map_anvil_curl_timeout() {
+    let mut config = EffectiveConfig::default_for_test().unwrap();
+    let mut map = HashMap::new();
+    map.insert("ANVIL_CURL_TIMEOUT".to_string(), "90".to_string());
+    config
+        .apply_overrides_for_test(&HashMap::new(), &map, &HashMap::new())
+        .expect("should apply");
+    assert_eq!(config.runtime.http_timeout_secs, 90);
+}
+
+#[test]
+fn http_timeout_clamp_zero_restored_to_default() {
+    let mut config = EffectiveConfig::default_for_test().unwrap();
+    config.runtime.http_timeout_secs = 0;
+    config.validate_for_test().expect("validation should pass");
+    assert_eq!(
+        config.runtime.http_timeout_secs, 300,
+        "zero http_timeout_secs should be restored to default (300)"
+    );
+}
+
+#[test]
+fn http_timeout_clamp_below_minimum() {
+    let mut config = EffectiveConfig::default_for_test().unwrap();
+    config.runtime.http_timeout_secs = 5;
+    config.validate_for_test().expect("validation should pass");
+    assert_eq!(
+        config.runtime.http_timeout_secs, 10,
+        "http_timeout_secs below 10 should be clamped to 10"
+    );
+}
+
+#[test]
+fn http_timeout_clamp_above_maximum() {
+    let mut config = EffectiveConfig::default_for_test().unwrap();
+    config.runtime.http_timeout_secs = 7200;
+    config.validate_for_test().expect("validation should pass");
+    assert_eq!(
+        config.runtime.http_timeout_secs, 3600,
+        "http_timeout_secs above 3600 should be clamped to 3600"
+    );
+}
+
+#[test]
+fn http_timeout_normal_value_unchanged() {
+    let mut config = EffectiveConfig::default_for_test().unwrap();
+    config.runtime.http_timeout_secs = 600;
+    config.validate_for_test().expect("validation should pass");
+    assert_eq!(config.runtime.http_timeout_secs, 600);
+}
+
+#[test]
+fn http_timeout_invalid_numeric_value() {
+    let mut config = EffectiveConfig::default_for_test().unwrap();
+    let mut map = HashMap::new();
+    map.insert("http_timeout_secs".to_string(), "not_a_number".to_string());
+    let result = config.apply_overrides_for_test(&map, &HashMap::new(), &HashMap::new());
+    assert!(result.is_err(), "non-numeric http_timeout_secs should fail");
+}
+
+#[test]
+fn http_timeout_cli_args_overrides_runtime() {
+    let mut config = EffectiveConfig::default_for_test().unwrap();
+    let cli = anvil::config::CliArgs {
+        timeout: Some(180),
+        ..Default::default()
+    };
+    config.apply_cli_args(&cli).expect("should apply");
+    assert_eq!(config.runtime.http_timeout_secs, 180);
+}
+
+#[test]
+fn http_timeout_cli_args_none_leaves_default() {
+    let mut config = EffectiveConfig::default_for_test().unwrap();
+    let cli = anvil::config::CliArgs::default();
+    config.apply_cli_args(&cli).expect("should apply");
+    assert_eq!(config.runtime.http_timeout_secs, 300);
+}

--- a/tests/provider_integration.rs
+++ b/tests/provider_integration.rs
@@ -3333,3 +3333,50 @@ fn session_record_deserialization_with_used_tools() {
     assert!(record.used_tools.contains("web.fetch"));
     assert!(record.used_tools.contains("agent.explore"));
 }
+
+// ============================================================
+// normalize_http_timeout tests (Issue #146)
+// ============================================================
+
+#[test]
+fn normalize_http_timeout_zero_returns_default() {
+    use anvil::provider::{DEFAULT_HTTP_TIMEOUT_SECS, normalize_http_timeout};
+    assert_eq!(normalize_http_timeout(0), DEFAULT_HTTP_TIMEOUT_SECS);
+}
+
+#[test]
+fn normalize_http_timeout_below_min_returns_min() {
+    use anvil::provider::normalize_http_timeout;
+    assert_eq!(normalize_http_timeout(1), 10);
+    assert_eq!(normalize_http_timeout(9), 10);
+}
+
+#[test]
+fn normalize_http_timeout_above_max_returns_max() {
+    use anvil::provider::normalize_http_timeout;
+    assert_eq!(normalize_http_timeout(3601), 3600);
+    assert_eq!(normalize_http_timeout(u64::MAX), 3600);
+}
+
+#[test]
+fn normalize_http_timeout_normal_values_unchanged() {
+    use anvil::provider::normalize_http_timeout;
+    assert_eq!(normalize_http_timeout(10), 10);
+    assert_eq!(normalize_http_timeout(300), 300);
+    assert_eq!(normalize_http_timeout(3600), 3600);
+}
+
+#[test]
+fn transport_with_timeout_constructs_successfully() {
+    use anvil::provider::ReqwestHttpTransport;
+    let _transport = ReqwestHttpTransport::with_timeout(60);
+}
+
+#[test]
+fn transport_with_timeout_and_shutdown_flag_constructs_successfully() {
+    use anvil::provider::ReqwestHttpTransport;
+    use std::sync::Arc;
+    use std::sync::atomic::AtomicBool;
+    let flag = Arc::new(AtomicBool::new(false));
+    let _transport = ReqwestHttpTransport::with_timeout_and_shutdown_flag(120, flag);
+}


### PR DESCRIPTION
## Summary
- `--timeout` CLIオプションを追加し、HTTP リクエストタイムアウトを外部設定可能に
- 設定ファイル、環境変数からも設定可能

Closes #146

## Test plan
- [x] cargo test: 全テストパス
- [x] cargo clippy: 警告0件

🤖 Generated with [Claude Code](https://claude.com/claude-code)