### PR TITLE
feat: ANVIL_FINAL の早期発火防止 (#144)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,7 +106,7 @@ src/
 │   └── tag_spec.rs      # ツールタグ仕様テーブル（TOOL_TAG_SPECS）
 ├── app/
 │   ├── mod.rs           # アプリケーションオーケストレータ
-│   ├── agentic.rs       # agenticツール実行ループ
+│   ├── agentic.rs       # agenticツール実行ループ（ANVIL_FINALガード・再試行ロジック含む）
 │   ├── cli.rs           # CLI入力ループ
 │   ├── context.rs       # コンテキスト注入（@file展開・サンドボックス検証）
 │   ├── plan.rs          # プラン管理

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -652,6 +652,9 @@ const PROMPT_TOOL_RULES: &str = concat!(
     "- Do not use any other tool syntax.\n",
     "- Always include ANVIL_FINAL after your tool blocks.\n",
     "- If no file operations are needed, just respond normally without tool blocks.\n",
+    "- When the user's request requires file changes (implement, fix, create, modify, etc.), \
+       you must complete the actual file modifications using file.write/file.edit, \
+       not just output a plan or description.\n",
     "- Start exploration with file.read on \".\" to list the project root before reading specific files.\n",
     "- Do not assume files like README.md exist — verify first.\n",
     "- For dev servers and watch processes (npm run dev, cargo watch, etc.), use background execution with '&' so the command returns immediately.\n",

--- a/src/agent/subagent.rs
+++ b/src/agent/subagent.rs
@@ -491,6 +491,9 @@ impl<'a, C: ProviderClient> SubAgentSession<'a, C> {
         ));
 
         // If no tool calls, this is the final response
+        // Note: ANVIL_FINAL file-modification guard is NOT applied to sub-agents.
+        // Sub-agents (Explore/Plan) are read-only and not expected to modify files.
+        // The guard is only enforced in the main agent loop (src/app/agentic.rs).
         if structured.tool_calls.is_empty() {
             let tokens = crate::contracts::tokens::estimate_tokens(
                 &token_buffer,

--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -148,6 +148,14 @@ fn execute_parallel_group_standalone(
     all_results
 }
 
+/// Maximum number of ANVIL_FINAL guard retries (no-file-modification detection).
+const MAX_FINAL_GUARD_RETRIES: u8 = 1;
+
+/// Message sent to LLM when ANVIL_FINAL fires without file modifications.
+const FINAL_GUARD_RETRY_MESSAGE: &str = "No file modifications detected (file.write/file.edit not called). \
+     Please implement the changes rather than just planning them. \
+     Use file.write or file.edit to make the necessary code changes.";
+
 /// Maximum number of sub-agent calls allowed in a single turn (SR4-006).
 const MAX_SUBAGENT_CALLS_PER_TURN: usize = 3;
 
@@ -248,6 +256,25 @@ impl App {
         (agent_results, normal_calls)
     }
 
+    /// Check if the ANVIL_FINAL guard should activate.
+    /// Returns true if no file modifications were detected and retries remain.
+    fn should_activate_final_guard(&self, retries: u8) -> bool {
+        retries < MAX_FINAL_GUARD_RETRIES && self.session.working_memory.touched_files.is_empty()
+    }
+
+    /// Inject a retry message into the session to prompt the LLM for actual implementation.
+    /// See also: PROMPT_TOOL_RULES in src/agent/mod.rs for preventive guidance.
+    fn inject_final_guard_retry(&mut self) {
+        tracing::warn!("ANVIL_FINAL guard: no file modifications detected, retrying");
+        let retry_msg = SessionMessage::new(
+            MessageRole::Tool,
+            "system",
+            FINAL_GUARD_RETRY_MESSAGE.to_string(),
+        )
+        .with_id(self.next_message_id("tool"));
+        self.session.push_message(retry_msg);
+    }
+
     /// Execute tool calls and feed results back to the LLM in a loop.
     ///
     /// This implements the agentic tool-use loop:
@@ -272,6 +299,7 @@ impl App {
         let mut frames = Vec::new();
         let mut total_tool_count = 0usize;
         let mut all_tool_log_views: Vec<ToolLogView> = Vec::new();
+        let mut final_guard_retries: u8 = 0;
 
         for iteration in 0..max_iterations {
             // Check shutdown flag before tool execution
@@ -435,6 +463,13 @@ impl App {
                 };
 
             if next_structured.tool_calls.is_empty() {
+                // ANVIL_FINAL guard: check if any file modifications were made
+                if self.should_activate_final_guard(final_guard_retries) {
+                    self.inject_final_guard_retry();
+                    final_guard_retries += 1;
+                    current = next_structured;
+                    continue;
+                }
                 // No more tool calls — this is the final answer
                 self.record_assistant_output(
                     self.next_message_id("assistant"),
@@ -974,6 +1009,123 @@ impl App {
         self.session.push_message(msg);
     }
 
+    /// Execute a single retry LLM turn after ANVIL_FINAL guard activation.
+    /// This is a simplified version of the agentic loop that processes exactly one LLM response.
+    /// After the retry, the response is accepted unconditionally (no further guard check).
+    ///
+    /// CB-005: The stream callback only processes `TokenDelta` events, consistent
+    /// with `complete_structured_response`. `ProviderEvent::Agent(Done)` is not
+    /// handled here because the retry response is parsed from the accumulated
+    /// token buffer directly (the same pattern used by the main agentic loop).
+    #[allow(clippy::too_many_arguments)]
+    fn run_guarded_retry_turn<C: ProviderClient>(
+        &mut self,
+        status: &str,
+        saved_status: &str,
+        elapsed_ms: u128,
+        inference_performance: Option<crate::contracts::InferencePerformanceView>,
+        tui: &Tui,
+        provider_client: &C,
+    ) -> Result<Vec<String>, AppError> {
+        // Build request and call LLM for one more turn
+        let system_prompt = self.build_dynamic_system_prompt();
+        let request = BasicAgentLoop::build_turn_request(
+            self.effective_model().to_string(),
+            &self.session,
+            self.provider.capabilities.streaming && self.config.runtime.stream,
+            self.effective_context_window(),
+            &system_prompt,
+        );
+
+        let spinner = Spinner::start(
+            format!("ANVIL_FINAL guard retry. model={}", self.effective_model()),
+            self.config.mode.interactive,
+        );
+
+        let mut token_buffer = String::new();
+        let mut first_token = true;
+        let mut spinner_opt = Some(spinner);
+
+        let stream_result = provider_client.stream_turn(&request, &mut |event| {
+            if let Some(s) = spinner_opt.take() {
+                s.stop();
+            }
+            if let ProviderEvent::TokenDelta(delta) = &event {
+                token_buffer.push_str(delta);
+                if first_token {
+                    first_token = false;
+                }
+                let _ = std::io::Write::write_fmt(&mut std::io::stderr(), format_args!("{delta}"));
+                let _ = std::io::Write::flush(&mut std::io::stderr());
+            }
+        });
+
+        if let Some(s) = spinner_opt.take() {
+            s.stop();
+        }
+        if !first_token {
+            let _ = std::io::Write::write_fmt(&mut std::io::stderr(), format_args!("\n"));
+        }
+
+        stream_result.map_err(|err| match err {
+            crate::provider::ProviderTurnError::Cancelled => {
+                AppError::ToolExecution("guarded retry cancelled".to_string())
+            }
+            other => AppError::ToolExecution(format!("guarded retry failed: {other}")),
+        })?;
+
+        // Parse the retry response
+        let retry_structured = match BasicAgentLoop::parse_structured_response(&token_buffer) {
+            Ok(parsed) => parsed,
+            Err(_) => {
+                let trimmed = token_buffer.trim();
+                StructuredAssistantResponse {
+                    tool_calls: Vec::new(),
+                    final_response: if trimmed.is_empty() {
+                        "Guard retry produced empty response.".to_string()
+                    } else {
+                        trimmed.to_string()
+                    },
+                }
+            }
+        };
+
+        // If response has tool_calls, delegate to complete_structured_response
+        if !retry_structured.tool_calls.is_empty() {
+            return self.complete_structured_response(
+                retry_structured,
+                status,
+                saved_status,
+                elapsed_ms,
+                inference_performance,
+                tui,
+                provider_client,
+            );
+        }
+
+        // No tool calls — accept as final answer (no further guard check)
+        self.record_assistant_output(
+            self.next_message_id("assistant"),
+            retry_structured.final_response,
+        )?;
+
+        // Transition to Done
+        let mut done = AppStateSnapshot::new(RuntimeState::Done)
+            .with_status(status.to_string())
+            .with_completion_summary(
+                format!("Guard retry completed. {saved_status}"),
+                saved_status.to_string(),
+            )
+            .with_elapsed_ms(elapsed_ms);
+        if let Some(perf) = inference_performance {
+            done = done.with_inference_performance(perf);
+        }
+        let mut done_snapshot = self.transition_with_context(done, StateTransition::Finish)?;
+        self.evaluate_context_warning(&mut done_snapshot);
+        let frames = vec![self.render_console(tui)?];
+        Ok(frames)
+    }
+
     pub(crate) fn handle_structured_done<C: ProviderClient>(
         &mut self,
         event: &crate::agent::AgentEvent,
@@ -996,6 +1148,32 @@ impl App {
         let structured = BasicAgentLoop::parse_structured_response(assistant_message)
             .map_err(AppError::ToolExecution)?;
         if structured.tool_calls.is_empty() {
+            // ANVIL_FINAL guard: only activate when the message contains a
+            // structured ANVIL_FINAL block (not plain-text Done messages).
+            // Inject retry message and re-invoke LLM directly (not via
+            // complete_structured_response, which would wastefully execute the
+            // empty tool_calls pipeline).
+            //
+            // CB-002: Retry count is always 0 here because this path handles
+            // the first-turn Done event (before any agentic loop iteration).
+            // MAX_FINAL_GUARD_RETRIES = 1 ensures at most one retry, so the
+            // hardcoded 0 is correct and sufficient for the current design.
+            if BasicAgentLoop::is_complete_structured_response(assistant_message)
+                && self.should_activate_final_guard(0)
+            {
+                self.inject_final_guard_retry();
+                // Record the assistant message that triggered the guard
+                self.record_assistant_output(self.next_message_id("assistant"), assistant_message)?;
+                // Re-invoke LLM and process the response
+                return Ok(Some(self.run_guarded_retry_turn(
+                    status,
+                    saved_status,
+                    *elapsed_ms,
+                    inference_performance.clone(),
+                    tui,
+                    provider_client,
+                )?));
+            }
             return Ok(None);
         }
 

--- a/tests/provider_integration.rs
+++ b/tests/provider_integration.rs
@@ -1218,11 +1218,13 @@ fn agentic_loop_multi_iteration_tool_calls_then_final_answer() {
         .expect("multi-iteration agentic loop should succeed");
 
     let requests = seen_requests.borrow();
-    // Should have made 3 calls: initial + 2 follow-ups
+    // Should have made 4 calls: initial + 2 follow-ups + 1 ANVIL_FINAL guard retry
+    // (file.read only, no file.write/file.edit => guard fires once on the plain-text
+    // final answer, then accepts the retry response unconditionally)
     assert_eq!(
         requests.len(),
-        3,
-        "expected 3 provider calls for multi-iteration loop"
+        4,
+        "expected 4 provider calls for multi-iteration loop (includes guard retry)"
     );
 
     // Final frame should show Done state
@@ -3332,4 +3334,307 @@ fn session_record_deserialization_with_used_tools() {
     assert_eq!(record.used_tools.len(), 2);
     assert!(record.used_tools.contains("web.fetch"));
     assert!(record.used_tools.contains("agent.explore"));
+}
+
+// ---------------------------------------------------------------------------
+// ANVIL_FINAL guard tests (Issue #144)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn anvil_final_guard_fires_when_no_file_modifications_detected() {
+    // Scenario: LLM outputs ANVIL_FINAL with file.read only (no file.write/edit).
+    // Guard should fire once, causing an extra LLM call, then accept.
+    let root = common::unique_test_dir("guard_fire");
+    let mut config = common::build_config_in(root.clone());
+    config.mode.approval_required = false;
+    let provider_ctx =
+        anvil::provider::ProviderRuntimeContext::bootstrap(&config).expect("provider bootstrap");
+    let mut app = anvil::app::App::new(
+        config,
+        provider_ctx,
+        std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+    )
+    .expect("app should initialize");
+    let tui = Tui::new();
+
+    std::fs::create_dir_all(root.join("src")).expect("create src dir");
+    std::fs::write(root.join("src/main.rs"), "fn main() {}").expect("write main.rs");
+
+    let seen_requests = Rc::new(RefCell::new(Vec::new()));
+
+    struct GuardFireProvider {
+        seen_requests: Rc<RefCell<Vec<ProviderTurnRequest>>>,
+    }
+
+    impl ProviderClient for GuardFireProvider {
+        fn stream_turn(
+            &self,
+            request: &ProviderTurnRequest,
+            emit: &mut dyn FnMut(ProviderEvent),
+        ) -> Result<(), ProviderTurnError> {
+            let call_index = self.seen_requests.borrow().len();
+            self.seen_requests.borrow_mut().push(request.clone());
+
+            match call_index {
+                0 => {
+                    // Initial: file.read only + ANVIL_FINAL
+                    emit(ProviderEvent::Agent(AgentEvent::Done {
+                        status: "Done. session saved".to_string(),
+                        assistant_message: concat!(
+                            "```ANVIL_TOOL\n",
+                            "{\"id\":\"call_001\",\"tool\":\"file.read\",\"path\":\"./src/main.rs\"}\n",
+                            "```\n",
+                            "```ANVIL_FINAL\n",
+                            "Read the source file.\n",
+                            "```\n"
+                        )
+                        .to_string(),
+                        completion_summary: "turn 1".to_string(),
+                        saved_status: "session saved".to_string(),
+                        tool_logs: Vec::new(),
+                        elapsed_ms: 0,
+                        inference_performance: None,
+                    }));
+                }
+                1 => {
+                    // Agentic follow-up after file.read: plain text final answer
+                    // (no more tool calls, guard will fire)
+                    emit(ProviderEvent::TokenDelta(
+                        "Here is my plan to improve the code.".to_string(),
+                    ));
+                }
+                _ => {
+                    // Guard retry: accept unconditionally
+                    emit(ProviderEvent::TokenDelta(
+                        "Actually, no changes needed.".to_string(),
+                    ));
+                }
+            }
+            Ok(())
+        }
+    }
+
+    let provider = GuardFireProvider {
+        seen_requests: seen_requests.clone(),
+    };
+
+    let _frames = app
+        .run_live_turn("improve the code", &provider, &tui)
+        .expect("guard fire scenario should succeed");
+
+    let requests = seen_requests.borrow();
+    // Initial call + agentic follow-up + guard retry = 3 calls
+    assert_eq!(
+        requests.len(),
+        3,
+        "expected 3 provider calls: initial + follow-up + guard retry"
+    );
+
+    // Verify the guard retry message was injected into the session
+    assert!(
+        app.session()
+            .messages
+            .iter()
+            .any(|m| m.content.contains("No file modifications detected")),
+        "guard retry message should be in session"
+    );
+}
+
+#[test]
+fn anvil_final_guard_does_not_fire_when_file_write_was_executed() {
+    // Scenario: LLM writes a file, then outputs ANVIL_FINAL.
+    // Guard should NOT fire because touched_files is non-empty.
+    let root = common::unique_test_dir("guard_skip");
+    let mut config = common::build_config_in(root.clone());
+    config.mode.approval_required = false;
+    let provider_ctx =
+        anvil::provider::ProviderRuntimeContext::bootstrap(&config).expect("provider bootstrap");
+    let mut app = anvil::app::App::new(
+        config,
+        provider_ctx,
+        std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+    )
+    .expect("app should initialize");
+    let tui = Tui::new();
+
+    let seen_requests = Rc::new(RefCell::new(Vec::new()));
+
+    let provider = RecordingProvider {
+        seen_requests: seen_requests.clone(),
+        events: vec![ProviderEvent::Agent(AgentEvent::Done {
+            status: "Done. session saved".to_string(),
+            assistant_message: concat!(
+                "```ANVIL_TOOL\n",
+                "{\"id\":\"call_001\",\"tool\":\"file.write\",\"path\":\"./output.txt\",\"content\":\"hello world\"}\n",
+                "```\n",
+                "```ANVIL_FINAL\n",
+                "Created output.txt with the requested content.\n",
+                "```\n"
+            )
+            .to_string(),
+            completion_summary: "turn 1".to_string(),
+            saved_status: "session saved".to_string(),
+            tool_logs: Vec::new(),
+            elapsed_ms: 0,
+            inference_performance: None,
+        })],
+        followup_events: vec![ProviderEvent::TokenDelta(
+            "All done.".to_string(),
+        )],
+        error: None,
+    };
+
+    let _frames = app
+        .run_live_turn("create a file", &provider, &tui)
+        .expect("file write scenario should succeed");
+
+    let requests = seen_requests.borrow();
+    // Initial call + 1 follow-up (no guard retry since file was written)
+    assert_eq!(
+        requests.len(),
+        2,
+        "expected 2 provider calls: initial + follow-up (no guard retry)"
+    );
+
+    // Verify guard retry message was NOT injected
+    assert!(
+        !app.session()
+            .messages
+            .iter()
+            .any(|m| m.content.contains("No file modifications detected")),
+        "guard retry message should NOT be in session when file was written"
+    );
+
+    // Verify the file was actually written
+    let content =
+        std::fs::read_to_string(root.join("output.txt")).expect("output.txt should exist");
+    assert!(content.contains("hello world"));
+}
+
+#[test]
+fn anvil_final_guard_handle_structured_done_fires_for_plan_only_response() {
+    // Scenario: Done event with ANVIL_FINAL but no tool calls (plan only).
+    // Guard should fire via handle_structured_done path.
+    let root = common::unique_test_dir("guard_done_path");
+    let mut config = common::build_config_in(root.clone());
+    config.mode.approval_required = false;
+    let provider_ctx =
+        anvil::provider::ProviderRuntimeContext::bootstrap(&config).expect("provider bootstrap");
+    let mut app = anvil::app::App::new(
+        config,
+        provider_ctx,
+        std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+    )
+    .expect("app should initialize");
+    let tui = Tui::new();
+
+    let seen_requests = Rc::new(RefCell::new(Vec::new()));
+
+    struct GuardDoneProvider {
+        seen_requests: Rc<RefCell<Vec<ProviderTurnRequest>>>,
+    }
+
+    impl ProviderClient for GuardDoneProvider {
+        fn stream_turn(
+            &self,
+            request: &ProviderTurnRequest,
+            emit: &mut dyn FnMut(ProviderEvent),
+        ) -> Result<(), ProviderTurnError> {
+            let call_index = self.seen_requests.borrow().len();
+            self.seen_requests.borrow_mut().push(request.clone());
+
+            match call_index {
+                0 => {
+                    // Done event with ANVIL_FINAL but NO tool calls (plan-only)
+                    emit(ProviderEvent::Agent(AgentEvent::Done {
+                        status: "Done. session saved".to_string(),
+                        assistant_message: concat!(
+                            "```ANVIL_FINAL\n",
+                            "Here is my plan:\n1. Create a new module\n2. Add tests\n",
+                            "```\n"
+                        )
+                        .to_string(),
+                        completion_summary: "plan only".to_string(),
+                        saved_status: "session saved".to_string(),
+                        tool_logs: Vec::new(),
+                        elapsed_ms: 100,
+                        inference_performance: None,
+                    }));
+                }
+                _ => {
+                    // Guard retry: LLM responds with plain text
+                    emit(ProviderEvent::TokenDelta(
+                        "I apologize, let me implement the changes now.".to_string(),
+                    ));
+                }
+            }
+            Ok(())
+        }
+    }
+
+    let provider = GuardDoneProvider {
+        seen_requests: seen_requests.clone(),
+    };
+
+    let _frames = app
+        .run_live_turn("implement the feature", &provider, &tui)
+        .expect("guard done path should succeed");
+
+    let requests = seen_requests.borrow();
+    // Initial call + guard retry = 2 calls
+    assert_eq!(
+        requests.len(),
+        2,
+        "expected 2 provider calls: initial + guard retry via handle_structured_done"
+    );
+
+    // Verify the guard retry message was injected
+    assert!(
+        app.session()
+            .messages
+            .iter()
+            .any(|m| m.content.contains("No file modifications detected")),
+        "guard retry message should be in session"
+    );
+}
+
+#[test]
+fn anvil_final_guard_prompt_tool_rules_contains_implementation_guidance() {
+    // Verify that the system prompt includes the implementation guidance text
+    let app = common::build_app();
+    let tui = Tui::new();
+    let seen_requests = Rc::new(RefCell::new(Vec::new()));
+    let provider = RecordingProvider {
+        seen_requests: seen_requests.clone(),
+        events: vec![
+            ProviderEvent::Agent(AgentEvent::Thinking {
+                status: "Thinking".to_string(),
+                plan_items: vec![],
+                active_index: None,
+                reasoning_summary: vec![],
+                elapsed_ms: 0,
+            }),
+            ProviderEvent::Agent(AgentEvent::Done {
+                status: "Done. session saved".to_string(),
+                assistant_message: "ok".to_string(),
+                completion_summary: "done".to_string(),
+                saved_status: "session saved".to_string(),
+                tool_logs: Vec::new(),
+                elapsed_ms: 0,
+                inference_performance: None,
+            }),
+        ],
+        followup_events: Vec::new(),
+        error: None,
+    };
+
+    let mut app = app;
+    let _ = app.run_live_turn("test", &provider, &tui);
+
+    let requests = seen_requests.borrow();
+    let system_prompt = &requests[0].messages[0].content;
+    assert!(
+        system_prompt.contains("you must complete the actual file modifications"),
+        "system prompt should contain implementation guidance from PROMPT_TOOL_RULES"
+    );
 }


### PR DESCRIPTION
## Summary
- ANVIL_FINAL 出力前にファイル変更の有無をチェックするガードを追加
- plan-only 出力（実装なし）の早期発火を防止

Closes #144

## Test plan
- [x] cargo test: 全テストパス
- [x] cargo clippy: 警告0件

🤖 Generated with [Claude Code](https://claude.com/claude-code)