### PR TITLE
release: local LLM runtime improvements v0.0.7 (#142-#147)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,6 +139,7 @@ src/
 ├── tooling/
 │   ├── mod.rs           # ツール実行・検証・CheckpointStack（undo用チェックポイント管理）
 │   ├── diff.rs          # 差分プレビュー生成（file.write/file.edit承認時）
+│   ├── file_cache.rs    # ファイル読み取りキャッシュ（FileReadCache: LRUエビクション・sandbox境界検証）
 │   └── shell_policy.rs  # ShellPolicy分類（ReadOnly/BuildTest/General）・offline用ネットワークコマンド検出
 ├── tui/mod.rs           # TUI描画
 └── walk.rs              # 共通ディレクトリウォーカー（.gitignore対応・統一スキップ/バイナリ除外）

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,7 +106,7 @@ src/
 │   └── tag_spec.rs      # ツールタグ仕様テーブル（TOOL_TAG_SPECS）
 ├── app/
 │   ├── mod.rs           # アプリケーションオーケストレータ
-│   ├── agentic.rs       # agenticツール実行ループ
+│   ├── agentic.rs       # agenticツール実行ループ（ANVIL_FINALガード・再試行ロジック含む）
 │   ├── cli.rs           # CLI入力ループ
 │   ├── context.rs       # コンテキスト注入（@file展開・サンドボックス検証）
 │   ├── plan.rs          # プラン管理

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,7 @@ src/
 │   ├── agentic.rs       # agenticツール実行ループ
 │   ├── cli.rs           # CLI入力ループ
 │   ├── context.rs       # コンテキスト注入（@file展開・サンドボックス検証）
+│   ├── loop_detector.rs # ループ検出（リングバッファ・段階的対応）
 │   ├── plan.rs          # プラン管理
 │   ├── policy.rs        # offlineポリシーチェック（共通ヘルパー）
 │   ├── render.rs        # コンソール描画
@@ -153,6 +154,7 @@ tests/
 ├── tui_console.rs       # TUIテスト
 ├── skills_system.rs     # スキルシステムテスト
 ├── hooks_system.rs      # フックシステムテスト
+├── loop_detection.rs    # ループ検出テスト
 ├── context_inject.rs    # コンテキスト注入テスト
 └── walk_system.rs       # ディレクトリウォーカーテスト
 ```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,6 +77,7 @@ dependencies = [
  "base64",
  "chrono",
  "clap",
+ "filetime",
  "ignore",
  "regex",
  "reqwest",
@@ -335,6 +336,17 @@ dependencies = [
  "cfg-if",
  "rustix",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
 ]
 
 [[package]]
@@ -807,6 +819,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
+name = "libredox"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
+dependencies = [
+ "bitflags",
+ "libc",
+ "plain",
+ "redox_syscall",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -930,6 +954,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "potential_utf"
@@ -1087,6 +1117,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,4 @@ ignore = "0.4"
 
 [dev-dependencies]
 tempfile = "3"
+filetime = "0.2"

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ ANVIL_MODEL=qwen3.5:35b           # モデル名
 ANVIL_PROVIDER_URL=http://...     # プロバイダーURL
 ANVIL_CONTEXT_WINDOW=200000       # コンテキストウィンドウサイズ
 ANVIL_CONTEXT_BUDGET=50000        # トークンバジェット明示指定
-ANVIL_MAX_AGENT_ITERATIONS=10     # agenticループの最大反復数
+ANVIL_MAX_AGENT_ITERATIONS=30     # agenticループの最大反復数（default: 30）
 ANVIL_HTTP_TIMEOUT=300            # LLMリクエストタイムアウト（秒）（旧ANVIL_CURL_TIMEOUTもフォールバックとして有効）
 ANVIL_API_KEY=sk-...              # OpenAI互換APIキー
 ```
@@ -221,7 +221,7 @@ anvil [OPTIONS]
       --sidecar-model <MODEL>            サイドカーモデル名
       --context-window <SIZE>            コンテキストウィンドウサイズ
       --context-budget <TOKENS>          トークンバジェット明示指定
-      --max-iterations <N>               agenticループ最大反復数
+      --max-iterations <N>               agenticループ最大反復数（default: 30）
       --no-stream                        ストリーミング無効
       --debug                            デバッグログ有効
       --no-approval                      全ツール自動承認

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -652,6 +652,9 @@ const PROMPT_TOOL_RULES: &str = concat!(
     "- Do not use any other tool syntax.\n",
     "- Always include ANVIL_FINAL after your tool blocks.\n",
     "- If no file operations are needed, just respond normally without tool blocks.\n",
+    "- When the user's request requires file changes (implement, fix, create, modify, etc.), \
+       you must complete the actual file modifications using file.write/file.edit, \
+       not just output a plan or description.\n",
     "- Start exploration with file.read on \".\" to list the project root before reading specific files.\n",
     "- Do not assume files like README.md exist — verify first.\n",
     "- For dev servers and watch processes (npm run dev, cargo watch, etc.), use background execution with '&' so the command returns immediately.\n",

--- a/src/agent/subagent.rs
+++ b/src/agent/subagent.rs
@@ -491,6 +491,9 @@ impl<'a, C: ProviderClient> SubAgentSession<'a, C> {
         ));
 
         // If no tool calls, this is the final response
+        // Note: ANVIL_FINAL file-modification guard is NOT applied to sub-agents.
+        // Sub-agents (Explore/Plan) are read-only and not expected to modify files.
+        // The guard is only enforced in the main agent loop (src/app/agentic.rs).
         if structured.tool_calls.is_empty() {
             let tokens = crate::contracts::tokens::estimate_tokens(
                 &token_buffer,

--- a/src/agent/subagent.rs
+++ b/src/agent/subagent.rs
@@ -506,8 +506,9 @@ impl<'a, C: ProviderClient> SubAgentSession<'a, C> {
 
         // Validate and execute tool calls
         // SR4-003: validate() is mandatory before execution
-        let mut executor = LocalToolExecutor::new(self.scope_path.clone(), &self.config.runtime)
-            .with_shutdown_flag(self.shutdown_flag.clone());
+        let mut executor =
+            LocalToolExecutor::new(self.scope_path.clone(), &self.config.runtime, None)
+                .with_shutdown_flag(self.shutdown_flag.clone());
 
         for call in &structured.tool_calls {
             // Validate against restricted registry

--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -79,6 +79,7 @@ fn execute_parallel_group_standalone(
     shutdown_flag: std::sync::Arc<std::sync::atomic::AtomicBool>,
     requests: Vec<(usize, ToolExecutionRequest)>,
     completed: Arc<AtomicUsize>,
+    file_cache: Option<std::sync::Arc<std::sync::Mutex<crate::tooling::file_cache::FileReadCache>>>,
 ) -> Vec<(usize, ToolExecutionResult)> {
     let cwd = config.paths.cwd.clone();
     let runtime = &config.runtime;
@@ -93,9 +94,10 @@ fn execute_parallel_group_standalone(
                     let shutdown = shutdown_flag.clone();
                     let idx = *idx;
                     let completed = completed.clone();
+                    let file_cache = file_cache.clone();
                     s.spawn(move || {
-                        let mut executor =
-                            LocalToolExecutor::new(cwd, runtime).with_shutdown_flag(shutdown);
+                        let mut executor = LocalToolExecutor::new(cwd, runtime, file_cache)
+                            .with_shutdown_flag(shutdown);
                         let tool_call_id = request.tool_call_id.clone();
                         let tool_name = request.spec.name.clone();
                         let result = executor.execute(request.clone()).unwrap_or_else(|err| {
@@ -583,8 +585,12 @@ impl App {
             .map(|entry| self.checkpoint_stack.push(entry));
 
         // Built-in tools: delegate to LocalToolExecutor
-        let mut executor = LocalToolExecutor::new(cwd, &self.config.runtime)
-            .with_shutdown_flag(self.shutdown_flag());
+        let mut executor = LocalToolExecutor::new(
+            cwd,
+            &self.config.runtime,
+            Some(self.file_read_cache.clone()),
+        )
+        .with_shutdown_flag(self.shutdown_flag());
 
         let result = executor
             .execute(request)
@@ -763,6 +769,7 @@ impl App {
                         self.shutdown_flag(),
                         requests,
                         completed,
+                        Some(self.file_read_cache.clone()),
                     );
                     spinner.stop();
                     seq_counter += parallel_results.len();

--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -99,12 +99,34 @@ fn execute_parallel_group_standalone(
                         let tool_call_id = request.tool_call_id.clone();
                         let tool_name = request.spec.name.clone();
                         let result = executor.execute(request.clone()).unwrap_or_else(|err| {
+                            let (summary, payload) = match &err {
+                                crate::tooling::ToolRuntimeError::EditNotFound {
+                                    message,
+                                    context_snippet,
+                                } => {
+                                    let payload_text = if let Some(ctx) = context_snippet {
+                                        format!(
+                                            "{message}\n\n--- File context (nearby lines) ---\n{ctx}"
+                                        )
+                                    } else {
+                                        message.clone()
+                                    };
+                                    (
+                                        message.clone(),
+                                        ToolExecutionPayload::Text(payload_text),
+                                    )
+                                }
+                                other => {
+                                    let msg = other.to_string();
+                                    (msg.clone(), ToolExecutionPayload::Text(msg))
+                                }
+                            };
                             ToolExecutionResult {
                                 tool_call_id,
                                 tool_name,
                                 status: ToolExecutionStatus::Failed,
-                                summary: err.to_string(),
-                                payload: ToolExecutionPayload::Text(err.to_string()),
+                                summary,
+                                payload,
                                 artifacts: Vec::new(),
                                 elapsed_ms: 0,
                             }
@@ -943,6 +965,33 @@ impl App {
             }
         }
 
+        // Edit fail tracker: track consecutive file.edit failures (Issue #143)
+        let mut edit_hint: Option<String> = None;
+        if result.tool_name == "file.edit" {
+            if result.status == ToolExecutionStatus::Failed {
+                // Extract path from summary (format: "file.edit: ... in {path}. ...")
+                if let Some(path) = extract_edit_path_from_summary(&result.summary)
+                    .filter(|p| self.edit_fail_tracker.record_failure(p))
+                {
+                    let count = self.edit_fail_tracker.failure_count(&path);
+                    edit_hint = Some(format!(
+                        "\n\n[Anvil hint] file.edit has failed {count} consecutive \
+                         times for '{path}'. Consider using file.read to get the \
+                         current content, then file.write to replace the entire file."
+                    ));
+                }
+            } else if result.status == ToolExecutionStatus::Completed {
+                // Reset on success — extract path from artifacts
+                if let Some(artifact) = result.artifacts.first() {
+                    let path_str = std::path::Path::new(artifact)
+                        .file_name()
+                        .and_then(|n| n.to_str())
+                        .unwrap_or(artifact);
+                    self.edit_fail_tracker.record_success(path_str);
+                }
+            }
+        }
+
         // Working memory: track errors (Issue #130)
         if result.status == ToolExecutionStatus::Failed {
             let sanitized_error = if result.tool_name == "shell.exec" {
@@ -958,12 +1007,14 @@ impl App {
         }
 
         let is_error = result.status == ToolExecutionStatus::Failed;
-        let mut msg = SessionMessage::new(
-            MessageRole::Tool,
-            &result.tool_name,
-            format_tool_result_message(result, self.config.runtime.tool_result_max_chars),
-        )
-        .with_id(self.next_message_id("tool"));
+        let mut formatted =
+            format_tool_result_message(result, self.config.runtime.tool_result_max_chars);
+        // Append edit recovery hint if consecutive failures detected
+        if let Some(hint) = edit_hint {
+            formatted.push_str(&hint);
+        }
+        let mut msg = SessionMessage::new(MessageRole::Tool, &result.tool_name, formatted)
+            .with_id(self.next_message_id("tool"));
         msg.is_error = is_error;
 
         // Attach image paths for Image payloads so the agent layer can
@@ -1102,6 +1153,24 @@ pub fn truncate_with_head_tail(content: &str, max_chars: usize, head_pct: usize)
         "{}\n\n... [{} chars truncated, {} chars total] ...\n\n{}",
         head, omitted, total_chars, tail
     )
+}
+
+/// Extract the file path from a file.edit error summary.
+/// Looks for patterns like "... in {path}. ..." or "... in {path},"
+fn extract_edit_path_from_summary(summary: &str) -> Option<String> {
+    // Pattern: "file.edit: ... in {path}. ..."
+    // or "file.edit: ... in {path}, ..."
+    let in_idx = summary.find(" in ")?;
+    let after_in = &summary[in_idx + 4..];
+    let end = after_in
+        .find(". ")
+        .or_else(|| after_in.find(", "))
+        .unwrap_or(after_in.len());
+    let path = after_in[..end].trim();
+    if path.is_empty() {
+        return None;
+    }
+    Some(path.to_string())
 }
 
 /// Format a tool execution result into a message that the LLM can interpret.

--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -148,6 +148,14 @@ fn execute_parallel_group_standalone(
     all_results
 }
 
+/// Maximum number of ANVIL_FINAL guard retries (no-file-modification detection).
+const MAX_FINAL_GUARD_RETRIES: u8 = 1;
+
+/// Message sent to LLM when ANVIL_FINAL fires without file modifications.
+const FINAL_GUARD_RETRY_MESSAGE: &str = "No file modifications detected (file.write/file.edit not called). \
+     Please implement the changes rather than just planning them. \
+     Use file.write or file.edit to make the necessary code changes.";
+
 /// Maximum number of sub-agent calls allowed in a single turn (SR4-006).
 const MAX_SUBAGENT_CALLS_PER_TURN: usize = 3;
 
@@ -248,6 +256,25 @@ impl App {
         (agent_results, normal_calls)
     }
 
+    /// Check if the ANVIL_FINAL guard should activate.
+    /// Returns true if no file modifications were detected and retries remain.
+    fn should_activate_final_guard(&self, retries: u8) -> bool {
+        retries < MAX_FINAL_GUARD_RETRIES && self.session.working_memory.touched_files.is_empty()
+    }
+
+    /// Inject a retry message into the session to prompt the LLM for actual implementation.
+    /// See also: PROMPT_TOOL_RULES in src/agent/mod.rs for preventive guidance.
+    fn inject_final_guard_retry(&mut self) {
+        tracing::warn!("ANVIL_FINAL guard: no file modifications detected, retrying");
+        let retry_msg = SessionMessage::new(
+            MessageRole::Tool,
+            "system",
+            FINAL_GUARD_RETRY_MESSAGE.to_string(),
+        )
+        .with_id(self.next_message_id("tool"));
+        self.session.push_message(retry_msg);
+    }
+
     /// Execute tool calls and feed results back to the LLM in a loop.
     ///
     /// This implements the agentic tool-use loop:
@@ -272,6 +299,7 @@ impl App {
         let mut frames = Vec::new();
         let mut total_tool_count = 0usize;
         let mut all_tool_log_views: Vec<ToolLogView> = Vec::new();
+        let mut final_guard_retries: u8 = 0;
 
         for iteration in 0..max_iterations {
             // Check shutdown flag before tool execution
@@ -435,6 +463,13 @@ impl App {
                 };
 
             if next_structured.tool_calls.is_empty() {
+                // ANVIL_FINAL guard: check if any file modifications were made
+                if self.should_activate_final_guard(final_guard_retries) {
+                    self.inject_final_guard_retry();
+                    final_guard_retries += 1;
+                    current = next_structured;
+                    continue;
+                }
                 // No more tool calls — this is the final answer
                 self.record_assistant_output(
                     self.next_message_id("assistant"),
@@ -974,6 +1009,123 @@ impl App {
         self.session.push_message(msg);
     }
 
+    /// Execute a single retry LLM turn after ANVIL_FINAL guard activation.
+    /// This is a simplified version of the agentic loop that processes exactly one LLM response.
+    /// After the retry, the response is accepted unconditionally (no further guard check).
+    ///
+    /// CB-005: The stream callback only processes `TokenDelta` events, consistent
+    /// with `complete_structured_response`. `ProviderEvent::Agent(Done)` is not
+    /// handled here because the retry response is parsed from the accumulated
+    /// token buffer directly (the same pattern used by the main agentic loop).
+    #[allow(clippy::too_many_arguments)]
+    fn run_guarded_retry_turn<C: ProviderClient>(
+        &mut self,
+        status: &str,
+        saved_status: &str,
+        elapsed_ms: u128,
+        inference_performance: Option<crate::contracts::InferencePerformanceView>,
+        tui: &Tui,
+        provider_client: &C,
+    ) -> Result<Vec<String>, AppError> {
+        // Build request and call LLM for one more turn
+        let system_prompt = self.build_dynamic_system_prompt();
+        let request = BasicAgentLoop::build_turn_request(
+            self.effective_model().to_string(),
+            &self.session,
+            self.provider.capabilities.streaming && self.config.runtime.stream,
+            self.effective_context_window(),
+            &system_prompt,
+        );
+
+        let spinner = Spinner::start(
+            format!("ANVIL_FINAL guard retry. model={}", self.effective_model()),
+            self.config.mode.interactive,
+        );
+
+        let mut token_buffer = String::new();
+        let mut first_token = true;
+        let mut spinner_opt = Some(spinner);
+
+        let stream_result = provider_client.stream_turn(&request, &mut |event| {
+            if let Some(s) = spinner_opt.take() {
+                s.stop();
+            }
+            if let ProviderEvent::TokenDelta(delta) = &event {
+                token_buffer.push_str(delta);
+                if first_token {
+                    first_token = false;
+                }
+                let _ = std::io::Write::write_fmt(&mut std::io::stderr(), format_args!("{delta}"));
+                let _ = std::io::Write::flush(&mut std::io::stderr());
+            }
+        });
+
+        if let Some(s) = spinner_opt.take() {
+            s.stop();
+        }
+        if !first_token {
+            let _ = std::io::Write::write_fmt(&mut std::io::stderr(), format_args!("\n"));
+        }
+
+        stream_result.map_err(|err| match err {
+            crate::provider::ProviderTurnError::Cancelled => {
+                AppError::ToolExecution("guarded retry cancelled".to_string())
+            }
+            other => AppError::ToolExecution(format!("guarded retry failed: {other}")),
+        })?;
+
+        // Parse the retry response
+        let retry_structured = match BasicAgentLoop::parse_structured_response(&token_buffer) {
+            Ok(parsed) => parsed,
+            Err(_) => {
+                let trimmed = token_buffer.trim();
+                StructuredAssistantResponse {
+                    tool_calls: Vec::new(),
+                    final_response: if trimmed.is_empty() {
+                        "Guard retry produced empty response.".to_string()
+                    } else {
+                        trimmed.to_string()
+                    },
+                }
+            }
+        };
+
+        // If response has tool_calls, delegate to complete_structured_response
+        if !retry_structured.tool_calls.is_empty() {
+            return self.complete_structured_response(
+                retry_structured,
+                status,
+                saved_status,
+                elapsed_ms,
+                inference_performance,
+                tui,
+                provider_client,
+            );
+        }
+
+        // No tool calls — accept as final answer (no further guard check)
+        self.record_assistant_output(
+            self.next_message_id("assistant"),
+            retry_structured.final_response,
+        )?;
+
+        // Transition to Done
+        let mut done = AppStateSnapshot::new(RuntimeState::Done)
+            .with_status(status.to_string())
+            .with_completion_summary(
+                format!("Guard retry completed. {saved_status}"),
+                saved_status.to_string(),
+            )
+            .with_elapsed_ms(elapsed_ms);
+        if let Some(perf) = inference_performance {
+            done = done.with_inference_performance(perf);
+        }
+        let mut done_snapshot = self.transition_with_context(done, StateTransition::Finish)?;
+        self.evaluate_context_warning(&mut done_snapshot);
+        let frames = vec![self.render_console(tui)?];
+        Ok(frames)
+    }
+
     pub(crate) fn handle_structured_done<C: ProviderClient>(
         &mut self,
         event: &crate::agent::AgentEvent,
@@ -996,6 +1148,32 @@ impl App {
         let structured = BasicAgentLoop::parse_structured_response(assistant_message)
             .map_err(AppError::ToolExecution)?;
         if structured.tool_calls.is_empty() {
+            // ANVIL_FINAL guard: only activate when the message contains a
+            // structured ANVIL_FINAL block (not plain-text Done messages).
+            // Inject retry message and re-invoke LLM directly (not via
+            // complete_structured_response, which would wastefully execute the
+            // empty tool_calls pipeline).
+            //
+            // CB-002: Retry count is always 0 here because this path handles
+            // the first-turn Done event (before any agentic loop iteration).
+            // MAX_FINAL_GUARD_RETRIES = 1 ensures at most one retry, so the
+            // hardcoded 0 is correct and sufficient for the current design.
+            if BasicAgentLoop::is_complete_structured_response(assistant_message)
+                && self.should_activate_final_guard(0)
+            {
+                self.inject_final_guard_retry();
+                // Record the assistant message that triggered the guard
+                self.record_assistant_output(self.next_message_id("assistant"), assistant_message)?;
+                // Re-invoke LLM and process the response
+                return Ok(Some(self.run_guarded_retry_turn(
+                    status,
+                    saved_status,
+                    *elapsed_ms,
+                    inference_performance.clone(),
+                    tui,
+                    provider_client,
+                )?));
+            }
             return Ok(None);
         }
 

--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -273,6 +273,9 @@ impl App {
         let mut total_tool_count = 0usize;
         let mut all_tool_log_views: Vec<ToolLogView> = Vec::new();
 
+        // Reset loop detector at the start of each top-level turn (Issue #145)
+        self.loop_detector.reset();
+
         for iteration in 0..max_iterations {
             // Check shutdown flag before tool execution
             if self.is_shutdown_requested() {
@@ -318,7 +321,7 @@ impl App {
             // live streaming output on stderr (Issue #1).
 
             // Execute normal tool calls and record results WITH payload
-            let results = self.execute_structured_tool_calls(&current_normal)?;
+            let (results, loop_action) = self.execute_structured_tool_calls(&current_normal)?;
             total_tool_count += results.len();
 
             let tool_log_views: Vec<ToolLogView> = results
@@ -337,6 +340,13 @@ impl App {
             let _ = self.transition_with_context(working, StateTransition::StartWorking)?;
             // Skip intermediate Working frames — tool execution output
             // is already shown on stderr (Issue #1).
+
+            // Handle loop detection Break action (Issue #145)
+            // Results are already recorded and visible above; now terminate the loop.
+            if let Some(super::loop_detector::LoopAction::Break(ref msg)) = loop_action {
+                tracing::warn!(reason = "loop_detected", message = %msg, "agentic loop terminated by loop detector");
+                break;
+            }
 
             // Check shutdown flag before LLM call
             if self.is_shutdown_requested() {
@@ -660,7 +670,13 @@ impl App {
     pub(crate) fn execute_structured_tool_calls(
         &mut self,
         structured: &StructuredAssistantResponse,
-    ) -> Result<Vec<ToolExecutionResult>, AppError> {
+    ) -> Result<
+        (
+            Vec<ToolExecutionResult>,
+            Option<super::loop_detector::LoopAction>,
+        ),
+        AppError,
+    > {
         // Phase 1: Validation + Approval
         let (validated_requests, mut failed_results) =
             self.validate_and_approve_all(&structured.tool_calls);
@@ -733,6 +749,58 @@ impl App {
             remaining
         } else {
             validated_requests
+        };
+
+        // Loop detection: record each validated tool call and check for repetition (Issue #145)
+        let mut worst_loop_action: Option<super::loop_detector::LoopAction> = None;
+        for (_, req) in &validated_requests {
+            if let Some((tool_name, tool_input)) = tool_input_map.get(&req.tool_call_id) {
+                let action = self.loop_detector.record_and_check(tool_name, tool_input);
+                worst_loop_action = match (&worst_loop_action, &action) {
+                    (_, super::loop_detector::LoopAction::Continue) => worst_loop_action,
+                    (None, _) => Some(action),
+                    (Some(super::loop_detector::LoopAction::Continue), _) => Some(action),
+                    (
+                        Some(super::loop_detector::LoopAction::Warn(_)),
+                        super::loop_detector::LoopAction::StrongWarn(_)
+                        | super::loop_detector::LoopAction::Break(_),
+                    ) => Some(action),
+                    (
+                        Some(super::loop_detector::LoopAction::StrongWarn(_)),
+                        super::loop_detector::LoopAction::Break(_),
+                    ) => Some(action),
+                    _ => worst_loop_action,
+                };
+            }
+        }
+
+        // If Break: skip tool execution entirely
+        if matches!(
+            worst_loop_action,
+            Some(super::loop_detector::LoopAction::Break(_))
+        ) {
+            // Return failed results with the Break action
+            failed_results.sort_by_key(|(idx, _)| *idx);
+            let results: Vec<ToolExecutionResult> =
+                failed_results.into_iter().map(|(_, r)| r).collect();
+            return Ok((results, worst_loop_action));
+        }
+
+        // For Warn/StrongWarn: create synthetic tool result to include in results
+        let synthetic_warning = match &worst_loop_action {
+            Some(super::loop_detector::LoopAction::Warn(msg))
+            | Some(super::loop_detector::LoopAction::StrongWarn(msg)) => {
+                Some(ToolExecutionResult {
+                    tool_call_id: "loop_detector_warning".to_string(),
+                    tool_name: "system.loop_detector".to_string(),
+                    status: ToolExecutionStatus::Completed,
+                    summary: msg.clone(),
+                    payload: ToolExecutionPayload::Text(msg.clone()),
+                    artifacts: vec![],
+                    elapsed_ms: 0,
+                })
+            }
+            _ => None,
         };
 
         // Phase 2: Grouping
@@ -918,8 +986,14 @@ impl App {
             results.push(result);
         }
 
+        // Append synthetic loop detection warning if present
+        if let Some(warning_result) = synthetic_warning {
+            self.record_tool_result(&warning_result);
+            results.push(warning_result);
+        }
+
         self.persist_session(crate::contracts::AppEvent::SessionSaved)?;
-        Ok(results)
+        Ok((results, worst_loop_action))
     }
 
     /// Push a tool execution result into the session as a tool message.

--- a/src/app/context.rs
+++ b/src/app/context.rs
@@ -53,73 +53,7 @@ pub(crate) fn parse_at_references(input: &str) -> Vec<AtReference> {
     refs
 }
 
-/// Sensitive file patterns that should never be expanded via @file.
-/// Prevents accidental leakage of secrets to LLM backends.
-const SENSITIVE_FILE_PATTERNS: &[&str] = &[
-    ".env",
-    ".env.*",
-    "*.pem",
-    "*.key",
-    "*.p12",
-    "*.pfx",
-    "id_rsa",
-    "id_ed25519",
-    "id_ecdsa",
-    "id_dsa",
-    "credentials.json",
-    "secrets.*",
-    "*.secret",
-    "*.secrets",
-    ".netrc",
-    ".npmrc",
-    ".pypirc",
-    "token.json",
-    "service-account*.json",
-];
-
-/// Check whether a file path matches the sensitive file blocklist.
-///
-/// Matching is performed against the file name (basename) only, using
-/// simple string operations: exact match, prefix (`starts_with`),
-/// suffix (`ends_with`), and prefix+suffix for patterns like `service-account*.json`.
-fn is_sensitive_file(path: &str) -> bool {
-    let file_name = Path::new(path)
-        .file_name()
-        .and_then(|n| n.to_str())
-        .unwrap_or("");
-    if file_name.is_empty() {
-        return false;
-    }
-    for pattern in SENSITIVE_FILE_PATTERNS {
-        if let Some(suffix) = pattern.strip_prefix('*') {
-            // e.g. "*.pem" → ends_with(".pem")
-            if file_name.ends_with(suffix) {
-                return true;
-            }
-        } else if let Some(prefix) = pattern.strip_suffix('*') {
-            // e.g. ".env.*" → starts_with(".env.")
-            if file_name.starts_with(prefix) {
-                return true;
-            }
-        } else if pattern.contains('*') {
-            // e.g. "service-account*.json" → starts_with("service-account") && ends_with(".json")
-            let parts: Vec<&str> = pattern.splitn(2, '*').collect();
-            if parts.len() == 2
-                && file_name.starts_with(parts[0])
-                && file_name.ends_with(parts[1])
-                && file_name.len() >= parts[0].len() + parts[1].len()
-            {
-                return true;
-            }
-        } else {
-            // exact match
-            if file_name == *pattern {
-                return true;
-            }
-        }
-    }
-    false
-}
+use crate::tooling::is_sensitive_file;
 
 /// Resolve a single @file reference, returning the file content as text.
 ///

--- a/src/app/edit_fail_tracker.rs
+++ b/src/app/edit_fail_tracker.rs
@@ -1,0 +1,87 @@
+use std::collections::HashMap;
+
+/// Tracks consecutive file.edit failures per file path.
+/// Used to detect when the LLM is stuck retrying edits on the same file
+/// and should be prompted to try an alternative approach.
+pub(crate) struct EditFailTracker {
+    consecutive_failures: HashMap<String, u32>,
+    threshold: u32,
+}
+
+impl EditFailTracker {
+    pub(crate) fn new(threshold: u32) -> Self {
+        Self {
+            consecutive_failures: HashMap::new(),
+            threshold,
+        }
+    }
+
+    /// Record a file.edit failure for the given path.
+    /// Returns true if the failure count has reached the threshold.
+    pub(crate) fn record_failure(&mut self, path: &str) -> bool {
+        let count = self
+            .consecutive_failures
+            .entry(path.to_string())
+            .or_insert(0);
+        *count += 1;
+        *count >= self.threshold
+    }
+
+    /// Record a successful file.edit, resetting the failure count for that path.
+    pub(crate) fn record_success(&mut self, path: &str) {
+        self.consecutive_failures.remove(path);
+    }
+
+    /// Get the current failure count for a path.
+    pub(crate) fn failure_count(&self, path: &str) -> u32 {
+        self.consecutive_failures.get(path).copied().unwrap_or(0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_tracker_basic_flow() {
+        let mut tracker = EditFailTracker::new(3);
+
+        assert!(!tracker.record_failure("foo.rs"));
+        assert!(!tracker.record_failure("foo.rs"));
+        assert!(tracker.record_failure("foo.rs")); // 3rd failure hits threshold
+        assert_eq!(tracker.failure_count("foo.rs"), 3);
+    }
+
+    #[test]
+    fn test_tracker_success_resets() {
+        let mut tracker = EditFailTracker::new(3);
+
+        tracker.record_failure("foo.rs");
+        tracker.record_failure("foo.rs");
+        tracker.record_success("foo.rs");
+        assert_eq!(tracker.failure_count("foo.rs"), 0);
+
+        // After reset, needs 3 more failures
+        assert!(!tracker.record_failure("foo.rs"));
+    }
+
+    #[test]
+    fn test_tracker_independent_paths() {
+        let mut tracker = EditFailTracker::new(3);
+
+        tracker.record_failure("foo.rs");
+        assert!(!tracker.record_failure("bar.rs")); // bar.rs: 1st
+        assert!(!tracker.record_failure("foo.rs")); // foo.rs: 2nd
+        assert!(!tracker.record_failure("bar.rs")); // bar.rs: 2nd
+        assert!(tracker.record_failure("foo.rs")); // foo.rs: 3rd = threshold
+        assert!(tracker.record_failure("bar.rs")); // bar.rs: 3rd = threshold
+    }
+
+    #[test]
+    fn test_tracker_threshold_2() {
+        let mut tracker = EditFailTracker::new(2);
+        assert!(!tracker.record_failure("a.rs")); // 1st
+        assert!(tracker.record_failure("a.rs")); // 2nd = threshold
+        assert!(tracker.record_failure("a.rs")); // 3rd, still above threshold
+    }
+}

--- a/src/app/loop_detector.rs
+++ b/src/app/loop_detector.rs
@@ -1,0 +1,150 @@
+//! Loop detection for the agentic tool-use loop (Issue #145).
+//!
+//! Detects repeated identical tool calls using a ring-buffer of fingerprints
+//! and responds with escalating actions: Warn → StrongWarn → Break.
+
+use std::collections::VecDeque;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+
+/// Ring buffer maximum size (fixed for Phase 1).
+pub const DEFAULT_MAX_HISTORY: usize = 20;
+
+/// Action to take based on loop detection results.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LoopAction {
+    /// No loop detected, continue normally.
+    Continue,
+    /// First detection: warning message inserted as synthetic tool result.
+    Warn(String),
+    /// Second detection: strong warning message.
+    StrongWarn(String),
+    /// Third detection: terminate the agentic loop.
+    Break(String),
+}
+
+/// Detects repeated identical tool calls within the agentic loop.
+pub struct LoopDetector {
+    /// Recent tool call fingerprints: (tool_name, input_hash).
+    history: VecDeque<(String, u64)>,
+    /// Maximum ring buffer size.
+    max_history: usize,
+    /// Number of identical consecutive calls before detection triggers.
+    threshold: usize,
+    /// Current escalation level (number of times detection has triggered).
+    escalation_count: usize,
+}
+
+/// Compute a deterministic fingerprint from tool name and input JSON.
+///
+/// Uses `DefaultHasher` for simplicity. The same tool_name + input_json
+/// combination always produces the same hash value within a single process.
+pub fn fingerprint(tool_name: &str, input_json: &serde_json::Value) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    tool_name.hash(&mut hasher);
+    if let Ok(s) = serde_json::to_string(input_json) {
+        s.hash(&mut hasher);
+    }
+    hasher.finish()
+}
+
+impl LoopDetector {
+    /// Create a new LoopDetector with the given threshold.
+    ///
+    /// # Panics
+    /// Panics if `threshold < 2` or `threshold > DEFAULT_MAX_HISTORY`.
+    pub fn new(threshold: usize) -> Self {
+        assert!(
+            (2..=DEFAULT_MAX_HISTORY).contains(&threshold),
+            "threshold must be in 2..={DEFAULT_MAX_HISTORY}, got {threshold}"
+        );
+        Self {
+            history: VecDeque::with_capacity(DEFAULT_MAX_HISTORY),
+            max_history: DEFAULT_MAX_HISTORY,
+            threshold,
+            escalation_count: 0,
+        }
+    }
+
+    /// Reset all state. Called at the start of each `complete_structured_response()` turn.
+    pub fn reset(&mut self) {
+        self.history.clear();
+        self.escalation_count = 0;
+    }
+
+    /// Record a tool call and check for loop patterns.
+    ///
+    /// This is the only public API that `agentic.rs` calls.
+    pub fn record_and_check(
+        &mut self,
+        tool_name: &str,
+        input_json: &serde_json::Value,
+    ) -> LoopAction {
+        let hash = fingerprint(tool_name, input_json);
+        self.record(tool_name.to_string(), hash);
+        self.check()
+    }
+
+    /// Append a fingerprint to the ring buffer, evicting oldest if full.
+    fn record(&mut self, tool_name: String, hash: u64) {
+        if self.history.len() >= self.max_history {
+            self.history.pop_front();
+        }
+        self.history.push_back((tool_name, hash));
+    }
+
+    /// Check the tail of the history for repeated identical fingerprints.
+    fn check(&mut self) -> LoopAction {
+        if self.history.len() < self.threshold {
+            return LoopAction::Continue;
+        }
+
+        // Check if the last `threshold` entries all share the same fingerprint.
+        let len = self.history.len();
+        let tail_start = len - self.threshold;
+        let (ref last_name, last_hash) = self.history[len - 1];
+
+        let all_same = self
+            .history
+            .iter()
+            .skip(tail_start)
+            .all(|(name, hash)| name == last_name && *hash == last_hash);
+
+        if !all_same {
+            return LoopAction::Continue;
+        }
+
+        self.escalation_count += 1;
+
+        match self.escalation_count {
+            1 => LoopAction::Warn(format!(
+                "[Loop Detection] The same tool call '{}' has been repeated {} times consecutively. \
+                 Consider trying a different approach or tool.",
+                last_name, self.threshold
+            )),
+            2 => LoopAction::StrongWarn(format!(
+                "[Loop Detection - WARNING] Tool '{}' is being called repeatedly with identical arguments. \
+                 You MUST change your approach immediately. Try a completely different strategy.",
+                last_name
+            )),
+            _ => LoopAction::Break(format!(
+                "[Loop Detection - TERMINATED] Agentic loop terminated due to repeated identical calls to '{}'. \
+                 The loop has been stopped to prevent infinite repetition.",
+                last_name
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fingerprint_is_deterministic() {
+        let val = serde_json::json!({"path": "src/main.rs"});
+        let h1 = fingerprint("file.read", &val);
+        let h2 = fingerprint("file.read", &val);
+        assert_eq!(h1, h2);
+    }
+}

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -41,8 +41,8 @@ use crate::tui::Tui;
 use std::collections::HashSet;
 use std::fmt::{Display, Formatter};
 use std::io::{self, Write};
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
 
 // Re-export render helpers that form the public API.
 pub use render::{cli_prompt, render_help_frame, slash_commands};
@@ -146,6 +146,8 @@ pub struct App {
     last_estimated_prompt_tokens: Option<usize>,
     /// System prompt verbosity tier, determined at session start.
     prompt_tier: PromptTier,
+    /// File read cache: reduces redundant file.read calls within a session.
+    file_read_cache: Arc<Mutex<crate::tooling::file_cache::FileReadCache>>,
 }
 
 /// Whether the session loop should continue or exit.
@@ -390,6 +392,10 @@ impl App {
 
         let trust_all = config.mode.trust_all;
 
+        let file_read_cache = Arc::new(Mutex::new(crate::tooling::file_cache::FileReadCache::new(
+            config.paths.cwd.clone(),
+        )));
+
         // Determine prompt tier from config override or model name heuristic
         let prompt_tier = {
             use crate::agent::model_classifier::classify_model_capability;
@@ -425,6 +431,7 @@ impl App {
             calibration_store: TokenCalibrationStore::new(),
             last_estimated_prompt_tokens: None,
             prompt_tier,
+            file_read_cache,
         })
     }
 
@@ -703,6 +710,11 @@ impl App {
         self.current_session_name = name.to_string();
         self.active_model = None;
         self.active_context_window = None;
+
+        // Clear file read cache on session switch (DR2-004)
+        if let Ok(mut cache) = self.file_read_cache.lock() {
+            cache.clear();
+        }
 
         tracing::info!(session_name = name, "Session switched");
 
@@ -1903,6 +1915,13 @@ impl App {
             format!("Undid {} of {} requested change(s).", restored_count, n)
         };
         lines.insert(0, summary.clone());
+
+        // Invalidate file read cache for restored paths
+        if let Ok(mut cache) = self.file_read_cache.lock() {
+            for entry in &entries {
+                cache.invalidate(&entry.path);
+            }
+        }
 
         // Sync working memory: remove undone files from touched_files (Issue #130)
         for result in &results {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -6,6 +6,7 @@
 pub mod agentic;
 pub mod cli;
 mod context;
+pub(crate) mod edit_fail_tracker;
 pub mod mock;
 pub mod plan;
 pub mod policy;
@@ -146,6 +147,8 @@ pub struct App {
     last_estimated_prompt_tokens: Option<usize>,
     /// System prompt verbosity tier, determined at session start.
     prompt_tier: PromptTier,
+    /// Tracks consecutive file.edit failures per path for recovery hints.
+    edit_fail_tracker: edit_fail_tracker::EditFailTracker,
 }
 
 /// Whether the session loop should continue or exit.
@@ -425,6 +428,7 @@ impl App {
             calibration_store: TokenCalibrationStore::new(),
             last_estimated_prompt_tokens: None,
             prompt_tier,
+            edit_fail_tracker: edit_fail_tracker::EditFailTracker::new(3),
         })
     }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -6,6 +6,7 @@
 pub mod agentic;
 pub mod cli;
 mod context;
+pub mod loop_detector;
 pub mod mock;
 pub mod plan;
 pub mod policy;
@@ -123,6 +124,8 @@ pub struct App {
     warning_tracker: ContextWarningTracker,
     /// Undo checkpoint stack. In-memory only, discarded on session exit.
     checkpoint_stack: CheckpointStack,
+    /// Loop detector for preventing infinite tool call repetitions (Issue #145).
+    loop_detector: loop_detector::LoopDetector,
     /// Hooks engine. `None` when hooks.json is absent or initialization failed.
     /// Declared before mcp_manager to maintain Drop order (DR3-007).
     hooks_engine: Option<crate::hooks::HooksEngine>,
@@ -401,6 +404,8 @@ impl App {
             capability.prompt_tier
         };
 
+        let loop_detection_threshold = config.runtime.loop_detection_threshold;
+
         Ok(Self {
             tools,
             config,
@@ -415,6 +420,7 @@ impl App {
             shutdown_flag,
             warning_tracker: ContextWarningTracker::new(),
             checkpoint_stack: CheckpointStack::new(),
+            loop_detector: loop_detector::LoopDetector::new(loop_detection_threshold),
             hooks_engine,
             mcp_manager,
             current_session_name,

--- a/src/config/cli_args.rs
+++ b/src/config/cli_args.rs
@@ -81,6 +81,10 @@ pub struct CliArgs {
     #[arg(long)]
     pub trust: bool,
 
+    /// HTTP request timeout in seconds (default: 300)
+    #[arg(long = "timeout")]
+    pub timeout: Option<u64>,
+
     /// Prompt tier override (full|compact|tiny)
     #[arg(long = "prompt-tier")]
     pub prompt_tier: Option<String>,

--- a/src/config/cli_args.rs
+++ b/src/config/cli_args.rs
@@ -33,7 +33,7 @@ pub struct CliArgs {
     #[arg(long = "context-budget")]
     pub context_budget: Option<u32>,
 
-    /// Max agent iterations
+    /// Max agent iterations [default: 30]
     #[arg(long = "max-iterations")]
     pub max_iterations: Option<usize>,
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -7,6 +7,7 @@
 pub mod cli_args;
 pub use cli_args::CliArgs;
 
+use crate::provider::transport::{DEFAULT_HTTP_TIMEOUT_SECS, normalize_http_timeout};
 use clap::Parser;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -76,6 +77,8 @@ pub struct RuntimeConfig {
     pub subagent_max_iterations: u32,
     /// Wall-clock timeout in seconds for the entire sub-agent run (Issue #129).
     pub subagent_timeout_secs: u64,
+    /// HTTP request timeout in seconds (Issue #146).
+    pub http_timeout_secs: u64,
 }
 
 #[derive(Debug, Clone)]
@@ -227,6 +230,7 @@ impl EffectiveConfig {
                 smart_compact_threshold_ratio: 0.75,
                 subagent_max_iterations: 10,
                 subagent_timeout_secs: 120,
+                http_timeout_secs: DEFAULT_HTTP_TIMEOUT_SECS,
             },
             mode: ModeConfig {
                 prompt_source: PromptSource::Interactive,
@@ -324,6 +328,8 @@ impl EffectiveConfig {
             "ANVIL_SMART_COMPACT_THRESHOLD_RATIO",
             "ANVIL_SUBAGENT_MAX_ITERATIONS",
             "ANVIL_SUBAGENT_TIMEOUT",
+            "ANVIL_HTTP_TIMEOUT",
+            "ANVIL_CURL_TIMEOUT",
         ] {
             if let Ok(value) = std::env::var(key) {
                 map.insert(key.to_string(), value);
@@ -410,6 +416,11 @@ impl EffectiveConfig {
         // Tag protocol flag
         if let Some(v) = cli.tag_protocol {
             self.runtime.tag_protocol = Some(v);
+        }
+
+        // HTTP timeout
+        if let Some(timeout) = cli.timeout {
+            self.runtime.http_timeout_secs = timeout;
         }
 
         // Prompt tier override
@@ -543,6 +554,11 @@ impl EffectiveConfig {
                         .parse()
                         .map_err(|_| ConfigError::InvalidNumericValue(value.clone()))?;
                 }
+                "http_timeout_secs" | "ANVIL_HTTP_TIMEOUT" | "ANVIL_CURL_TIMEOUT" => {
+                    self.runtime.http_timeout_secs = value
+                        .parse()
+                        .map_err(|_| ConfigError::InvalidNumericValue(value.clone()))?;
+                }
                 _ => {}
             }
         }
@@ -569,7 +585,17 @@ impl EffectiveConfig {
         self.clamp_agent_iterations();
         self.clamp_smart_compact_ratio();
         self.clamp_subagent_settings();
+        self.clamp_http_timeout();
         Ok(())
+    }
+
+    fn clamp_http_timeout(&mut self) {
+        let old = self.runtime.http_timeout_secs;
+        let normalized = normalize_http_timeout(old);
+        if normalized != old {
+            self.runtime.http_timeout_secs = normalized;
+            eprintln!("Warning: http_timeout_secs={old} adjusted to {normalized}");
+        }
     }
 
     /// Clamp smart_compact_threshold_ratio to [0.1, 0.95].
@@ -925,6 +951,7 @@ impl std::fmt::Debug for RuntimeConfig {
                 "smart_compact_threshold_ratio",
                 &self.smart_compact_threshold_ratio,
             )
+            .field("http_timeout_secs", &self.http_timeout_secs)
             .finish()
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -76,6 +76,8 @@ pub struct RuntimeConfig {
     pub subagent_max_iterations: u32,
     /// Wall-clock timeout in seconds for the entire sub-agent run (Issue #129).
     pub subagent_timeout_secs: u64,
+    /// Loop detection threshold: number of identical tool calls before detection triggers (Issue #145).
+    pub loop_detection_threshold: usize,
 }
 
 #[derive(Debug, Clone)]
@@ -227,6 +229,7 @@ impl EffectiveConfig {
                 smart_compact_threshold_ratio: 0.75,
                 subagent_max_iterations: 10,
                 subagent_timeout_secs: 120,
+                loop_detection_threshold: 3,
             },
             mode: ModeConfig {
                 prompt_source: PromptSource::Interactive,
@@ -324,6 +327,7 @@ impl EffectiveConfig {
             "ANVIL_SMART_COMPACT_THRESHOLD_RATIO",
             "ANVIL_SUBAGENT_MAX_ITERATIONS",
             "ANVIL_SUBAGENT_TIMEOUT",
+            "ANVIL_LOOP_DETECTION_THRESHOLD",
         ] {
             if let Ok(value) = std::env::var(key) {
                 map.insert(key.to_string(), value);
@@ -543,6 +547,15 @@ impl EffectiveConfig {
                         .parse()
                         .map_err(|_| ConfigError::InvalidNumericValue(value.clone()))?;
                 }
+                "loop_detection_threshold" | "ANVIL_LOOP_DETECTION_THRESHOLD" => {
+                    let v: usize = value
+                        .parse()
+                        .map_err(|_| ConfigError::InvalidNumericValue(value.clone()))?;
+                    if !(2..=20).contains(&v) {
+                        return Err(ConfigError::InvalidNumericValue(value.clone()));
+                    }
+                    self.runtime.loop_detection_threshold = v;
+                }
                 _ => {}
             }
         }
@@ -569,6 +582,7 @@ impl EffectiveConfig {
         self.clamp_agent_iterations();
         self.clamp_smart_compact_ratio();
         self.clamp_subagent_settings();
+        self.clamp_loop_detection_threshold();
         Ok(())
     }
 
@@ -674,6 +688,10 @@ impl EffectiveConfig {
                 "Warning: subagent_timeout_secs={old} exceeds maximum ({MAX_SUBAGENT_TIMEOUT_SECS}), adjusted to {MAX_SUBAGENT_TIMEOUT_SECS}"
             );
         }
+    }
+
+    fn clamp_loop_detection_threshold(&mut self) {
+        self.runtime.loop_detection_threshold = self.runtime.loop_detection_threshold.clamp(2, 20);
     }
 
     pub fn validate_for_test(&mut self) -> Result<(), ConfigError> {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -214,7 +214,7 @@ impl EffectiveConfig {
                 api_key: None,
                 context_window: 200_000,
                 context_budget: None,
-                max_agent_iterations: 10,
+                max_agent_iterations: DEFAULT_MAX_AGENT_ITERATIONS,
                 max_console_messages: 5,
                 auto_compact_threshold: 64,
                 tool_result_max_chars: 8000,
@@ -225,8 +225,8 @@ impl EffectiveConfig {
                 tag_protocol: None,
                 prompt_tier: None,
                 smart_compact_threshold_ratio: 0.75,
-                subagent_max_iterations: 10,
-                subagent_timeout_secs: 120,
+                subagent_max_iterations: DEFAULT_SUBAGENT_MAX_ITERATIONS,
+                subagent_timeout_secs: DEFAULT_SUBAGENT_TIMEOUT_SECS,
             },
             mode: ModeConfig {
                 prompt_source: PromptSource::Interactive,
@@ -653,11 +653,8 @@ impl EffectiveConfig {
     /// Clamp sub-agent iteration/timeout settings.
     /// If 0, restore to default values. Enforce upper bounds.
     fn clamp_subagent_settings(&mut self) {
-        const MAX_SUBAGENT_ITERATIONS: u32 = 100;
-        const MAX_SUBAGENT_TIMEOUT_SECS: u64 = 3600;
-
         if self.runtime.subagent_max_iterations == 0 {
-            self.runtime.subagent_max_iterations = 10;
+            self.runtime.subagent_max_iterations = DEFAULT_SUBAGENT_MAX_ITERATIONS;
         } else if self.runtime.subagent_max_iterations > MAX_SUBAGENT_ITERATIONS {
             let old = self.runtime.subagent_max_iterations;
             self.runtime.subagent_max_iterations = MAX_SUBAGENT_ITERATIONS;
@@ -666,7 +663,7 @@ impl EffectiveConfig {
             );
         }
         if self.runtime.subagent_timeout_secs == 0 {
-            self.runtime.subagent_timeout_secs = 120;
+            self.runtime.subagent_timeout_secs = DEFAULT_SUBAGENT_TIMEOUT_SECS;
         } else if self.runtime.subagent_timeout_secs > MAX_SUBAGENT_TIMEOUT_SECS {
             let old = self.runtime.subagent_timeout_secs;
             self.runtime.subagent_timeout_secs = MAX_SUBAGENT_TIMEOUT_SECS;
@@ -700,6 +697,11 @@ impl EffectiveConfig {
 
 const MAX_PROJECT_INSTRUCTIONS_CHARS: usize = 4000;
 const MIN_CONTEXT_WINDOW: u32 = 1000;
+const DEFAULT_MAX_AGENT_ITERATIONS: usize = 30;
+const DEFAULT_SUBAGENT_MAX_ITERATIONS: u32 = 20;
+const DEFAULT_SUBAGENT_TIMEOUT_SECS: u64 = 120;
+const MAX_SUBAGENT_ITERATIONS: u32 = 100;
+const MAX_SUBAGENT_TIMEOUT_SECS: u64 = 3600;
 const MIN_AGENT_ITERATIONS: usize = 1;
 const MAX_AGENT_ITERATIONS: usize = 100;
 

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -20,6 +20,7 @@ pub enum TerminationReason {
     Completed,
     Timeout,
     MaxIterations,
+    LoopDetected,
 }
 
 impl std::fmt::Display for TerminationReason {
@@ -28,6 +29,7 @@ impl std::fmt::Display for TerminationReason {
             Self::Completed => write!(f, "completed"),
             Self::Timeout => write!(f, "timeout"),
             Self::MaxIterations => write!(f, "max_iterations"),
+            Self::LoopDetected => write!(f, "loop_detected"),
         }
     }
 }
@@ -733,6 +735,7 @@ mod tests {
             TerminationReason::MaxIterations.to_string(),
             "max_iterations"
         );
+        assert_eq!(TerminationReason::LoopDetected.to_string(), "loop_detected");
     }
 
     #[test]
@@ -741,6 +744,7 @@ mod tests {
             TerminationReason::Completed,
             TerminationReason::Timeout,
             TerminationReason::MaxIterations,
+            TerminationReason::LoopDetected,
         ] {
             let json = serde_json::to_string(&reason).expect("serialize");
             let back: TerminationReason = serde_json::from_str(&json).expect("deserialize");

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -23,9 +23,9 @@ pub use ollama::{
     parse_model_list_from_tags_response, resolve_ollama_model_alias,
 };
 pub use transport::{
-    HttpResponse, HttpTransport, ReqwestHttpTransport, RetryConfig, RetryTransport,
-    classify_http_error, classify_reqwest_error, http_timeout, redact_secrets,
-    sanitize_error_message,
+    DEFAULT_HTTP_TIMEOUT_SECS, HttpResponse, HttpTransport, ReqwestHttpTransport, RetryConfig,
+    RetryTransport, classify_http_error, classify_reqwest_error, http_timeout,
+    normalize_http_timeout, redact_secrets, sanitize_error_message,
 };
 
 /// Default transport used by provider clients: reqwest with retry wrapper.
@@ -405,7 +405,10 @@ pub fn build_local_provider_client(
     config: &EffectiveConfig,
     shutdown_flag: Arc<AtomicBool>,
 ) -> Result<LocalProviderClient, ProviderBootstrapError> {
-    let reqwest_transport = ReqwestHttpTransport::with_shutdown_flag(Arc::clone(&shutdown_flag));
+    let reqwest_transport = ReqwestHttpTransport::with_timeout_and_shutdown_flag(
+        config.runtime.http_timeout_secs,
+        Arc::clone(&shutdown_flag),
+    );
     let transport = RetryTransport::with_shutdown_flag(
         reqwest_transport,
         RetryConfig::default(),

--- a/src/provider/transport.rs
+++ b/src/provider/transport.rs
@@ -112,19 +112,37 @@ pub fn classify_reqwest_error(err: reqwest::Error) -> ProviderTurnError {
     }
 }
 
+/// Default HTTP request timeout in seconds.
+pub const DEFAULT_HTTP_TIMEOUT_SECS: u64 = 300;
+
+/// Normalize timeout values shared by config validation and env fallback.
+///
+/// - 0 → `DEFAULT_HTTP_TIMEOUT_SECS` (restore default)
+/// - <10 → 10
+/// - >3600 → 3600
+/// - otherwise → unchanged
+pub fn normalize_http_timeout(timeout_secs: u64) -> u64 {
+    const MIN_HTTP_TIMEOUT_SECS: u64 = 10;
+    const MAX_HTTP_TIMEOUT_SECS: u64 = 3600;
+
+    if timeout_secs == 0 {
+        DEFAULT_HTTP_TIMEOUT_SECS
+    } else {
+        timeout_secs.clamp(MIN_HTTP_TIMEOUT_SECS, MAX_HTTP_TIMEOUT_SECS)
+    }
+}
+
 /// Read the HTTP timeout from the environment.
 ///
 /// Checks `ANVIL_HTTP_TIMEOUT` first, then falls back to `ANVIL_CURL_TIMEOUT`
-/// for backward compatibility, defaulting to 300 seconds.
+/// for backward compatibility, defaulting to `DEFAULT_HTTP_TIMEOUT_SECS`.
 pub fn http_timeout() -> u64 {
-    static TIMEOUT: std::sync::OnceLock<u64> = std::sync::OnceLock::new();
-    *TIMEOUT.get_or_init(|| {
-        std::env::var("ANVIL_HTTP_TIMEOUT")
-            .or_else(|_| std::env::var("ANVIL_CURL_TIMEOUT"))
-            .unwrap_or_else(|_| "300".to_string())
-            .parse::<u64>()
-            .unwrap_or(300)
-    })
+    let parsed = std::env::var("ANVIL_HTTP_TIMEOUT")
+        .or_else(|_| std::env::var("ANVIL_CURL_TIMEOUT"))
+        .unwrap_or_else(|_| DEFAULT_HTTP_TIMEOUT_SECS.to_string())
+        .parse::<u64>()
+        .unwrap_or(DEFAULT_HTTP_TIMEOUT_SECS);
+    normalize_http_timeout(parsed)
 }
 
 /// HTTP transport backed by `reqwest::blocking::Client`.
@@ -144,11 +162,10 @@ impl Default for ReqwestHttpTransport {
 }
 
 impl ReqwestHttpTransport {
-    /// Create a new transport without a shutdown flag.
-    pub fn new() -> Self {
-        let timeout = http_timeout();
+    /// Create a new transport with explicit timeout.
+    pub fn with_timeout(timeout_secs: u64) -> Self {
         let client = reqwest::blocking::Client::builder()
-            .timeout(Duration::from_secs(timeout))
+            .timeout(Duration::from_secs(timeout_secs))
             .redirect(reqwest::redirect::Policy::none())
             .build()
             .expect("Failed to build HTTP client");
@@ -164,7 +181,22 @@ impl ReqwestHttpTransport {
         }
     }
 
-    /// Create a new transport with a shutdown flag for graceful shutdown.
+    /// Create a new transport (reads timeout from environment).
+    pub fn new() -> Self {
+        Self::with_timeout(http_timeout())
+    }
+
+    /// Create a new transport with explicit timeout and shutdown flag.
+    pub fn with_timeout_and_shutdown_flag(
+        timeout_secs: u64,
+        shutdown_flag: Arc<AtomicBool>,
+    ) -> Self {
+        let mut transport = Self::with_timeout(timeout_secs);
+        transport.shutdown_flag = Some(shutdown_flag);
+        transport
+    }
+
+    /// Create a new transport with a shutdown flag for graceful shutdown (reads timeout from environment).
     pub fn with_shutdown_flag(shutdown_flag: Arc<AtomicBool>) -> Self {
         let mut transport = Self::new();
         transport.shutdown_flag = Some(shutdown_flag);

--- a/src/tooling/file_cache.rs
+++ b/src/tooling/file_cache.rs
@@ -1,0 +1,190 @@
+//! File read cache for reducing redundant `file.read` operations.
+//!
+//! Caches file content keyed by canonical path, validated against mtime.
+//! LRU eviction with dual limits (entry count + byte size).
+//! All public methods perform canonicalize + sandbox boundary check internally.
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{Instant, SystemTime};
+
+/// Default maximum number of cached entries.
+const DEFAULT_MAX_ENTRIES: usize = 100;
+
+/// Default maximum total bytes across all cached entries (10 MB).
+const DEFAULT_MAX_BYTES: usize = 10_485_760;
+
+/// A single cached file entry.
+pub struct CacheEntry {
+    pub content: String,
+    pub mtime: SystemTime,
+    pub byte_size: usize,
+    pub last_access: Instant,
+}
+
+/// In-memory file read cache with LRU eviction and sandbox boundary enforcement.
+///
+/// Design notes:
+/// - LRU tracking uses `CacheEntry.last_access` only (Single Source of Truth, DR1-001).
+/// - Eviction does linear scan on `last_access`; max 100 entries so performance is fine.
+/// - Eviction pattern is similar to `CheckpointStack::evict_oldest_while` but uses
+///   LRU (last_access oldest) instead of FIFO (DR1-002).
+pub struct FileReadCache {
+    root: PathBuf,
+    entries: HashMap<PathBuf, CacheEntry>,
+    total_bytes: usize,
+    max_entries: usize,
+    max_bytes: usize,
+}
+
+impl FileReadCache {
+    /// Create a new cache with default limits.
+    pub fn new(root: PathBuf) -> Self {
+        Self {
+            root,
+            entries: HashMap::new(),
+            total_bytes: 0,
+            max_entries: DEFAULT_MAX_ENTRIES,
+            max_bytes: DEFAULT_MAX_BYTES,
+        }
+    }
+
+    /// Create a new cache with custom limits.
+    pub fn with_limits(root: PathBuf, max_entries: usize, max_bytes: usize) -> Self {
+        Self {
+            root,
+            entries: HashMap::new(),
+            total_bytes: 0,
+            max_entries,
+            max_bytes,
+        }
+    }
+
+    /// High-level API: check cache for a file, returning content if hit.
+    ///
+    /// Internally performs canonicalize + mtime check + sandbox boundary validation.
+    /// Returns `None` on miss, canonicalize failure, or sandbox violation.
+    /// Updates `last_access` on hit (DR1-005).
+    pub fn try_get(&mut self, resolved_path: &Path) -> Option<String> {
+        let canonical = self.validate_canonical_path(resolved_path)?;
+        let mtime = fs::metadata(&canonical).ok()?.modified().ok()?;
+
+        let entry = self.entries.get_mut(&canonical)?;
+        if entry.mtime != mtime {
+            // mtime changed — stale entry, remove it
+            let byte_size = entry.byte_size;
+            self.entries.remove(&canonical);
+            self.total_bytes = self.total_bytes.saturating_sub(byte_size);
+            return None;
+        }
+
+        entry.last_access = Instant::now();
+        Some(entry.content.clone())
+    }
+
+    /// High-level API: record a file's content in the cache.
+    ///
+    /// Internally performs canonicalize + sandbox validation + LRU eviction.
+    /// No-op if canonicalize fails or path is outside sandbox.
+    pub fn record(&mut self, resolved_path: &Path, content: String) {
+        let canonical = match self.validate_canonical_path(resolved_path) {
+            Some(p) => p,
+            None => return,
+        };
+        let mtime = match fs::metadata(&canonical).and_then(|m| m.modified()) {
+            Ok(t) => t,
+            Err(_) => return,
+        };
+
+        let byte_size = content.len();
+
+        // Remove existing entry if present (update case)
+        if let Some(old) = self.entries.remove(&canonical) {
+            self.total_bytes = self.total_bytes.saturating_sub(old.byte_size);
+        }
+
+        // Insert new entry
+        self.entries.insert(
+            canonical,
+            CacheEntry {
+                content,
+                mtime,
+                byte_size,
+                last_access: Instant::now(),
+            },
+        );
+        self.total_bytes += byte_size;
+
+        // LRU eviction: while over limits, remove oldest entry
+        self.evict_while_over_limits();
+    }
+
+    /// Invalidate (remove) a cached entry for the given path.
+    ///
+    /// Internally performs canonicalize. No-op if canonicalize fails or entry not found.
+    pub fn invalidate(&mut self, resolved_path: &Path) {
+        if let Some(canonical) = self.validate_canonical_path(resolved_path)
+            && let Some(old) = self.entries.remove(&canonical)
+        {
+            self.total_bytes = self.total_bytes.saturating_sub(old.byte_size);
+        }
+    }
+
+    /// Clear all cached entries (e.g., on session switch).
+    pub fn clear(&mut self) {
+        self.entries.clear();
+        self.total_bytes = 0;
+    }
+
+    /// Resolve a path to its canonical form and verify it is within the sandbox root.
+    ///
+    /// Returns `None` if canonicalize fails or the path is outside root.
+    /// Security: all public API methods go through this to prevent cache poisoning
+    /// and sandbox boundary escape.
+    pub fn validate_canonical_path(&self, resolved_path: &Path) -> Option<PathBuf> {
+        let canonical = fs::canonicalize(resolved_path).ok()?;
+        let root_canonical = fs::canonicalize(&self.root).ok()?;
+        if canonical.starts_with(&root_canonical) {
+            Some(canonical)
+        } else {
+            None
+        }
+    }
+
+    /// Return the number of cached entries.
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Return whether the cache is empty.
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Return the total cached bytes.
+    pub fn total_bytes(&self) -> usize {
+        self.total_bytes
+    }
+
+    /// Evict LRU entries while over capacity limits.
+    fn evict_while_over_limits(&mut self) {
+        while self.entries.len() > self.max_entries || self.total_bytes > self.max_bytes {
+            // Find the entry with the oldest last_access
+            let oldest_key = self
+                .entries
+                .iter()
+                .min_by_key(|(_, entry)| entry.last_access)
+                .map(|(key, _)| key.clone());
+
+            match oldest_key {
+                Some(key) => {
+                    if let Some(removed) = self.entries.remove(&key) {
+                        self.total_bytes = self.total_bytes.saturating_sub(removed.byte_size);
+                    }
+                }
+                None => break, // should not happen, but safety
+            }
+        }
+    }
+}

--- a/src/tooling/mod.rs
+++ b/src/tooling/mod.rs
@@ -5,6 +5,7 @@
 //! [`LocalToolExecutor`] within a sandboxed workspace root.
 
 pub mod diff;
+pub mod file_cache;
 pub mod shell_policy;
 
 pub use shell_policy::{ShellPolicy, classify_shell_policy, is_network_command};
@@ -899,6 +900,7 @@ pub struct LocalToolExecutor {
     serper_api_key: Option<String>,
     shutdown_flag: Option<std::sync::Arc<std::sync::atomic::AtomicBool>>,
     http_client: reqwest::blocking::Client,
+    file_cache: Option<std::sync::Arc<std::sync::Mutex<file_cache::FileReadCache>>>,
 }
 
 /// Build the shared HTTP client used by tooling (web.fetch / web.search).
@@ -943,7 +945,11 @@ impl Display for ToolRuntimeError {
 impl std::error::Error for ToolRuntimeError {}
 
 impl LocalToolExecutor {
-    pub fn new(root: impl Into<PathBuf>, config: &RuntimeConfig) -> Self {
+    pub fn new(
+        root: impl Into<PathBuf>,
+        config: &RuntimeConfig,
+        file_cache: Option<std::sync::Arc<std::sync::Mutex<file_cache::FileReadCache>>>,
+    ) -> Self {
         let interval = match config.web_search_provider {
             WebSearchProvider::DuckDuckGo => RATE_LIMIT_DUCKDUCKGO,
             WebSearchProvider::SerperApi => RATE_LIMIT_SERPER_API,
@@ -956,6 +962,7 @@ impl LocalToolExecutor {
             serper_api_key: config.serper_api_key.clone(),
             shutdown_flag: None,
             http_client: build_tooling_http_client(),
+            file_cache,
         }
     }
 
@@ -969,6 +976,7 @@ impl LocalToolExecutor {
             serper_api_key: None,
             shutdown_flag: None,
             http_client: build_tooling_http_client(),
+            file_cache: None,
         }
     }
 
@@ -1073,12 +1081,51 @@ impl LocalToolExecutor {
         if let Some(mime_type) = detect_image_mime(&resolved) {
             return self.execute_image_read(request, path, &resolved, mime_type, started);
         }
-        let content = fs::read_to_string(&resolved).map_err(|err| {
+
+        // TOCTOU defense (DR4-002): resolve canonical path ONCE and use it for both
+        // cache lookup and file read, preventing symlink swap between check and read.
+        let canonical_for_read = self
+            .file_cache
+            .as_ref()
+            .and_then(|c| c.lock().ok())
+            .and_then(|c| c.validate_canonical_path(&resolved));
+
+        // Cache check (high-level API: canonicalize + mtime internal)
+        if let Some(ref cache_arc) = self.file_cache
+            && let Ok(mut cache) = cache_arc.lock()
+            && let Some(cached) = cache.try_get(&resolved)
+        {
+            tracing::debug!(path = %path, "file.read cache hit");
+            let msg = format!(
+                "[cached] File previously read (content unchanged, {} bytes)",
+                cached.len()
+            );
+            return Ok(build_completed_result(
+                request,
+                path.to_string(),
+                ToolExecutionPayload::Text(msg),
+                vec![resolved.display().to_string()],
+                started,
+            ));
+        }
+        // Mutex poison → fall through to normal read (best-effort)
+
+        // Read from canonical path when available (TOCTOU defense), fallback to resolved
+        let read_path = canonical_for_read.as_deref().unwrap_or(&resolved);
+        let content = fs::read_to_string(read_path).map_err(|err| {
             ToolRuntimeError::Io(format!(
                 "file.read failed for {}: {err}",
                 resolved.display()
             ))
         })?;
+
+        // Cache record (high-level API: canonicalize + LRU eviction internal)
+        if let Some(ref cache_arc) = self.file_cache
+            && let Ok(mut cache) = cache_arc.lock()
+        {
+            cache.record(&resolved, content.clone());
+        }
+
         Ok(build_completed_result(
             request,
             path.to_string(),
@@ -1148,6 +1195,12 @@ impl LocalToolExecutor {
                 resolved.display()
             ))
         })?;
+        // Invalidate cache after write
+        if let Some(ref cache_arc) = self.file_cache
+            && let Ok(mut cache) = cache_arc.lock()
+        {
+            cache.invalidate(&resolved);
+        }
         Ok(build_completed_result(
             request,
             path.to_string(),
@@ -1202,6 +1255,12 @@ impl LocalToolExecutor {
                 resolved.display()
             ))
         })?;
+        // Invalidate cache after edit
+        if let Some(ref cache_arc) = self.file_cache
+            && let Ok(mut cache) = cache_arc.lock()
+        {
+            cache.invalidate(&resolved);
+        }
         Ok(build_completed_result(
             request,
             path.to_string(),
@@ -1248,6 +1307,12 @@ impl LocalToolExecutor {
                         resolved.display()
                     ))
                 })?;
+                // Invalidate cache after anchor edit
+                if let Some(ref cache_arc) = self.file_cache
+                    && let Ok(mut cache) = cache_arc.lock()
+                {
+                    cache.invalidate(&resolved);
+                }
                 Ok(build_completed_result(
                     request,
                     path.to_string(),

--- a/src/tooling/mod.rs
+++ b/src/tooling/mod.rs
@@ -914,13 +914,34 @@ fn build_tooling_http_client() -> reqwest::blocking::Client {
 pub enum ToolRuntimeError {
     InvalidPath(String),
     Io(String),
-    CaptchaBlocked { query: String },
-    EditNotFound(String),
+    CaptchaBlocked {
+        query: String,
+    },
+    EditNotFound {
+        message: String,
+        context_snippet: Option<String>,
+    },
 }
 
 impl ToolRuntimeError {
+    /// Create an EditNotFound error without context snippet.
+    pub fn edit_not_found(message: impl Into<String>) -> Self {
+        Self::EditNotFound {
+            message: message.into(),
+            context_snippet: None,
+        }
+    }
+
+    /// Create an EditNotFound error with a file context snippet.
+    pub fn edit_not_found_with_context(message: impl Into<String>, context: String) -> Self {
+        Self::EditNotFound {
+            message: message.into(),
+            context_snippet: Some(context),
+        }
+    }
+
     pub fn is_edit_not_found(&self) -> bool {
-        matches!(self, Self::EditNotFound(_))
+        matches!(self, Self::EditNotFound { .. })
     }
 }
 
@@ -935,12 +956,107 @@ impl Display for ToolRuntimeError {
                  Consider setting SERPER_API_KEY for automatic fallback, \
                  or use web.fetch to access specific URLs directly."
             ),
-            Self::EditNotFound(message) => write!(f, "{message}"),
+            Self::EditNotFound { message, .. } => write!(f, "{message}"),
         }
     }
 }
 
 impl std::error::Error for ToolRuntimeError {}
+
+/// Sensitive file patterns that should never have their content included
+/// in error responses to prevent accidental leakage of secrets.
+const SENSITIVE_FILE_PATTERNS: &[&str] = &[
+    ".env",
+    ".env.*",
+    "*.pem",
+    "*.key",
+    "*.p12",
+    "*.pfx",
+    "id_rsa",
+    "id_ed25519",
+    "id_ecdsa",
+    "id_dsa",
+    "credentials.json",
+    "secrets.*",
+    "*.secret",
+    "*.secrets",
+    ".netrc",
+    ".npmrc",
+    ".pypirc",
+    "token.json",
+    "service-account*.json",
+];
+
+/// Check whether a file path matches the sensitive file blocklist.
+///
+/// Matching is performed against the file name (basename) only, using
+/// simple string operations: exact match, prefix (`starts_with`),
+/// suffix (`ends_with`), and prefix+suffix for patterns like `service-account*.json`.
+pub fn is_sensitive_file(path: &str) -> bool {
+    let file_name = std::path::Path::new(path)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("");
+    if file_name.is_empty() {
+        return false;
+    }
+    for pattern in SENSITIVE_FILE_PATTERNS {
+        if let Some(suffix) = pattern.strip_prefix('*') {
+            if file_name.ends_with(suffix) {
+                return true;
+            }
+        } else if let Some(prefix) = pattern.strip_suffix('*') {
+            if file_name.starts_with(prefix) {
+                return true;
+            }
+        } else if pattern.contains('*') {
+            let parts: Vec<&str> = pattern.splitn(2, '*').collect();
+            if parts.len() == 2
+                && file_name.starts_with(parts[0])
+                && file_name.ends_with(parts[1])
+                && file_name.len() >= parts[0].len() + parts[1].len()
+            {
+                return true;
+            }
+        } else if file_name == *pattern {
+            return true;
+        }
+    }
+    false
+}
+
+/// Extract context lines around the best matching location for `old_string`
+/// in `content`. Searches for the first line of `old_string` (trimmed) and
+/// returns surrounding lines with line numbers.
+pub fn extract_edit_context(
+    content: &str,
+    old_string: &str,
+    context_lines: usize,
+) -> Option<String> {
+    let first_line = old_string.lines().next()?.trim();
+    if first_line.is_empty() {
+        return None;
+    }
+
+    let lines: Vec<&str> = content.lines().collect();
+    let match_idx = lines
+        .iter()
+        .enumerate()
+        .find(|(_, line)| line.trim().contains(first_line))?
+        .0;
+
+    let start = match_idx.saturating_sub(context_lines);
+    let end = (match_idx + context_lines + 1).min(lines.len());
+
+    let context: String = lines[start..end]
+        .iter()
+        .enumerate()
+        .map(|(i, line)| format!("{:4} | {}", start + i + 1, line))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    Some(context)
+}
 
 impl LocalToolExecutor {
     pub fn new(root: impl Into<PathBuf>, config: &RuntimeConfig) -> Self {
@@ -1183,14 +1299,14 @@ impl LocalToolExecutor {
         }
         let count = content.matches(old_string).count();
         if count == 0 {
-            return Err(ToolRuntimeError::EditNotFound(format!(
+            return Err(ToolRuntimeError::edit_not_found(format!(
                 "file.edit: old_string not found in {path}. \
                  Ensure the string exactly matches the file content, \
                  including whitespace and indentation."
             )));
         }
         if count > 1 {
-            return Err(ToolRuntimeError::EditNotFound(format!(
+            return Err(ToolRuntimeError::edit_not_found(format!(
                 "file.edit: old_string found {count} times in {path}. \
                  Include more surrounding context to make the match unique."
             )));
@@ -1256,16 +1372,17 @@ impl LocalToolExecutor {
                     started,
                 ))
             }
-            0 => Err(ToolRuntimeError::EditNotFound(format!(
+            0 => Err(ToolRuntimeError::edit_not_found(format!(
                 "anchor: normalized old_content not found in {path}"
             ))),
-            n => Err(ToolRuntimeError::EditNotFound(format!(
+            n => Err(ToolRuntimeError::edit_not_found(format!(
                 "anchor: old_content matched {n} locations in {path}, need unique match"
             ))),
         }
     }
 
-    /// Try file.edit first, fall back to anchor-based edit on EditNotFound.
+    /// Try file.edit with 3-level fallback: strict → trailing-ws → anchor.
+    /// On final failure, includes file context snippet in the error for LLM recovery.
     fn execute_file_edit_with_fallback(
         &self,
         request: &ToolExecutionRequest,
@@ -1274,23 +1391,152 @@ impl LocalToolExecutor {
         new_string: &str,
         started: Instant,
     ) -> Result<ToolExecutionResult, ToolRuntimeError> {
-        match self.execute_file_edit(request, path, old_string, new_string, started) {
-            Ok(result) => Ok(result),
-            Err(original_err) if original_err.is_edit_not_found() => {
-                let params = AnchorEditParams {
-                    old_content: old_string.to_string(),
-                    new_content: new_string.to_string(),
-                };
-                match self.execute_file_edit_anchor(request, path, &params, started) {
-                    Ok(mut result) => {
-                        result.summary = format!("{} (anchor fallback)", result.summary);
-                        Ok(result)
-                    }
-                    // Anchor also failed — return the original error for better diagnostics
-                    Err(_) => Err(original_err),
-                }
+        // Level 1: strict replace
+        let original_err =
+            match self.execute_file_edit(request, path, old_string, new_string, started) {
+                Ok(result) => return Ok(result),
+                Err(err) if !err.is_edit_not_found() => return Err(err),
+                Err(err) => err,
+            };
+
+        // Level 2: trailing whitespace normalized
+        if let Ok(mut result) =
+            self.execute_file_edit_trailing_ws(request, path, old_string, new_string, started)
+        {
+            result.summary = format!("{} (trailing-ws fallback)", result.summary);
+            return Ok(result);
+        }
+
+        // Level 3: anchor-based (indent-normalized)
+        let params = AnchorEditParams {
+            old_content: old_string.to_string(),
+            new_content: new_string.to_string(),
+        };
+        match self.execute_file_edit_anchor(request, path, &params, started) {
+            Ok(mut result) => {
+                result.summary = format!("{} (anchor fallback)", result.summary);
+                Ok(result)
             }
-            Err(err) => Err(err),
+            // All levels failed — enrich error with file context
+            Err(_) => Err(self.build_edit_not_found_with_context(path, old_string, &original_err)),
+        }
+    }
+
+    /// Level 2 fallback: match after stripping trailing whitespace from each line.
+    fn execute_file_edit_trailing_ws(
+        &self,
+        request: &ToolExecutionRequest,
+        path: &str,
+        old_string: &str,
+        new_string: &str,
+        started: Instant,
+    ) -> Result<ToolExecutionResult, ToolRuntimeError> {
+        let resolved = self.resolve_path(path)?;
+        let content = fs::read_to_string(&resolved).map_err(|err| {
+            ToolRuntimeError::Io(format!(
+                "file.edit failed to read {}: {err}",
+                resolved.display()
+            ))
+        })?;
+
+        let normalize_lines = |s: &str| -> Vec<String> {
+            s.lines().map(|line| line.trim_end().to_string()).collect()
+        };
+
+        let content_lines = normalize_lines(&content);
+        let old_lines = normalize_lines(old_string);
+
+        if old_lines.is_empty() {
+            return Err(ToolRuntimeError::edit_not_found(
+                "file.edit: empty old_string",
+            ));
+        }
+
+        // Find matching line range using trailing-ws-normalized comparison
+        let mut match_positions = Vec::new();
+        for i in 0..content_lines.len() {
+            if i + old_lines.len() > content_lines.len() {
+                break;
+            }
+            if content_lines[i..i + old_lines.len()] == old_lines[..] {
+                match_positions.push(i);
+            }
+        }
+
+        if match_positions.len() != 1 {
+            return Err(ToolRuntimeError::edit_not_found(format!(
+                "file.edit: trailing-ws-normalized old_string {} in {path}",
+                if match_positions.is_empty() {
+                    "not found".to_string()
+                } else {
+                    format!("found {} times", match_positions.len())
+                }
+            )));
+        }
+
+        let match_start = match_positions[0];
+        let match_end = match_start + old_lines.len();
+
+        // Replace the matched line range with new_string
+        let original_lines: Vec<&str> = content.lines().collect();
+        let mut result_parts: Vec<&str> = Vec::new();
+        for (i, line) in original_lines.iter().enumerate() {
+            if i < match_start || i >= match_end {
+                result_parts.push(line);
+            } else if i == match_start {
+                // Insert new_string at match position
+                result_parts.push(new_string);
+            }
+        }
+
+        // Handle trailing newline from original content
+        let new_content = if content.ends_with('\n') {
+            format!("{}\n", result_parts.join("\n"))
+        } else {
+            result_parts.join("\n")
+        };
+
+        fs::write(&resolved, &new_content).map_err(|err| {
+            ToolRuntimeError::Io(format!(
+                "file.edit failed to write {}: {err}",
+                resolved.display()
+            ))
+        })?;
+
+        Ok(build_completed_result(
+            request,
+            path.to_string(),
+            ToolExecutionPayload::None,
+            vec![resolved.display().to_string()],
+            started,
+        ))
+    }
+
+    /// Build an EditNotFound error enriched with file context snippet.
+    /// Skips context for sensitive files (e.g., .env, credentials).
+    fn build_edit_not_found_with_context(
+        &self,
+        path: &str,
+        old_string: &str,
+        original_err: &ToolRuntimeError,
+    ) -> ToolRuntimeError {
+        let message = original_err.to_string();
+
+        // Don't include context for sensitive files
+        if is_sensitive_file(path) {
+            return ToolRuntimeError::edit_not_found(message);
+        }
+
+        // Try to read file content for context extraction
+        let context_snippet = self
+            .resolve_path(path)
+            .ok()
+            .and_then(|resolved| fs::read_to_string(resolved).ok())
+            .and_then(|content| extract_edit_context(&content, old_string, 5));
+
+        match context_snippet {
+            Some(ctx) => ToolRuntimeError::edit_not_found_with_context(message, ctx),
+            None => ToolRuntimeError::edit_not_found(message),
         }
     }
 

--- a/tests/config_bootstrap.rs
+++ b/tests/config_bootstrap.rs
@@ -787,3 +787,115 @@ fn subagent_config_invalid_numeric_value() {
     let result = config.apply_overrides_for_test(&map, &HashMap::new(), &HashMap::new());
     assert!(result.is_err(), "non-numeric value should fail");
 }
+
+// ============================================================
+// HTTP timeout config tests (Issue #146)
+// ============================================================
+
+#[test]
+fn http_timeout_default() {
+    let config = EffectiveConfig::default_for_test().unwrap();
+    assert_eq!(config.runtime.http_timeout_secs, 300);
+}
+
+#[test]
+fn http_timeout_from_map_config_key() {
+    let mut config = EffectiveConfig::default_for_test().unwrap();
+    let mut map = HashMap::new();
+    map.insert("http_timeout_secs".to_string(), "60".to_string());
+    config
+        .apply_overrides_for_test(&map, &HashMap::new(), &HashMap::new())
+        .expect("should apply");
+    assert_eq!(config.runtime.http_timeout_secs, 60);
+}
+
+#[test]
+fn http_timeout_from_map_anvil_http_timeout() {
+    let mut config = EffectiveConfig::default_for_test().unwrap();
+    let mut map = HashMap::new();
+    map.insert("ANVIL_HTTP_TIMEOUT".to_string(), "120".to_string());
+    config
+        .apply_overrides_for_test(&HashMap::new(), &map, &HashMap::new())
+        .expect("should apply");
+    assert_eq!(config.runtime.http_timeout_secs, 120);
+}
+
+#[test]
+fn http_timeout_from_map_anvil_curl_timeout() {
+    let mut config = EffectiveConfig::default_for_test().unwrap();
+    let mut map = HashMap::new();
+    map.insert("ANVIL_CURL_TIMEOUT".to_string(), "90".to_string());
+    config
+        .apply_overrides_for_test(&HashMap::new(), &map, &HashMap::new())
+        .expect("should apply");
+    assert_eq!(config.runtime.http_timeout_secs, 90);
+}
+
+#[test]
+fn http_timeout_clamp_zero_restored_to_default() {
+    let mut config = EffectiveConfig::default_for_test().unwrap();
+    config.runtime.http_timeout_secs = 0;
+    config.validate_for_test().expect("validation should pass");
+    assert_eq!(
+        config.runtime.http_timeout_secs, 300,
+        "zero http_timeout_secs should be restored to default (300)"
+    );
+}
+
+#[test]
+fn http_timeout_clamp_below_minimum() {
+    let mut config = EffectiveConfig::default_for_test().unwrap();
+    config.runtime.http_timeout_secs = 5;
+    config.validate_for_test().expect("validation should pass");
+    assert_eq!(
+        config.runtime.http_timeout_secs, 10,
+        "http_timeout_secs below 10 should be clamped to 10"
+    );
+}
+
+#[test]
+fn http_timeout_clamp_above_maximum() {
+    let mut config = EffectiveConfig::default_for_test().unwrap();
+    config.runtime.http_timeout_secs = 7200;
+    config.validate_for_test().expect("validation should pass");
+    assert_eq!(
+        config.runtime.http_timeout_secs, 3600,
+        "http_timeout_secs above 3600 should be clamped to 3600"
+    );
+}
+
+#[test]
+fn http_timeout_normal_value_unchanged() {
+    let mut config = EffectiveConfig::default_for_test().unwrap();
+    config.runtime.http_timeout_secs = 600;
+    config.validate_for_test().expect("validation should pass");
+    assert_eq!(config.runtime.http_timeout_secs, 600);
+}
+
+#[test]
+fn http_timeout_invalid_numeric_value() {
+    let mut config = EffectiveConfig::default_for_test().unwrap();
+    let mut map = HashMap::new();
+    map.insert("http_timeout_secs".to_string(), "not_a_number".to_string());
+    let result = config.apply_overrides_for_test(&map, &HashMap::new(), &HashMap::new());
+    assert!(result.is_err(), "non-numeric http_timeout_secs should fail");
+}
+
+#[test]
+fn http_timeout_cli_args_overrides_runtime() {
+    let mut config = EffectiveConfig::default_for_test().unwrap();
+    let cli = anvil::config::CliArgs {
+        timeout: Some(180),
+        ..Default::default()
+    };
+    config.apply_cli_args(&cli).expect("should apply");
+    assert_eq!(config.runtime.http_timeout_secs, 180);
+}
+
+#[test]
+fn http_timeout_cli_args_none_leaves_default() {
+    let mut config = EffectiveConfig::default_for_test().unwrap();
+    let cli = anvil::config::CliArgs::default();
+    config.apply_cli_args(&cli).expect("should apply");
+    assert_eq!(config.runtime.http_timeout_secs, 300);
+}

--- a/tests/config_bootstrap.rs
+++ b/tests/config_bootstrap.rs
@@ -142,9 +142,9 @@ fn override_precedence_is_file_then_env_then_cli() {
 }
 
 #[test]
-fn max_agent_iterations_defaults_to_ten() {
+fn max_agent_iterations_defaults_to_thirty() {
     let config = EffectiveConfig::default_for_test().expect("config should load");
-    assert_eq!(config.runtime.max_agent_iterations, 10);
+    assert_eq!(config.runtime.max_agent_iterations, 30);
 }
 
 #[test]
@@ -727,7 +727,7 @@ fn tag_protocol_cli_args_unset_leaves_none() {
 #[test]
 fn subagent_config_defaults() {
     let config = EffectiveConfig::default_for_test().unwrap();
-    assert_eq!(config.runtime.subagent_max_iterations, 10);
+    assert_eq!(config.runtime.subagent_max_iterations, 20);
     assert_eq!(config.runtime.subagent_timeout_secs, 120);
 }
 
@@ -735,12 +735,12 @@ fn subagent_config_defaults() {
 fn subagent_config_apply_map() {
     let mut config = EffectiveConfig::default_for_test().unwrap();
     let mut map = HashMap::new();
-    map.insert("subagent_max_iterations".to_string(), "20".to_string());
+    map.insert("subagent_max_iterations".to_string(), "25".to_string());
     map.insert("subagent_timeout_secs".to_string(), "300".to_string());
     config
         .apply_overrides_for_test(&map, &HashMap::new(), &HashMap::new())
         .expect("should apply");
-    assert_eq!(config.runtime.subagent_max_iterations, 20);
+    assert_eq!(config.runtime.subagent_max_iterations, 25);
     assert_eq!(config.runtime.subagent_timeout_secs, 300);
 }
 
@@ -767,8 +767,8 @@ fn subagent_config_zero_restored_to_defaults() {
     config.runtime.subagent_timeout_secs = 0;
     config.validate_for_test().expect("validation should pass");
     assert_eq!(
-        config.runtime.subagent_max_iterations, 10,
-        "zero subagent_max_iterations should be restored to default"
+        config.runtime.subagent_max_iterations, 20,
+        "zero subagent_max_iterations should be restored to default (20)"
     );
     assert_eq!(
         config.runtime.subagent_timeout_secs, 120,

--- a/tests/loop_detection.rs
+++ b/tests/loop_detection.rs
@@ -1,0 +1,200 @@
+//! Tests for the LoopDetector module (Issue #145).
+
+use anvil::app::loop_detector::{DEFAULT_MAX_HISTORY, LoopAction, LoopDetector, fingerprint};
+
+fn same_input() -> serde_json::Value {
+    serde_json::json!({"path": "src/main.rs"})
+}
+
+#[test]
+fn test_no_detection_below_threshold() {
+    let mut detector = LoopDetector::new(3);
+    // Only 2 calls — below threshold of 3
+    let a1 = detector.record_and_check("file.read", &same_input());
+    let a2 = detector.record_and_check("file.read", &same_input());
+    assert_eq!(a1, LoopAction::Continue);
+    assert_eq!(a2, LoopAction::Continue);
+}
+
+#[test]
+fn test_detection_at_threshold() {
+    let mut detector = LoopDetector::new(3);
+    detector.record_and_check("file.read", &same_input());
+    detector.record_and_check("file.read", &same_input());
+    let action = detector.record_and_check("file.read", &same_input());
+    assert!(
+        matches!(action, LoopAction::Warn(_)),
+        "Expected Warn at threshold, got {:?}",
+        action
+    );
+}
+
+#[test]
+fn test_escalation_to_strong_warn() {
+    let mut detector = LoopDetector::new(3);
+    // First 3: Warn
+    for _ in 0..3 {
+        detector.record_and_check("file.read", &same_input());
+    }
+    // 4th: should still be Continue (not yet threshold again since escalation_count == 1)
+    // Actually after Warn, the next call makes history 4 long, and the tail 3 are still identical
+    let action = detector.record_and_check("file.read", &same_input());
+    assert!(
+        matches!(action, LoopAction::StrongWarn(_)),
+        "Expected StrongWarn, got {:?}",
+        action
+    );
+}
+
+#[test]
+fn test_escalation_to_break() {
+    let mut detector = LoopDetector::new(3);
+    // Calls 1-3: Warn at 3rd
+    for _ in 0..3 {
+        detector.record_and_check("file.read", &same_input());
+    }
+    // Call 4: StrongWarn
+    detector.record_and_check("file.read", &same_input());
+    // Call 5: Break
+    let action = detector.record_and_check("file.read", &same_input());
+    assert!(
+        matches!(action, LoopAction::Break(_)),
+        "Expected Break, got {:?}",
+        action
+    );
+}
+
+#[test]
+fn test_different_tool_names_no_detection() {
+    let mut detector = LoopDetector::new(3);
+    let input = same_input();
+    let a1 = detector.record_and_check("file.read", &input);
+    let a2 = detector.record_and_check("file.write", &input);
+    let a3 = detector.record_and_check("shell.exec", &input);
+    assert_eq!(a1, LoopAction::Continue);
+    assert_eq!(a2, LoopAction::Continue);
+    assert_eq!(a3, LoopAction::Continue);
+}
+
+#[test]
+fn test_same_tool_different_args_no_detection() {
+    let mut detector = LoopDetector::new(3);
+    let a1 = detector.record_and_check("file.read", &serde_json::json!({"path": "a.rs"}));
+    let a2 = detector.record_and_check("file.read", &serde_json::json!({"path": "b.rs"}));
+    let a3 = detector.record_and_check("file.read", &serde_json::json!({"path": "c.rs"}));
+    assert_eq!(a1, LoopAction::Continue);
+    assert_eq!(a2, LoopAction::Continue);
+    assert_eq!(a3, LoopAction::Continue);
+}
+
+#[test]
+fn test_custom_threshold() {
+    let mut detector = LoopDetector::new(5);
+    let input = same_input();
+    // 4 calls: below threshold
+    for _ in 0..4 {
+        let action = detector.record_and_check("file.read", &input);
+        assert_eq!(action, LoopAction::Continue);
+    }
+    // 5th call: detection
+    let action = detector.record_and_check("file.read", &input);
+    assert!(matches!(action, LoopAction::Warn(_)));
+}
+
+#[test]
+fn test_ring_buffer_capacity() {
+    let mut detector = LoopDetector::new(3);
+    let input = same_input();
+    // Fill buffer well beyond max_history
+    for i in 0..DEFAULT_MAX_HISTORY + 5 {
+        let different_input = serde_json::json!({"path": format!("file_{}.rs", i)});
+        detector.record_and_check("file.read", &different_input);
+    }
+    // Now add threshold identical calls — should detect
+    for _ in 0..2 {
+        detector.record_and_check("file.read", &input);
+    }
+    let action = detector.record_and_check("file.read", &input);
+    assert!(
+        matches!(action, LoopAction::Warn(_)),
+        "Expected Warn after ring buffer overflow, got {:?}",
+        action
+    );
+}
+
+#[test]
+fn test_reset_clears_state() {
+    let mut detector = LoopDetector::new(3);
+    let input = same_input();
+    // Build up to detection
+    for _ in 0..3 {
+        detector.record_and_check("file.read", &input);
+    }
+    // Reset
+    detector.reset();
+    // Should be back to clean state
+    for _ in 0..2 {
+        let action = detector.record_and_check("file.read", &input);
+        assert_eq!(action, LoopAction::Continue);
+    }
+    // 3rd call after reset should be Warn (escalation_count reset)
+    let action = detector.record_and_check("file.read", &input);
+    assert!(
+        matches!(action, LoopAction::Warn(_)),
+        "Expected Warn after reset, got {:?}",
+        action
+    );
+}
+
+#[test]
+fn test_fingerprint_deterministic() {
+    let input = serde_json::json!({"path": "src/main.rs", "content": "hello"});
+    let h1 = fingerprint("file.write", &input);
+    let h2 = fingerprint("file.write", &input);
+    assert_eq!(h1, h2, "fingerprint should be deterministic");
+
+    // Different tool name → different hash
+    let h3 = fingerprint("file.read", &input);
+    assert_ne!(
+        h1, h3,
+        "different tool names should produce different hashes"
+    );
+
+    // Different input → different hash
+    let other_input = serde_json::json!({"path": "src/lib.rs"});
+    let h4 = fingerprint("file.write", &other_input);
+    assert_ne!(h1, h4, "different inputs should produce different hashes");
+}
+
+#[test]
+fn test_warning_message_does_not_contain_input() {
+    let mut detector = LoopDetector::new(3);
+    let malicious_input = serde_json::json!({"path": "INJECTED_PAYLOAD_$(evil_command)", "content": "<script>alert(1)</script>"});
+
+    for _ in 0..3 {
+        detector.record_and_check("file.read", &malicious_input);
+    }
+    // The Warn message should contain the tool name but not the raw input
+    // We already consumed the Warn above. Reset and try again to inspect.
+    detector.reset();
+    for _ in 0..2 {
+        detector.record_and_check("file.read", &malicious_input);
+    }
+    let action = detector.record_and_check("file.read", &malicious_input);
+    if let LoopAction::Warn(msg) = action {
+        assert!(
+            !msg.contains("INJECTED_PAYLOAD"),
+            "Warning should not echo untrusted input"
+        );
+        assert!(
+            !msg.contains("<script>"),
+            "Warning should not echo untrusted input"
+        );
+        assert!(
+            msg.contains("file.read"),
+            "Warning should contain the tool name"
+        );
+    } else {
+        panic!("Expected Warn, got {:?}", action);
+    }
+}

--- a/tests/provider_integration.rs
+++ b/tests/provider_integration.rs
@@ -1218,11 +1218,13 @@ fn agentic_loop_multi_iteration_tool_calls_then_final_answer() {
         .expect("multi-iteration agentic loop should succeed");
 
     let requests = seen_requests.borrow();
-    // Should have made 3 calls: initial + 2 follow-ups
+    // Should have made 4 calls: initial + 2 follow-ups + 1 ANVIL_FINAL guard retry
+    // (file.read only, no file.write/file.edit => guard fires once on the plain-text
+    // final answer, then accepts the retry response unconditionally)
     assert_eq!(
         requests.len(),
-        3,
-        "expected 3 provider calls for multi-iteration loop"
+        4,
+        "expected 4 provider calls for multi-iteration loop (includes guard retry)"
     );
 
     // Final frame should show Done state
@@ -3332,4 +3334,307 @@ fn session_record_deserialization_with_used_tools() {
     assert_eq!(record.used_tools.len(), 2);
     assert!(record.used_tools.contains("web.fetch"));
     assert!(record.used_tools.contains("agent.explore"));
+}
+
+// ---------------------------------------------------------------------------
+// ANVIL_FINAL guard tests (Issue #144)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn anvil_final_guard_fires_when_no_file_modifications_detected() {
+    // Scenario: LLM outputs ANVIL_FINAL with file.read only (no file.write/edit).
+    // Guard should fire once, causing an extra LLM call, then accept.
+    let root = common::unique_test_dir("guard_fire");
+    let mut config = common::build_config_in(root.clone());
+    config.mode.approval_required = false;
+    let provider_ctx =
+        anvil::provider::ProviderRuntimeContext::bootstrap(&config).expect("provider bootstrap");
+    let mut app = anvil::app::App::new(
+        config,
+        provider_ctx,
+        std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+    )
+    .expect("app should initialize");
+    let tui = Tui::new();
+
+    std::fs::create_dir_all(root.join("src")).expect("create src dir");
+    std::fs::write(root.join("src/main.rs"), "fn main() {}").expect("write main.rs");
+
+    let seen_requests = Rc::new(RefCell::new(Vec::new()));
+
+    struct GuardFireProvider {
+        seen_requests: Rc<RefCell<Vec<ProviderTurnRequest>>>,
+    }
+
+    impl ProviderClient for GuardFireProvider {
+        fn stream_turn(
+            &self,
+            request: &ProviderTurnRequest,
+            emit: &mut dyn FnMut(ProviderEvent),
+        ) -> Result<(), ProviderTurnError> {
+            let call_index = self.seen_requests.borrow().len();
+            self.seen_requests.borrow_mut().push(request.clone());
+
+            match call_index {
+                0 => {
+                    // Initial: file.read only + ANVIL_FINAL
+                    emit(ProviderEvent::Agent(AgentEvent::Done {
+                        status: "Done. session saved".to_string(),
+                        assistant_message: concat!(
+                            "```ANVIL_TOOL\n",
+                            "{\"id\":\"call_001\",\"tool\":\"file.read\",\"path\":\"./src/main.rs\"}\n",
+                            "```\n",
+                            "```ANVIL_FINAL\n",
+                            "Read the source file.\n",
+                            "```\n"
+                        )
+                        .to_string(),
+                        completion_summary: "turn 1".to_string(),
+                        saved_status: "session saved".to_string(),
+                        tool_logs: Vec::new(),
+                        elapsed_ms: 0,
+                        inference_performance: None,
+                    }));
+                }
+                1 => {
+                    // Agentic follow-up after file.read: plain text final answer
+                    // (no more tool calls, guard will fire)
+                    emit(ProviderEvent::TokenDelta(
+                        "Here is my plan to improve the code.".to_string(),
+                    ));
+                }
+                _ => {
+                    // Guard retry: accept unconditionally
+                    emit(ProviderEvent::TokenDelta(
+                        "Actually, no changes needed.".to_string(),
+                    ));
+                }
+            }
+            Ok(())
+        }
+    }
+
+    let provider = GuardFireProvider {
+        seen_requests: seen_requests.clone(),
+    };
+
+    let _frames = app
+        .run_live_turn("improve the code", &provider, &tui)
+        .expect("guard fire scenario should succeed");
+
+    let requests = seen_requests.borrow();
+    // Initial call + agentic follow-up + guard retry = 3 calls
+    assert_eq!(
+        requests.len(),
+        3,
+        "expected 3 provider calls: initial + follow-up + guard retry"
+    );
+
+    // Verify the guard retry message was injected into the session
+    assert!(
+        app.session()
+            .messages
+            .iter()
+            .any(|m| m.content.contains("No file modifications detected")),
+        "guard retry message should be in session"
+    );
+}
+
+#[test]
+fn anvil_final_guard_does_not_fire_when_file_write_was_executed() {
+    // Scenario: LLM writes a file, then outputs ANVIL_FINAL.
+    // Guard should NOT fire because touched_files is non-empty.
+    let root = common::unique_test_dir("guard_skip");
+    let mut config = common::build_config_in(root.clone());
+    config.mode.approval_required = false;
+    let provider_ctx =
+        anvil::provider::ProviderRuntimeContext::bootstrap(&config).expect("provider bootstrap");
+    let mut app = anvil::app::App::new(
+        config,
+        provider_ctx,
+        std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+    )
+    .expect("app should initialize");
+    let tui = Tui::new();
+
+    let seen_requests = Rc::new(RefCell::new(Vec::new()));
+
+    let provider = RecordingProvider {
+        seen_requests: seen_requests.clone(),
+        events: vec![ProviderEvent::Agent(AgentEvent::Done {
+            status: "Done. session saved".to_string(),
+            assistant_message: concat!(
+                "```ANVIL_TOOL\n",
+                "{\"id\":\"call_001\",\"tool\":\"file.write\",\"path\":\"./output.txt\",\"content\":\"hello world\"}\n",
+                "```\n",
+                "```ANVIL_FINAL\n",
+                "Created output.txt with the requested content.\n",
+                "```\n"
+            )
+            .to_string(),
+            completion_summary: "turn 1".to_string(),
+            saved_status: "session saved".to_string(),
+            tool_logs: Vec::new(),
+            elapsed_ms: 0,
+            inference_performance: None,
+        })],
+        followup_events: vec![ProviderEvent::TokenDelta(
+            "All done.".to_string(),
+        )],
+        error: None,
+    };
+
+    let _frames = app
+        .run_live_turn("create a file", &provider, &tui)
+        .expect("file write scenario should succeed");
+
+    let requests = seen_requests.borrow();
+    // Initial call + 1 follow-up (no guard retry since file was written)
+    assert_eq!(
+        requests.len(),
+        2,
+        "expected 2 provider calls: initial + follow-up (no guard retry)"
+    );
+
+    // Verify guard retry message was NOT injected
+    assert!(
+        !app.session()
+            .messages
+            .iter()
+            .any(|m| m.content.contains("No file modifications detected")),
+        "guard retry message should NOT be in session when file was written"
+    );
+
+    // Verify the file was actually written
+    let content =
+        std::fs::read_to_string(root.join("output.txt")).expect("output.txt should exist");
+    assert!(content.contains("hello world"));
+}
+
+#[test]
+fn anvil_final_guard_handle_structured_done_fires_for_plan_only_response() {
+    // Scenario: Done event with ANVIL_FINAL but no tool calls (plan only).
+    // Guard should fire via handle_structured_done path.
+    let root = common::unique_test_dir("guard_done_path");
+    let mut config = common::build_config_in(root.clone());
+    config.mode.approval_required = false;
+    let provider_ctx =
+        anvil::provider::ProviderRuntimeContext::bootstrap(&config).expect("provider bootstrap");
+    let mut app = anvil::app::App::new(
+        config,
+        provider_ctx,
+        std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+    )
+    .expect("app should initialize");
+    let tui = Tui::new();
+
+    let seen_requests = Rc::new(RefCell::new(Vec::new()));
+
+    struct GuardDoneProvider {
+        seen_requests: Rc<RefCell<Vec<ProviderTurnRequest>>>,
+    }
+
+    impl ProviderClient for GuardDoneProvider {
+        fn stream_turn(
+            &self,
+            request: &ProviderTurnRequest,
+            emit: &mut dyn FnMut(ProviderEvent),
+        ) -> Result<(), ProviderTurnError> {
+            let call_index = self.seen_requests.borrow().len();
+            self.seen_requests.borrow_mut().push(request.clone());
+
+            match call_index {
+                0 => {
+                    // Done event with ANVIL_FINAL but NO tool calls (plan-only)
+                    emit(ProviderEvent::Agent(AgentEvent::Done {
+                        status: "Done. session saved".to_string(),
+                        assistant_message: concat!(
+                            "```ANVIL_FINAL\n",
+                            "Here is my plan:\n1. Create a new module\n2. Add tests\n",
+                            "```\n"
+                        )
+                        .to_string(),
+                        completion_summary: "plan only".to_string(),
+                        saved_status: "session saved".to_string(),
+                        tool_logs: Vec::new(),
+                        elapsed_ms: 100,
+                        inference_performance: None,
+                    }));
+                }
+                _ => {
+                    // Guard retry: LLM responds with plain text
+                    emit(ProviderEvent::TokenDelta(
+                        "I apologize, let me implement the changes now.".to_string(),
+                    ));
+                }
+            }
+            Ok(())
+        }
+    }
+
+    let provider = GuardDoneProvider {
+        seen_requests: seen_requests.clone(),
+    };
+
+    let _frames = app
+        .run_live_turn("implement the feature", &provider, &tui)
+        .expect("guard done path should succeed");
+
+    let requests = seen_requests.borrow();
+    // Initial call + guard retry = 2 calls
+    assert_eq!(
+        requests.len(),
+        2,
+        "expected 2 provider calls: initial + guard retry via handle_structured_done"
+    );
+
+    // Verify the guard retry message was injected
+    assert!(
+        app.session()
+            .messages
+            .iter()
+            .any(|m| m.content.contains("No file modifications detected")),
+        "guard retry message should be in session"
+    );
+}
+
+#[test]
+fn anvil_final_guard_prompt_tool_rules_contains_implementation_guidance() {
+    // Verify that the system prompt includes the implementation guidance text
+    let app = common::build_app();
+    let tui = Tui::new();
+    let seen_requests = Rc::new(RefCell::new(Vec::new()));
+    let provider = RecordingProvider {
+        seen_requests: seen_requests.clone(),
+        events: vec![
+            ProviderEvent::Agent(AgentEvent::Thinking {
+                status: "Thinking".to_string(),
+                plan_items: vec![],
+                active_index: None,
+                reasoning_summary: vec![],
+                elapsed_ms: 0,
+            }),
+            ProviderEvent::Agent(AgentEvent::Done {
+                status: "Done. session saved".to_string(),
+                assistant_message: "ok".to_string(),
+                completion_summary: "done".to_string(),
+                saved_status: "session saved".to_string(),
+                tool_logs: Vec::new(),
+                elapsed_ms: 0,
+                inference_performance: None,
+            }),
+        ],
+        followup_events: Vec::new(),
+        error: None,
+    };
+
+    let mut app = app;
+    let _ = app.run_live_turn("test", &provider, &tui);
+
+    let requests = seen_requests.borrow();
+    let system_prompt = &requests[0].messages[0].content;
+    assert!(
+        system_prompt.contains("you must complete the actual file modifications"),
+        "system prompt should contain implementation guidance from PROMPT_TOOL_RULES"
+    );
 }

--- a/tests/provider_integration.rs
+++ b/tests/provider_integration.rs
@@ -3333,3 +3333,50 @@ fn session_record_deserialization_with_used_tools() {
     assert!(record.used_tools.contains("web.fetch"));
     assert!(record.used_tools.contains("agent.explore"));
 }
+
+// ============================================================
+// normalize_http_timeout tests (Issue #146)
+// ============================================================
+
+#[test]
+fn normalize_http_timeout_zero_returns_default() {
+    use anvil::provider::{DEFAULT_HTTP_TIMEOUT_SECS, normalize_http_timeout};
+    assert_eq!(normalize_http_timeout(0), DEFAULT_HTTP_TIMEOUT_SECS);
+}
+
+#[test]
+fn normalize_http_timeout_below_min_returns_min() {
+    use anvil::provider::normalize_http_timeout;
+    assert_eq!(normalize_http_timeout(1), 10);
+    assert_eq!(normalize_http_timeout(9), 10);
+}
+
+#[test]
+fn normalize_http_timeout_above_max_returns_max() {
+    use anvil::provider::normalize_http_timeout;
+    assert_eq!(normalize_http_timeout(3601), 3600);
+    assert_eq!(normalize_http_timeout(u64::MAX), 3600);
+}
+
+#[test]
+fn normalize_http_timeout_normal_values_unchanged() {
+    use anvil::provider::normalize_http_timeout;
+    assert_eq!(normalize_http_timeout(10), 10);
+    assert_eq!(normalize_http_timeout(300), 300);
+    assert_eq!(normalize_http_timeout(3600), 3600);
+}
+
+#[test]
+fn transport_with_timeout_constructs_successfully() {
+    use anvil::provider::ReqwestHttpTransport;
+    let _transport = ReqwestHttpTransport::with_timeout(60);
+}
+
+#[test]
+fn transport_with_timeout_and_shutdown_flag_constructs_successfully() {
+    use anvil::provider::ReqwestHttpTransport;
+    use std::sync::Arc;
+    use std::sync::atomic::AtomicBool;
+    let flag = Arc::new(AtomicBool::new(false));
+    let _transport = ReqwestHttpTransport::with_timeout_and_shutdown_flag(120, flag);
+}

--- a/tests/tooling_system.rs
+++ b/tests/tooling_system.rs
@@ -4819,8 +4819,248 @@ fn file_edit_fallback_indent_mismatch() {
 
 #[test]
 fn edit_not_found_error_is_distinguishable() {
-    let err = anvil::tooling::ToolRuntimeError::EditNotFound("test".to_string());
+    let err = anvil::tooling::ToolRuntimeError::edit_not_found("test");
     assert!(err.is_edit_not_found());
+    assert_eq!(err.to_string(), "test");
+
     let io_err = anvil::tooling::ToolRuntimeError::Io("test".to_string());
     assert!(!io_err.is_edit_not_found());
+}
+
+#[test]
+fn edit_not_found_with_context_snippet() {
+    let err = anvil::tooling::ToolRuntimeError::edit_not_found_with_context(
+        "old_string not found in foo.rs",
+        "   5 | fn main() {\n   6 |     println!(\"hello\");\n   7 | }".to_string(),
+    );
+    assert!(err.is_edit_not_found());
+    // Display should only show message, not context
+    assert_eq!(err.to_string(), "old_string not found in foo.rs");
+    // context_snippet should be accessible
+    match &err {
+        anvil::tooling::ToolRuntimeError::EditNotFound {
+            context_snippet, ..
+        } => {
+            assert!(context_snippet.is_some());
+            assert!(context_snippet.as_ref().unwrap().contains("fn main()"));
+        }
+        _ => panic!("expected EditNotFound"),
+    }
+}
+
+#[test]
+fn extract_edit_context_finds_matching_line() {
+    let content = "line 1\nline 2\nfn hello() {\n    println!(\"hi\");\n}\nline 6\nline 7\nline 8\nline 9\nline 10\nline 11";
+    let old_string = "fn hello() {\n    println!(\"world\");\n}";
+    let result = anvil::tooling::extract_edit_context(content, old_string, 2);
+    assert!(
+        result.is_some(),
+        "should find context for partial first-line match"
+    );
+    let ctx = result.unwrap();
+    assert!(
+        ctx.contains("fn hello()"),
+        "context should contain matching line"
+    );
+    assert!(
+        ctx.contains("println!"),
+        "context should contain nearby lines"
+    );
+}
+
+#[test]
+fn extract_edit_context_returns_none_for_no_match() {
+    let content = "line 1\nline 2\nline 3";
+    let old_string = "nonexistent function";
+    let result = anvil::tooling::extract_edit_context(content, old_string, 5);
+    assert!(result.is_none());
+}
+
+#[test]
+fn extract_edit_context_returns_none_for_empty_old_string() {
+    let content = "line 1\nline 2";
+    let result = anvil::tooling::extract_edit_context(content, "", 5);
+    assert!(result.is_none());
+}
+
+#[test]
+fn extract_edit_context_respects_line_count() {
+    let content = (1..=20)
+        .map(|i| format!("line {i}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let old_string = "line 10";
+    let result = anvil::tooling::extract_edit_context(&content, old_string, 2);
+    let ctx = result.unwrap();
+    let lines: Vec<&str> = ctx.lines().collect();
+    // Should have at most 5 lines (2 before + match + 2 after)
+    assert!(
+        lines.len() <= 5,
+        "context should be limited, got {} lines",
+        lines.len()
+    );
+}
+
+#[test]
+fn edit_fallback_includes_context_on_failure() {
+    let root = std::env::temp_dir().join("anvil_edit_ctx_test");
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(&root).unwrap();
+    fs::write(
+        root.join("test.rs"),
+        "fn main() {\n    println!(\"hello\");\n}\n\nfn other() {\n    return 42;\n}\n",
+    )
+    .unwrap();
+
+    let mut executor = LocalToolExecutor::new_without_rate_limit(root.clone());
+    let err = executor
+        .execute(ToolExecutionRequest {
+            tool_call_id: "ctx_001".to_string(),
+            spec: build_registry()
+                .get("file.edit")
+                .expect("file.edit spec")
+                .clone(),
+            input: ToolInput::FileEdit {
+                path: "./test.rs".to_string(),
+                // First line matches "fn main()" but second line differs
+                old_string: "fn main() {\n    let x = wrong;\n}".to_string(),
+                new_string: "fn main() {\n    let x = correct;\n}".to_string(),
+            },
+        })
+        .unwrap_err();
+    assert!(err.is_edit_not_found());
+    match &err {
+        anvil::tooling::ToolRuntimeError::EditNotFound {
+            context_snippet, ..
+        } => {
+            assert!(
+                context_snippet.is_some(),
+                "should include context for non-sensitive file"
+            );
+            let ctx = context_snippet.as_ref().unwrap();
+            assert!(ctx.contains("println!"), "context should show nearby code");
+        }
+        _ => panic!("expected EditNotFound"),
+    }
+    let _ = fs::remove_dir_all(&root);
+}
+
+#[test]
+fn edit_fallback_no_context_for_sensitive_file() {
+    let root = std::env::temp_dir().join("anvil_edit_sensitive_test");
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(&root).unwrap();
+    fs::write(
+        root.join(".env"),
+        "SECRET_KEY=abc123\nDB_PASSWORD=hunter2\n",
+    )
+    .unwrap();
+
+    let mut executor = LocalToolExecutor::new_without_rate_limit(root.clone());
+    let err = executor
+        .execute(ToolExecutionRequest {
+            tool_call_id: "ctx_002".to_string(),
+            spec: build_registry()
+                .get("file.edit")
+                .expect("file.edit spec")
+                .clone(),
+            input: ToolInput::FileEdit {
+                path: "./.env".to_string(),
+                old_string: "NONEXISTENT=value".to_string(),
+                new_string: "REPLACED=value".to_string(),
+            },
+        })
+        .unwrap_err();
+    match &err {
+        anvil::tooling::ToolRuntimeError::EditNotFound {
+            context_snippet, ..
+        } => {
+            assert!(
+                context_snippet.is_none(),
+                "should NOT include context for sensitive file"
+            );
+        }
+        _ => panic!("expected EditNotFound"),
+    }
+    let _ = fs::remove_dir_all(&root);
+}
+
+#[test]
+fn trailing_ws_normalized_match_succeeds() {
+    let root = std::env::temp_dir().join("anvil_trailing_ws_test");
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(&root).unwrap();
+    // File has trailing spaces on some lines
+    fs::write(root.join("test.txt"), "fn hello() {  \n    world()  \n}\n").unwrap();
+
+    let mut executor = LocalToolExecutor::new_without_rate_limit(root.clone());
+    let result = executor
+        .execute(ToolExecutionRequest {
+            tool_call_id: "tw_001".to_string(),
+            spec: build_registry()
+                .get("file.edit")
+                .expect("file.edit spec")
+                .clone(),
+            input: ToolInput::FileEdit {
+                path: "./test.txt".to_string(),
+                // old_string without trailing spaces — should still match
+                old_string: "fn hello() {\n    world()\n}".to_string(),
+                new_string: "fn hello() {\n    universe()\n}".to_string(),
+            },
+        })
+        .expect("trailing-ws normalized edit should succeed");
+
+    assert_eq!(result.status, ToolExecutionStatus::Completed);
+    assert!(
+        result.summary.contains("trailing-ws"),
+        "summary should indicate trailing-ws fallback: {}",
+        result.summary
+    );
+    let content = fs::read_to_string(root.join("test.txt")).unwrap();
+    assert!(
+        content.contains("universe()"),
+        "content should be edited: {content}"
+    );
+    let _ = fs::remove_dir_all(&root);
+}
+
+#[test]
+fn edit_not_found_error_payload_contains_context_but_summary_does_not() {
+    // Verify that when EditNotFound has context_snippet,
+    // the Display (used for summary) does NOT include it
+    let err = anvil::tooling::ToolRuntimeError::edit_not_found_with_context(
+        "file.edit: old_string not found in foo.rs",
+        "   3 | fn main() {".to_string(),
+    );
+    let display = err.to_string();
+    assert!(
+        !display.contains("fn main()"),
+        "Display should NOT contain context"
+    );
+    assert!(
+        display.contains("old_string not found"),
+        "Display should contain the error message"
+    );
+}
+
+#[test]
+fn is_sensitive_file_from_tooling() {
+    assert!(anvil::tooling::is_sensitive_file(".env"));
+    assert!(anvil::tooling::is_sensitive_file("secrets.yaml"));
+    assert!(!anvil::tooling::is_sensitive_file("src/main.rs"));
+}
+
+#[test]
+fn edit_not_found_factory_without_context() {
+    let err = anvil::tooling::ToolRuntimeError::edit_not_found("no match");
+    match &err {
+        anvil::tooling::ToolRuntimeError::EditNotFound {
+            message,
+            context_snippet,
+        } => {
+            assert_eq!(message, "no match");
+            assert!(context_snippet.is_none());
+        }
+        _ => panic!("expected EditNotFound"),
+    }
 }

--- a/tests/tooling_system.rs
+++ b/tests/tooling_system.rs
@@ -1,4 +1,5 @@
 use anvil::app::agentic::{ExecutionGroup, group_by_execution_mode};
+use anvil::tooling::file_cache::FileReadCache;
 use anvil::tooling::{
     CheckpointEntry, CheckpointStack, ExecutionClass, ExecutionMode, LocalToolExecutor,
     ParallelExecutionPlan, ParallelExecutionPlanError, PermissionClass, PlanModePolicy,
@@ -4823,4 +4824,248 @@ fn edit_not_found_error_is_distinguishable() {
     assert!(err.is_edit_not_found());
     let io_err = anvil::tooling::ToolRuntimeError::Io("test".to_string());
     assert!(!io_err.is_edit_not_found());
+}
+
+// ===== FileReadCache unit tests =====
+
+#[test]
+fn file_cache_hit_same_path_same_mtime() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().to_path_buf();
+    let file = root.join("test.txt");
+    fs::write(&file, "hello world").unwrap();
+
+    let mut cache = FileReadCache::new(root);
+    cache.record(&file, "hello world".to_string());
+
+    let result = cache.try_get(&file);
+    assert_eq!(result, Some("hello world".to_string()));
+}
+
+#[test]
+fn file_cache_miss_unknown_path() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().to_path_buf();
+    let file = root.join("nonexistent.txt");
+
+    let mut cache = FileReadCache::new(root);
+    let result = cache.try_get(&file);
+    assert!(result.is_none());
+}
+
+#[test]
+fn file_cache_miss_mtime_changed() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().to_path_buf();
+    let file = root.join("test.txt");
+    fs::write(&file, "version1").unwrap();
+
+    let mut cache = FileReadCache::new(root);
+    cache.record(&file, "version1".to_string());
+
+    // Modify the file to change mtime
+    // Use filetime crate logic via std: set mtime to future
+    let future = std::time::SystemTime::now() + std::time::Duration::from_secs(10);
+    let ft = filetime::FileTime::from_system_time(future);
+    filetime::set_file_mtime(&file, ft).unwrap();
+
+    let result = cache.try_get(&file);
+    assert!(result.is_none(), "should miss after mtime change");
+    // Entry should be removed on stale mtime
+    assert!(cache.is_empty(), "stale entry should be evicted");
+}
+
+#[test]
+fn file_cache_invalidate_removes_entry() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().to_path_buf();
+    let file = root.join("test.txt");
+    fs::write(&file, "content").unwrap();
+
+    let mut cache = FileReadCache::new(root);
+    cache.record(&file, "content".to_string());
+    assert_eq!(cache.len(), 1);
+
+    cache.invalidate(&file);
+    assert!(cache.is_empty());
+    assert_eq!(cache.total_bytes(), 0);
+}
+
+#[test]
+fn file_cache_clear_removes_all() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().to_path_buf();
+    let f1 = root.join("a.txt");
+    let f2 = root.join("b.txt");
+    fs::write(&f1, "aaa").unwrap();
+    fs::write(&f2, "bbb").unwrap();
+
+    let mut cache = FileReadCache::new(root);
+    cache.record(&f1, "aaa".to_string());
+    cache.record(&f2, "bbb".to_string());
+    assert_eq!(cache.len(), 2);
+
+    cache.clear();
+    assert!(cache.is_empty());
+    assert_eq!(cache.total_bytes(), 0);
+}
+
+#[test]
+fn file_cache_lru_eviction_by_entry_count() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().to_path_buf();
+
+    // Create cache with max 3 entries
+    let mut cache = FileReadCache::with_limits(root.clone(), 3, 10_485_760);
+
+    // Create and record 4 files
+    for i in 0..4 {
+        let file = root.join(format!("file{i}.txt"));
+        fs::write(&file, format!("content{i}")).unwrap();
+        cache.record(&file, format!("content{i}"));
+        // Small sleep to ensure different Instant values for LRU ordering
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+
+    // Should have evicted the oldest (file0)
+    assert_eq!(cache.len(), 3);
+    let file0 = root.join("file0.txt");
+    assert!(
+        cache.try_get(&file0).is_none(),
+        "oldest entry should be evicted"
+    );
+    // file3 should still be present
+    let file3 = root.join("file3.txt");
+    assert_eq!(cache.try_get(&file3), Some("content3".to_string()));
+}
+
+#[test]
+fn file_cache_lru_eviction_by_byte_size() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().to_path_buf();
+
+    // Max 20 bytes total
+    let mut cache = FileReadCache::with_limits(root.clone(), 100, 20);
+
+    let f1 = root.join("f1.txt");
+    let f2 = root.join("f2.txt");
+    let f3 = root.join("f3.txt");
+    fs::write(&f1, "aaaaaaaaaa").unwrap(); // 10 bytes
+    fs::write(&f2, "bbbbbbbbbb").unwrap(); // 10 bytes
+    fs::write(&f3, "cccccccccc").unwrap(); // 10 bytes
+
+    cache.record(&f1, "aaaaaaaaaa".to_string());
+    std::thread::sleep(std::time::Duration::from_millis(10));
+    cache.record(&f2, "bbbbbbbbbb".to_string());
+    assert_eq!(cache.len(), 2);
+    assert_eq!(cache.total_bytes(), 20);
+
+    // Adding f3 should evict f1 (oldest)
+    std::thread::sleep(std::time::Duration::from_millis(10));
+    cache.record(&f3, "cccccccccc".to_string());
+    assert!(cache.total_bytes() <= 20);
+    assert!(
+        cache.try_get(&f1).is_none(),
+        "oldest entry should be evicted by byte limit"
+    );
+}
+
+#[test]
+fn file_cache_rejects_path_outside_root() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().to_path_buf();
+    let outside = tempfile::tempdir().unwrap();
+    let outside_file = outside.path().join("secret.txt");
+    fs::write(&outside_file, "secret").unwrap();
+
+    let mut cache = FileReadCache::new(root);
+    // record should be no-op for outside path
+    cache.record(&outside_file, "secret".to_string());
+    assert!(cache.is_empty(), "should not cache files outside root");
+
+    // try_get should return None
+    assert!(cache.try_get(&outside_file).is_none());
+}
+
+#[test]
+fn file_cache_canonicalize_failure_graceful_degrade() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().to_path_buf();
+    let nonexistent = root.join("does_not_exist.txt");
+
+    let mut cache = FileReadCache::new(root);
+    // record for nonexistent path should be no-op
+    cache.record(&nonexistent, "content".to_string());
+    assert!(cache.is_empty());
+
+    // try_get for nonexistent path should return None
+    assert!(cache.try_get(&nonexistent).is_none());
+}
+
+#[test]
+fn file_cache_parallel_access_no_panic() {
+    use std::sync::{Arc, Mutex};
+
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().to_path_buf();
+
+    // Create some files
+    for i in 0..10 {
+        let file = root.join(format!("file{i}.txt"));
+        fs::write(&file, format!("content{i}")).unwrap();
+    }
+
+    let cache = Arc::new(Mutex::new(FileReadCache::new(root.clone())));
+
+    // Record from multiple threads
+    std::thread::scope(|s| {
+        for i in 0..10 {
+            let cache = Arc::clone(&cache);
+            let root = root.clone();
+            s.spawn(move || {
+                let file = root.join(format!("file{i}.txt"));
+                if let Ok(mut c) = cache.lock() {
+                    c.record(&file, format!("content{i}"));
+                }
+            });
+        }
+    });
+
+    // Read from multiple threads
+    std::thread::scope(|s| {
+        for i in 0..10 {
+            let cache = Arc::clone(&cache);
+            let root = root.clone();
+            s.spawn(move || {
+                let file = root.join(format!("file{i}.txt"));
+                if let Ok(mut c) = cache.lock() {
+                    let _ = c.try_get(&file);
+                }
+            });
+        }
+    });
+
+    // No panic means success
+    let c = cache.lock().unwrap();
+    assert_eq!(c.len(), 10);
+}
+
+#[test]
+fn file_cache_update_existing_entry() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().to_path_buf();
+    let file = root.join("test.txt");
+    fs::write(&file, "v1").unwrap();
+
+    let mut cache = FileReadCache::new(root);
+    cache.record(&file, "v1".to_string());
+    assert_eq!(cache.total_bytes(), 2);
+
+    // Update with new content (simulate re-read after external change)
+    fs::write(&file, "version2_longer").unwrap();
+    cache.record(&file, "version2_longer".to_string());
+
+    assert_eq!(cache.len(), 1);
+    assert_eq!(cache.total_bytes(), 15); // "version2_longer".len()
+    assert_eq!(cache.try_get(&file), Some("version2_longer".to_string()));
 }


### PR DESCRIPTION
## Summary
Issue #142〜#147 のローカルLLMランタイム改善をmainにマージするリリースPRです。

### #142: ファイル読み取りキャッシュの導入 (PR #150)
- `file_cache.rs` 新規追加（LRUキャッシュ、最大100エントリ/10MB）
- mtimeベースの変更検知による自動無効化
- 同一ファイルの重複 file.read を削減

### #143: file.edit エラー時のリカバリー改善 (PR #151)
- `edit_fail_tracker.rs` 新規追加
- 3段階フォールバック（コンテキストヒント → anchor → file.write）
- 連続失敗時の具体的なヒント生成

### #144: ANVIL_FINAL の早期発火防止 (PR #152)
- ファイル変更なしでANVIL_FINALが発火した場合のリトライガード
- plan-only出力（実装なし）の早期発火を防止

### #145: 反復ループの検出と自己修正 (PR #153)
- `loop_detector.rs` 新規追加（リングバッファ＋フィンガープリント）
- 同一ツール呼び出しの繰り返しを検出し Warn → StrongWarn → Break でエスカレーション
- 設定可能な `loop_detection_threshold`（デフォルト3）

### #146: タイムアウト設定の外部化 (PR #148)
- `--timeout` CLIオプション追加
- 優先順位: CLI > `ANVIL_HTTP_TIMEOUT` > `ANVIL_CURL_TIMEOUT` > デフォルト(300秒)
- 範囲バリデーション（10〜3600秒）

### #147: --max-iterations デフォルト値の見直し (PR #149)
- `max_agent_iterations` / `subagent_max_iterations` のデフォルト値を引き上げ
- 大規模プロジェクトでのファイル探索に十分な反復回数を確保

## 品質チェック
- cargo build: Pass
- cargo clippy --all-targets: Pass（警告0件）
- cargo test: Pass（21テストスイート全パス）
- cargo fmt --check: Pass

## UAT結果
全6 Issue、13テスト項目が **ALL PASS (100%)** で ACCEPTED（実機起動確認済み）

| Issue | テスト | 判定 |
|-------|--------|------|
| #142 | 2/2 PASS | ACCEPTED |
| #143 | 2/2 PASS | ACCEPTED |
| #144 | 2/2 PASS | ACCEPTED |
| #145 | 2/2 PASS | ACCEPTED |
| #146 | 3/3 PASS | ACCEPTED |
| #147 | 2/2 PASS | ACCEPTED |

## 変更統計
- 22ファイル変更、+2,470行、-152行
- 新規ファイル: `src/tooling/file_cache.rs`, `src/app/edit_fail_tracker.rs`, `src/app/loop_detector.rs`, `tests/loop_detection.rs`

Closes #142, Closes #143, Closes #144, Closes #145, Closes #146, Closes #147

## Test plan
- [x] cargo build: Pass
- [x] cargo clippy --all-targets: 警告0件
- [x] cargo test: 全テストスイートパス
- [x] cargo fmt --check: 差分なし
- [x] UAT全13テスト項目PASS（実機起動確認済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)