### PR TITLE
feat: file.edit エラー時のリカバリー改善 (#143)

### DIFF
--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -99,12 +99,34 @@ fn execute_parallel_group_standalone(
                         let tool_call_id = request.tool_call_id.clone();
                         let tool_name = request.spec.name.clone();
                         let result = executor.execute(request.clone()).unwrap_or_else(|err| {
+                            let (summary, payload) = match &err {
+                                crate::tooling::ToolRuntimeError::EditNotFound {
+                                    message,
+                                    context_snippet,
+                                } => {
+                                    let payload_text = if let Some(ctx) = context_snippet {
+                                        format!(
+                                            "{message}\n\n--- File context (nearby lines) ---\n{ctx}"
+                                        )
+                                    } else {
+                                        message.clone()
+                                    };
+                                    (
+                                        message.clone(),
+                                        ToolExecutionPayload::Text(payload_text),
+                                    )
+                                }
+                                other => {
+                                    let msg = other.to_string();
+                                    (msg.clone(), ToolExecutionPayload::Text(msg))
+                                }
+                            };
                             ToolExecutionResult {
                                 tool_call_id,
                                 tool_name,
                                 status: ToolExecutionStatus::Failed,
-                                summary: err.to_string(),
-                                payload: ToolExecutionPayload::Text(err.to_string()),
+                                summary,
+                                payload,
                                 artifacts: Vec::new(),
                                 elapsed_ms: 0,
                             }
@@ -943,6 +965,33 @@ impl App {
             }
         }
 
+        // Edit fail tracker: track consecutive file.edit failures (Issue #143)
+        let mut edit_hint: Option<String> = None;
+        if result.tool_name == "file.edit" {
+            if result.status == ToolExecutionStatus::Failed {
+                // Extract path from summary (format: "file.edit: ... in {path}. ...")
+                if let Some(path) = extract_edit_path_from_summary(&result.summary)
+                    .filter(|p| self.edit_fail_tracker.record_failure(p))
+                {
+                    let count = self.edit_fail_tracker.failure_count(&path);
+                    edit_hint = Some(format!(
+                        "\n\n[Anvil hint] file.edit has failed {count} consecutive \
+                         times for '{path}'. Consider using file.read to get the \
+                         current content, then file.write to replace the entire file."
+                    ));
+                }
+            } else if result.status == ToolExecutionStatus::Completed {
+                // Reset on success — extract path from artifacts
+                if let Some(artifact) = result.artifacts.first() {
+                    let path_str = std::path::Path::new(artifact)
+                        .file_name()
+                        .and_then(|n| n.to_str())
+                        .unwrap_or(artifact);
+                    self.edit_fail_tracker.record_success(path_str);
+                }
+            }
+        }
+
         // Working memory: track errors (Issue #130)
         if result.status == ToolExecutionStatus::Failed {
             let sanitized_error = if result.tool_name == "shell.exec" {
@@ -958,12 +1007,14 @@ impl App {
         }
 
         let is_error = result.status == ToolExecutionStatus::Failed;
-        let mut msg = SessionMessage::new(
-            MessageRole::Tool,
-            &result.tool_name,
-            format_tool_result_message(result, self.config.runtime.tool_result_max_chars),
-        )
-        .with_id(self.next_message_id("tool"));
+        let mut formatted =
+            format_tool_result_message(result, self.config.runtime.tool_result_max_chars);
+        // Append edit recovery hint if consecutive failures detected
+        if let Some(hint) = edit_hint {
+            formatted.push_str(&hint);
+        }
+        let mut msg = SessionMessage::new(MessageRole::Tool, &result.tool_name, formatted)
+            .with_id(self.next_message_id("tool"));
         msg.is_error = is_error;
 
         // Attach image paths for Image payloads so the agent layer can
@@ -1102,6 +1153,24 @@ pub fn truncate_with_head_tail(content: &str, max_chars: usize, head_pct: usize)
         "{}\n\n... [{} chars truncated, {} chars total] ...\n\n{}",
         head, omitted, total_chars, tail
     )
+}
+
+/// Extract the file path from a file.edit error summary.
+/// Looks for patterns like "... in {path}. ..." or "... in {path},"
+fn extract_edit_path_from_summary(summary: &str) -> Option<String> {
+    // Pattern: "file.edit: ... in {path}. ..."
+    // or "file.edit: ... in {path}, ..."
+    let in_idx = summary.find(" in ")?;
+    let after_in = &summary[in_idx + 4..];
+    let end = after_in
+        .find(". ")
+        .or_else(|| after_in.find(", "))
+        .unwrap_or(after_in.len());
+    let path = after_in[..end].trim();
+    if path.is_empty() {
+        return None;
+    }
+    Some(path.to_string())
 }
 
 /// Format a tool execution result into a message that the LLM can interpret.

--- a/src/app/context.rs
+++ b/src/app/context.rs
@@ -53,73 +53,7 @@ pub(crate) fn parse_at_references(input: &str) -> Vec<AtReference> {
     refs
 }
 
-/// Sensitive file patterns that should never be expanded via @file.
-/// Prevents accidental leakage of secrets to LLM backends.
-const SENSITIVE_FILE_PATTERNS: &[&str] = &[
-    ".env",
-    ".env.*",
-    "*.pem",
-    "*.key",
-    "*.p12",
-    "*.pfx",
-    "id_rsa",
-    "id_ed25519",
-    "id_ecdsa",
-    "id_dsa",
-    "credentials.json",
-    "secrets.*",
-    "*.secret",
-    "*.secrets",
-    ".netrc",
-    ".npmrc",
-    ".pypirc",
-    "token.json",
-    "service-account*.json",
-];
-
-/// Check whether a file path matches the sensitive file blocklist.
-///
-/// Matching is performed against the file name (basename) only, using
-/// simple string operations: exact match, prefix (`starts_with`),
-/// suffix (`ends_with`), and prefix+suffix for patterns like `service-account*.json`.
-fn is_sensitive_file(path: &str) -> bool {
-    let file_name = Path::new(path)
-        .file_name()
-        .and_then(|n| n.to_str())
-        .unwrap_or("");
-    if file_name.is_empty() {
-        return false;
-    }
-    for pattern in SENSITIVE_FILE_PATTERNS {
-        if let Some(suffix) = pattern.strip_prefix('*') {
-            // e.g. "*.pem" → ends_with(".pem")
-            if file_name.ends_with(suffix) {
-                return true;
-            }
-        } else if let Some(prefix) = pattern.strip_suffix('*') {
-            // e.g. ".env.*" → starts_with(".env.")
-            if file_name.starts_with(prefix) {
-                return true;
-            }
-        } else if pattern.contains('*') {
-            // e.g. "service-account*.json" → starts_with("service-account") && ends_with(".json")
-            let parts: Vec<&str> = pattern.splitn(2, '*').collect();
-            if parts.len() == 2
-                && file_name.starts_with(parts[0])
-                && file_name.ends_with(parts[1])
-                && file_name.len() >= parts[0].len() + parts[1].len()
-            {
-                return true;
-            }
-        } else {
-            // exact match
-            if file_name == *pattern {
-                return true;
-            }
-        }
-    }
-    false
-}
+use crate::tooling::is_sensitive_file;
 
 /// Resolve a single @file reference, returning the file content as text.
 ///

--- a/src/app/edit_fail_tracker.rs
+++ b/src/app/edit_fail_tracker.rs
@@ -1,0 +1,87 @@
+use std::collections::HashMap;
+
+/// Tracks consecutive file.edit failures per file path.
+/// Used to detect when the LLM is stuck retrying edits on the same file
+/// and should be prompted to try an alternative approach.
+pub(crate) struct EditFailTracker {
+    consecutive_failures: HashMap<String, u32>,
+    threshold: u32,
+}
+
+impl EditFailTracker {
+    pub(crate) fn new(threshold: u32) -> Self {
+        Self {
+            consecutive_failures: HashMap::new(),
+            threshold,
+        }
+    }
+
+    /// Record a file.edit failure for the given path.
+    /// Returns true if the failure count has reached the threshold.
+    pub(crate) fn record_failure(&mut self, path: &str) -> bool {
+        let count = self
+            .consecutive_failures
+            .entry(path.to_string())
+            .or_insert(0);
+        *count += 1;
+        *count >= self.threshold
+    }
+
+    /// Record a successful file.edit, resetting the failure count for that path.
+    pub(crate) fn record_success(&mut self, path: &str) {
+        self.consecutive_failures.remove(path);
+    }
+
+    /// Get the current failure count for a path.
+    pub(crate) fn failure_count(&self, path: &str) -> u32 {
+        self.consecutive_failures.get(path).copied().unwrap_or(0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_tracker_basic_flow() {
+        let mut tracker = EditFailTracker::new(3);
+
+        assert!(!tracker.record_failure("foo.rs"));
+        assert!(!tracker.record_failure("foo.rs"));
+        assert!(tracker.record_failure("foo.rs")); // 3rd failure hits threshold
+        assert_eq!(tracker.failure_count("foo.rs"), 3);
+    }
+
+    #[test]
+    fn test_tracker_success_resets() {
+        let mut tracker = EditFailTracker::new(3);
+
+        tracker.record_failure("foo.rs");
+        tracker.record_failure("foo.rs");
+        tracker.record_success("foo.rs");
+        assert_eq!(tracker.failure_count("foo.rs"), 0);
+
+        // After reset, needs 3 more failures
+        assert!(!tracker.record_failure("foo.rs"));
+    }
+
+    #[test]
+    fn test_tracker_independent_paths() {
+        let mut tracker = EditFailTracker::new(3);
+
+        tracker.record_failure("foo.rs");
+        assert!(!tracker.record_failure("bar.rs")); // bar.rs: 1st
+        assert!(!tracker.record_failure("foo.rs")); // foo.rs: 2nd
+        assert!(!tracker.record_failure("bar.rs")); // bar.rs: 2nd
+        assert!(tracker.record_failure("foo.rs")); // foo.rs: 3rd = threshold
+        assert!(tracker.record_failure("bar.rs")); // bar.rs: 3rd = threshold
+    }
+
+    #[test]
+    fn test_tracker_threshold_2() {
+        let mut tracker = EditFailTracker::new(2);
+        assert!(!tracker.record_failure("a.rs")); // 1st
+        assert!(tracker.record_failure("a.rs")); // 2nd = threshold
+        assert!(tracker.record_failure("a.rs")); // 3rd, still above threshold
+    }
+}

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -6,6 +6,7 @@
 pub mod agentic;
 pub mod cli;
 mod context;
+pub(crate) mod edit_fail_tracker;
 pub mod mock;
 pub mod plan;
 pub mod policy;
@@ -146,6 +147,8 @@ pub struct App {
     last_estimated_prompt_tokens: Option<usize>,
     /// System prompt verbosity tier, determined at session start.
     prompt_tier: PromptTier,
+    /// Tracks consecutive file.edit failures per path for recovery hints.
+    edit_fail_tracker: edit_fail_tracker::EditFailTracker,
 }
 
 /// Whether the session loop should continue or exit.
@@ -425,6 +428,7 @@ impl App {
             calibration_store: TokenCalibrationStore::new(),
             last_estimated_prompt_tokens: None,
             prompt_tier,
+            edit_fail_tracker: edit_fail_tracker::EditFailTracker::new(3),
         })
     }
 

--- a/src/tooling/mod.rs
+++ b/src/tooling/mod.rs
@@ -914,13 +914,34 @@ fn build_tooling_http_client() -> reqwest::blocking::Client {
 pub enum ToolRuntimeError {
     InvalidPath(String),
     Io(String),
-    CaptchaBlocked { query: String },
-    EditNotFound(String),
+    CaptchaBlocked {
+        query: String,
+    },
+    EditNotFound {
+        message: String,
+        context_snippet: Option<String>,
+    },
 }
 
 impl ToolRuntimeError {
+    /// Create an EditNotFound error without context snippet.
+    pub fn edit_not_found(message: impl Into<String>) -> Self {
+        Self::EditNotFound {
+            message: message.into(),
+            context_snippet: None,
+        }
+    }
+
+    /// Create an EditNotFound error with a file context snippet.
+    pub fn edit_not_found_with_context(message: impl Into<String>, context: String) -> Self {
+        Self::EditNotFound {
+            message: message.into(),
+            context_snippet: Some(context),
+        }
+    }
+
     pub fn is_edit_not_found(&self) -> bool {
-        matches!(self, Self::EditNotFound(_))
+        matches!(self, Self::EditNotFound { .. })
     }
 }
 
@@ -935,12 +956,107 @@ impl Display for ToolRuntimeError {
                  Consider setting SERPER_API_KEY for automatic fallback, \
                  or use web.fetch to access specific URLs directly."
             ),
-            Self::EditNotFound(message) => write!(f, "{message}"),
+            Self::EditNotFound { message, .. } => write!(f, "{message}"),
         }
     }
 }
 
 impl std::error::Error for ToolRuntimeError {}
+
+/// Sensitive file patterns that should never have their content included
+/// in error responses to prevent accidental leakage of secrets.
+const SENSITIVE_FILE_PATTERNS: &[&str] = &[
+    ".env",
+    ".env.*",
+    "*.pem",
+    "*.key",
+    "*.p12",
+    "*.pfx",
+    "id_rsa",
+    "id_ed25519",
+    "id_ecdsa",
+    "id_dsa",
+    "credentials.json",
+    "secrets.*",
+    "*.secret",
+    "*.secrets",
+    ".netrc",
+    ".npmrc",
+    ".pypirc",
+    "token.json",
+    "service-account*.json",
+];
+
+/// Check whether a file path matches the sensitive file blocklist.
+///
+/// Matching is performed against the file name (basename) only, using
+/// simple string operations: exact match, prefix (`starts_with`),
+/// suffix (`ends_with`), and prefix+suffix for patterns like `service-account*.json`.
+pub fn is_sensitive_file(path: &str) -> bool {
+    let file_name = std::path::Path::new(path)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("");
+    if file_name.is_empty() {
+        return false;
+    }
+    for pattern in SENSITIVE_FILE_PATTERNS {
+        if let Some(suffix) = pattern.strip_prefix('*') {
+            if file_name.ends_with(suffix) {
+                return true;
+            }
+        } else if let Some(prefix) = pattern.strip_suffix('*') {
+            if file_name.starts_with(prefix) {
+                return true;
+            }
+        } else if pattern.contains('*') {
+            let parts: Vec<&str> = pattern.splitn(2, '*').collect();
+            if parts.len() == 2
+                && file_name.starts_with(parts[0])
+                && file_name.ends_with(parts[1])
+                && file_name.len() >= parts[0].len() + parts[1].len()
+            {
+                return true;
+            }
+        } else if file_name == *pattern {
+            return true;
+        }
+    }
+    false
+}
+
+/// Extract context lines around the best matching location for `old_string`
+/// in `content`. Searches for the first line of `old_string` (trimmed) and
+/// returns surrounding lines with line numbers.
+pub fn extract_edit_context(
+    content: &str,
+    old_string: &str,
+    context_lines: usize,
+) -> Option<String> {
+    let first_line = old_string.lines().next()?.trim();
+    if first_line.is_empty() {
+        return None;
+    }
+
+    let lines: Vec<&str> = content.lines().collect();
+    let match_idx = lines
+        .iter()
+        .enumerate()
+        .find(|(_, line)| line.trim().contains(first_line))?
+        .0;
+
+    let start = match_idx.saturating_sub(context_lines);
+    let end = (match_idx + context_lines + 1).min(lines.len());
+
+    let context: String = lines[start..end]
+        .iter()
+        .enumerate()
+        .map(|(i, line)| format!("{:4} | {}", start + i + 1, line))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    Some(context)
+}
 
 impl LocalToolExecutor {
     pub fn new(root: impl Into<PathBuf>, config: &RuntimeConfig) -> Self {
@@ -1183,14 +1299,14 @@ impl LocalToolExecutor {
         }
         let count = content.matches(old_string).count();
         if count == 0 {
-            return Err(ToolRuntimeError::EditNotFound(format!(
+            return Err(ToolRuntimeError::edit_not_found(format!(
                 "file.edit: old_string not found in {path}. \
                  Ensure the string exactly matches the file content, \
                  including whitespace and indentation."
             )));
         }
         if count > 1 {
-            return Err(ToolRuntimeError::EditNotFound(format!(
+            return Err(ToolRuntimeError::edit_not_found(format!(
                 "file.edit: old_string found {count} times in {path}. \
                  Include more surrounding context to make the match unique."
             )));
@@ -1256,16 +1372,17 @@ impl LocalToolExecutor {
                     started,
                 ))
             }
-            0 => Err(ToolRuntimeError::EditNotFound(format!(
+            0 => Err(ToolRuntimeError::edit_not_found(format!(
                 "anchor: normalized old_content not found in {path}"
             ))),
-            n => Err(ToolRuntimeError::EditNotFound(format!(
+            n => Err(ToolRuntimeError::edit_not_found(format!(
                 "anchor: old_content matched {n} locations in {path}, need unique match"
             ))),
         }
     }
 
-    /// Try file.edit first, fall back to anchor-based edit on EditNotFound.
+    /// Try file.edit with 3-level fallback: strict → trailing-ws → anchor.
+    /// On final failure, includes file context snippet in the error for LLM recovery.
     fn execute_file_edit_with_fallback(
         &self,
         request: &ToolExecutionRequest,
@@ -1274,23 +1391,152 @@ impl LocalToolExecutor {
         new_string: &str,
         started: Instant,
     ) -> Result<ToolExecutionResult, ToolRuntimeError> {
-        match self.execute_file_edit(request, path, old_string, new_string, started) {
-            Ok(result) => Ok(result),
-            Err(original_err) if original_err.is_edit_not_found() => {
-                let params = AnchorEditParams {
-                    old_content: old_string.to_string(),
-                    new_content: new_string.to_string(),
-                };
-                match self.execute_file_edit_anchor(request, path, &params, started) {
-                    Ok(mut result) => {
-                        result.summary = format!("{} (anchor fallback)", result.summary);
-                        Ok(result)
-                    }
-                    // Anchor also failed — return the original error for better diagnostics
-                    Err(_) => Err(original_err),
-                }
+        // Level 1: strict replace
+        let original_err =
+            match self.execute_file_edit(request, path, old_string, new_string, started) {
+                Ok(result) => return Ok(result),
+                Err(err) if !err.is_edit_not_found() => return Err(err),
+                Err(err) => err,
+            };
+
+        // Level 2: trailing whitespace normalized
+        if let Ok(mut result) =
+            self.execute_file_edit_trailing_ws(request, path, old_string, new_string, started)
+        {
+            result.summary = format!("{} (trailing-ws fallback)", result.summary);
+            return Ok(result);
+        }
+
+        // Level 3: anchor-based (indent-normalized)
+        let params = AnchorEditParams {
+            old_content: old_string.to_string(),
+            new_content: new_string.to_string(),
+        };
+        match self.execute_file_edit_anchor(request, path, &params, started) {
+            Ok(mut result) => {
+                result.summary = format!("{} (anchor fallback)", result.summary);
+                Ok(result)
             }
-            Err(err) => Err(err),
+            // All levels failed — enrich error with file context
+            Err(_) => Err(self.build_edit_not_found_with_context(path, old_string, &original_err)),
+        }
+    }
+
+    /// Level 2 fallback: match after stripping trailing whitespace from each line.
+    fn execute_file_edit_trailing_ws(
+        &self,
+        request: &ToolExecutionRequest,
+        path: &str,
+        old_string: &str,
+        new_string: &str,
+        started: Instant,
+    ) -> Result<ToolExecutionResult, ToolRuntimeError> {
+        let resolved = self.resolve_path(path)?;
+        let content = fs::read_to_string(&resolved).map_err(|err| {
+            ToolRuntimeError::Io(format!(
+                "file.edit failed to read {}: {err}",
+                resolved.display()
+            ))
+        })?;
+
+        let normalize_lines = |s: &str| -> Vec<String> {
+            s.lines().map(|line| line.trim_end().to_string()).collect()
+        };
+
+        let content_lines = normalize_lines(&content);
+        let old_lines = normalize_lines(old_string);
+
+        if old_lines.is_empty() {
+            return Err(ToolRuntimeError::edit_not_found(
+                "file.edit: empty old_string",
+            ));
+        }
+
+        // Find matching line range using trailing-ws-normalized comparison
+        let mut match_positions = Vec::new();
+        for i in 0..content_lines.len() {
+            if i + old_lines.len() > content_lines.len() {
+                break;
+            }
+            if content_lines[i..i + old_lines.len()] == old_lines[..] {
+                match_positions.push(i);
+            }
+        }
+
+        if match_positions.len() != 1 {
+            return Err(ToolRuntimeError::edit_not_found(format!(
+                "file.edit: trailing-ws-normalized old_string {} in {path}",
+                if match_positions.is_empty() {
+                    "not found".to_string()
+                } else {
+                    format!("found {} times", match_positions.len())
+                }
+            )));
+        }
+
+        let match_start = match_positions[0];
+        let match_end = match_start + old_lines.len();
+
+        // Replace the matched line range with new_string
+        let original_lines: Vec<&str> = content.lines().collect();
+        let mut result_parts: Vec<&str> = Vec::new();
+        for (i, line) in original_lines.iter().enumerate() {
+            if i < match_start || i >= match_end {
+                result_parts.push(line);
+            } else if i == match_start {
+                // Insert new_string at match position
+                result_parts.push(new_string);
+            }
+        }
+
+        // Handle trailing newline from original content
+        let new_content = if content.ends_with('\n') {
+            format!("{}\n", result_parts.join("\n"))
+        } else {
+            result_parts.join("\n")
+        };
+
+        fs::write(&resolved, &new_content).map_err(|err| {
+            ToolRuntimeError::Io(format!(
+                "file.edit failed to write {}: {err}",
+                resolved.display()
+            ))
+        })?;
+
+        Ok(build_completed_result(
+            request,
+            path.to_string(),
+            ToolExecutionPayload::None,
+            vec![resolved.display().to_string()],
+            started,
+        ))
+    }
+
+    /// Build an EditNotFound error enriched with file context snippet.
+    /// Skips context for sensitive files (e.g., .env, credentials).
+    fn build_edit_not_found_with_context(
+        &self,
+        path: &str,
+        old_string: &str,
+        original_err: &ToolRuntimeError,
+    ) -> ToolRuntimeError {
+        let message = original_err.to_string();
+
+        // Don't include context for sensitive files
+        if is_sensitive_file(path) {
+            return ToolRuntimeError::edit_not_found(message);
+        }
+
+        // Try to read file content for context extraction
+        let context_snippet = self
+            .resolve_path(path)
+            .ok()
+            .and_then(|resolved| fs::read_to_string(resolved).ok())
+            .and_then(|content| extract_edit_context(&content, old_string, 5));
+
+        match context_snippet {
+            Some(ctx) => ToolRuntimeError::edit_not_found_with_context(message, ctx),
+            None => ToolRuntimeError::edit_not_found(message),
         }
     }
 

--- a/tests/tooling_system.rs
+++ b/tests/tooling_system.rs
@@ -4819,8 +4819,248 @@ fn file_edit_fallback_indent_mismatch() {
 
 #[test]
 fn edit_not_found_error_is_distinguishable() {
-    let err = anvil::tooling::ToolRuntimeError::EditNotFound("test".to_string());
+    let err = anvil::tooling::ToolRuntimeError::edit_not_found("test");
     assert!(err.is_edit_not_found());
+    assert_eq!(err.to_string(), "test");
+
     let io_err = anvil::tooling::ToolRuntimeError::Io("test".to_string());
     assert!(!io_err.is_edit_not_found());
+}
+
+#[test]
+fn edit_not_found_with_context_snippet() {
+    let err = anvil::tooling::ToolRuntimeError::edit_not_found_with_context(
+        "old_string not found in foo.rs",
+        "   5 | fn main() {\n   6 |     println!(\"hello\");\n   7 | }".to_string(),
+    );
+    assert!(err.is_edit_not_found());
+    // Display should only show message, not context
+    assert_eq!(err.to_string(), "old_string not found in foo.rs");
+    // context_snippet should be accessible
+    match &err {
+        anvil::tooling::ToolRuntimeError::EditNotFound {
+            context_snippet, ..
+        } => {
+            assert!(context_snippet.is_some());
+            assert!(context_snippet.as_ref().unwrap().contains("fn main()"));
+        }
+        _ => panic!("expected EditNotFound"),
+    }
+}
+
+#[test]
+fn extract_edit_context_finds_matching_line() {
+    let content = "line 1\nline 2\nfn hello() {\n    println!(\"hi\");\n}\nline 6\nline 7\nline 8\nline 9\nline 10\nline 11";
+    let old_string = "fn hello() {\n    println!(\"world\");\n}";
+    let result = anvil::tooling::extract_edit_context(content, old_string, 2);
+    assert!(
+        result.is_some(),
+        "should find context for partial first-line match"
+    );
+    let ctx = result.unwrap();
+    assert!(
+        ctx.contains("fn hello()"),
+        "context should contain matching line"
+    );
+    assert!(
+        ctx.contains("println!"),
+        "context should contain nearby lines"
+    );
+}
+
+#[test]
+fn extract_edit_context_returns_none_for_no_match() {
+    let content = "line 1\nline 2\nline 3";
+    let old_string = "nonexistent function";
+    let result = anvil::tooling::extract_edit_context(content, old_string, 5);
+    assert!(result.is_none());
+}
+
+#[test]
+fn extract_edit_context_returns_none_for_empty_old_string() {
+    let content = "line 1\nline 2";
+    let result = anvil::tooling::extract_edit_context(content, "", 5);
+    assert!(result.is_none());
+}
+
+#[test]
+fn extract_edit_context_respects_line_count() {
+    let content = (1..=20)
+        .map(|i| format!("line {i}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let old_string = "line 10";
+    let result = anvil::tooling::extract_edit_context(&content, old_string, 2);
+    let ctx = result.unwrap();
+    let lines: Vec<&str> = ctx.lines().collect();
+    // Should have at most 5 lines (2 before + match + 2 after)
+    assert!(
+        lines.len() <= 5,
+        "context should be limited, got {} lines",
+        lines.len()
+    );
+}
+
+#[test]
+fn edit_fallback_includes_context_on_failure() {
+    let root = std::env::temp_dir().join("anvil_edit_ctx_test");
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(&root).unwrap();
+    fs::write(
+        root.join("test.rs"),
+        "fn main() {\n    println!(\"hello\");\n}\n\nfn other() {\n    return 42;\n}\n",
+    )
+    .unwrap();
+
+    let mut executor = LocalToolExecutor::new_without_rate_limit(root.clone());
+    let err = executor
+        .execute(ToolExecutionRequest {
+            tool_call_id: "ctx_001".to_string(),
+            spec: build_registry()
+                .get("file.edit")
+                .expect("file.edit spec")
+                .clone(),
+            input: ToolInput::FileEdit {
+                path: "./test.rs".to_string(),
+                // First line matches "fn main()" but second line differs
+                old_string: "fn main() {\n    let x = wrong;\n}".to_string(),
+                new_string: "fn main() {\n    let x = correct;\n}".to_string(),
+            },
+        })
+        .unwrap_err();
+    assert!(err.is_edit_not_found());
+    match &err {
+        anvil::tooling::ToolRuntimeError::EditNotFound {
+            context_snippet, ..
+        } => {
+            assert!(
+                context_snippet.is_some(),
+                "should include context for non-sensitive file"
+            );
+            let ctx = context_snippet.as_ref().unwrap();
+            assert!(ctx.contains("println!"), "context should show nearby code");
+        }
+        _ => panic!("expected EditNotFound"),
+    }
+    let _ = fs::remove_dir_all(&root);
+}
+
+#[test]
+fn edit_fallback_no_context_for_sensitive_file() {
+    let root = std::env::temp_dir().join("anvil_edit_sensitive_test");
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(&root).unwrap();
+    fs::write(
+        root.join(".env"),
+        "SECRET_KEY=abc123\nDB_PASSWORD=hunter2\n",
+    )
+    .unwrap();
+
+    let mut executor = LocalToolExecutor::new_without_rate_limit(root.clone());
+    let err = executor
+        .execute(ToolExecutionRequest {
+            tool_call_id: "ctx_002".to_string(),
+            spec: build_registry()
+                .get("file.edit")
+                .expect("file.edit spec")
+                .clone(),
+            input: ToolInput::FileEdit {
+                path: "./.env".to_string(),
+                old_string: "NONEXISTENT=value".to_string(),
+                new_string: "REPLACED=value".to_string(),
+            },
+        })
+        .unwrap_err();
+    match &err {
+        anvil::tooling::ToolRuntimeError::EditNotFound {
+            context_snippet, ..
+        } => {
+            assert!(
+                context_snippet.is_none(),
+                "should NOT include context for sensitive file"
+            );
+        }
+        _ => panic!("expected EditNotFound"),
+    }
+    let _ = fs::remove_dir_all(&root);
+}
+
+#[test]
+fn trailing_ws_normalized_match_succeeds() {
+    let root = std::env::temp_dir().join("anvil_trailing_ws_test");
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(&root).unwrap();
+    // File has trailing spaces on some lines
+    fs::write(root.join("test.txt"), "fn hello() {  \n    world()  \n}\n").unwrap();
+
+    let mut executor = LocalToolExecutor::new_without_rate_limit(root.clone());
+    let result = executor
+        .execute(ToolExecutionRequest {
+            tool_call_id: "tw_001".to_string(),
+            spec: build_registry()
+                .get("file.edit")
+                .expect("file.edit spec")
+                .clone(),
+            input: ToolInput::FileEdit {
+                path: "./test.txt".to_string(),
+                // old_string without trailing spaces — should still match
+                old_string: "fn hello() {\n    world()\n}".to_string(),
+                new_string: "fn hello() {\n    universe()\n}".to_string(),
+            },
+        })
+        .expect("trailing-ws normalized edit should succeed");
+
+    assert_eq!(result.status, ToolExecutionStatus::Completed);
+    assert!(
+        result.summary.contains("trailing-ws"),
+        "summary should indicate trailing-ws fallback: {}",
+        result.summary
+    );
+    let content = fs::read_to_string(root.join("test.txt")).unwrap();
+    assert!(
+        content.contains("universe()"),
+        "content should be edited: {content}"
+    );
+    let _ = fs::remove_dir_all(&root);
+}
+
+#[test]
+fn edit_not_found_error_payload_contains_context_but_summary_does_not() {
+    // Verify that when EditNotFound has context_snippet,
+    // the Display (used for summary) does NOT include it
+    let err = anvil::tooling::ToolRuntimeError::edit_not_found_with_context(
+        "file.edit: old_string not found in foo.rs",
+        "   3 | fn main() {".to_string(),
+    );
+    let display = err.to_string();
+    assert!(
+        !display.contains("fn main()"),
+        "Display should NOT contain context"
+    );
+    assert!(
+        display.contains("old_string not found"),
+        "Display should contain the error message"
+    );
+}
+
+#[test]
+fn is_sensitive_file_from_tooling() {
+    assert!(anvil::tooling::is_sensitive_file(".env"));
+    assert!(anvil::tooling::is_sensitive_file("secrets.yaml"));
+    assert!(!anvil::tooling::is_sensitive_file("src/main.rs"));
+}
+
+#[test]
+fn edit_not_found_factory_without_context() {
+    let err = anvil::tooling::ToolRuntimeError::edit_not_found("no match");
+    match &err {
+        anvil::tooling::ToolRuntimeError::EditNotFound {
+            message,
+            context_snippet,
+        } => {
+            assert_eq!(message, "no match");
+            assert!(context_snippet.is_none());
+        }
+        _ => panic!("expected EditNotFound"),
+    }
 }


### PR DESCRIPTION
## Summary
- file.edit 失敗時の3段階フォールバック（コンテキストヒント → anchor → 再試行）
- EditFailTracker によるエラーパターン追跡
- 失敗時の具体的なヒント生成

Closes #143

## Test plan
- [x] cargo test: 全テストパス
- [x] cargo clippy: 警告0件

🤖 Generated with [Claude Code](https://claude.com/claude-code)