### PR TITLE
feat: 反復ループの検出と自己修正 (#145)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,7 @@ src/
 │   ├── agentic.rs       # agenticツール実行ループ
 │   ├── cli.rs           # CLI入力ループ
 │   ├── context.rs       # コンテキスト注入（@file展開・サンドボックス検証）
+│   ├── loop_detector.rs # ループ検出（リングバッファ・段階的対応）
 │   ├── plan.rs          # プラン管理
 │   ├── policy.rs        # offlineポリシーチェック（共通ヘルパー）
 │   ├── render.rs        # コンソール描画
@@ -153,6 +154,7 @@ tests/
 ├── tui_console.rs       # TUIテスト
 ├── skills_system.rs     # スキルシステムテスト
 ├── hooks_system.rs      # フックシステムテスト
+├── loop_detection.rs    # ループ検出テスト
 ├── context_inject.rs    # コンテキスト注入テスト
 └── walk_system.rs       # ディレクトリウォーカーテスト
 ```

--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -273,6 +273,9 @@ impl App {
         let mut total_tool_count = 0usize;
         let mut all_tool_log_views: Vec<ToolLogView> = Vec::new();
 
+        // Reset loop detector at the start of each top-level turn (Issue #145)
+        self.loop_detector.reset();
+
         for iteration in 0..max_iterations {
             // Check shutdown flag before tool execution
             if self.is_shutdown_requested() {
@@ -318,7 +321,7 @@ impl App {
             // live streaming output on stderr (Issue #1).
 
             // Execute normal tool calls and record results WITH payload
-            let results = self.execute_structured_tool_calls(&current_normal)?;
+            let (results, loop_action) = self.execute_structured_tool_calls(&current_normal)?;
             total_tool_count += results.len();
 
             let tool_log_views: Vec<ToolLogView> = results
@@ -337,6 +340,13 @@ impl App {
             let _ = self.transition_with_context(working, StateTransition::StartWorking)?;
             // Skip intermediate Working frames — tool execution output
             // is already shown on stderr (Issue #1).
+
+            // Handle loop detection Break action (Issue #145)
+            // Results are already recorded and visible above; now terminate the loop.
+            if let Some(super::loop_detector::LoopAction::Break(ref msg)) = loop_action {
+                tracing::warn!(reason = "loop_detected", message = %msg, "agentic loop terminated by loop detector");
+                break;
+            }
 
             // Check shutdown flag before LLM call
             if self.is_shutdown_requested() {
@@ -660,7 +670,13 @@ impl App {
     pub(crate) fn execute_structured_tool_calls(
         &mut self,
         structured: &StructuredAssistantResponse,
-    ) -> Result<Vec<ToolExecutionResult>, AppError> {
+    ) -> Result<
+        (
+            Vec<ToolExecutionResult>,
+            Option<super::loop_detector::LoopAction>,
+        ),
+        AppError,
+    > {
         // Phase 1: Validation + Approval
         let (validated_requests, mut failed_results) =
             self.validate_and_approve_all(&structured.tool_calls);
@@ -733,6 +749,58 @@ impl App {
             remaining
         } else {
             validated_requests
+        };
+
+        // Loop detection: record each validated tool call and check for repetition (Issue #145)
+        let mut worst_loop_action: Option<super::loop_detector::LoopAction> = None;
+        for (_, req) in &validated_requests {
+            if let Some((tool_name, tool_input)) = tool_input_map.get(&req.tool_call_id) {
+                let action = self.loop_detector.record_and_check(tool_name, tool_input);
+                worst_loop_action = match (&worst_loop_action, &action) {
+                    (_, super::loop_detector::LoopAction::Continue) => worst_loop_action,
+                    (None, _) => Some(action),
+                    (Some(super::loop_detector::LoopAction::Continue), _) => Some(action),
+                    (
+                        Some(super::loop_detector::LoopAction::Warn(_)),
+                        super::loop_detector::LoopAction::StrongWarn(_)
+                        | super::loop_detector::LoopAction::Break(_),
+                    ) => Some(action),
+                    (
+                        Some(super::loop_detector::LoopAction::StrongWarn(_)),
+                        super::loop_detector::LoopAction::Break(_),
+                    ) => Some(action),
+                    _ => worst_loop_action,
+                };
+            }
+        }
+
+        // If Break: skip tool execution entirely
+        if matches!(
+            worst_loop_action,
+            Some(super::loop_detector::LoopAction::Break(_))
+        ) {
+            // Return failed results with the Break action
+            failed_results.sort_by_key(|(idx, _)| *idx);
+            let results: Vec<ToolExecutionResult> =
+                failed_results.into_iter().map(|(_, r)| r).collect();
+            return Ok((results, worst_loop_action));
+        }
+
+        // For Warn/StrongWarn: create synthetic tool result to include in results
+        let synthetic_warning = match &worst_loop_action {
+            Some(super::loop_detector::LoopAction::Warn(msg))
+            | Some(super::loop_detector::LoopAction::StrongWarn(msg)) => {
+                Some(ToolExecutionResult {
+                    tool_call_id: "loop_detector_warning".to_string(),
+                    tool_name: "system.loop_detector".to_string(),
+                    status: ToolExecutionStatus::Completed,
+                    summary: msg.clone(),
+                    payload: ToolExecutionPayload::Text(msg.clone()),
+                    artifacts: vec![],
+                    elapsed_ms: 0,
+                })
+            }
+            _ => None,
         };
 
         // Phase 2: Grouping
@@ -918,8 +986,14 @@ impl App {
             results.push(result);
         }
 
+        // Append synthetic loop detection warning if present
+        if let Some(warning_result) = synthetic_warning {
+            self.record_tool_result(&warning_result);
+            results.push(warning_result);
+        }
+
         self.persist_session(crate::contracts::AppEvent::SessionSaved)?;
-        Ok(results)
+        Ok((results, worst_loop_action))
     }
 
     /// Push a tool execution result into the session as a tool message.

--- a/src/app/loop_detector.rs
+++ b/src/app/loop_detector.rs
@@ -1,0 +1,150 @@
+//! Loop detection for the agentic tool-use loop (Issue #145).
+//!
+//! Detects repeated identical tool calls using a ring-buffer of fingerprints
+//! and responds with escalating actions: Warn → StrongWarn → Break.
+
+use std::collections::VecDeque;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+
+/// Ring buffer maximum size (fixed for Phase 1).
+pub const DEFAULT_MAX_HISTORY: usize = 20;
+
+/// Action to take based on loop detection results.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LoopAction {
+    /// No loop detected, continue normally.
+    Continue,
+    /// First detection: warning message inserted as synthetic tool result.
+    Warn(String),
+    /// Second detection: strong warning message.
+    StrongWarn(String),
+    /// Third detection: terminate the agentic loop.
+    Break(String),
+}
+
+/// Detects repeated identical tool calls within the agentic loop.
+pub struct LoopDetector {
+    /// Recent tool call fingerprints: (tool_name, input_hash).
+    history: VecDeque<(String, u64)>,
+    /// Maximum ring buffer size.
+    max_history: usize,
+    /// Number of identical consecutive calls before detection triggers.
+    threshold: usize,
+    /// Current escalation level (number of times detection has triggered).
+    escalation_count: usize,
+}
+
+/// Compute a deterministic fingerprint from tool name and input JSON.
+///
+/// Uses `DefaultHasher` for simplicity. The same tool_name + input_json
+/// combination always produces the same hash value within a single process.
+pub fn fingerprint(tool_name: &str, input_json: &serde_json::Value) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    tool_name.hash(&mut hasher);
+    if let Ok(s) = serde_json::to_string(input_json) {
+        s.hash(&mut hasher);
+    }
+    hasher.finish()
+}
+
+impl LoopDetector {
+    /// Create a new LoopDetector with the given threshold.
+    ///
+    /// # Panics
+    /// Panics if `threshold < 2` or `threshold > DEFAULT_MAX_HISTORY`.
+    pub fn new(threshold: usize) -> Self {
+        assert!(
+            (2..=DEFAULT_MAX_HISTORY).contains(&threshold),
+            "threshold must be in 2..={DEFAULT_MAX_HISTORY}, got {threshold}"
+        );
+        Self {
+            history: VecDeque::with_capacity(DEFAULT_MAX_HISTORY),
+            max_history: DEFAULT_MAX_HISTORY,
+            threshold,
+            escalation_count: 0,
+        }
+    }
+
+    /// Reset all state. Called at the start of each `complete_structured_response()` turn.
+    pub fn reset(&mut self) {
+        self.history.clear();
+        self.escalation_count = 0;
+    }
+
+    /// Record a tool call and check for loop patterns.
+    ///
+    /// This is the only public API that `agentic.rs` calls.
+    pub fn record_and_check(
+        &mut self,
+        tool_name: &str,
+        input_json: &serde_json::Value,
+    ) -> LoopAction {
+        let hash = fingerprint(tool_name, input_json);
+        self.record(tool_name.to_string(), hash);
+        self.check()
+    }
+
+    /// Append a fingerprint to the ring buffer, evicting oldest if full.
+    fn record(&mut self, tool_name: String, hash: u64) {
+        if self.history.len() >= self.max_history {
+            self.history.pop_front();
+        }
+        self.history.push_back((tool_name, hash));
+    }
+
+    /// Check the tail of the history for repeated identical fingerprints.
+    fn check(&mut self) -> LoopAction {
+        if self.history.len() < self.threshold {
+            return LoopAction::Continue;
+        }
+
+        // Check if the last `threshold` entries all share the same fingerprint.
+        let len = self.history.len();
+        let tail_start = len - self.threshold;
+        let (ref last_name, last_hash) = self.history[len - 1];
+
+        let all_same = self
+            .history
+            .iter()
+            .skip(tail_start)
+            .all(|(name, hash)| name == last_name && *hash == last_hash);
+
+        if !all_same {
+            return LoopAction::Continue;
+        }
+
+        self.escalation_count += 1;
+
+        match self.escalation_count {
+            1 => LoopAction::Warn(format!(
+                "[Loop Detection] The same tool call '{}' has been repeated {} times consecutively. \
+                 Consider trying a different approach or tool.",
+                last_name, self.threshold
+            )),
+            2 => LoopAction::StrongWarn(format!(
+                "[Loop Detection - WARNING] Tool '{}' is being called repeatedly with identical arguments. \
+                 You MUST change your approach immediately. Try a completely different strategy.",
+                last_name
+            )),
+            _ => LoopAction::Break(format!(
+                "[Loop Detection - TERMINATED] Agentic loop terminated due to repeated identical calls to '{}'. \
+                 The loop has been stopped to prevent infinite repetition.",
+                last_name
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fingerprint_is_deterministic() {
+        let val = serde_json::json!({"path": "src/main.rs"});
+        let h1 = fingerprint("file.read", &val);
+        let h2 = fingerprint("file.read", &val);
+        assert_eq!(h1, h2);
+    }
+}

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -6,6 +6,7 @@
 pub mod agentic;
 pub mod cli;
 mod context;
+pub mod loop_detector;
 pub mod mock;
 pub mod plan;
 pub mod policy;
@@ -123,6 +124,8 @@ pub struct App {
     warning_tracker: ContextWarningTracker,
     /// Undo checkpoint stack. In-memory only, discarded on session exit.
     checkpoint_stack: CheckpointStack,
+    /// Loop detector for preventing infinite tool call repetitions (Issue #145).
+    loop_detector: loop_detector::LoopDetector,
     /// Hooks engine. `None` when hooks.json is absent or initialization failed.
     /// Declared before mcp_manager to maintain Drop order (DR3-007).
     hooks_engine: Option<crate::hooks::HooksEngine>,
@@ -401,6 +404,8 @@ impl App {
             capability.prompt_tier
         };
 
+        let loop_detection_threshold = config.runtime.loop_detection_threshold;
+
         Ok(Self {
             tools,
             config,
@@ -415,6 +420,7 @@ impl App {
             shutdown_flag,
             warning_tracker: ContextWarningTracker::new(),
             checkpoint_stack: CheckpointStack::new(),
+            loop_detector: loop_detector::LoopDetector::new(loop_detection_threshold),
             hooks_engine,
             mcp_manager,
             current_session_name,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -76,6 +76,8 @@ pub struct RuntimeConfig {
     pub subagent_max_iterations: u32,
     /// Wall-clock timeout in seconds for the entire sub-agent run (Issue #129).
     pub subagent_timeout_secs: u64,
+    /// Loop detection threshold: number of identical tool calls before detection triggers (Issue #145).
+    pub loop_detection_threshold: usize,
 }
 
 #[derive(Debug, Clone)]
@@ -227,6 +229,7 @@ impl EffectiveConfig {
                 smart_compact_threshold_ratio: 0.75,
                 subagent_max_iterations: 10,
                 subagent_timeout_secs: 120,
+                loop_detection_threshold: 3,
             },
             mode: ModeConfig {
                 prompt_source: PromptSource::Interactive,
@@ -324,6 +327,7 @@ impl EffectiveConfig {
             "ANVIL_SMART_COMPACT_THRESHOLD_RATIO",
             "ANVIL_SUBAGENT_MAX_ITERATIONS",
             "ANVIL_SUBAGENT_TIMEOUT",
+            "ANVIL_LOOP_DETECTION_THRESHOLD",
         ] {
             if let Ok(value) = std::env::var(key) {
                 map.insert(key.to_string(), value);
@@ -543,6 +547,15 @@ impl EffectiveConfig {
                         .parse()
                         .map_err(|_| ConfigError::InvalidNumericValue(value.clone()))?;
                 }
+                "loop_detection_threshold" | "ANVIL_LOOP_DETECTION_THRESHOLD" => {
+                    let v: usize = value
+                        .parse()
+                        .map_err(|_| ConfigError::InvalidNumericValue(value.clone()))?;
+                    if !(2..=20).contains(&v) {
+                        return Err(ConfigError::InvalidNumericValue(value.clone()));
+                    }
+                    self.runtime.loop_detection_threshold = v;
+                }
                 _ => {}
             }
         }
@@ -569,6 +582,7 @@ impl EffectiveConfig {
         self.clamp_agent_iterations();
         self.clamp_smart_compact_ratio();
         self.clamp_subagent_settings();
+        self.clamp_loop_detection_threshold();
         Ok(())
     }
 
@@ -674,6 +688,10 @@ impl EffectiveConfig {
                 "Warning: subagent_timeout_secs={old} exceeds maximum ({MAX_SUBAGENT_TIMEOUT_SECS}), adjusted to {MAX_SUBAGENT_TIMEOUT_SECS}"
             );
         }
+    }
+
+    fn clamp_loop_detection_threshold(&mut self) {
+        self.runtime.loop_detection_threshold = self.runtime.loop_detection_threshold.clamp(2, 20);
     }
 
     pub fn validate_for_test(&mut self) -> Result<(), ConfigError> {

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -20,6 +20,7 @@ pub enum TerminationReason {
     Completed,
     Timeout,
     MaxIterations,
+    LoopDetected,
 }
 
 impl std::fmt::Display for TerminationReason {
@@ -28,6 +29,7 @@ impl std::fmt::Display for TerminationReason {
             Self::Completed => write!(f, "completed"),
             Self::Timeout => write!(f, "timeout"),
             Self::MaxIterations => write!(f, "max_iterations"),
+            Self::LoopDetected => write!(f, "loop_detected"),
         }
     }
 }
@@ -733,6 +735,7 @@ mod tests {
             TerminationReason::MaxIterations.to_string(),
             "max_iterations"
         );
+        assert_eq!(TerminationReason::LoopDetected.to_string(), "loop_detected");
     }
 
     #[test]
@@ -741,6 +744,7 @@ mod tests {
             TerminationReason::Completed,
             TerminationReason::Timeout,
             TerminationReason::MaxIterations,
+            TerminationReason::LoopDetected,
         ] {
             let json = serde_json::to_string(&reason).expect("serialize");
             let back: TerminationReason = serde_json::from_str(&json).expect("deserialize");

--- a/tests/loop_detection.rs
+++ b/tests/loop_detection.rs
@@ -1,0 +1,200 @@
+//! Tests for the LoopDetector module (Issue #145).
+
+use anvil::app::loop_detector::{DEFAULT_MAX_HISTORY, LoopAction, LoopDetector, fingerprint};
+
+fn same_input() -> serde_json::Value {
+    serde_json::json!({"path": "src/main.rs"})
+}
+
+#[test]
+fn test_no_detection_below_threshold() {
+    let mut detector = LoopDetector::new(3);
+    // Only 2 calls — below threshold of 3
+    let a1 = detector.record_and_check("file.read", &same_input());
+    let a2 = detector.record_and_check("file.read", &same_input());
+    assert_eq!(a1, LoopAction::Continue);
+    assert_eq!(a2, LoopAction::Continue);
+}
+
+#[test]
+fn test_detection_at_threshold() {
+    let mut detector = LoopDetector::new(3);
+    detector.record_and_check("file.read", &same_input());
+    detector.record_and_check("file.read", &same_input());
+    let action = detector.record_and_check("file.read", &same_input());
+    assert!(
+        matches!(action, LoopAction::Warn(_)),
+        "Expected Warn at threshold, got {:?}",
+        action
+    );
+}
+
+#[test]
+fn test_escalation_to_strong_warn() {
+    let mut detector = LoopDetector::new(3);
+    // First 3: Warn
+    for _ in 0..3 {
+        detector.record_and_check("file.read", &same_input());
+    }
+    // 4th: should still be Continue (not yet threshold again since escalation_count == 1)
+    // Actually after Warn, the next call makes history 4 long, and the tail 3 are still identical
+    let action = detector.record_and_check("file.read", &same_input());
+    assert!(
+        matches!(action, LoopAction::StrongWarn(_)),
+        "Expected StrongWarn, got {:?}",
+        action
+    );
+}
+
+#[test]
+fn test_escalation_to_break() {
+    let mut detector = LoopDetector::new(3);
+    // Calls 1-3: Warn at 3rd
+    for _ in 0..3 {
+        detector.record_and_check("file.read", &same_input());
+    }
+    // Call 4: StrongWarn
+    detector.record_and_check("file.read", &same_input());
+    // Call 5: Break
+    let action = detector.record_and_check("file.read", &same_input());
+    assert!(
+        matches!(action, LoopAction::Break(_)),
+        "Expected Break, got {:?}",
+        action
+    );
+}
+
+#[test]
+fn test_different_tool_names_no_detection() {
+    let mut detector = LoopDetector::new(3);
+    let input = same_input();
+    let a1 = detector.record_and_check("file.read", &input);
+    let a2 = detector.record_and_check("file.write", &input);
+    let a3 = detector.record_and_check("shell.exec", &input);
+    assert_eq!(a1, LoopAction::Continue);
+    assert_eq!(a2, LoopAction::Continue);
+    assert_eq!(a3, LoopAction::Continue);
+}
+
+#[test]
+fn test_same_tool_different_args_no_detection() {
+    let mut detector = LoopDetector::new(3);
+    let a1 = detector.record_and_check("file.read", &serde_json::json!({"path": "a.rs"}));
+    let a2 = detector.record_and_check("file.read", &serde_json::json!({"path": "b.rs"}));
+    let a3 = detector.record_and_check("file.read", &serde_json::json!({"path": "c.rs"}));
+    assert_eq!(a1, LoopAction::Continue);
+    assert_eq!(a2, LoopAction::Continue);
+    assert_eq!(a3, LoopAction::Continue);
+}
+
+#[test]
+fn test_custom_threshold() {
+    let mut detector = LoopDetector::new(5);
+    let input = same_input();
+    // 4 calls: below threshold
+    for _ in 0..4 {
+        let action = detector.record_and_check("file.read", &input);
+        assert_eq!(action, LoopAction::Continue);
+    }
+    // 5th call: detection
+    let action = detector.record_and_check("file.read", &input);
+    assert!(matches!(action, LoopAction::Warn(_)));
+}
+
+#[test]
+fn test_ring_buffer_capacity() {
+    let mut detector = LoopDetector::new(3);
+    let input = same_input();
+    // Fill buffer well beyond max_history
+    for i in 0..DEFAULT_MAX_HISTORY + 5 {
+        let different_input = serde_json::json!({"path": format!("file_{}.rs", i)});
+        detector.record_and_check("file.read", &different_input);
+    }
+    // Now add threshold identical calls — should detect
+    for _ in 0..2 {
+        detector.record_and_check("file.read", &input);
+    }
+    let action = detector.record_and_check("file.read", &input);
+    assert!(
+        matches!(action, LoopAction::Warn(_)),
+        "Expected Warn after ring buffer overflow, got {:?}",
+        action
+    );
+}
+
+#[test]
+fn test_reset_clears_state() {
+    let mut detector = LoopDetector::new(3);
+    let input = same_input();
+    // Build up to detection
+    for _ in 0..3 {
+        detector.record_and_check("file.read", &input);
+    }
+    // Reset
+    detector.reset();
+    // Should be back to clean state
+    for _ in 0..2 {
+        let action = detector.record_and_check("file.read", &input);
+        assert_eq!(action, LoopAction::Continue);
+    }
+    // 3rd call after reset should be Warn (escalation_count reset)
+    let action = detector.record_and_check("file.read", &input);
+    assert!(
+        matches!(action, LoopAction::Warn(_)),
+        "Expected Warn after reset, got {:?}",
+        action
+    );
+}
+
+#[test]
+fn test_fingerprint_deterministic() {
+    let input = serde_json::json!({"path": "src/main.rs", "content": "hello"});
+    let h1 = fingerprint("file.write", &input);
+    let h2 = fingerprint("file.write", &input);
+    assert_eq!(h1, h2, "fingerprint should be deterministic");
+
+    // Different tool name → different hash
+    let h3 = fingerprint("file.read", &input);
+    assert_ne!(
+        h1, h3,
+        "different tool names should produce different hashes"
+    );
+
+    // Different input → different hash
+    let other_input = serde_json::json!({"path": "src/lib.rs"});
+    let h4 = fingerprint("file.write", &other_input);
+    assert_ne!(h1, h4, "different inputs should produce different hashes");
+}
+
+#[test]
+fn test_warning_message_does_not_contain_input() {
+    let mut detector = LoopDetector::new(3);
+    let malicious_input = serde_json::json!({"path": "INJECTED_PAYLOAD_$(evil_command)", "content": "<script>alert(1)</script>"});
+
+    for _ in 0..3 {
+        detector.record_and_check("file.read", &malicious_input);
+    }
+    // The Warn message should contain the tool name but not the raw input
+    // We already consumed the Warn above. Reset and try again to inspect.
+    detector.reset();
+    for _ in 0..2 {
+        detector.record_and_check("file.read", &malicious_input);
+    }
+    let action = detector.record_and_check("file.read", &malicious_input);
+    if let LoopAction::Warn(msg) = action {
+        assert!(
+            !msg.contains("INJECTED_PAYLOAD"),
+            "Warning should not echo untrusted input"
+        );
+        assert!(
+            !msg.contains("<script>"),
+            "Warning should not echo untrusted input"
+        );
+        assert!(
+            msg.contains("file.read"),
+            "Warning should contain the tool name"
+        );
+    } else {
+        panic!("Expected Warn, got {:?}", action);
+    }
+}


### PR DESCRIPTION
## Summary
- 同一ファイルの繰り返し読み取りパターンを検出するループ検出機能を追加
- 検出時にLLMへの自己修正プロンプトを注入
- 設定可能な loop_detection_threshold

Closes #145

## Test plan
- [x] cargo test: 全テストパス
- [x] cargo clippy: 警告0件

🤖 Generated with [Claude Code](https://claude.com/claude-code)