### PR TITLE
feat: --max-iterations のデフォルト値引き上げ (#147)

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ ANVIL_MODEL=qwen3.5:35b           # モデル名
 ANVIL_PROVIDER_URL=http://...     # プロバイダーURL
 ANVIL_CONTEXT_WINDOW=200000       # コンテキストウィンドウサイズ
 ANVIL_CONTEXT_BUDGET=50000        # トークンバジェット明示指定
-ANVIL_MAX_AGENT_ITERATIONS=10     # agenticループの最大反復数
+ANVIL_MAX_AGENT_ITERATIONS=30     # agenticループの最大反復数（default: 30）
 ANVIL_HTTP_TIMEOUT=300            # LLMリクエストタイムアウト（秒）（旧ANVIL_CURL_TIMEOUTもフォールバックとして有効）
 ANVIL_API_KEY=sk-...              # OpenAI互換APIキー
 ```
@@ -221,7 +221,7 @@ anvil [OPTIONS]
       --sidecar-model <MODEL>            サイドカーモデル名
       --context-window <SIZE>            コンテキストウィンドウサイズ
       --context-budget <TOKENS>          トークンバジェット明示指定
-      --max-iterations <N>               agenticループ最大反復数
+      --max-iterations <N>               agenticループ最大反復数（default: 30）
       --no-stream                        ストリーミング無効
       --debug                            デバッグログ有効
       --no-approval                      全ツール自動承認

--- a/src/config/cli_args.rs
+++ b/src/config/cli_args.rs
@@ -33,7 +33,7 @@ pub struct CliArgs {
     #[arg(long = "context-budget")]
     pub context_budget: Option<u32>,
 
-    /// Max agent iterations
+    /// Max agent iterations [default: 30]
     #[arg(long = "max-iterations")]
     pub max_iterations: Option<usize>,
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -214,7 +214,7 @@ impl EffectiveConfig {
                 api_key: None,
                 context_window: 200_000,
                 context_budget: None,
-                max_agent_iterations: 10,
+                max_agent_iterations: DEFAULT_MAX_AGENT_ITERATIONS,
                 max_console_messages: 5,
                 auto_compact_threshold: 64,
                 tool_result_max_chars: 8000,
@@ -225,8 +225,8 @@ impl EffectiveConfig {
                 tag_protocol: None,
                 prompt_tier: None,
                 smart_compact_threshold_ratio: 0.75,
-                subagent_max_iterations: 10,
-                subagent_timeout_secs: 120,
+                subagent_max_iterations: DEFAULT_SUBAGENT_MAX_ITERATIONS,
+                subagent_timeout_secs: DEFAULT_SUBAGENT_TIMEOUT_SECS,
             },
             mode: ModeConfig {
                 prompt_source: PromptSource::Interactive,
@@ -653,11 +653,8 @@ impl EffectiveConfig {
     /// Clamp sub-agent iteration/timeout settings.
     /// If 0, restore to default values. Enforce upper bounds.
     fn clamp_subagent_settings(&mut self) {
-        const MAX_SUBAGENT_ITERATIONS: u32 = 100;
-        const MAX_SUBAGENT_TIMEOUT_SECS: u64 = 3600;
-
         if self.runtime.subagent_max_iterations == 0 {
-            self.runtime.subagent_max_iterations = 10;
+            self.runtime.subagent_max_iterations = DEFAULT_SUBAGENT_MAX_ITERATIONS;
         } else if self.runtime.subagent_max_iterations > MAX_SUBAGENT_ITERATIONS {
             let old = self.runtime.subagent_max_iterations;
             self.runtime.subagent_max_iterations = MAX_SUBAGENT_ITERATIONS;
@@ -666,7 +663,7 @@ impl EffectiveConfig {
             );
         }
         if self.runtime.subagent_timeout_secs == 0 {
-            self.runtime.subagent_timeout_secs = 120;
+            self.runtime.subagent_timeout_secs = DEFAULT_SUBAGENT_TIMEOUT_SECS;
         } else if self.runtime.subagent_timeout_secs > MAX_SUBAGENT_TIMEOUT_SECS {
             let old = self.runtime.subagent_timeout_secs;
             self.runtime.subagent_timeout_secs = MAX_SUBAGENT_TIMEOUT_SECS;
@@ -700,6 +697,11 @@ impl EffectiveConfig {
 
 const MAX_PROJECT_INSTRUCTIONS_CHARS: usize = 4000;
 const MIN_CONTEXT_WINDOW: u32 = 1000;
+const DEFAULT_MAX_AGENT_ITERATIONS: usize = 30;
+const DEFAULT_SUBAGENT_MAX_ITERATIONS: u32 = 20;
+const DEFAULT_SUBAGENT_TIMEOUT_SECS: u64 = 120;
+const MAX_SUBAGENT_ITERATIONS: u32 = 100;
+const MAX_SUBAGENT_TIMEOUT_SECS: u64 = 3600;
 const MIN_AGENT_ITERATIONS: usize = 1;
 const MAX_AGENT_ITERATIONS: usize = 100;
 

--- a/tests/config_bootstrap.rs
+++ b/tests/config_bootstrap.rs
@@ -142,9 +142,9 @@ fn override_precedence_is_file_then_env_then_cli() {
 }
 
 #[test]
-fn max_agent_iterations_defaults_to_ten() {
+fn max_agent_iterations_defaults_to_thirty() {
     let config = EffectiveConfig::default_for_test().expect("config should load");
-    assert_eq!(config.runtime.max_agent_iterations, 10);
+    assert_eq!(config.runtime.max_agent_iterations, 30);
 }
 
 #[test]
@@ -727,7 +727,7 @@ fn tag_protocol_cli_args_unset_leaves_none() {
 #[test]
 fn subagent_config_defaults() {
     let config = EffectiveConfig::default_for_test().unwrap();
-    assert_eq!(config.runtime.subagent_max_iterations, 10);
+    assert_eq!(config.runtime.subagent_max_iterations, 20);
     assert_eq!(config.runtime.subagent_timeout_secs, 120);
 }
 
@@ -735,12 +735,12 @@ fn subagent_config_defaults() {
 fn subagent_config_apply_map() {
     let mut config = EffectiveConfig::default_for_test().unwrap();
     let mut map = HashMap::new();
-    map.insert("subagent_max_iterations".to_string(), "20".to_string());
+    map.insert("subagent_max_iterations".to_string(), "25".to_string());
     map.insert("subagent_timeout_secs".to_string(), "300".to_string());
     config
         .apply_overrides_for_test(&map, &HashMap::new(), &HashMap::new())
         .expect("should apply");
-    assert_eq!(config.runtime.subagent_max_iterations, 20);
+    assert_eq!(config.runtime.subagent_max_iterations, 25);
     assert_eq!(config.runtime.subagent_timeout_secs, 300);
 }
 
@@ -767,8 +767,8 @@ fn subagent_config_zero_restored_to_defaults() {
     config.runtime.subagent_timeout_secs = 0;
     config.validate_for_test().expect("validation should pass");
     assert_eq!(
-        config.runtime.subagent_max_iterations, 10,
-        "zero subagent_max_iterations should be restored to default"
+        config.runtime.subagent_max_iterations, 20,
+        "zero subagent_max_iterations should be restored to default (20)"
     );
     assert_eq!(
         config.runtime.subagent_timeout_secs, 120,


### PR DESCRIPTION
## Summary
- max_agent_iterations / subagent_max_iterations のデフォルト値を見直し
- 大規模プロジェクトでのファイル探索に十分な反復回数を確保

Closes #147

## Test plan
- [x] cargo test: 全テストパス
- [x] cargo clippy: 警告0件

🤖 Generated with [Claude Code](https://claude.com/claude-code)