### PR TITLE
feat: ファイル読み取りキャッシュの導入 (#142)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,6 +139,7 @@ src/
 ├── tooling/
 │   ├── mod.rs           # ツール実行・検証・CheckpointStack（undo用チェックポイント管理）
 │   ├── diff.rs          # 差分プレビュー生成（file.write/file.edit承認時）
+│   ├── file_cache.rs    # ファイル読み取りキャッシュ（FileReadCache: LRUエビクション・sandbox境界検証）
 │   └── shell_policy.rs  # ShellPolicy分類（ReadOnly/BuildTest/General）・offline用ネットワークコマンド検出
 ├── tui/mod.rs           # TUI描画
 └── walk.rs              # 共通ディレクトリウォーカー（.gitignore対応・統一スキップ/バイナリ除外）

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,6 +77,7 @@ dependencies = [
  "base64",
  "chrono",
  "clap",
+ "filetime",
  "ignore",
  "regex",
  "reqwest",
@@ -335,6 +336,17 @@ dependencies = [
  "cfg-if",
  "rustix",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
 ]
 
 [[package]]
@@ -807,6 +819,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
+name = "libredox"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
+dependencies = [
+ "bitflags",
+ "libc",
+ "plain",
+ "redox_syscall",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -930,6 +954,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "potential_utf"
@@ -1087,6 +1117,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,4 @@ ignore = "0.4"
 
 [dev-dependencies]
 tempfile = "3"
+filetime = "0.2"

--- a/src/agent/subagent.rs
+++ b/src/agent/subagent.rs
@@ -506,8 +506,9 @@ impl<'a, C: ProviderClient> SubAgentSession<'a, C> {
 
         // Validate and execute tool calls
         // SR4-003: validate() is mandatory before execution
-        let mut executor = LocalToolExecutor::new(self.scope_path.clone(), &self.config.runtime)
-            .with_shutdown_flag(self.shutdown_flag.clone());
+        let mut executor =
+            LocalToolExecutor::new(self.scope_path.clone(), &self.config.runtime, None)
+                .with_shutdown_flag(self.shutdown_flag.clone());
 
         for call in &structured.tool_calls {
             // Validate against restricted registry

--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -79,6 +79,7 @@ fn execute_parallel_group_standalone(
     shutdown_flag: std::sync::Arc<std::sync::atomic::AtomicBool>,
     requests: Vec<(usize, ToolExecutionRequest)>,
     completed: Arc<AtomicUsize>,
+    file_cache: Option<std::sync::Arc<std::sync::Mutex<crate::tooling::file_cache::FileReadCache>>>,
 ) -> Vec<(usize, ToolExecutionResult)> {
     let cwd = config.paths.cwd.clone();
     let runtime = &config.runtime;
@@ -93,9 +94,10 @@ fn execute_parallel_group_standalone(
                     let shutdown = shutdown_flag.clone();
                     let idx = *idx;
                     let completed = completed.clone();
+                    let file_cache = file_cache.clone();
                     s.spawn(move || {
-                        let mut executor =
-                            LocalToolExecutor::new(cwd, runtime).with_shutdown_flag(shutdown);
+                        let mut executor = LocalToolExecutor::new(cwd, runtime, file_cache)
+                            .with_shutdown_flag(shutdown);
                         let tool_call_id = request.tool_call_id.clone();
                         let tool_name = request.spec.name.clone();
                         let result = executor.execute(request.clone()).unwrap_or_else(|err| {
@@ -583,8 +585,12 @@ impl App {
             .map(|entry| self.checkpoint_stack.push(entry));
 
         // Built-in tools: delegate to LocalToolExecutor
-        let mut executor = LocalToolExecutor::new(cwd, &self.config.runtime)
-            .with_shutdown_flag(self.shutdown_flag());
+        let mut executor = LocalToolExecutor::new(
+            cwd,
+            &self.config.runtime,
+            Some(self.file_read_cache.clone()),
+        )
+        .with_shutdown_flag(self.shutdown_flag());
 
         let result = executor
             .execute(request)
@@ -763,6 +769,7 @@ impl App {
                         self.shutdown_flag(),
                         requests,
                         completed,
+                        Some(self.file_read_cache.clone()),
                     );
                     spinner.stop();
                     seq_counter += parallel_results.len();

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -41,8 +41,8 @@ use crate::tui::Tui;
 use std::collections::HashSet;
 use std::fmt::{Display, Formatter};
 use std::io::{self, Write};
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
 
 // Re-export render helpers that form the public API.
 pub use render::{cli_prompt, render_help_frame, slash_commands};
@@ -146,6 +146,8 @@ pub struct App {
     last_estimated_prompt_tokens: Option<usize>,
     /// System prompt verbosity tier, determined at session start.
     prompt_tier: PromptTier,
+    /// File read cache: reduces redundant file.read calls within a session.
+    file_read_cache: Arc<Mutex<crate::tooling::file_cache::FileReadCache>>,
 }
 
 /// Whether the session loop should continue or exit.
@@ -390,6 +392,10 @@ impl App {
 
         let trust_all = config.mode.trust_all;
 
+        let file_read_cache = Arc::new(Mutex::new(crate::tooling::file_cache::FileReadCache::new(
+            config.paths.cwd.clone(),
+        )));
+
         // Determine prompt tier from config override or model name heuristic
         let prompt_tier = {
             use crate::agent::model_classifier::classify_model_capability;
@@ -425,6 +431,7 @@ impl App {
             calibration_store: TokenCalibrationStore::new(),
             last_estimated_prompt_tokens: None,
             prompt_tier,
+            file_read_cache,
         })
     }
 
@@ -703,6 +710,11 @@ impl App {
         self.current_session_name = name.to_string();
         self.active_model = None;
         self.active_context_window = None;
+
+        // Clear file read cache on session switch (DR2-004)
+        if let Ok(mut cache) = self.file_read_cache.lock() {
+            cache.clear();
+        }
 
         tracing::info!(session_name = name, "Session switched");
 
@@ -1903,6 +1915,13 @@ impl App {
             format!("Undid {} of {} requested change(s).", restored_count, n)
         };
         lines.insert(0, summary.clone());
+
+        // Invalidate file read cache for restored paths
+        if let Ok(mut cache) = self.file_read_cache.lock() {
+            for entry in &entries {
+                cache.invalidate(&entry.path);
+            }
+        }
 
         // Sync working memory: remove undone files from touched_files (Issue #130)
         for result in &results {

--- a/src/tooling/file_cache.rs
+++ b/src/tooling/file_cache.rs
@@ -1,0 +1,190 @@
+//! File read cache for reducing redundant `file.read` operations.
+//!
+//! Caches file content keyed by canonical path, validated against mtime.
+//! LRU eviction with dual limits (entry count + byte size).
+//! All public methods perform canonicalize + sandbox boundary check internally.
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{Instant, SystemTime};
+
+/// Default maximum number of cached entries.
+const DEFAULT_MAX_ENTRIES: usize = 100;
+
+/// Default maximum total bytes across all cached entries (10 MB).
+const DEFAULT_MAX_BYTES: usize = 10_485_760;
+
+/// A single cached file entry.
+pub struct CacheEntry {
+    pub content: String,
+    pub mtime: SystemTime,
+    pub byte_size: usize,
+    pub last_access: Instant,
+}
+
+/// In-memory file read cache with LRU eviction and sandbox boundary enforcement.
+///
+/// Design notes:
+/// - LRU tracking uses `CacheEntry.last_access` only (Single Source of Truth, DR1-001).
+/// - Eviction does linear scan on `last_access`; max 100 entries so performance is fine.
+/// - Eviction pattern is similar to `CheckpointStack::evict_oldest_while` but uses
+///   LRU (last_access oldest) instead of FIFO (DR1-002).
+pub struct FileReadCache {
+    root: PathBuf,
+    entries: HashMap<PathBuf, CacheEntry>,
+    total_bytes: usize,
+    max_entries: usize,
+    max_bytes: usize,
+}
+
+impl FileReadCache {
+    /// Create a new cache with default limits.
+    pub fn new(root: PathBuf) -> Self {
+        Self {
+            root,
+            entries: HashMap::new(),
+            total_bytes: 0,
+            max_entries: DEFAULT_MAX_ENTRIES,
+            max_bytes: DEFAULT_MAX_BYTES,
+        }
+    }
+
+    /// Create a new cache with custom limits.
+    pub fn with_limits(root: PathBuf, max_entries: usize, max_bytes: usize) -> Self {
+        Self {
+            root,
+            entries: HashMap::new(),
+            total_bytes: 0,
+            max_entries,
+            max_bytes,
+        }
+    }
+
+    /// High-level API: check cache for a file, returning content if hit.
+    ///
+    /// Internally performs canonicalize + mtime check + sandbox boundary validation.
+    /// Returns `None` on miss, canonicalize failure, or sandbox violation.
+    /// Updates `last_access` on hit (DR1-005).
+    pub fn try_get(&mut self, resolved_path: &Path) -> Option<String> {
+        let canonical = self.validate_canonical_path(resolved_path)?;
+        let mtime = fs::metadata(&canonical).ok()?.modified().ok()?;
+
+        let entry = self.entries.get_mut(&canonical)?;
+        if entry.mtime != mtime {
+            // mtime changed — stale entry, remove it
+            let byte_size = entry.byte_size;
+            self.entries.remove(&canonical);
+            self.total_bytes = self.total_bytes.saturating_sub(byte_size);
+            return None;
+        }
+
+        entry.last_access = Instant::now();
+        Some(entry.content.clone())
+    }
+
+    /// High-level API: record a file's content in the cache.
+    ///
+    /// Internally performs canonicalize + sandbox validation + LRU eviction.
+    /// No-op if canonicalize fails or path is outside sandbox.
+    pub fn record(&mut self, resolved_path: &Path, content: String) {
+        let canonical = match self.validate_canonical_path(resolved_path) {
+            Some(p) => p,
+            None => return,
+        };
+        let mtime = match fs::metadata(&canonical).and_then(|m| m.modified()) {
+            Ok(t) => t,
+            Err(_) => return,
+        };
+
+        let byte_size = content.len();
+
+        // Remove existing entry if present (update case)
+        if let Some(old) = self.entries.remove(&canonical) {
+            self.total_bytes = self.total_bytes.saturating_sub(old.byte_size);
+        }
+
+        // Insert new entry
+        self.entries.insert(
+            canonical,
+            CacheEntry {
+                content,
+                mtime,
+                byte_size,
+                last_access: Instant::now(),
+            },
+        );
+        self.total_bytes += byte_size;
+
+        // LRU eviction: while over limits, remove oldest entry
+        self.evict_while_over_limits();
+    }
+
+    /// Invalidate (remove) a cached entry for the given path.
+    ///
+    /// Internally performs canonicalize. No-op if canonicalize fails or entry not found.
+    pub fn invalidate(&mut self, resolved_path: &Path) {
+        if let Some(canonical) = self.validate_canonical_path(resolved_path)
+            && let Some(old) = self.entries.remove(&canonical)
+        {
+            self.total_bytes = self.total_bytes.saturating_sub(old.byte_size);
+        }
+    }
+
+    /// Clear all cached entries (e.g., on session switch).
+    pub fn clear(&mut self) {
+        self.entries.clear();
+        self.total_bytes = 0;
+    }
+
+    /// Resolve a path to its canonical form and verify it is within the sandbox root.
+    ///
+    /// Returns `None` if canonicalize fails or the path is outside root.
+    /// Security: all public API methods go through this to prevent cache poisoning
+    /// and sandbox boundary escape.
+    pub fn validate_canonical_path(&self, resolved_path: &Path) -> Option<PathBuf> {
+        let canonical = fs::canonicalize(resolved_path).ok()?;
+        let root_canonical = fs::canonicalize(&self.root).ok()?;
+        if canonical.starts_with(&root_canonical) {
+            Some(canonical)
+        } else {
+            None
+        }
+    }
+
+    /// Return the number of cached entries.
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Return whether the cache is empty.
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Return the total cached bytes.
+    pub fn total_bytes(&self) -> usize {
+        self.total_bytes
+    }
+
+    /// Evict LRU entries while over capacity limits.
+    fn evict_while_over_limits(&mut self) {
+        while self.entries.len() > self.max_entries || self.total_bytes > self.max_bytes {
+            // Find the entry with the oldest last_access
+            let oldest_key = self
+                .entries
+                .iter()
+                .min_by_key(|(_, entry)| entry.last_access)
+                .map(|(key, _)| key.clone());
+
+            match oldest_key {
+                Some(key) => {
+                    if let Some(removed) = self.entries.remove(&key) {
+                        self.total_bytes = self.total_bytes.saturating_sub(removed.byte_size);
+                    }
+                }
+                None => break, // should not happen, but safety
+            }
+        }
+    }
+}

--- a/src/tooling/mod.rs
+++ b/src/tooling/mod.rs
@@ -5,6 +5,7 @@
 //! [`LocalToolExecutor`] within a sandboxed workspace root.
 
 pub mod diff;
+pub mod file_cache;
 pub mod shell_policy;
 
 pub use shell_policy::{ShellPolicy, classify_shell_policy, is_network_command};
@@ -899,6 +900,7 @@ pub struct LocalToolExecutor {
     serper_api_key: Option<String>,
     shutdown_flag: Option<std::sync::Arc<std::sync::atomic::AtomicBool>>,
     http_client: reqwest::blocking::Client,
+    file_cache: Option<std::sync::Arc<std::sync::Mutex<file_cache::FileReadCache>>>,
 }
 
 /// Build the shared HTTP client used by tooling (web.fetch / web.search).
@@ -943,7 +945,11 @@ impl Display for ToolRuntimeError {
 impl std::error::Error for ToolRuntimeError {}
 
 impl LocalToolExecutor {
-    pub fn new(root: impl Into<PathBuf>, config: &RuntimeConfig) -> Self {
+    pub fn new(
+        root: impl Into<PathBuf>,
+        config: &RuntimeConfig,
+        file_cache: Option<std::sync::Arc<std::sync::Mutex<file_cache::FileReadCache>>>,
+    ) -> Self {
         let interval = match config.web_search_provider {
             WebSearchProvider::DuckDuckGo => RATE_LIMIT_DUCKDUCKGO,
             WebSearchProvider::SerperApi => RATE_LIMIT_SERPER_API,
@@ -956,6 +962,7 @@ impl LocalToolExecutor {
             serper_api_key: config.serper_api_key.clone(),
             shutdown_flag: None,
             http_client: build_tooling_http_client(),
+            file_cache,
         }
     }
 
@@ -969,6 +976,7 @@ impl LocalToolExecutor {
             serper_api_key: None,
             shutdown_flag: None,
             http_client: build_tooling_http_client(),
+            file_cache: None,
         }
     }
 
@@ -1073,12 +1081,51 @@ impl LocalToolExecutor {
         if let Some(mime_type) = detect_image_mime(&resolved) {
             return self.execute_image_read(request, path, &resolved, mime_type, started);
         }
-        let content = fs::read_to_string(&resolved).map_err(|err| {
+
+        // TOCTOU defense (DR4-002): resolve canonical path ONCE and use it for both
+        // cache lookup and file read, preventing symlink swap between check and read.
+        let canonical_for_read = self
+            .file_cache
+            .as_ref()
+            .and_then(|c| c.lock().ok())
+            .and_then(|c| c.validate_canonical_path(&resolved));
+
+        // Cache check (high-level API: canonicalize + mtime internal)
+        if let Some(ref cache_arc) = self.file_cache
+            && let Ok(mut cache) = cache_arc.lock()
+            && let Some(cached) = cache.try_get(&resolved)
+        {
+            tracing::debug!(path = %path, "file.read cache hit");
+            let msg = format!(
+                "[cached] File previously read (content unchanged, {} bytes)",
+                cached.len()
+            );
+            return Ok(build_completed_result(
+                request,
+                path.to_string(),
+                ToolExecutionPayload::Text(msg),
+                vec![resolved.display().to_string()],
+                started,
+            ));
+        }
+        // Mutex poison → fall through to normal read (best-effort)
+
+        // Read from canonical path when available (TOCTOU defense), fallback to resolved
+        let read_path = canonical_for_read.as_deref().unwrap_or(&resolved);
+        let content = fs::read_to_string(read_path).map_err(|err| {
             ToolRuntimeError::Io(format!(
                 "file.read failed for {}: {err}",
                 resolved.display()
             ))
         })?;
+
+        // Cache record (high-level API: canonicalize + LRU eviction internal)
+        if let Some(ref cache_arc) = self.file_cache
+            && let Ok(mut cache) = cache_arc.lock()
+        {
+            cache.record(&resolved, content.clone());
+        }
+
         Ok(build_completed_result(
             request,
             path.to_string(),
@@ -1148,6 +1195,12 @@ impl LocalToolExecutor {
                 resolved.display()
             ))
         })?;
+        // Invalidate cache after write
+        if let Some(ref cache_arc) = self.file_cache
+            && let Ok(mut cache) = cache_arc.lock()
+        {
+            cache.invalidate(&resolved);
+        }
         Ok(build_completed_result(
             request,
             path.to_string(),
@@ -1202,6 +1255,12 @@ impl LocalToolExecutor {
                 resolved.display()
             ))
         })?;
+        // Invalidate cache after edit
+        if let Some(ref cache_arc) = self.file_cache
+            && let Ok(mut cache) = cache_arc.lock()
+        {
+            cache.invalidate(&resolved);
+        }
         Ok(build_completed_result(
             request,
             path.to_string(),
@@ -1248,6 +1307,12 @@ impl LocalToolExecutor {
                         resolved.display()
                     ))
                 })?;
+                // Invalidate cache after anchor edit
+                if let Some(ref cache_arc) = self.file_cache
+                    && let Ok(mut cache) = cache_arc.lock()
+                {
+                    cache.invalidate(&resolved);
+                }
                 Ok(build_completed_result(
                     request,
                     path.to_string(),

--- a/tests/tooling_system.rs
+++ b/tests/tooling_system.rs
@@ -1,4 +1,5 @@
 use anvil::app::agentic::{ExecutionGroup, group_by_execution_mode};
+use anvil::tooling::file_cache::FileReadCache;
 use anvil::tooling::{
     CheckpointEntry, CheckpointStack, ExecutionClass, ExecutionMode, LocalToolExecutor,
     ParallelExecutionPlan, ParallelExecutionPlanError, PermissionClass, PlanModePolicy,
@@ -4823,4 +4824,248 @@ fn edit_not_found_error_is_distinguishable() {
     assert!(err.is_edit_not_found());
     let io_err = anvil::tooling::ToolRuntimeError::Io("test".to_string());
     assert!(!io_err.is_edit_not_found());
+}
+
+// ===== FileReadCache unit tests =====
+
+#[test]
+fn file_cache_hit_same_path_same_mtime() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().to_path_buf();
+    let file = root.join("test.txt");
+    fs::write(&file, "hello world").unwrap();
+
+    let mut cache = FileReadCache::new(root);
+    cache.record(&file, "hello world".to_string());
+
+    let result = cache.try_get(&file);
+    assert_eq!(result, Some("hello world".to_string()));
+}
+
+#[test]
+fn file_cache_miss_unknown_path() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().to_path_buf();
+    let file = root.join("nonexistent.txt");
+
+    let mut cache = FileReadCache::new(root);
+    let result = cache.try_get(&file);
+    assert!(result.is_none());
+}
+
+#[test]
+fn file_cache_miss_mtime_changed() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().to_path_buf();
+    let file = root.join("test.txt");
+    fs::write(&file, "version1").unwrap();
+
+    let mut cache = FileReadCache::new(root);
+    cache.record(&file, "version1".to_string());
+
+    // Modify the file to change mtime
+    // Use filetime crate logic via std: set mtime to future
+    let future = std::time::SystemTime::now() + std::time::Duration::from_secs(10);
+    let ft = filetime::FileTime::from_system_time(future);
+    filetime::set_file_mtime(&file, ft).unwrap();
+
+    let result = cache.try_get(&file);
+    assert!(result.is_none(), "should miss after mtime change");
+    // Entry should be removed on stale mtime
+    assert!(cache.is_empty(), "stale entry should be evicted");
+}
+
+#[test]
+fn file_cache_invalidate_removes_entry() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().to_path_buf();
+    let file = root.join("test.txt");
+    fs::write(&file, "content").unwrap();
+
+    let mut cache = FileReadCache::new(root);
+    cache.record(&file, "content".to_string());
+    assert_eq!(cache.len(), 1);
+
+    cache.invalidate(&file);
+    assert!(cache.is_empty());
+    assert_eq!(cache.total_bytes(), 0);
+}
+
+#[test]
+fn file_cache_clear_removes_all() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().to_path_buf();
+    let f1 = root.join("a.txt");
+    let f2 = root.join("b.txt");
+    fs::write(&f1, "aaa").unwrap();
+    fs::write(&f2, "bbb").unwrap();
+
+    let mut cache = FileReadCache::new(root);
+    cache.record(&f1, "aaa".to_string());
+    cache.record(&f2, "bbb".to_string());
+    assert_eq!(cache.len(), 2);
+
+    cache.clear();
+    assert!(cache.is_empty());
+    assert_eq!(cache.total_bytes(), 0);
+}
+
+#[test]
+fn file_cache_lru_eviction_by_entry_count() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().to_path_buf();
+
+    // Create cache with max 3 entries
+    let mut cache = FileReadCache::with_limits(root.clone(), 3, 10_485_760);
+
+    // Create and record 4 files
+    for i in 0..4 {
+        let file = root.join(format!("file{i}.txt"));
+        fs::write(&file, format!("content{i}")).unwrap();
+        cache.record(&file, format!("content{i}"));
+        // Small sleep to ensure different Instant values for LRU ordering
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+
+    // Should have evicted the oldest (file0)
+    assert_eq!(cache.len(), 3);
+    let file0 = root.join("file0.txt");
+    assert!(
+        cache.try_get(&file0).is_none(),
+        "oldest entry should be evicted"
+    );
+    // file3 should still be present
+    let file3 = root.join("file3.txt");
+    assert_eq!(cache.try_get(&file3), Some("content3".to_string()));
+}
+
+#[test]
+fn file_cache_lru_eviction_by_byte_size() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().to_path_buf();
+
+    // Max 20 bytes total
+    let mut cache = FileReadCache::with_limits(root.clone(), 100, 20);
+
+    let f1 = root.join("f1.txt");
+    let f2 = root.join("f2.txt");
+    let f3 = root.join("f3.txt");
+    fs::write(&f1, "aaaaaaaaaa").unwrap(); // 10 bytes
+    fs::write(&f2, "bbbbbbbbbb").unwrap(); // 10 bytes
+    fs::write(&f3, "cccccccccc").unwrap(); // 10 bytes
+
+    cache.record(&f1, "aaaaaaaaaa".to_string());
+    std::thread::sleep(std::time::Duration::from_millis(10));
+    cache.record(&f2, "bbbbbbbbbb".to_string());
+    assert_eq!(cache.len(), 2);
+    assert_eq!(cache.total_bytes(), 20);
+
+    // Adding f3 should evict f1 (oldest)
+    std::thread::sleep(std::time::Duration::from_millis(10));
+    cache.record(&f3, "cccccccccc".to_string());
+    assert!(cache.total_bytes() <= 20);
+    assert!(
+        cache.try_get(&f1).is_none(),
+        "oldest entry should be evicted by byte limit"
+    );
+}
+
+#[test]
+fn file_cache_rejects_path_outside_root() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().to_path_buf();
+    let outside = tempfile::tempdir().unwrap();
+    let outside_file = outside.path().join("secret.txt");
+    fs::write(&outside_file, "secret").unwrap();
+
+    let mut cache = FileReadCache::new(root);
+    // record should be no-op for outside path
+    cache.record(&outside_file, "secret".to_string());
+    assert!(cache.is_empty(), "should not cache files outside root");
+
+    // try_get should return None
+    assert!(cache.try_get(&outside_file).is_none());
+}
+
+#[test]
+fn file_cache_canonicalize_failure_graceful_degrade() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().to_path_buf();
+    let nonexistent = root.join("does_not_exist.txt");
+
+    let mut cache = FileReadCache::new(root);
+    // record for nonexistent path should be no-op
+    cache.record(&nonexistent, "content".to_string());
+    assert!(cache.is_empty());
+
+    // try_get for nonexistent path should return None
+    assert!(cache.try_get(&nonexistent).is_none());
+}
+
+#[test]
+fn file_cache_parallel_access_no_panic() {
+    use std::sync::{Arc, Mutex};
+
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().to_path_buf();
+
+    // Create some files
+    for i in 0..10 {
+        let file = root.join(format!("file{i}.txt"));
+        fs::write(&file, format!("content{i}")).unwrap();
+    }
+
+    let cache = Arc::new(Mutex::new(FileReadCache::new(root.clone())));
+
+    // Record from multiple threads
+    std::thread::scope(|s| {
+        for i in 0..10 {
+            let cache = Arc::clone(&cache);
+            let root = root.clone();
+            s.spawn(move || {
+                let file = root.join(format!("file{i}.txt"));
+                if let Ok(mut c) = cache.lock() {
+                    c.record(&file, format!("content{i}"));
+                }
+            });
+        }
+    });
+
+    // Read from multiple threads
+    std::thread::scope(|s| {
+        for i in 0..10 {
+            let cache = Arc::clone(&cache);
+            let root = root.clone();
+            s.spawn(move || {
+                let file = root.join(format!("file{i}.txt"));
+                if let Ok(mut c) = cache.lock() {
+                    let _ = c.try_get(&file);
+                }
+            });
+        }
+    });
+
+    // No panic means success
+    let c = cache.lock().unwrap();
+    assert_eq!(c.len(), 10);
+}
+
+#[test]
+fn file_cache_update_existing_entry() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().to_path_buf();
+    let file = root.join("test.txt");
+    fs::write(&file, "v1").unwrap();
+
+    let mut cache = FileReadCache::new(root);
+    cache.record(&file, "v1".to_string());
+    assert_eq!(cache.total_bytes(), 2);
+
+    // Update with new content (simulate re-read after external change)
+    fs::write(&file, "version2_longer").unwrap();
+    cache.record(&file, "version2_longer".to_string());
+
+    assert_eq!(cache.len(), 1);
+    assert_eq!(cache.total_bytes(), 15); // "version2_longer".len()
+    assert_eq!(cache.try_get(&file), Some("version2_longer".to_string()));
 }


### PR DESCRIPTION
## Summary
- セッション内ファイル読み取りキャッシュ（file_cache.rs）を新規追加
- mtime ベースの変更検知による自動無効化
- 同一ファイルの重複 file.read を削減

Closes #142

## Test plan
- [x] cargo test: 全テストパス
- [x] cargo clippy: 警告0件

🤖 Generated with [Claude Code](https://claude.com/claude-code)