### PR TITLE
release: runtime robustness improvements v0.0.8 (#142-#162)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,7 +109,9 @@ src/
 │   ├── agentic.rs       # agenticツール実行ループ（ANVIL_FINALガード・再試行ロジック含む）
 │   ├── cli.rs           # CLI入力ループ
 │   ├── context.rs       # コンテキスト注入（@file展開・サンドボックス検証）
+│   ├── edit_fail_tracker.rs # 連続file.edit失敗の検出・回復ヒント注入
 │   ├── loop_detector.rs # ループ検出（リングバッファ・段階的対応）
+│   ├── phase_estimator.rs # フェーズ推定（ツール呼び出しパターンベース・フォールバック完了検出）
 │   ├── plan.rs          # プラン管理
 │   ├── policy.rs        # offlineポリシーチェック（共通ヘルパー）
 │   ├── render.rs        # コンソール描画
@@ -156,6 +158,7 @@ tests/
 ├── skills_system.rs     # スキルシステムテスト
 ├── hooks_system.rs      # フックシステムテスト
 ├── loop_detection.rs    # ループ検出テスト
+├── phase_estimation.rs  # フェーズ推定テスト
 ├── context_inject.rs    # コンテキスト注入テスト
 └── walk_system.rs       # ディレクトリウォーカーテスト
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,6 +110,7 @@ src/
 │   ├── cli.rs           # CLI入力ループ
 │   ├── context.rs       # コンテキスト注入（@file展開・サンドボックス検証）
 │   ├── loop_detector.rs # ループ検出（リングバッファ・段階的対応）
+│   ├── write_fail_tracker.rs # file.write連続失敗トラッキング（ヒント提供・閾値2）
 │   ├── plan.rs          # プラン管理
 │   ├── policy.rs        # offlineポリシーチェック（共通ヘルパー）
 │   ├── render.rs        # コンソール描画

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -16,7 +16,7 @@ use crate::provider::{
     ImageContent, ProviderClient, ProviderEvent, ProviderMessage, ProviderMessageRole,
     ProviderTurnError, ProviderTurnRequest,
 };
-use crate::session::{MessageRole, SessionRecord};
+use crate::session::{MessageRole, SessionMessage, SessionRecord};
 use crate::tooling::{ToolCallRequest, ToolInput, detect_image_mime};
 use base64::Engine;
 use serde::{Deserialize, Serialize};
@@ -224,6 +224,30 @@ impl BasicAgentLoop {
             system_prompt,
             calibration_ratio,
         )
+    }
+
+    /// Estimate the number of session messages that would be pruned.
+    /// Uses the same shared selection logic as `build_turn_request_with_calibration()`.
+    /// Returns `(pruned_count, selected_tokens)`.
+    pub fn estimate_pruned_message_count(
+        session: &SessionRecord,
+        context_window: u32,
+        system_prompt_tokens: usize,
+        calibration_ratio: f64,
+    ) -> (usize, usize) {
+        let token_budget = derive_context_budget(context_window);
+        let budget_for_messages = token_budget
+            .saturating_sub(system_prompt_tokens)
+            .max(MINIMUM_MESSAGE_BUDGET);
+
+        let (selected, selected_tokens) = select_messages_within_budget(
+            session.messages.iter(),
+            budget_for_messages,
+            calibration_ratio,
+        );
+
+        let pruned_count = session.messages.len().saturating_sub(selected.len());
+        (pruned_count, selected_tokens)
     }
 
     pub fn run_turn<C: ProviderClient>(
@@ -435,6 +459,30 @@ fn to_provider_message_with_images(
     msg
 }
 
+/// Shared message selection within token budget.
+/// Returns (selected messages in reverse order, used_tokens).
+fn select_messages_within_budget<'a>(
+    messages: impl DoubleEndedIterator<Item = &'a SessionMessage>,
+    budget_for_messages: usize,
+    calibration_ratio: f64,
+) -> (Vec<&'a SessionMessage>, usize) {
+    let mut selected = Vec::new();
+    let mut used_tokens = 0usize;
+
+    for message in messages.rev() {
+        let kind = ContentKind::from_message_role(message.role);
+        let estimated =
+            estimate_tokens_calibrated(message.effective_content(), kind, calibration_ratio);
+        if !selected.is_empty() && used_tokens + estimated > budget_for_messages {
+            break;
+        }
+        used_tokens += estimated;
+        selected.push(message);
+    }
+
+    (selected, used_tokens)
+}
+
 /// Internal helper: build a turn request with calibration ratio applied.
 ///
 /// Both `build_turn_request_with_token_budget` (ratio=NO_CALIBRATION) and
@@ -453,19 +501,11 @@ fn build_turn_request_with_calibration(
         .saturating_sub(system_prompt_tokens)
         .max(MINIMUM_MESSAGE_BUDGET);
 
-    let mut selected = Vec::new();
-    let mut used_tokens = 0usize;
-
-    for message in session.messages.iter().rev() {
-        let kind = ContentKind::from_message_role(message.role);
-        let estimated =
-            estimate_tokens_calibrated(message.effective_content(), kind, calibration_ratio);
-        if !selected.is_empty() && used_tokens + estimated > budget_for_messages {
-            break;
-        }
-        used_tokens += estimated;
-        selected.push(message);
-    }
+    let (mut selected, used_tokens) = select_messages_within_budget(
+        session.messages.iter(),
+        budget_for_messages,
+        calibration_ratio,
+    );
 
     selected.reverse();
 
@@ -1188,5 +1228,53 @@ mod tests {
                 one_liner
             );
         }
+    }
+
+    // ── Issue #157: estimate_pruned_message_count tests ───────────────
+
+    #[test]
+    fn estimate_pruned_zero_when_messages_fit() {
+        let mut session = SessionRecord::new(std::path::PathBuf::from("/tmp/test"));
+        for i in 0..3 {
+            session.push_message(SessionMessage::new(
+                MessageRole::User,
+                "you",
+                format!("msg {i}"),
+            ));
+        }
+        // Large context window, small messages => no pruning
+        let (pruned, _tokens) =
+            BasicAgentLoop::estimate_pruned_message_count(&session, 128_000, 100, 1.0);
+        assert_eq!(pruned, 0);
+    }
+
+    #[test]
+    fn estimate_pruned_count_with_many_messages() {
+        let mut session = SessionRecord::new(std::path::PathBuf::from("/tmp/test"));
+        // Add many large messages to exceed a small budget
+        for i in 0..50 {
+            session.push_message(SessionMessage::new(
+                MessageRole::User,
+                "you",
+                format!(
+                    "message content that is somewhat long to consume tokens #{i} {}",
+                    "x".repeat(200)
+                ),
+            ));
+        }
+        // Very small context window to force pruning
+        let (pruned, _tokens) =
+            BasicAgentLoop::estimate_pruned_message_count(&session, 512, 50, 1.0);
+        assert!(pruned > 0, "should prune some messages with tiny budget");
+        assert!(pruned < 50, "should keep at least one message");
+    }
+
+    #[test]
+    fn estimate_pruned_zero_for_empty_session() {
+        let session = SessionRecord::new(std::path::PathBuf::from("/tmp/test"));
+        let (pruned, tokens) =
+            BasicAgentLoop::estimate_pruned_message_count(&session, 128_000, 100, 1.0);
+        assert_eq!(pruned, 0);
+        assert_eq!(tokens, 0);
     }
 }

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -237,12 +237,23 @@ impl BasicAgentLoop {
 
     pub fn parse_structured_response(content: &str) -> Result<StructuredAssistantResponse, String> {
         let tool_blocks = extract_fenced_blocks(content, "ANVIL_TOOL");
+
+        // ANVIL_FINALの位置を取得（カットオフポイント）
+        let final_cutoff = content.find("```ANVIL_FINAL\n");
+
         // Try strict extraction first, fall back to lenient for unclosed blocks.
         let final_block = extract_final_block(content, "ANVIL_FINAL")
             .or_else(|| extract_final_block_lenient(content, "ANVIL_FINAL"));
 
         let mut tool_calls = Vec::new();
-        for block in tool_blocks {
+        for (offset, block) in tool_blocks {
+            // ANVIL_TOOLブロックの開始マーカー位置(offset)が
+            // ANVIL_FINALの開始マーカー位置(cutoff)と同じかそれ以降にある場合に除外
+            if let Some(cutoff) = final_cutoff
+                && offset >= cutoff
+            {
+                continue;
+            }
             tool_calls.push(parse_tool_call_block_multi_tier(&block)?);
         }
 
@@ -1024,17 +1035,18 @@ pub fn tool_protocol_system_prompt_tag_based(
     )
 }
 
-fn extract_fenced_blocks(content: &str, label: &str) -> Vec<String> {
+fn extract_fenced_blocks(content: &str, label: &str) -> Vec<(usize, String)> {
     let mut blocks = Vec::new();
     let start_marker = format!("```{label}\n");
     let end_marker = "\n```";
     let mut cursor = 0usize;
 
     while let Some(start) = content[cursor..].find(&start_marker) {
-        let block_start = cursor + start + start_marker.len();
+        let abs_start = cursor + start; // マーカーの絶対位置
+        let block_start = abs_start + start_marker.len();
         if let Some(end) = content[block_start..].find(end_marker) {
             let block_end = block_start + end;
-            blocks.push(content[block_start..block_end].to_string());
+            blocks.push((abs_start, content[block_start..block_end].to_string()));
             cursor = block_end + end_marker.len();
         } else {
             break;

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -655,6 +655,7 @@ const PROMPT_TOOL_RULES: &str = concat!(
     "- When the user's request requires file changes (implement, fix, create, modify, etc.), \
        you must complete the actual file modifications using file.write/file.edit, \
        not just output a plan or description.\n",
+    "- For large existing files, file.write may be blocked. Use file.edit or file.edit_anchor for targeted modifications instead of rewriting entire files.\n",
     "- Start exploration with file.read on \".\" to list the project root before reading specific files.\n",
     "- Do not assume files like README.md exist — verify first.\n",
     "- For dev servers and watch processes (npm run dev, cargo watch, etc.), use background execution with '&' so the command returns immediately.\n",

--- a/src/agent/subagent.rs
+++ b/src/agent/subagent.rs
@@ -220,6 +220,7 @@ impl SubAgentResult {
             payload: ToolExecutionPayload::Text(json),
             artifacts: Vec::new(),
             elapsed_ms: 0,
+            diff_summary: None,
         }
     }
 }
@@ -269,6 +270,7 @@ impl SubAgentError {
             payload: ToolExecutionPayload::Text(output),
             artifacts: Vec::new(),
             elapsed_ms: 0,
+            diff_summary: None,
         }
     }
 }
@@ -574,6 +576,7 @@ impl<'a, C: ProviderClient> SubAgentSession<'a, C> {
                     payload: ToolExecutionPayload::Text(err.to_string()),
                     artifacts: Vec::new(),
                     elapsed_ms: 0,
+                    diff_summary: None,
                 });
 
             // Record tool result in the sub-agent session

--- a/src/agent/subagent.rs
+++ b/src/agent/subagent.rs
@@ -137,11 +137,22 @@ You are a Plan sub-agent specializing in implementation planning.
 - Note: Offline mode is active. Web access is unavailable.
 "#;
 
+/// Options for sub-agent system prompt generation (Issue #162).
+pub struct SubAgentPromptOptions<'a> {
+    pub offline: bool,
+    pub ui_language: Option<&'a str>,
+}
+
 /// Build a system prompt for a sub-agent of the given kind.
 ///
-/// When `offline` is `true`, web-related tool descriptions and prompts
+/// When `opts.offline` is `true`, web-related tool descriptions and prompts
 /// are excluded from the Plan sub-agent prompt.
-pub fn build_subagent_system_prompt(kind: &SubAgentKind, offline: bool) -> String {
+pub fn build_subagent_system_prompt(
+    kind: &SubAgentKind,
+    opts: &SubAgentPromptOptions<'_>,
+) -> String {
+    use crate::config::{effective_ui_language_code, language_constraint_prompt};
+
     let mut prompt = String::new();
     prompt.push_str(SUBAGENT_PROTOCOL_BASE);
     match kind {
@@ -156,17 +167,22 @@ pub fn build_subagent_system_prompt(kind: &SubAgentKind, offline: bool) -> Strin
         SubAgentKind::Plan => {
             prompt.push_str(TOOL_DESC_FILE_READ);
             prompt.push_str(TOOL_DESC_FILE_SEARCH);
-            if !offline {
+            if !opts.offline {
                 prompt.push_str(TOOL_DESC_WEB_FETCH);
             }
             prompt.push_str(TOOL_DESC_GIT_STATUS);
-            prompt.push_str(if offline {
+            prompt.push_str(if opts.offline {
                 PLAN_ROLE_PROMPT_OFFLINE
             } else {
                 PLAN_ROLE_PROMPT
             });
         }
     }
+
+    // Language constraint (Issue #162)
+    let lang = effective_ui_language_code(opts.ui_language);
+    prompt.push_str(&language_constraint_prompt(lang));
+
     prompt
 }
 
@@ -423,7 +439,11 @@ impl<'a, C: ProviderClient> SubAgentSession<'a, C> {
         }
 
         // 3. Dedicated system prompt
-        let system_prompt = build_subagent_system_prompt(&kind, config.mode.offline);
+        let prompt_opts = SubAgentPromptOptions {
+            offline: config.mode.offline,
+            ui_language: config.runtime.ui_language.as_deref(),
+        };
+        let system_prompt = build_subagent_system_prompt(&kind, &prompt_opts);
 
         SubAgentSession {
             kind,

--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -1108,6 +1108,9 @@ impl App {
             }
         }
 
+        // Write fail tracker: track consecutive file.write failures (Issue #161)
+        let write_hint = self.update_write_tracker(result);
+
         // Working memory: track errors (Issue #130)
         if result.status == ToolExecutionStatus::Failed {
             let sanitized_error = if result.tool_name == "shell.exec" {
@@ -1129,6 +1132,10 @@ impl App {
         if let Some(hint) = edit_hint {
             formatted.push_str(&hint);
         }
+        // Append write recovery hint if consecutive failures detected
+        if let Some(hint) = write_hint {
+            formatted.push_str(&hint);
+        }
         let mut msg = SessionMessage::new(MessageRole::Tool, &result.tool_name, formatted)
             .with_id(self.next_message_id("tool"));
         msg.is_error = is_error;
@@ -1139,6 +1146,33 @@ impl App {
             msg = msg.with_image_paths(vec![source_path.clone()]);
         }
         self.session.push_message(msg);
+    }
+
+    /// Track consecutive file.write failures and return a hint if threshold reached.
+    fn update_write_tracker(&mut self, result: &ToolExecutionResult) -> Option<String> {
+        if result.tool_name != "file.write" {
+            return None;
+        }
+        if result.status == ToolExecutionStatus::Failed {
+            if let Some(path) = extract_write_path_from_summary(&result.summary)
+                .filter(|p| self.write_fail_tracker.record_failure(p))
+            {
+                let count = self.write_fail_tracker.failure_count(&path);
+                let safe_path = crate::session::sanitize_for_prompt_entry(&path);
+                return Some(format!(
+                    "\n\n[Anvil hint] file.write has failed {count} consecutive \
+                     times for '{safe_path}'. Please check the error message carefully. \
+                     Consider: (1) verifying the file path is correct, \
+                     (2) splitting the content into smaller files, \
+                     (3) using file.edit for partial modifications instead."
+                ));
+            }
+        } else if result.status == ToolExecutionStatus::Completed
+            && let Some(artifact) = result.artifacts.first()
+        {
+            self.write_fail_tracker.record_success(artifact);
+        }
+        None
     }
 
     /// Execute a single retry LLM turn after ANVIL_FINAL guard activation.
@@ -1432,6 +1466,25 @@ fn extract_edit_path_from_summary(summary: &str) -> Option<String> {
     Some(path.to_string())
 }
 
+/// Extract the file path from a file.write error summary.
+/// Looks for patterns like "file.write failed for {path}: {err}"
+/// or "file.write failed for {path} (parent creation failed for {parent}): {err}"
+fn extract_write_path_from_summary(summary: &str) -> Option<String> {
+    let prefix = "file.write failed for ";
+    let rest = summary.strip_prefix(prefix)?;
+
+    // Priority 1: check for the parent-creation fixed marker first
+    let parent_marker = " (parent creation failed for ";
+    if let Some(marker_pos) = rest.find(parent_marker) {
+        return Some(rest[..marker_pos].to_string());
+    }
+
+    // Priority 2: normal format — use rsplit_once to find the LAST ": " boundary,
+    // which avoids mis-splitting on paths containing ": " (rare but legal on Unix).
+    // The error portion after the last ": " is the OS I/O error message.
+    rest.rsplit_once(": ").map(|(path, _err)| path.to_string())
+}
+
 /// Format a tool execution result into a message that the LLM can interpret.
 ///
 /// Includes the actual payload (file content, search matches) so the LLM
@@ -1656,5 +1709,32 @@ mod trust_tests {
             false,
             &trusted_tools,
         ));
+    }
+
+    #[test]
+    fn test_extract_write_path_from_summary() {
+        let summary = "file.write failed for /tmp/foo.rs: Permission denied";
+        assert_eq!(
+            extract_write_path_from_summary(summary),
+            Some("/tmp/foo.rs".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_write_path_parent_fail() {
+        let summary = "file.write failed for /tmp/dir/foo.rs (parent creation failed for /tmp/dir): No such file or directory";
+        assert_eq!(
+            extract_write_path_from_summary(summary),
+            Some("/tmp/dir/foo.rs".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_write_path_invalid() {
+        assert_eq!(extract_write_path_from_summary("some random error"), None);
+        assert_eq!(
+            extract_write_path_from_summary("file.edit: something in foo.rs. blah"),
+            None
+        );
     }
 }

--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -324,9 +324,12 @@ impl App {
         let mut total_tool_count = 0usize;
         let mut all_tool_log_views: Vec<ToolLogView> = Vec::new();
         let mut final_guard_retries: u8 = 0;
+        let mut fallback_completed = false;
 
         // Reset loop detector at the start of each top-level turn (Issue #145)
         self.loop_detector.reset();
+        // Reset phase estimator per-turn counters (Issue #159)
+        self.phase_estimator.reset();
 
         for iteration in 0..max_iterations {
             // Check shutdown flag before tool execution
@@ -499,11 +502,29 @@ impl App {
             if next_structured.tool_calls.is_empty() {
                 // ANVIL_FINAL guard: check if any file modifications were made
                 if self.should_activate_final_guard(final_guard_retries) {
+                    // ANVIL_FINAL was detected → record observation (Issue #159)
+                    self.phase_estimator.observe_anvil_final();
                     self.inject_final_guard_retry();
                     final_guard_retries += 1;
                     current = next_structured;
                     continue;
                 }
+
+                // Fallback completion detection (Issue #159):
+                // When ANVIL_FINAL was never observed, check if tool patterns
+                // indicate the agent has finished (write succeeded + verification reads + empty response).
+                if let super::phase_estimator::PhaseAction::FallbackComplete =
+                    self.phase_estimator.check_empty_response()
+                {
+                    tracing::info!("Phase estimator: fallback completion detected");
+                    self.record_assistant_output(
+                        self.next_message_id("assistant"),
+                        next_structured.final_response,
+                    )?;
+                    fallback_completed = true;
+                    break;
+                }
+
                 // No more tool calls — this is the final answer
                 self.record_assistant_output(
                     self.next_message_id("assistant"),
@@ -521,10 +542,17 @@ impl App {
             .with_status(status.to_string())
             .with_tool_logs(all_tool_log_views)
             .with_completion_summary(
-                format!(
-                    "Executed {} tool call(s) across agentic loop. {}",
-                    total_tool_count, saved_status
-                ),
+                if fallback_completed {
+                    format!(
+                        "Executed {} tool call(s) across agentic loop (fallback completion). {}",
+                        total_tool_count, saved_status
+                    )
+                } else {
+                    format!(
+                        "Executed {} tool call(s) across agentic loop. {}",
+                        total_tool_count, saved_status
+                    )
+                },
                 saved_status.to_string(),
             )
             .with_elapsed_ms(elapsed_ms);
@@ -1000,8 +1028,17 @@ impl App {
         // Phase 4: Sort by index, record results, run PostToolUse hooks (DR2-004)
         indexed_results.sort_by_key(|(idx, _)| *idx);
         let mut results: Vec<ToolExecutionResult> = Vec::with_capacity(indexed_results.len());
+        let mut phase_action = super::phase_estimator::PhaseAction::Continue;
         for (_, result) in indexed_results {
             self.record_tool_result(&result);
+            // Phase estimator: record tool call pattern (Issue #159)
+            let success = result.status == ToolExecutionStatus::Completed;
+            let pa = self
+                .phase_estimator
+                .record_tool_call(&result.tool_name, success);
+            if !matches!(pa, super::phase_estimator::PhaseAction::Continue) {
+                phase_action = pa;
+            }
 
             // Emit folded tool result to stderr for interactive sessions
             if interactive {
@@ -1054,6 +1091,33 @@ impl App {
         if let Some(warning_result) = synthetic_warning {
             self.record_tool_result(&warning_result);
             results.push(warning_result);
+        }
+
+        // Phase estimator: inject force-transition message if needed (Issue #159).
+        // Skip if LoopDetector already issued a warning (priority: LoopDetector > PhaseEstimator).
+        if matches!(
+            worst_loop_action,
+            None | Some(super::loop_detector::LoopAction::Continue)
+        ) && let super::phase_estimator::PhaseAction::ForceTransition(msg) = phase_action
+        {
+            // Context window protection: skip if usage >= 90%
+            let usage = crate::contracts::ContextUsageView {
+                estimated_tokens: self.session.estimated_token_count(),
+                max_tokens: self.effective_context_window(),
+            };
+            if usage.usage_ratio() < 0.9 {
+                let transition_result = ToolExecutionResult {
+                    tool_call_id: "phase_estimator_transition".to_string(),
+                    tool_name: "system.phase_estimator".to_string(),
+                    status: ToolExecutionStatus::Completed,
+                    summary: msg.clone(),
+                    payload: ToolExecutionPayload::Text(msg),
+                    artifacts: vec![],
+                    elapsed_ms: 0,
+                };
+                self.record_tool_result(&transition_result);
+                results.push(transition_result);
+            }
         }
 
         self.persist_session(crate::contracts::AppEvent::SessionSaved)?;
@@ -1293,6 +1357,8 @@ impl App {
             if BasicAgentLoop::is_complete_structured_response(assistant_message)
                 && self.should_activate_final_guard(0)
             {
+                // ANVIL_FINAL detected → record observation (Issue #159)
+                self.phase_estimator.observe_anvil_final();
                 self.inject_final_guard_retry();
                 // Record the assistant message that triggered the guard
                 self.record_assistant_output(self.next_message_id("assistant"), assistant_message)?;

--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -1081,29 +1081,39 @@ impl App {
             }
         }
 
-        // Edit fail tracker: track consecutive file.edit failures (Issue #143)
+        // Edit fail tracker: track consecutive file.edit/file.edit_anchor failures (Issue #143, #158)
         let mut edit_hint: Option<String> = None;
-        if result.tool_name == "file.edit" {
+        if result.tool_name == "file.edit" || result.tool_name == "file.edit_anchor" {
             if result.status == ToolExecutionStatus::Failed {
-                // Extract path from summary (format: "file.edit: ... in {path}. ...")
-                if let Some(path) = extract_edit_path_from_summary(&result.summary)
-                    .filter(|p| self.edit_fail_tracker.record_failure(p))
-                {
+                if let Some(raw_path) = extract_edit_path_from_summary(&result.summary) {
+                    let path = resolve_edit_tracker_path(&raw_path);
+                    let action = self.edit_fail_tracker.record_failure(&path);
                     let count = self.edit_fail_tracker.failure_count(&path);
-                    edit_hint = Some(format!(
-                        "\n\n[Anvil hint] file.edit has failed {count} consecutive \
-                         times for '{path}'. Consider using file.read to get the \
-                         current content, then file.write to replace the entire file."
-                    ));
+                    match action {
+                        crate::app::edit_fail_tracker::EditFallbackAction::Continue => {}
+                        crate::app::edit_fail_tracker::EditFallbackAction::ReRead => {
+                            edit_hint = Some(format!(
+                                "\n\n[Anvil hint] file.edit has failed {count} consecutive \
+                                 times for '{path}'. Use file.read to get the current file \
+                                 content, then retry file.edit with the correct old_string."
+                            ));
+                        }
+                        crate::app::edit_fail_tracker::EditFallbackAction::WriteFallback => {
+                            self.prepare_write_fallback();
+                            edit_hint = Some(format!(
+                                "\n\n[Anvil hint] file.edit has failed {count} consecutive \
+                                 times for '{path}'. Consider using file.read to get the \
+                                 current content, then file.write to replace the entire file \
+                                 with the corrected version."
+                            ));
+                        }
+                    }
                 }
             } else if result.status == ToolExecutionStatus::Completed {
-                // Reset on success — extract path from artifacts
+                // Reset on success — use consistent path resolution
                 if let Some(artifact) = result.artifacts.first() {
-                    let path_str = std::path::Path::new(artifact)
-                        .file_name()
-                        .and_then(|n| n.to_str())
-                        .unwrap_or(artifact);
-                    self.edit_fail_tracker.record_success(path_str);
+                    let path_str = resolve_edit_tracker_path(artifact);
+                    self.edit_fail_tracker.record_success(&path_str);
                 }
             }
         }
@@ -1416,6 +1426,12 @@ pub fn truncate_with_head_tail(content: &str, max_chars: usize, head_pct: usize)
 
 /// Extract the file path from a file.edit error summary.
 /// Looks for patterns like "... in {path}. ..." or "... in {path},"
+/// Normalize a file path for consistent EditFailTracker key usage (Issue #158).
+/// Used by both failure (from summary) and success (from artifact) paths.
+fn resolve_edit_tracker_path(raw_path: &str) -> String {
+    raw_path.trim_start_matches("./").to_string()
+}
+
 fn extract_edit_path_from_summary(summary: &str) -> Option<String> {
     // Pattern: "file.edit: ... in {path}. ..."
     // or "file.edit: ... in {path}, ..."

--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -131,6 +131,7 @@ fn execute_parallel_group_standalone(
                                 payload,
                                 artifacts: Vec::new(),
                                 elapsed_ms: 0,
+                                diff_summary: None,
                             }
                         });
                         completed.fetch_add(1, Ordering::Relaxed);
@@ -160,6 +161,7 @@ fn execute_parallel_group_standalone(
                                 payload: ToolExecutionPayload::None,
                                 artifacts: Vec::new(),
                                 elapsed_ms: 0,
+                                diff_summary: None,
                             },
                         ));
                     }
@@ -210,6 +212,7 @@ impl App {
                     ),
                     artifacts: Vec::new(),
                     elapsed_ms: 0,
+                    diff_summary: None,
                 });
                 continue;
             }
@@ -415,13 +418,14 @@ impl App {
                 self.config.mode.interactive,
             );
 
-            let system_prompt = self.build_dynamic_system_prompt();
-            let request = BasicAgentLoop::build_turn_request(
+            let (system_prompt, calibration_ratio) = self.prepare_turn_context();
+            let (request, _) = BasicAgentLoop::build_turn_request_calibrated(
                 self.effective_model().to_string(),
                 &self.session,
                 self.provider.capabilities.streaming && self.config.runtime.stream,
                 self.effective_context_window(),
                 &system_prompt,
+                calibration_ratio,
             );
 
             let mut next_token_buffer = String::new();
@@ -575,6 +579,7 @@ impl App {
                         payload: ToolExecutionPayload::Text(OFFLINE_BLOCK_PAYLOAD.to_string()),
                         artifacts: Vec::new(),
                         elapsed_ms: 0,
+                        diff_summary: None,
                     },
                 ));
                 continue;
@@ -669,6 +674,7 @@ impl App {
                 payload: ToolExecutionPayload::Text(err.to_string()),
                 artifacts: Vec::new(),
                 elapsed_ms: 0,
+                diff_summary: None,
             });
 
         // Remove checkpoint if tool execution failed.
@@ -702,6 +708,7 @@ impl App {
                 payload: ToolExecutionPayload::None,
                 artifacts: Vec::new(),
                 elapsed_ms: 0,
+                diff_summary: None,
             };
         };
 
@@ -727,6 +734,7 @@ impl App {
             payload,
             artifacts: Vec::new(),
             elapsed_ms: started.elapsed().as_millis(),
+            diff_summary: None,
         }
     }
 
@@ -791,6 +799,7 @@ impl App {
                                     payload: crate::tooling::ToolExecutionPayload::None,
                                     artifacts: Vec::new(),
                                     elapsed_ms: 0,
+                                    diff_summary: None,
                                 },
                             ));
                         }
@@ -861,6 +870,7 @@ impl App {
                     payload: ToolExecutionPayload::Text(msg.clone()),
                     artifacts: vec![],
                     elapsed_ms: 0,
+                    diff_summary: None,
                 })
             }
             _ => None,
@@ -1065,8 +1075,11 @@ impl App {
         // Track tool usage for dynamic system prompt generation (Issue #73)
         self.session.used_tools.insert(result.tool_name.clone());
 
-        // Working memory: track touched files (file-mutating tools only) (Issue #130)
-        let is_file_tool = matches!(result.tool_name.as_str(), "file.write" | "file.edit");
+        // Working memory: track touched files (file-mutating tools only) (Issue #130, #157)
+        let is_file_tool = matches!(
+            result.tool_name.as_str(),
+            "file.write" | "file.edit" | "file.edit_anchor"
+        );
         if is_file_tool
             && result.status == ToolExecutionStatus::Completed
             && !result.summary.contains("[rolled back]")
@@ -1078,6 +1091,22 @@ impl App {
                 } else {
                     tracing::warn!("skip touched_files update for non-relative artifact");
                 }
+            }
+
+            // Update recent_diffs with diff_summary (Issue #157)
+            if let Some(ref diff) = result.diff_summary {
+                let current = self
+                    .session
+                    .working_memory
+                    .recent_diffs
+                    .clone()
+                    .unwrap_or_default();
+                let updated = if current.is_empty() {
+                    diff.clone()
+                } else {
+                    format!("{}\n{}", current, diff)
+                };
+                self.session.working_memory.set_recent_diffs(Some(updated));
             }
         }
 
@@ -1160,13 +1189,14 @@ impl App {
         provider_client: &C,
     ) -> Result<Vec<String>, AppError> {
         // Build request and call LLM for one more turn
-        let system_prompt = self.build_dynamic_system_prompt();
-        let request = BasicAgentLoop::build_turn_request(
+        let (system_prompt, calibration_ratio) = self.prepare_turn_context();
+        let (request, _) = BasicAgentLoop::build_turn_request_calibrated(
             self.effective_model().to_string(),
             &self.session,
             self.provider.capabilities.streaming && self.config.runtime.stream,
             self.effective_context_window(),
             &system_prompt,
+            calibration_ratio,
         );
 
         let spinner = Spinner::start(
@@ -1484,6 +1514,7 @@ fn build_failed_result(
         payload: crate::tooling::ToolExecutionPayload::None,
         artifacts: Vec::new(),
         elapsed_ms: 0,
+        diff_summary: None,
     }
 }
 

--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -596,7 +596,10 @@ impl App {
                     );
                 } else {
                     let summary = tool_call_approval_summary(call);
-                    let diff_preview = generate_diff_preview(&self.config.paths.cwd, &call.input);
+                    let diff_options =
+                        crate::tooling::diff::DiffOptions::from_runtime(&self.config.runtime);
+                    let diff_preview =
+                        generate_diff_preview(&self.config.paths.cwd, &call.input, &diff_options);
                     let approved = prompt_inline_approval(&summary, diff_preview.as_deref());
                     if !approved {
                         failed_results

--- a/src/app/edit_fail_tracker.rs
+++ b/src/app/edit_fail_tracker.rs
@@ -1,30 +1,93 @@
 use std::collections::HashMap;
+use std::fmt;
+use std::str::FromStr;
+
+/// Edit/write fallback strategy (Issue #158).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum EditStrategy {
+    /// Prefer file.edit, fallback to file.write after consecutive failures.
+    #[default]
+    EditFirst,
+    /// Prefer file.write from the start (advisory via system prompt).
+    WriteFirst,
+}
+
+impl fmt::Display for EditStrategy {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EditFirst => write!(f, "edit-first"),
+            Self::WriteFirst => write!(f, "write-first"),
+        }
+    }
+}
+
+impl FromStr for EditStrategy {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "edit-first" | "edit_first" => Ok(Self::EditFirst),
+            "write-first" | "write_first" => Ok(Self::WriteFirst),
+            other => Err(format!("invalid edit strategy: {other}")),
+        }
+    }
+}
+
+/// Recommended action after a file.edit failure (Issue #158).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EditFallbackAction {
+    /// Normal continuation (failure count < reread_threshold).
+    Continue,
+    /// Recommend re-reading the file before retrying edit.
+    ReRead,
+    /// Recommend switching to file.write.
+    WriteFallback,
+}
+
+/// Determine the fallback action based on failure count and thresholds.
+///
+/// Separated from `EditFailTracker` to maintain SRP (counter vs policy).
+pub(crate) fn determine_fallback_action(
+    count: u32,
+    reread_threshold: u32,
+    write_fallback_threshold: u32,
+) -> EditFallbackAction {
+    if count >= write_fallback_threshold {
+        EditFallbackAction::WriteFallback
+    } else if count >= reread_threshold {
+        EditFallbackAction::ReRead
+    } else {
+        EditFallbackAction::Continue
+    }
+}
 
 /// Tracks consecutive file.edit failures per file path.
 /// Used to detect when the LLM is stuck retrying edits on the same file
-/// and should be prompted to try an alternative approach.
+/// and should be prompted to try an alternative approach (Issue #158).
 pub(crate) struct EditFailTracker {
     consecutive_failures: HashMap<String, u32>,
-    threshold: u32,
+    reread_threshold: u32,
+    write_fallback_threshold: u32,
 }
 
 impl EditFailTracker {
-    pub(crate) fn new(threshold: u32) -> Self {
+    pub(crate) fn new(reread_threshold: u32, write_fallback_threshold: u32) -> Self {
         Self {
             consecutive_failures: HashMap::new(),
-            threshold,
+            reread_threshold,
+            write_fallback_threshold,
         }
     }
 
     /// Record a file.edit failure for the given path.
-    /// Returns true if the failure count has reached the threshold.
-    pub(crate) fn record_failure(&mut self, path: &str) -> bool {
+    /// Returns the recommended fallback action based on the cumulative failure count.
+    pub(crate) fn record_failure(&mut self, path: &str) -> EditFallbackAction {
         let count = self
             .consecutive_failures
             .entry(path.to_string())
             .or_insert(0);
         *count += 1;
-        *count >= self.threshold
+        determine_fallback_action(*count, self.reread_threshold, self.write_fallback_threshold)
     }
 
     /// Record a successful file.edit, resetting the failure count for that path.
@@ -42,46 +105,171 @@ impl EditFailTracker {
 mod tests {
     use super::*;
 
+    // --- EditStrategy tests ---
+
+    #[test]
+    fn test_edit_strategy_display() {
+        assert_eq!(EditStrategy::EditFirst.to_string(), "edit-first");
+        assert_eq!(EditStrategy::WriteFirst.to_string(), "write-first");
+    }
+
+    #[test]
+    fn test_edit_strategy_from_str() {
+        assert_eq!(
+            "edit-first".parse::<EditStrategy>().unwrap(),
+            EditStrategy::EditFirst
+        );
+        assert_eq!(
+            "edit_first".parse::<EditStrategy>().unwrap(),
+            EditStrategy::EditFirst
+        );
+        assert_eq!(
+            "write-first".parse::<EditStrategy>().unwrap(),
+            EditStrategy::WriteFirst
+        );
+        assert_eq!(
+            "write_first".parse::<EditStrategy>().unwrap(),
+            EditStrategy::WriteFirst
+        );
+        assert!("invalid".parse::<EditStrategy>().is_err());
+    }
+
+    #[test]
+    fn test_edit_strategy_default() {
+        assert_eq!(EditStrategy::default(), EditStrategy::EditFirst);
+    }
+
+    // --- determine_fallback_action tests ---
+
+    #[test]
+    fn test_determine_fallback_action() {
+        // N=3, M=5
+        assert_eq!(
+            determine_fallback_action(0, 3, 5),
+            EditFallbackAction::Continue
+        );
+        assert_eq!(
+            determine_fallback_action(1, 3, 5),
+            EditFallbackAction::Continue
+        );
+        assert_eq!(
+            determine_fallback_action(2, 3, 5),
+            EditFallbackAction::Continue
+        );
+        assert_eq!(
+            determine_fallback_action(3, 3, 5),
+            EditFallbackAction::ReRead
+        );
+        assert_eq!(
+            determine_fallback_action(4, 3, 5),
+            EditFallbackAction::ReRead
+        );
+        assert_eq!(
+            determine_fallback_action(5, 3, 5),
+            EditFallbackAction::WriteFallback
+        );
+        assert_eq!(
+            determine_fallback_action(6, 3, 5),
+            EditFallbackAction::WriteFallback
+        );
+        assert_eq!(
+            determine_fallback_action(100, 3, 5),
+            EditFallbackAction::WriteFallback
+        );
+    }
+
+    // --- EditFailTracker tests ---
+
     #[test]
     fn test_tracker_basic_flow() {
-        let mut tracker = EditFailTracker::new(3);
+        let mut tracker = EditFailTracker::new(3, 5);
 
-        assert!(!tracker.record_failure("foo.rs"));
-        assert!(!tracker.record_failure("foo.rs"));
-        assert!(tracker.record_failure("foo.rs")); // 3rd failure hits threshold
+        // 1st and 2nd failure: Continue
+        assert_eq!(
+            tracker.record_failure("foo.rs"),
+            EditFallbackAction::Continue
+        );
+        assert_eq!(
+            tracker.record_failure("foo.rs"),
+            EditFallbackAction::Continue
+        );
+        // 3rd failure: ReRead
+        assert_eq!(tracker.record_failure("foo.rs"), EditFallbackAction::ReRead);
         assert_eq!(tracker.failure_count("foo.rs"), 3);
+        // 4th failure: ReRead
+        assert_eq!(tracker.record_failure("foo.rs"), EditFallbackAction::ReRead);
+        // 5th failure: WriteFallback
+        assert_eq!(
+            tracker.record_failure("foo.rs"),
+            EditFallbackAction::WriteFallback
+        );
+        assert_eq!(tracker.failure_count("foo.rs"), 5);
     }
 
     #[test]
     fn test_tracker_success_resets() {
-        let mut tracker = EditFailTracker::new(3);
+        let mut tracker = EditFailTracker::new(3, 5);
 
         tracker.record_failure("foo.rs");
         tracker.record_failure("foo.rs");
         tracker.record_success("foo.rs");
         assert_eq!(tracker.failure_count("foo.rs"), 0);
 
-        // After reset, needs 3 more failures
-        assert!(!tracker.record_failure("foo.rs"));
+        // After reset, starts from Continue again
+        assert_eq!(
+            tracker.record_failure("foo.rs"),
+            EditFallbackAction::Continue
+        );
     }
 
     #[test]
     fn test_tracker_independent_paths() {
-        let mut tracker = EditFailTracker::new(3);
+        let mut tracker = EditFailTracker::new(3, 5);
 
         tracker.record_failure("foo.rs");
-        assert!(!tracker.record_failure("bar.rs")); // bar.rs: 1st
-        assert!(!tracker.record_failure("foo.rs")); // foo.rs: 2nd
-        assert!(!tracker.record_failure("bar.rs")); // bar.rs: 2nd
-        assert!(tracker.record_failure("foo.rs")); // foo.rs: 3rd = threshold
-        assert!(tracker.record_failure("bar.rs")); // bar.rs: 3rd = threshold
+        assert_eq!(
+            tracker.record_failure("bar.rs"),
+            EditFallbackAction::Continue
+        ); // bar: 1st
+        assert_eq!(
+            tracker.record_failure("foo.rs"),
+            EditFallbackAction::Continue
+        ); // foo: 2nd
+        assert_eq!(
+            tracker.record_failure("bar.rs"),
+            EditFallbackAction::Continue
+        ); // bar: 2nd
+        assert_eq!(tracker.record_failure("foo.rs"), EditFallbackAction::ReRead); // foo: 3rd
+        assert_eq!(tracker.record_failure("bar.rs"), EditFallbackAction::ReRead); // bar: 3rd
     }
 
     #[test]
-    fn test_tracker_threshold_2() {
-        let mut tracker = EditFailTracker::new(2);
-        assert!(!tracker.record_failure("a.rs")); // 1st
-        assert!(tracker.record_failure("a.rs")); // 2nd = threshold
-        assert!(tracker.record_failure("a.rs")); // 3rd, still above threshold
+    fn test_tracker_custom_thresholds() {
+        let mut tracker = EditFailTracker::new(2, 4);
+        assert_eq!(tracker.record_failure("a.rs"), EditFallbackAction::Continue); // 1st
+        assert_eq!(tracker.record_failure("a.rs"), EditFallbackAction::ReRead); // 2nd = reread
+        assert_eq!(tracker.record_failure("a.rs"), EditFallbackAction::ReRead); // 3rd
+        assert_eq!(
+            tracker.record_failure("a.rs"),
+            EditFallbackAction::WriteFallback
+        ); // 4th = write
+    }
+
+    #[test]
+    fn test_tracker_write_fallback_persists() {
+        let mut tracker = EditFailTracker::new(3, 5);
+        for _ in 0..5 {
+            tracker.record_failure("a.rs");
+        }
+        // Beyond threshold, still WriteFallback
+        assert_eq!(
+            tracker.record_failure("a.rs"),
+            EditFallbackAction::WriteFallback
+        );
+        assert_eq!(
+            tracker.record_failure("a.rs"),
+            EditFallbackAction::WriteFallback
+        );
+        assert_eq!(tracker.failure_count("a.rs"), 7);
     }
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -486,6 +486,68 @@ impl App {
         &self.config
     }
 
+    /// Prepare turn context: system prompt generation, pruning pre-check,
+    /// context_notice update, and Critical-level warning injection.
+    /// Returns (system_prompt, calibration_ratio).
+    fn prepare_turn_context(&mut self) -> (String, f64) {
+        use crate::contracts::tokens::{ContentKind, estimate_tokens_calibrated};
+
+        let calibration_ratio = self.calibration_store.get_ratio(self.effective_model());
+
+        // 1. Preliminary system prompt (context_notice may be from previous turn)
+        let preliminary_prompt = self.build_dynamic_system_prompt();
+        let system_prompt_tokens =
+            estimate_tokens_calibrated(&preliminary_prompt, ContentKind::Text, calibration_ratio);
+
+        // 2. Pruning pre-check
+        let context_window = self.effective_context_window();
+        let (pruned_count, selected_tokens) = BasicAgentLoop::estimate_pruned_message_count(
+            &self.session,
+            context_window,
+            system_prompt_tokens,
+            calibration_ratio,
+        );
+
+        // 3. Update context_notice
+        let old_notice = self.session.working_memory.context_notice.clone();
+        if pruned_count > 0 {
+            let notice = format!(
+                "{} earlier messages were omitted due to context limits. \
+                 Files listed in 'Touched files' have already been modified. \
+                 Do not re-read or re-edit them unless necessary.",
+                pruned_count
+            );
+            self.session.working_memory.set_context_notice(Some(notice));
+        } else {
+            self.session.working_memory.set_context_notice(None);
+        }
+
+        // 4. Regenerate prompt if context_notice changed
+        let system_prompt = if self.session.working_memory.context_notice != old_notice {
+            self.build_dynamic_system_prompt()
+        } else {
+            preliminary_prompt
+        };
+
+        // 5. Critical-level warning injection
+        let estimated_total = system_prompt_tokens + selected_tokens;
+        let usage = ContextUsageView {
+            estimated_tokens: estimated_total,
+            max_tokens: context_window,
+        };
+        let mut final_prompt = system_prompt;
+        if usage.warning_level() == Some(ContextWarningLevel::Critical) {
+            final_prompt.push_str(
+                "\n\n## CRITICAL: Context limit approaching\n\
+                 Context usage exceeds 90%. Prioritize completing pending file \
+                 changes and report progress via ANVIL_FINAL. Avoid reading \
+                 files already listed in Touched files above.",
+            );
+        }
+
+        (final_prompt, calibration_ratio)
+    }
+
     /// Build a dynamic system prompt based on current session state.
     ///
     /// Called each turn to include only relevant tool descriptions.
@@ -861,8 +923,7 @@ impl App {
         )?;
         self.begin_live_turn_state()?;
 
-        let system_prompt = self.build_dynamic_system_prompt();
-        let calibration_ratio = self.calibration_store.get_ratio(self.effective_model());
+        let (system_prompt, calibration_ratio) = self.prepare_turn_context();
         let (request, estimated_prompt_tokens) = BasicAgentLoop::build_turn_request_calibrated(
             self.effective_model().to_string(),
             &self.session,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -599,6 +599,13 @@ impl App {
             );
         }
 
+        // Language constraint (Issue #162)
+        {
+            use crate::config::{effective_ui_language_code, language_constraint_prompt};
+            let lang = effective_ui_language_code(self.config.runtime.ui_language.as_deref());
+            prompt.push_str(&language_constraint_prompt(lang));
+        }
+
         // Working memory injection (Issue #130)
         if let Some(wm_prompt) = self.session.working_memory.format_for_prompt() {
             prompt.push_str("\n\n");

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -12,6 +12,7 @@ pub mod mock;
 pub mod plan;
 pub mod policy;
 pub mod render;
+pub(crate) mod write_fail_tracker;
 
 use crate::agent::BasicAgentLoop;
 use crate::agent::{AgentEvent, AgentRuntime, PendingTurnState, ProjectLanguage, PromptTier};
@@ -152,6 +153,8 @@ pub struct App {
     prompt_tier: PromptTier,
     /// Tracks consecutive file.edit failures per path for recovery hints.
     edit_fail_tracker: edit_fail_tracker::EditFailTracker,
+    /// Tracks consecutive file.write failures per path for recovery hints.
+    write_fail_tracker: write_fail_tracker::WriteFailTracker,
     /// File read cache: reduces redundant file.read calls within a session.
     file_read_cache: Arc<Mutex<crate::tooling::file_cache::FileReadCache>>,
 }
@@ -441,6 +444,7 @@ impl App {
             last_estimated_prompt_tokens: None,
             prompt_tier,
             edit_fail_tracker: edit_fail_tracker::EditFailTracker::new(3),
+            write_fail_tracker: write_fail_tracker::WriteFailTracker::new(2),
             file_read_cache,
         })
     }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1305,9 +1305,12 @@ impl App {
                             .find(|tc| tc.tool_call_id == *tool_call_id)
                     })
                     .and_then(|tc| {
+                        let diff_options =
+                            crate::tooling::diff::DiffOptions::from_runtime(&self.config.runtime);
                         crate::tooling::diff::generate_diff_preview(
                             &self.config.paths.cwd,
                             &tc.input,
+                            &diff_options,
                         )
                     });
                 let snapshot = AppStateSnapshot::new(RuntimeState::AwaitingApproval)

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -9,6 +9,7 @@ mod context;
 pub(crate) mod edit_fail_tracker;
 pub mod loop_detector;
 pub mod mock;
+pub mod phase_estimator;
 pub mod plan;
 pub mod policy;
 pub mod render;
@@ -152,6 +153,8 @@ pub struct App {
     prompt_tier: PromptTier,
     /// Tracks consecutive file.edit failures per path for recovery hints.
     edit_fail_tracker: edit_fail_tracker::EditFailTracker,
+    /// Phase estimator for fallback phase control (Issue #159).
+    phase_estimator: phase_estimator::PhaseEstimator,
     /// File read cache: reduces redundant file.read calls within a session.
     file_read_cache: Arc<Mutex<crate::tooling::file_cache::FileReadCache>>,
 }
@@ -414,6 +417,9 @@ impl App {
         };
 
         let loop_detection_threshold = config.runtime.loop_detection_threshold;
+        let phase_explore = config.runtime.phase_explore_threshold;
+        let phase_force = config.runtime.phase_force_transition_threshold;
+        let phase_completion = config.runtime.phase_completion_read_threshold;
 
         Ok(Self {
             tools,
@@ -441,6 +447,11 @@ impl App {
             last_estimated_prompt_tokens: None,
             prompt_tier,
             edit_fail_tracker: edit_fail_tracker::EditFailTracker::new(3),
+            phase_estimator: phase_estimator::PhaseEstimator::new(
+                phase_explore,
+                phase_force,
+                phase_completion,
+            ),
             file_read_cache,
         })
     }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -414,6 +414,8 @@ impl App {
         };
 
         let loop_detection_threshold = config.runtime.loop_detection_threshold;
+        let edit_reread_threshold = config.runtime.edit_reread_threshold;
+        let edit_write_fallback_threshold = config.runtime.edit_write_fallback_threshold;
 
         Ok(Self {
             tools,
@@ -440,7 +442,10 @@ impl App {
             calibration_store: TokenCalibrationStore::new(),
             last_estimated_prompt_tokens: None,
             prompt_tier,
-            edit_fail_tracker: edit_fail_tracker::EditFailTracker::new(3),
+            edit_fail_tracker: edit_fail_tracker::EditFailTracker::new(
+                edit_reread_threshold,
+                edit_write_fallback_threshold,
+            ),
             file_read_cache,
         })
     }
@@ -551,6 +556,11 @@ impl App {
             .strip_prefix(cwd)
             .ok()
             .map(|rel| rel.to_string_lossy().into_owned())
+    }
+
+    /// Prepare for write fallback: take checkpoint snapshot (Issue #158, DR4-007).
+    fn prepare_write_fallback(&mut self) {
+        self.checkpoint_stack.mark();
     }
 
     /// Check whether a shutdown has been requested via the shared flag.

--- a/src/app/phase_estimator.rs
+++ b/src/app/phase_estimator.rs
@@ -1,0 +1,324 @@
+//! Phase estimation based on tool call patterns (Issue #159).
+//!
+//! For LLM models that do not emit ANVIL_FINAL markers, this module estimates
+//! the current agent phase (exploring vs implementing) from the sequence of
+//! tool calls and provides fallback completion detection.
+
+/// Read-category tool names.
+const READ_TOOLS: &[&str] = &["file.read", "file.search", "web.fetch"];
+/// Write-category tool names.
+const WRITE_TOOLS: &[&str] = &["file.edit", "file.write"];
+
+/// Action recommended by the phase estimator.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PhaseAction {
+    /// No action needed.
+    Continue,
+    /// Inject a system message to nudge the LLM toward implementation.
+    ForceTransition(String),
+    /// Fallback completion detected (ANVIL_FINAL was never observed).
+    FallbackComplete,
+}
+
+/// Estimated agent phase (for logging/debugging).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(dead_code)]
+pub enum Phase {
+    /// Not enough data to determine phase.
+    Unknown,
+    /// Predominantly reading files.
+    Exploring,
+    /// Has performed write operations.
+    Implementing,
+}
+
+/// Tool category for phase estimation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ToolCategory {
+    Read,
+    Write,
+    Other,
+}
+
+fn classify_tool(tool_name: &str) -> ToolCategory {
+    if READ_TOOLS.contains(&tool_name) {
+        ToolCategory::Read
+    } else if WRITE_TOOLS.contains(&tool_name) {
+        ToolCategory::Write
+    } else {
+        ToolCategory::Other
+    }
+}
+
+/// Estimates the agent phase from tool call patterns and provides
+/// fallback completion detection when ANVIL_FINAL is not emitted.
+pub struct PhaseEstimator {
+    /// Consecutive read-category tool calls (reset on write success or reset()).
+    consecutive_reads: usize,
+    /// Whether a write-category tool has succeeded at least once.
+    has_written: bool,
+    /// Whether ANVIL_FINAL has been observed at least once in this session.
+    anvil_final_observed: bool,
+    /// Threshold N: consecutive reads to enter "exploring" phase.
+    #[allow(dead_code)]
+    explore_threshold: usize,
+    /// Threshold M: consecutive reads to trigger forced transition (M > N).
+    force_transition_threshold: usize,
+    /// Threshold K: consecutive reads after last write for fallback completion.
+    completion_read_threshold: usize,
+}
+
+impl PhaseEstimator {
+    /// Create a new PhaseEstimator with the given thresholds.
+    pub fn new(
+        explore_threshold: usize,
+        force_transition_threshold: usize,
+        completion_read_threshold: usize,
+    ) -> Self {
+        Self {
+            consecutive_reads: 0,
+            has_written: false,
+            anvil_final_observed: false,
+            explore_threshold,
+            force_transition_threshold,
+            completion_read_threshold,
+        }
+    }
+
+    /// Reset per-turn counters. Called at the start of each
+    /// `complete_structured_response()` turn.
+    ///
+    /// `has_written` and `anvil_final_observed` are **preserved** across turns.
+    pub fn reset(&mut self) {
+        self.consecutive_reads = 0;
+    }
+
+    /// Record a tool call and return a recommended action.
+    ///
+    /// Returns `Continue` or `ForceTransition`. Never returns `FallbackComplete`
+    /// (use [`check_empty_response`] for that).
+    pub fn record_tool_call(&mut self, tool_name: &str, success: bool) -> PhaseAction {
+        match classify_tool(tool_name) {
+            ToolCategory::Read => {
+                self.consecutive_reads += 1;
+                if self.consecutive_reads >= self.force_transition_threshold {
+                    return PhaseAction::ForceTransition(
+                        "You have been reading files extensively. \
+                         Please proceed to implementation using file.edit or file.write."
+                            .to_string(),
+                    );
+                }
+                PhaseAction::Continue
+            }
+            ToolCategory::Write => {
+                if success {
+                    self.consecutive_reads = 0;
+                    self.has_written = true;
+                }
+                PhaseAction::Continue
+            }
+            ToolCategory::Other => PhaseAction::Continue,
+        }
+    }
+
+    /// Check whether an empty-tool-calls response indicates fallback completion.
+    ///
+    /// Returns `FallbackComplete` when:
+    /// - `has_written` is true (at least one successful write)
+    /// - `consecutive_reads >= completion_read_threshold` (verification reads after write)
+    /// - `anvil_final_observed` is false (ANVIL_FINAL was never seen)
+    ///
+    /// Otherwise returns `Continue`.
+    pub fn check_empty_response(&self) -> PhaseAction {
+        if self.anvil_final_observed {
+            return PhaseAction::Continue;
+        }
+        if self.has_written && self.consecutive_reads >= self.completion_read_threshold {
+            return PhaseAction::FallbackComplete;
+        }
+        PhaseAction::Continue
+    }
+
+    /// Record that ANVIL_FINAL was observed. Disables fallback completion
+    /// for the remainder of the session.
+    pub fn observe_anvil_final(&mut self) {
+        self.anvil_final_observed = true;
+    }
+
+    /// Reset model-dependent state (called on `/model` switch).
+    /// Clears `anvil_final_observed` since a new model may not emit ANVIL_FINAL.
+    #[allow(dead_code)]
+    pub fn reset_model_state(&mut self) {
+        self.anvil_final_observed = false;
+    }
+
+    /// Return the estimated phase for logging/debugging.
+    #[allow(dead_code)]
+    pub fn current_phase(&self) -> Phase {
+        if self.has_written {
+            Phase::Implementing
+        } else if self.consecutive_reads >= self.explore_threshold {
+            Phase::Exploring
+        } else {
+            Phase::Unknown
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn default_estimator() -> PhaseEstimator {
+        PhaseEstimator::new(5, 10, 5)
+    }
+
+    #[test]
+    fn classify_tool_read() {
+        assert_eq!(classify_tool("file.read"), ToolCategory::Read);
+        assert_eq!(classify_tool("file.search"), ToolCategory::Read);
+        assert_eq!(classify_tool("web.fetch"), ToolCategory::Read);
+    }
+
+    #[test]
+    fn classify_tool_write() {
+        assert_eq!(classify_tool("file.edit"), ToolCategory::Write);
+        assert_eq!(classify_tool("file.write"), ToolCategory::Write);
+    }
+
+    #[test]
+    fn classify_tool_other() {
+        assert_eq!(classify_tool("shell.exec"), ToolCategory::Other);
+        assert_eq!(classify_tool("agent.explore"), ToolCategory::Other);
+        assert_eq!(classify_tool("agent.plan"), ToolCategory::Other);
+        assert_eq!(classify_tool("unknown.tool"), ToolCategory::Other);
+    }
+
+    #[test]
+    fn consecutive_reads_trigger_exploring_phase() {
+        let mut est = default_estimator();
+        for _ in 0..5 {
+            est.record_tool_call("file.read", true);
+        }
+        assert_eq!(est.current_phase(), Phase::Exploring);
+    }
+
+    #[test]
+    fn write_success_resets_consecutive_reads() {
+        let mut est = default_estimator();
+        for _ in 0..4 {
+            est.record_tool_call("file.read", true);
+        }
+        assert_eq!(est.consecutive_reads, 4);
+        est.record_tool_call("file.edit", true);
+        assert_eq!(est.consecutive_reads, 0);
+        assert!(est.has_written);
+    }
+
+    #[test]
+    fn write_failure_does_not_reset() {
+        let mut est = default_estimator();
+        for _ in 0..4 {
+            est.record_tool_call("file.read", true);
+        }
+        est.record_tool_call("file.edit", false);
+        assert_eq!(est.consecutive_reads, 4);
+        assert!(!est.has_written);
+    }
+
+    #[test]
+    fn force_transition_at_m_reads() {
+        let mut est = default_estimator();
+        for i in 0..10 {
+            let action = est.record_tool_call("file.read", true);
+            if i < 9 {
+                assert_eq!(action, PhaseAction::Continue);
+            } else {
+                assert!(matches!(action, PhaseAction::ForceTransition(_)));
+            }
+        }
+    }
+
+    #[test]
+    fn fallback_complete_conditions() {
+        let mut est = default_estimator();
+        // No write yet → no fallback
+        for _ in 0..5 {
+            est.record_tool_call("file.read", true);
+        }
+        assert_eq!(est.check_empty_response(), PhaseAction::Continue);
+
+        // Write, then K reads → fallback
+        est.record_tool_call("file.write", true);
+        for _ in 0..5 {
+            est.record_tool_call("file.read", true);
+        }
+        assert_eq!(est.check_empty_response(), PhaseAction::FallbackComplete);
+    }
+
+    #[test]
+    fn anvil_final_observed_disables_fallback() {
+        let mut est = default_estimator();
+        est.record_tool_call("file.write", true);
+        for _ in 0..5 {
+            est.record_tool_call("file.read", true);
+        }
+        est.observe_anvil_final();
+        assert_eq!(est.check_empty_response(), PhaseAction::Continue);
+    }
+
+    #[test]
+    fn reset_preserves_has_written_and_anvil_final() {
+        let mut est = default_estimator();
+        est.record_tool_call("file.write", true);
+        est.observe_anvil_final();
+        est.record_tool_call("file.read", true);
+
+        est.reset();
+
+        assert_eq!(est.consecutive_reads, 0);
+        assert!(est.has_written);
+        assert!(est.anvil_final_observed);
+    }
+
+    #[test]
+    fn reset_model_state_clears_anvil_final() {
+        let mut est = default_estimator();
+        est.observe_anvil_final();
+        assert!(est.anvil_final_observed);
+
+        est.reset_model_state();
+        assert!(!est.anvil_final_observed);
+    }
+
+    #[test]
+    fn current_phase_unknown_initially() {
+        let est = default_estimator();
+        assert_eq!(est.current_phase(), Phase::Unknown);
+    }
+
+    #[test]
+    fn current_phase_implementing_after_write() {
+        let mut est = default_estimator();
+        est.record_tool_call("file.edit", true);
+        assert_eq!(est.current_phase(), Phase::Implementing);
+    }
+
+    #[test]
+    fn other_tools_do_not_affect_counts() {
+        let mut est = default_estimator();
+        est.record_tool_call("shell.exec", true);
+        assert_eq!(est.consecutive_reads, 0);
+        assert!(!est.has_written);
+    }
+
+    #[test]
+    fn record_tool_call_never_returns_fallback_complete() {
+        let mut est = default_estimator();
+        est.record_tool_call("file.write", true);
+        for _ in 0..20 {
+            let action = est.record_tool_call("file.read", true);
+            assert_ne!(action, PhaseAction::FallbackComplete);
+        }
+    }
+}

--- a/src/app/write_fail_tracker.rs
+++ b/src/app/write_fail_tracker.rs
@@ -1,0 +1,83 @@
+use std::collections::HashMap;
+
+/// Tracks consecutive file.write failures per file path.
+/// Used to detect when the LLM is stuck retrying writes on the same file
+/// and should be prompted to try an alternative approach.
+pub(crate) struct WriteFailTracker {
+    consecutive_failures: HashMap<String, u32>,
+    threshold: u32,
+}
+
+impl WriteFailTracker {
+    pub(crate) fn new(threshold: u32) -> Self {
+        Self {
+            consecutive_failures: HashMap::new(),
+            threshold,
+        }
+    }
+
+    /// Record a file.write failure for the given path.
+    /// Returns true if the failure count has reached the threshold.
+    pub(crate) fn record_failure(&mut self, path: &str) -> bool {
+        let count = self
+            .consecutive_failures
+            .entry(path.to_string())
+            .or_insert(0);
+        *count += 1;
+        *count >= self.threshold
+    }
+
+    /// Record a successful file.write, resetting the failure count for that path.
+    pub(crate) fn record_success(&mut self, path: &str) {
+        self.consecutive_failures.remove(path);
+    }
+
+    /// Get the current failure count for a path.
+    pub(crate) fn failure_count(&self, path: &str) -> u32 {
+        self.consecutive_failures.get(path).copied().unwrap_or(0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_tracker_basic_flow() {
+        let mut tracker = WriteFailTracker::new(2);
+
+        assert!(!tracker.record_failure("foo.rs"));
+        assert!(tracker.record_failure("foo.rs")); // 2nd failure hits threshold
+        assert_eq!(tracker.failure_count("foo.rs"), 2);
+    }
+
+    #[test]
+    fn test_tracker_success_resets() {
+        let mut tracker = WriteFailTracker::new(2);
+
+        tracker.record_failure("foo.rs");
+        tracker.record_success("foo.rs");
+        assert_eq!(tracker.failure_count("foo.rs"), 0);
+
+        // After reset, needs 2 more failures
+        assert!(!tracker.record_failure("foo.rs"));
+    }
+
+    #[test]
+    fn test_tracker_independent_paths() {
+        let mut tracker = WriteFailTracker::new(2);
+
+        tracker.record_failure("foo.rs");
+        assert!(!tracker.record_failure("bar.rs")); // bar.rs: 1st
+        assert!(tracker.record_failure("foo.rs")); // foo.rs: 2nd = threshold
+        assert!(tracker.record_failure("bar.rs")); // bar.rs: 2nd = threshold
+    }
+
+    #[test]
+    fn test_tracker_threshold_boundary() {
+        let mut tracker = WriteFailTracker::new(2);
+        assert!(!tracker.record_failure("a.rs")); // 1st, below threshold
+        assert!(tracker.record_failure("a.rs")); // 2nd = threshold
+        assert!(tracker.record_failure("a.rs")); // 3rd, still above threshold
+    }
+}

--- a/src/config/cli_args.rs
+++ b/src/config/cli_args.rs
@@ -85,6 +85,10 @@ pub struct CliArgs {
     #[arg(long = "timeout")]
     pub timeout: Option<u64>,
 
+    /// Edit/write fallback strategy (edit-first|write-first)
+    #[arg(long = "edit-strategy")]
+    pub edit_strategy: Option<String>,
+
     /// Prompt tier override (full|compact|tiny)
     #[arg(long = "prompt-tier")]
     pub prompt_tier: Option<String>,

--- a/src/config/cli_args.rs
+++ b/src/config/cli_args.rs
@@ -104,6 +104,14 @@ pub struct CliArgs {
     /// Not parsed from CLI args directly.
     #[arg(skip)]
     pub tag_protocol: Option<bool>,
+
+    /// Maximum line count for file.write on existing files (0 = disabled)
+    #[arg(long = "safe-write-max-lines")]
+    pub safe_write_max_lines: Option<usize>,
+
+    /// Deletion ratio threshold for diff warning (0.0-1.0)
+    #[arg(long = "safe-write-deletion-ratio")]
+    pub safe_write_deletion_ratio: Option<f64>,
 }
 
 impl CliArgs {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -81,6 +81,12 @@ pub struct RuntimeConfig {
     pub loop_detection_threshold: usize,
     /// HTTP request timeout in seconds (Issue #146).
     pub http_timeout_secs: u64,
+    /// Edit/write fallback strategy: edit-first or write-first (Issue #158).
+    pub edit_strategy: crate::app::edit_fail_tracker::EditStrategy,
+    /// Consecutive edit failures before re-read hint (Issue #158).
+    pub edit_reread_threshold: u32,
+    /// Consecutive edit failures before write fallback hint (Issue #158).
+    pub edit_write_fallback_threshold: u32,
 }
 
 #[derive(Debug, Clone)]
@@ -234,6 +240,9 @@ impl EffectiveConfig {
                 subagent_timeout_secs: DEFAULT_SUBAGENT_TIMEOUT_SECS,
                 loop_detection_threshold: 3,
                 http_timeout_secs: DEFAULT_HTTP_TIMEOUT_SECS,
+                edit_strategy: crate::app::edit_fail_tracker::EditStrategy::EditFirst,
+                edit_reread_threshold: 3,
+                edit_write_fallback_threshold: 5,
             },
             mode: ModeConfig {
                 prompt_source: PromptSource::Interactive,
@@ -334,6 +343,9 @@ impl EffectiveConfig {
             "ANVIL_LOOP_DETECTION_THRESHOLD",
             "ANVIL_HTTP_TIMEOUT",
             "ANVIL_CURL_TIMEOUT",
+            "ANVIL_EDIT_STRATEGY",
+            "ANVIL_EDIT_REREAD_THRESHOLD",
+            "ANVIL_EDIT_WRITE_FALLBACK_THRESHOLD",
         ] {
             if let Ok(value) = std::env::var(key) {
                 map.insert(key.to_string(), value);
@@ -430,6 +442,13 @@ impl EffectiveConfig {
         // Prompt tier override
         if let Some(ref v) = cli.prompt_tier {
             self.runtime.prompt_tier = Some(v.clone());
+        }
+
+        // Edit strategy override (Issue #158)
+        if let Some(ref v) = cli.edit_strategy {
+            self.runtime.edit_strategy = v
+                .parse::<crate::app::edit_fail_tracker::EditStrategy>()
+                .map_err(ConfigError::ValidationError)?;
         }
 
         // --session flag: override session file path
@@ -572,6 +591,29 @@ impl EffectiveConfig {
                         .parse()
                         .map_err(|_| ConfigError::InvalidNumericValue(value.clone()))?;
                 }
+                "edit_strategy" | "ANVIL_EDIT_STRATEGY" => {
+                    self.runtime.edit_strategy = value
+                        .parse::<crate::app::edit_fail_tracker::EditStrategy>()
+                        .map_err(ConfigError::ValidationError)?;
+                }
+                "edit_reread_threshold" | "ANVIL_EDIT_REREAD_THRESHOLD" => {
+                    let v: u32 = value
+                        .parse()
+                        .map_err(|_| ConfigError::InvalidNumericValue(value.clone()))?;
+                    if !(1..=20).contains(&v) {
+                        return Err(ConfigError::InvalidNumericValue(value.clone()));
+                    }
+                    self.runtime.edit_reread_threshold = v;
+                }
+                "edit_write_fallback_threshold" | "ANVIL_EDIT_WRITE_FALLBACK_THRESHOLD" => {
+                    let v: u32 = value
+                        .parse()
+                        .map_err(|_| ConfigError::InvalidNumericValue(value.clone()))?;
+                    if !(1..=20).contains(&v) {
+                        return Err(ConfigError::InvalidNumericValue(value.clone()));
+                    }
+                    self.runtime.edit_write_fallback_threshold = v;
+                }
                 _ => {}
             }
         }
@@ -599,6 +641,7 @@ impl EffectiveConfig {
         self.clamp_smart_compact_ratio();
         self.clamp_subagent_settings();
         self.clamp_loop_detection_threshold();
+        self.clamp_edit_thresholds();
         self.clamp_http_timeout();
         Ok(())
     }
@@ -715,6 +758,16 @@ impl EffectiveConfig {
 
     fn clamp_loop_detection_threshold(&mut self) {
         self.runtime.loop_detection_threshold = self.runtime.loop_detection_threshold.clamp(2, 20);
+    }
+
+    fn clamp_edit_thresholds(&mut self) {
+        self.runtime.edit_reread_threshold = self.runtime.edit_reread_threshold.clamp(1, 20);
+        self.runtime.edit_write_fallback_threshold =
+            self.runtime.edit_write_fallback_threshold.clamp(1, 20);
+        // Ensure write_fallback > reread
+        if self.runtime.edit_write_fallback_threshold <= self.runtime.edit_reread_threshold {
+            self.runtime.edit_write_fallback_threshold = self.runtime.edit_reread_threshold + 2;
+        }
     }
 
     pub fn validate_for_test(&mut self) -> Result<(), ConfigError> {
@@ -972,6 +1025,12 @@ impl std::fmt::Debug for RuntimeConfig {
                 &self.smart_compact_threshold_ratio,
             )
             .field("http_timeout_secs", &self.http_timeout_secs)
+            .field("edit_strategy", &self.edit_strategy)
+            .field("edit_reread_threshold", &self.edit_reread_threshold)
+            .field(
+                "edit_write_fallback_threshold",
+                &self.edit_write_fallback_threshold,
+            )
             .finish()
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -81,6 +81,10 @@ pub struct RuntimeConfig {
     pub loop_detection_threshold: usize,
     /// HTTP request timeout in seconds (Issue #146).
     pub http_timeout_secs: u64,
+    /// Maximum line count for file.write on existing files (0 = disabled, Issue #156).
+    pub safe_write_max_lines: usize,
+    /// Deletion ratio threshold for diff warning (0.0-1.0, Issue #156).
+    pub safe_write_deletion_ratio: f64,
 }
 
 #[derive(Debug, Clone)]
@@ -234,6 +238,8 @@ impl EffectiveConfig {
                 subagent_timeout_secs: DEFAULT_SUBAGENT_TIMEOUT_SECS,
                 loop_detection_threshold: 3,
                 http_timeout_secs: DEFAULT_HTTP_TIMEOUT_SECS,
+                safe_write_max_lines: 500,
+                safe_write_deletion_ratio: 0.5,
             },
             mode: ModeConfig {
                 prompt_source: PromptSource::Interactive,
@@ -334,6 +340,8 @@ impl EffectiveConfig {
             "ANVIL_LOOP_DETECTION_THRESHOLD",
             "ANVIL_HTTP_TIMEOUT",
             "ANVIL_CURL_TIMEOUT",
+            "ANVIL_SAFE_WRITE_MAX_LINES",
+            "ANVIL_SAFE_WRITE_DELETION_RATIO",
         ] {
             if let Ok(value) = std::env::var(key) {
                 map.insert(key.to_string(), value);
@@ -430,6 +438,19 @@ impl EffectiveConfig {
         // Prompt tier override
         if let Some(ref v) = cli.prompt_tier {
             self.runtime.prompt_tier = Some(v.clone());
+        }
+
+        // Safe write settings
+        if let Some(v) = cli.safe_write_max_lines {
+            self.runtime.safe_write_max_lines = v;
+        }
+        if let Some(v) = cli.safe_write_deletion_ratio {
+            if !is_valid_deletion_ratio(v) {
+                return Err(ConfigError::InvalidNumericValue(format!(
+                    "safe_write_deletion_ratio must be between 0.0 and 1.0, got {v}"
+                )));
+            }
+            self.runtime.safe_write_deletion_ratio = v;
         }
 
         // --session flag: override session file path
@@ -571,6 +592,20 @@ impl EffectiveConfig {
                     self.runtime.http_timeout_secs = value
                         .parse()
                         .map_err(|_| ConfigError::InvalidNumericValue(value.clone()))?;
+                }
+                "safe_write_max_lines" | "ANVIL_SAFE_WRITE_MAX_LINES" => {
+                    self.runtime.safe_write_max_lines = value
+                        .parse()
+                        .map_err(|_| ConfigError::InvalidNumericValue(value.clone()))?;
+                }
+                "safe_write_deletion_ratio" | "ANVIL_SAFE_WRITE_DELETION_RATIO" => {
+                    let v: f64 = value
+                        .parse()
+                        .map_err(|_| ConfigError::InvalidNumericValue(value.clone()))?;
+                    if !is_valid_deletion_ratio(v) {
+                        return Err(ConfigError::InvalidNumericValue(value.clone()));
+                    }
+                    self.runtime.safe_write_deletion_ratio = v;
                 }
                 _ => {}
             }
@@ -747,6 +782,11 @@ const DEFAULT_SUBAGENT_TIMEOUT_SECS: u64 = 120;
 const MAX_SUBAGENT_ITERATIONS: u32 = 100;
 const MAX_SUBAGENT_TIMEOUT_SECS: u64 = 3600;
 const MIN_AGENT_ITERATIONS: usize = 1;
+
+/// Validate that a deletion ratio value is finite and within [0.0, 1.0].
+fn is_valid_deletion_ratio(v: f64) -> bool {
+    v.is_finite() && (0.0..=1.0).contains(&v)
+}
 const MAX_AGENT_ITERATIONS: usize = 100;
 
 /// Sensitive keys and their recommended environment variable names.
@@ -972,6 +1012,8 @@ impl std::fmt::Debug for RuntimeConfig {
                 &self.smart_compact_threshold_ratio,
             )
             .field("http_timeout_secs", &self.http_timeout_secs)
+            .field("safe_write_max_lines", &self.safe_write_max_lines)
+            .field("safe_write_deletion_ratio", &self.safe_write_deletion_ratio)
             .finish()
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -16,6 +16,42 @@ use std::{
     fmt::{Display, Formatter},
 };
 
+// ---------------------------------------------------------------------------
+// Language constants and helpers (Issue #162)
+// ---------------------------------------------------------------------------
+
+/// Default UI language fallback.
+pub const DEFAULT_UI_LANGUAGE: &str = "ja";
+
+/// Supported languages: (code, display_name).
+pub const SUPPORTED_LANGUAGES: &[(&str, &str)] = &[("ja", "Japanese"), ("en", "English")];
+
+/// Look up display name for a language code using SUPPORTED_LANGUAGES table.
+/// Returns the display name, or DEFAULT_UI_LANGUAGE's display name as fallback.
+pub fn lang_display_name(code: &str) -> &'static str {
+    SUPPORTED_LANGUAGES
+        .iter()
+        .find(|(c, _)| *c == code)
+        .map(|(_, name)| *name)
+        .unwrap_or("Japanese")
+}
+
+/// Return the effective UI language code.
+/// `None` or unsupported values fall back to [`DEFAULT_UI_LANGUAGE`].
+pub fn effective_ui_language_code(configured: Option<&str>) -> &str {
+    configured.unwrap_or(DEFAULT_UI_LANGUAGE)
+}
+
+/// Shared language constraint prompt for main/sub-agent.
+pub fn language_constraint_prompt(ui_language: &str) -> String {
+    let lang_name = lang_display_name(ui_language);
+    format!(
+        "\n\n## Language constraint\nYou MUST respond in {lang_name}. \
+         All explanations, comments, plans, and summaries must be written in {lang_name}. \
+         Do NOT switch to any other language during your response."
+    )
+}
+
 /// Determines where the user prompt originates from.
 #[derive(Debug, Clone)]
 pub enum PromptSource {
@@ -81,6 +117,10 @@ pub struct RuntimeConfig {
     pub loop_detection_threshold: usize,
     /// HTTP request timeout in seconds (Issue #146).
     pub http_timeout_secs: u64,
+    /// UI language for LLM responses (Issue #162).
+    /// `None` means "use default language via effective_ui_language_code()".
+    /// Supported: "ja", "en".
+    pub ui_language: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -234,6 +274,7 @@ impl EffectiveConfig {
                 subagent_timeout_secs: DEFAULT_SUBAGENT_TIMEOUT_SECS,
                 loop_detection_threshold: 3,
                 http_timeout_secs: DEFAULT_HTTP_TIMEOUT_SECS,
+                ui_language: None,
             },
             mode: ModeConfig {
                 prompt_source: PromptSource::Interactive,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -383,6 +383,7 @@ impl EffectiveConfig {
             "ANVIL_CURL_TIMEOUT",
             "ANVIL_SAFE_WRITE_MAX_LINES",
             "ANVIL_SAFE_WRITE_DELETION_RATIO",
+            "ANVIL_UI_LANGUAGE",
         ] {
             if let Ok(value) = std::env::var(key) {
                 map.insert(key.to_string(), value);
@@ -648,6 +649,13 @@ impl EffectiveConfig {
                     }
                     self.runtime.safe_write_deletion_ratio = v;
                 }
+                "ui_language" | "ANVIL_UI_LANGUAGE" => {
+                    self.runtime.ui_language = if value.is_empty() {
+                        None
+                    } else {
+                        Some(value.clone())
+                    };
+                }
                 _ => {}
             }
         }
@@ -676,7 +684,25 @@ impl EffectiveConfig {
         self.clamp_subagent_settings();
         self.clamp_loop_detection_threshold();
         self.clamp_http_timeout();
+        self.sanitize_ui_language();
         Ok(())
+    }
+
+    /// Validate `ui_language`: keep `None` and supported values, reset invalid to `None`.
+    fn sanitize_ui_language(&mut self) {
+        let is_supported = |code: &str| SUPPORTED_LANGUAGES.iter().any(|(c, _)| *c == code);
+        match self.runtime.ui_language.as_deref() {
+            None => {}
+            Some(code) if is_supported(code) => {}
+            Some(invalid) => {
+                eprintln!(
+                    "Warning: ui_language=\"{}\" is not supported, falling back to \"{}\"",
+                    invalid.escape_debug(),
+                    DEFAULT_UI_LANGUAGE
+                );
+                self.runtime.ui_language = None;
+            }
+        }
     }
 
     fn clamp_http_timeout(&mut self) {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -81,6 +81,12 @@ pub struct RuntimeConfig {
     pub loop_detection_threshold: usize,
     /// HTTP request timeout in seconds (Issue #146).
     pub http_timeout_secs: u64,
+    /// Phase estimator: consecutive read calls to enter "exploring" phase (Issue #159).
+    pub phase_explore_threshold: usize,
+    /// Phase estimator: consecutive read calls to force transition to implementation (Issue #159).
+    pub phase_force_transition_threshold: usize,
+    /// Phase estimator: consecutive reads after last write for fallback completion (Issue #159).
+    pub phase_completion_read_threshold: usize,
 }
 
 #[derive(Debug, Clone)]
@@ -234,6 +240,9 @@ impl EffectiveConfig {
                 subagent_timeout_secs: DEFAULT_SUBAGENT_TIMEOUT_SECS,
                 loop_detection_threshold: 3,
                 http_timeout_secs: DEFAULT_HTTP_TIMEOUT_SECS,
+                phase_explore_threshold: 5,
+                phase_force_transition_threshold: 10,
+                phase_completion_read_threshold: 5,
             },
             mode: ModeConfig {
                 prompt_source: PromptSource::Interactive,
@@ -572,6 +581,33 @@ impl EffectiveConfig {
                         .parse()
                         .map_err(|_| ConfigError::InvalidNumericValue(value.clone()))?;
                 }
+                "phase_explore_threshold" | "ANVIL_PHASE_EXPLORE_THRESHOLD" => {
+                    let v: usize = value
+                        .parse()
+                        .map_err(|_| ConfigError::InvalidNumericValue(value.clone()))?;
+                    if !(2..=20).contains(&v) {
+                        return Err(ConfigError::InvalidNumericValue(value.clone()));
+                    }
+                    self.runtime.phase_explore_threshold = v;
+                }
+                "phase_force_transition_threshold" | "ANVIL_PHASE_FORCE_TRANSITION_THRESHOLD" => {
+                    let v: usize = value
+                        .parse()
+                        .map_err(|_| ConfigError::InvalidNumericValue(value.clone()))?;
+                    if !(3..=30).contains(&v) {
+                        return Err(ConfigError::InvalidNumericValue(value.clone()));
+                    }
+                    self.runtime.phase_force_transition_threshold = v;
+                }
+                "phase_completion_read_threshold" | "ANVIL_PHASE_COMPLETION_READ_THRESHOLD" => {
+                    let v: usize = value
+                        .parse()
+                        .map_err(|_| ConfigError::InvalidNumericValue(value.clone()))?;
+                    if !(2..=20).contains(&v) {
+                        return Err(ConfigError::InvalidNumericValue(value.clone()));
+                    }
+                    self.runtime.phase_completion_read_threshold = v;
+                }
                 _ => {}
             }
         }
@@ -599,6 +635,7 @@ impl EffectiveConfig {
         self.clamp_smart_compact_ratio();
         self.clamp_subagent_settings();
         self.clamp_loop_detection_threshold();
+        self.clamp_phase_thresholds();
         self.clamp_http_timeout();
         Ok(())
     }
@@ -715,6 +752,20 @@ impl EffectiveConfig {
 
     fn clamp_loop_detection_threshold(&mut self) {
         self.runtime.loop_detection_threshold = self.runtime.loop_detection_threshold.clamp(2, 20);
+    }
+
+    /// Clamp phase estimator thresholds and enforce N < M constraint (Issue #159).
+    fn clamp_phase_thresholds(&mut self) {
+        self.runtime.phase_explore_threshold = self.runtime.phase_explore_threshold.clamp(2, 20);
+        self.runtime.phase_force_transition_threshold =
+            self.runtime.phase_force_transition_threshold.clamp(3, 30);
+        self.runtime.phase_completion_read_threshold =
+            self.runtime.phase_completion_read_threshold.clamp(2, 20);
+        // Enforce N < M: if explore >= force_transition, adjust force_transition.
+        if self.runtime.phase_explore_threshold >= self.runtime.phase_force_transition_threshold {
+            self.runtime.phase_force_transition_threshold =
+                (self.runtime.phase_explore_threshold + 5).min(30);
+        }
     }
 
     pub fn validate_for_test(&mut self) -> Result<(), ConfigError> {

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -16,11 +16,15 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum TerminationReason {
-    #[default]
-    Completed,
+    /// ANVIL_FINAL未発火時のフォールバック完了検出 (Issue #159).
+    FallbackCompleted,
     Timeout,
     MaxIterations,
     LoopDetected,
+    /// Normal completion. Also serves as fallback for unknown variants via `#[serde(other)]`.
+    #[default]
+    #[serde(other)]
+    Completed,
 }
 
 impl std::fmt::Display for TerminationReason {
@@ -30,6 +34,7 @@ impl std::fmt::Display for TerminationReason {
             Self::Timeout => write!(f, "timeout"),
             Self::MaxIterations => write!(f, "max_iterations"),
             Self::LoopDetected => write!(f, "loop_detected"),
+            Self::FallbackCompleted => write!(f, "fallback_completed"),
         }
     }
 }

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -48,6 +48,11 @@ pub struct WorkingMemory {
     /// Recent diff summary. Capped at ~500 tokens.
     #[serde(default)]
     pub recent_diffs: Option<String>,
+
+    /// Context pruning notice. Set when messages are pruned from the
+    /// turn request. Cleared each turn or after compaction.
+    #[serde(default)]
+    pub context_notice: Option<String>,
 }
 
 impl WorkingMemory {
@@ -103,6 +108,11 @@ impl WorkingMemory {
         self.recent_diffs = diffs.map(|d| truncate_to_token_limit(&d, Self::MAX_DIFF_TOKENS));
     }
 
+    /// Set or clear the context pruning notice.
+    pub fn set_context_notice(&mut self, notice: Option<String>) {
+        self.context_notice = notice;
+    }
+
     /// Add a constraint string.
     pub fn add_constraint(&mut self, constraint: impl Into<String>) {
         self.constraints.push(constraint.into());
@@ -115,6 +125,7 @@ impl WorkingMemory {
             && self.touched_files.is_empty()
             && self.unresolved_errors.is_empty()
             && self.recent_diffs.is_none()
+            && self.context_notice.is_none()
     }
 
     /// Serialize working memory into a human-readable format for system prompt injection.
@@ -150,6 +161,13 @@ impl WorkingMemory {
             sections.push(format!(
                 "**Recent diffs:**\n```\n{}\n```",
                 sanitize_for_prompt_entry(diffs)
+            ));
+        }
+
+        if let Some(ref notice) = self.context_notice {
+            sections.push(format!(
+                "**Context notice:** {}",
+                sanitize_for_prompt_entry(notice)
             ));
         }
 
@@ -189,12 +207,13 @@ fn truncate_to_token_limit(input: &str, max_tokens: usize) -> String {
     if tokens <= max_tokens {
         return input.to_string();
     }
-    // Approximate: cut characters proportionally
+    // Keep the *latest* content (tail) since new diffs are appended at the end (CB-003).
     let chars: Vec<char> = input.chars().collect();
     let ratio = max_tokens as f64 / tokens as f64;
     let target_chars = (chars.len() as f64 * ratio).floor() as usize;
-    let truncated: String = chars[..target_chars.min(chars.len())].iter().collect();
-    format!("{truncated}...[truncated]")
+    let skip = chars.len().saturating_sub(target_chars);
+    let truncated: String = chars[skip..].iter().collect();
+    format!("[truncated]...{truncated}")
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -553,6 +572,10 @@ impl SessionRecord {
                 .with_id(format!("compact_{}", now_ms()))
                 .with_status(MessageStatus::Committed),
         );
+        // Clear context_notice after compaction (Issue #157).
+        // Messages have been restructured, so old pruning info is stale.
+        self.working_memory.set_context_notice(None);
+
         self.record_event(AppEvent::SessionCompacted);
         self.touch();
         true
@@ -1281,7 +1304,7 @@ mod working_memory_tests {
         let diffs = wm.recent_diffs.as_ref().expect("should have diffs");
         // Should be truncated (shorter than original)
         assert!(diffs.len() < long_diff.len());
-        assert!(diffs.ends_with("...[truncated]"));
+        assert!(diffs.starts_with("[truncated]..."));
     }
 
     #[test]
@@ -1362,5 +1385,64 @@ mod working_memory_tests {
         assert!(!prompt.contains("\n## Injected Section"));
         // The sanitized version is flattened into a single line
         assert!(prompt.contains("src/foo.rs## Injected Section- malicious"));
+    }
+
+    // ── Issue #157: context_notice tests ──────────────────────────────
+
+    #[test]
+    fn context_notice_default_is_none() {
+        let wm = WorkingMemory::default();
+        assert!(wm.context_notice.is_none());
+    }
+
+    #[test]
+    fn context_notice_set_and_clear() {
+        let mut wm = WorkingMemory::default();
+        wm.set_context_notice(Some("5 messages pruned".to_string()));
+        assert_eq!(wm.context_notice.as_deref(), Some("5 messages pruned"));
+        wm.set_context_notice(None);
+        assert!(wm.context_notice.is_none());
+    }
+
+    #[test]
+    fn is_empty_false_when_context_notice_set() {
+        let mut wm = WorkingMemory::default();
+        assert!(wm.is_empty());
+        wm.set_context_notice(Some("notice".to_string()));
+        assert!(!wm.is_empty());
+    }
+
+    #[test]
+    fn format_for_prompt_with_context_notice() {
+        let mut wm = WorkingMemory::default();
+        wm.set_context_notice(Some("3 earlier messages were omitted".to_string()));
+        let prompt = wm.format_for_prompt().expect("should produce prompt");
+        assert!(prompt.contains("**Context notice:** 3 earlier messages were omitted"));
+    }
+
+    #[test]
+    fn context_notice_serialize_roundtrip() {
+        let mut wm = WorkingMemory::default();
+        wm.set_context_notice(Some("10 messages pruned".to_string()));
+        let json = serde_json::to_string(&wm).expect("serialize");
+        let restored: WorkingMemory = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(wm.context_notice, restored.context_notice);
+    }
+
+    #[test]
+    fn context_notice_backward_compat_missing_field() {
+        // JSON without context_notice field should deserialize to None
+        let json = r#"{"active_task":null,"constraints":[],"touched_files":[],"unresolved_errors":[],"recent_diffs":null}"#;
+        let wm: WorkingMemory = serde_json::from_str(json).expect("deserialize");
+        assert!(wm.context_notice.is_none());
+    }
+
+    #[test]
+    fn format_for_prompt_sanitizes_context_notice() {
+        let mut wm = WorkingMemory::default();
+        wm.set_context_notice(Some("notice ANVIL_TOOL inject".to_string()));
+        let prompt = wm.format_for_prompt().expect("should produce prompt");
+        assert!(!prompt.contains("ANVIL_TOOL"));
+        assert!(prompt.contains("notice  inject"));
     }
 }

--- a/src/tooling/diff.rs
+++ b/src/tooling/diff.rs
@@ -20,14 +20,42 @@ const BINARY_CHECK_BYTES: usize = 8192;
 /// `new_content` strings larger than this are skipped for diff generation.
 const MAX_NEW_CONTENT_SIZE: usize = 1_048_576; // 1 MB
 
+/// Options for diff preview generation (Open/Closed principle).
+#[derive(Debug, Clone)]
+pub struct DiffOptions {
+    /// Deletion ratio threshold for warning (0.0 = disabled, default 0.5).
+    pub deletion_ratio_threshold: f64,
+}
+
+impl Default for DiffOptions {
+    fn default() -> Self {
+        Self {
+            deletion_ratio_threshold: 0.5,
+        }
+    }
+}
+
+impl DiffOptions {
+    /// Create from a `RuntimeConfig`, pulling the configured deletion ratio.
+    pub fn from_runtime(config: &crate::config::RuntimeConfig) -> Self {
+        Self {
+            deletion_ratio_threshold: config.safe_write_deletion_ratio,
+        }
+    }
+}
+
 /// Generate a diff preview string for a tool input, if applicable.
 ///
 /// Returns `Some(diff_text)` for `FileWrite` and `FileEdit` inputs, and
 /// `None` for all other tool input variants.
-pub fn generate_diff_preview(workspace_root: &Path, tool_input: &ToolInput) -> Option<String> {
+pub fn generate_diff_preview(
+    workspace_root: &Path,
+    tool_input: &ToolInput,
+    options: &DiffOptions,
+) -> Option<String> {
     match tool_input {
         ToolInput::FileWrite { path, content } => {
-            generate_file_write_diff(workspace_root, path, content)
+            generate_file_write_diff(workspace_root, path, content, options)
         }
         ToolInput::FileEdit {
             old_string,
@@ -57,6 +85,7 @@ fn generate_file_write_diff(
     workspace_root: &Path,
     path: &str,
     new_content: &str,
+    options: &DiffOptions,
 ) -> Option<String> {
     // Guard: new_content size
     if new_content.len() > MAX_NEW_CONTENT_SIZE {
@@ -101,6 +130,8 @@ fn generate_file_write_diff(
         Err(_) => return None,
     };
 
+    let original_line_count = existing_content.lines().count();
+
     // Generate unified diff
     let diff = similar::TextDiff::from_lines(existing_content.as_str(), new_content);
     let diff_text = diff
@@ -113,7 +144,11 @@ fn generate_file_write_diff(
         return Some("(no changes)".to_string());
     }
 
-    Some(truncate_diff(&diff_text))
+    Some(truncate_diff(
+        &diff_text,
+        Some(original_line_count),
+        options.deletion_ratio_threshold,
+    ))
 }
 
 /// Generate a diff preview for `file.edit` (old_string -> new_string).
@@ -136,11 +171,18 @@ fn generate_file_edit_diff(old_string: &str, new_string: &str) -> Option<String>
         return Some("(no changes)".to_string());
     }
 
-    Some(truncate_diff(&diff_text))
+    Some(truncate_diff(&diff_text, None, 0.0))
 }
 
 /// Truncate a diff if the number of added/deleted lines exceeds the threshold.
-fn truncate_diff(diff_text: &str) -> String {
+///
+/// When `original_line_count` is provided and `deletion_ratio_threshold > 0.0`,
+/// appends a warning if the deletion ratio exceeds the threshold.
+fn truncate_diff(
+    diff_text: &str,
+    original_line_count: Option<usize>,
+    deletion_ratio_threshold: f64,
+) -> String {
     let mut additions = 0usize;
     let mut deletions = 0usize;
 
@@ -152,29 +194,46 @@ fn truncate_diff(diff_text: &str) -> String {
         }
     }
 
-    if additions + deletions <= DIFF_TRUNCATE_THRESHOLD {
-        return diff_text.to_string();
+    let mut result = if additions + deletions <= DIFF_TRUNCATE_THRESHOLD {
+        diff_text.to_string()
+    } else {
+        // Keep the header and first few lines, then add a truncation notice
+        let mut buf = String::new();
+        let mut change_count = 0usize;
+        for line in diff_text.lines() {
+            let is_change = (line.starts_with('+') && !line.starts_with("+++"))
+                || (line.starts_with('-') && !line.starts_with("---"));
+            if is_change {
+                change_count += 1;
+            }
+            if change_count > DIFF_TRUNCATE_THRESHOLD {
+                break;
+            }
+            buf.push_str(line);
+            buf.push('\n');
+        }
+        buf.push_str(&format!(
+            "... (+{} lines added, -{} lines deleted)\n",
+            additions, deletions
+        ));
+        buf
+    };
+
+    // Deletion ratio warning
+    if deletion_ratio_threshold > 0.0
+        && let Some(orig) = original_line_count
+        && orig > 0
+    {
+        let ratio = deletions as f64 / orig as f64;
+        if ratio > deletion_ratio_threshold {
+            let pct = (ratio * 100.0).round() as u64;
+            result.push_str(&format!(
+                "[WARNING: {}/{} lines deleted ({}%) — consider using file.edit for targeted changes]\n",
+                deletions, orig, pct
+            ));
+        }
     }
 
-    // Keep the header and first few lines, then add a truncation notice
-    let mut result = String::new();
-    let mut change_count = 0usize;
-    for line in diff_text.lines() {
-        let is_change = (line.starts_with('+') && !line.starts_with("+++"))
-            || (line.starts_with('-') && !line.starts_with("---"));
-        if is_change {
-            change_count += 1;
-        }
-        if change_count > DIFF_TRUNCATE_THRESHOLD {
-            break;
-        }
-        result.push_str(line);
-        result.push('\n');
-    }
-    result.push_str(&format!(
-        "... (+{} lines added, -{} lines deleted)\n",
-        additions, deletions
-    ));
     result
 }
 

--- a/src/tooling/diff.rs
+++ b/src/tooling/diff.rs
@@ -120,7 +120,7 @@ fn generate_file_write_diff(
 ///
 /// This does not require any file I/O — it works purely on the provided
 /// strings.
-fn generate_file_edit_diff(old_string: &str, new_string: &str) -> Option<String> {
+pub(crate) fn generate_file_edit_diff(old_string: &str, new_string: &str) -> Option<String> {
     if old_string == new_string {
         return Some("(no changes)".to_string());
     }

--- a/src/tooling/mod.rs
+++ b/src/tooling/mod.rs
@@ -608,6 +608,9 @@ pub struct ToolExecutionResult {
     pub payload: ToolExecutionPayload,
     pub artifacts: Vec<String>,
     pub elapsed_ms: u128,
+    /// Compact diff summary for file-mutating tools (file.write/file.edit/file.edit_anchor).
+    /// `None` for non-mutating tools, MCP tools, and subagent results.
+    pub diff_summary: Option<String>,
 }
 
 impl ToolExecutionResult {
@@ -1317,12 +1320,14 @@ impl LocalToolExecutor {
         {
             cache.invalidate(&resolved);
         }
-        Ok(build_completed_result(
+        let diff = format!("wrote {} bytes to {}", content.len(), path);
+        Ok(build_completed_result_with_diff(
             request,
             path.to_string(),
             ToolExecutionPayload::None,
             vec![resolved.display().to_string()],
             started,
+            Some(diff),
         ))
     }
 
@@ -1377,12 +1382,19 @@ impl LocalToolExecutor {
         {
             cache.invalidate(&resolved);
         }
-        Ok(build_completed_result(
+        let diff = format!(
+            "{}: replaced {} chars with {} chars",
+            path,
+            old_string.len(),
+            new_string.len()
+        );
+        Ok(build_completed_result_with_diff(
             request,
             path.to_string(),
             ToolExecutionPayload::None,
             vec![resolved.display().to_string()],
             started,
+            Some(diff),
         ))
     }
 
@@ -1429,12 +1441,19 @@ impl LocalToolExecutor {
                 {
                     cache.invalidate(&resolved);
                 }
-                Ok(build_completed_result(
+                let diff = format!(
+                    "{}: replaced {} chars with {} chars",
+                    path,
+                    params.old_content.len(),
+                    params.new_content.len()
+                );
+                Ok(build_completed_result_with_diff(
                     request,
                     path.to_string(),
                     ToolExecutionPayload::None,
                     vec![resolved.display().to_string()],
                     started,
+                    Some(diff),
                 ))
             }
             0 => Err(ToolRuntimeError::edit_not_found(format!(
@@ -1762,6 +1781,7 @@ impl LocalToolExecutor {
                     payload: ToolExecutionPayload::Text(combined),
                     artifacts: Vec::new(),
                     elapsed_ms: started.elapsed().as_millis(),
+                    diff_summary: None,
                 });
             }
             match child.try_wait() {
@@ -1797,6 +1817,7 @@ impl LocalToolExecutor {
             payload: ToolExecutionPayload::Text(combined),
             artifacts: Vec::new(),
             elapsed_ms: started.elapsed().as_millis(),
+            diff_summary: None,
         })
     }
 
@@ -1985,6 +2006,7 @@ impl LocalToolExecutor {
                 payload: ToolExecutionPayload::Text(error_msg),
                 artifacts: Vec::new(),
                 elapsed_ms: started.elapsed().as_millis(),
+                diff_summary: None,
             });
         }
 
@@ -2240,6 +2262,17 @@ fn build_completed_result(
     artifacts: Vec<String>,
     started: Instant,
 ) -> ToolExecutionResult {
+    build_completed_result_with_diff(request, summary, payload, artifacts, started, None)
+}
+
+fn build_completed_result_with_diff(
+    request: &ToolExecutionRequest,
+    summary: String,
+    payload: ToolExecutionPayload,
+    artifacts: Vec<String>,
+    started: Instant,
+    diff_summary: Option<String>,
+) -> ToolExecutionResult {
     ToolExecutionResult {
         tool_call_id: request.tool_call_id.clone(),
         tool_name: request.spec.name.clone(),
@@ -2248,6 +2281,7 @@ fn build_completed_result(
         payload,
         artifacts,
         elapsed_ms: started.elapsed().as_millis(),
+        diff_summary,
     }
 }
 

--- a/src/tooling/mod.rs
+++ b/src/tooling/mod.rs
@@ -1119,6 +1119,15 @@ impl LocalToolExecutor {
             .is_some_and(|f| f.load(std::sync::atomic::Ordering::Relaxed))
     }
 
+    /// Invalidate the file cache entry for the given path (best-effort).
+    fn invalidate_cache(&self, resolved: &Path) {
+        if let Some(ref cache_arc) = self.file_cache
+            && let Ok(mut cache) = cache_arc.lock()
+        {
+            cache.invalidate(resolved);
+        }
+    }
+
     pub fn execute(
         &mut self,
         request: ToolExecutionRequest,
@@ -1311,12 +1320,7 @@ impl LocalToolExecutor {
                 resolved.display()
             ))
         })?;
-        // Invalidate cache after write
-        if let Some(ref cache_arc) = self.file_cache
-            && let Ok(mut cache) = cache_arc.lock()
-        {
-            cache.invalidate(&resolved);
-        }
+        self.invalidate_cache(&resolved);
         Ok(build_completed_result(
             request,
             path.to_string(),
@@ -1324,6 +1328,13 @@ impl LocalToolExecutor {
             vec![resolved.display().to_string()],
             started,
         ))
+    }
+
+    /// file.edit成功時のdiffフィードバック用Payloadを生成
+    fn build_edit_diff_payload(old_string: &str, new_string: &str) -> ToolExecutionPayload {
+        diff::generate_file_edit_diff(old_string, new_string)
+            .map(ToolExecutionPayload::Text)
+            .unwrap_or(ToolExecutionPayload::None)
     }
 
     fn execute_file_edit(
@@ -1371,16 +1382,11 @@ impl LocalToolExecutor {
                 resolved.display()
             ))
         })?;
-        // Invalidate cache after edit
-        if let Some(ref cache_arc) = self.file_cache
-            && let Ok(mut cache) = cache_arc.lock()
-        {
-            cache.invalidate(&resolved);
-        }
+        self.invalidate_cache(&resolved);
         Ok(build_completed_result(
             request,
             path.to_string(),
-            ToolExecutionPayload::None,
+            Self::build_edit_diff_payload(old_string, new_string),
             vec![resolved.display().to_string()],
             started,
         ))
@@ -1423,16 +1429,11 @@ impl LocalToolExecutor {
                         resolved.display()
                     ))
                 })?;
-                // Invalidate cache after anchor edit
-                if let Some(ref cache_arc) = self.file_cache
-                    && let Ok(mut cache) = cache_arc.lock()
-                {
-                    cache.invalidate(&resolved);
-                }
+                self.invalidate_cache(&resolved);
                 Ok(build_completed_result(
                     request,
                     path.to_string(),
-                    ToolExecutionPayload::None,
+                    Self::build_edit_diff_payload(&params.old_content, &params.new_content),
                     vec![resolved.display().to_string()],
                     started,
                 ))
@@ -1567,11 +1568,12 @@ impl LocalToolExecutor {
                 resolved.display()
             ))
         })?;
+        self.invalidate_cache(&resolved);
 
         Ok(build_completed_result(
             request,
             path.to_string(),
-            ToolExecutionPayload::None,
+            Self::build_edit_diff_payload(old_string, new_string),
             vec![resolved.display().to_string()],
             started,
         ))

--- a/src/tooling/mod.rs
+++ b/src/tooling/mod.rs
@@ -28,6 +28,10 @@ const MAX_CONTEXT_LINES: u32 = 10;
 /// Maximum number of matched files returned by file.search.
 const MAX_SEARCH_RESULTS: usize = 100;
 
+/// Files larger than this are blocked by the safe-write guard without reading
+/// their full contents, to avoid memory pressure (10 MB).
+const MAX_SAFE_WRITE_GUARD_READ_BYTES: u64 = 10 * 1024 * 1024;
+
 /// Detect the MIME type of an image file based on its extension.
 ///
 /// Returns `None` for non-image extensions.
@@ -901,6 +905,7 @@ pub struct LocalToolExecutor {
     shutdown_flag: Option<std::sync::Arc<std::sync::atomic::AtomicBool>>,
     http_client: reqwest::blocking::Client,
     file_cache: Option<std::sync::Arc<std::sync::Mutex<file_cache::FileReadCache>>>,
+    safe_write_max_lines: usize,
 }
 
 /// Build the shared HTTP client used by tooling (web.fetch / web.search).
@@ -922,6 +927,11 @@ pub enum ToolRuntimeError {
     EditNotFound {
         message: String,
         context_snippet: Option<String>,
+    },
+    LargeFileBlocked {
+        path: String,
+        line_count: usize,
+        threshold: usize,
     },
 }
 
@@ -959,8 +969,26 @@ impl Display for ToolRuntimeError {
                  or use web.fetch to access specific URLs directly."
             ),
             Self::EditNotFound { message, .. } => write!(f, "{message}"),
+            Self::LargeFileBlocked {
+                path,
+                line_count,
+                threshold,
+            } => write!(
+                f,
+                "File '{}' has {} lines (threshold: {}).\n\
+                 Large existing files cannot be overwritten with file.write.\n\
+                 Use file.edit or file.edit_anchor to make targeted changes instead.",
+                sanitize_path_for_display(path),
+                line_count,
+                threshold
+            ),
         }
     }
+}
+
+/// Sanitize a path string for display by removing control characters.
+fn sanitize_path_for_display(path: &str) -> String {
+    path.chars().filter(|c| !c.is_control()).collect()
 }
 
 impl std::error::Error for ToolRuntimeError {}
@@ -1079,6 +1107,7 @@ impl LocalToolExecutor {
             shutdown_flag: None,
             http_client: build_tooling_http_client(),
             file_cache,
+            safe_write_max_lines: config.safe_write_max_lines,
         }
     }
 
@@ -1093,7 +1122,13 @@ impl LocalToolExecutor {
             shutdown_flag: None,
             http_client: build_tooling_http_client(),
             file_cache: None,
+            safe_write_max_lines: 0,
         }
+    }
+
+    /// Set the safe_write_max_lines threshold (for tests).
+    pub fn set_safe_write_max_lines(&mut self, value: usize) {
+        self.safe_write_max_lines = value;
     }
 
     /// Create an executor with a Serper API key set (for testing fallback).
@@ -1297,6 +1332,44 @@ impl LocalToolExecutor {
         started: Instant,
     ) -> Result<ToolExecutionResult, ToolRuntimeError> {
         let resolved = self.resolve_path(path)?;
+
+        // Large file write guard (safe_write_max_lines > 0 = enabled)
+        if self.safe_write_max_lines > 0 {
+            match std::fs::metadata(&resolved) {
+                Ok(meta) => {
+                    // Extremely large files: block without full read to avoid memory pressure
+                    if meta.len() > MAX_SAFE_WRITE_GUARD_READ_BYTES {
+                        return Err(ToolRuntimeError::LargeFileBlocked {
+                            path: path.to_string(),
+                            line_count: 0,
+                            threshold: self.safe_write_max_lines,
+                        });
+                    }
+                    if let Ok(existing) = std::fs::read(&resolved) {
+                        let newline_count = existing.iter().filter(|&&b| b == b'\n').count();
+                        let line_count = if existing.is_empty() {
+                            0
+                        } else {
+                            newline_count + usize::from(!existing.ends_with(b"\n"))
+                        };
+                        if line_count > self.safe_write_max_lines {
+                            return Err(ToolRuntimeError::LargeFileBlocked {
+                                path: path.to_string(),
+                                line_count,
+                                threshold: self.safe_write_max_lines,
+                            });
+                        }
+                    }
+                }
+                Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                    // New file creation — not subject to the guard
+                }
+                Err(_) => {
+                    // Other metadata errors — proceed to let fs::write handle it
+                }
+            }
+        }
+
         if let Some(parent) = resolved.parent() {
             fs::create_dir_all(parent).map_err(|err| {
                 ToolRuntimeError::Io(format!(

--- a/src/tooling/mod.rs
+++ b/src/tooling/mod.rs
@@ -1300,7 +1300,8 @@ impl LocalToolExecutor {
         if let Some(parent) = resolved.parent() {
             fs::create_dir_all(parent).map_err(|err| {
                 ToolRuntimeError::Io(format!(
-                    "file.write failed to create parent {}: {err}",
+                    "file.write failed for {} (parent creation failed for {}): {err}",
+                    resolved.display(),
                     parent.display()
                 ))
             })?;

--- a/tests/config_bootstrap.rs
+++ b/tests/config_bootstrap.rs
@@ -899,3 +899,181 @@ fn http_timeout_cli_args_none_leaves_default() {
     config.apply_cli_args(&cli).expect("should apply");
     assert_eq!(config.runtime.http_timeout_secs, 300);
 }
+
+// ============================================================
+// safe_write_max_lines / safe_write_deletion_ratio tests (Issue #156)
+// ============================================================
+
+#[test]
+fn safe_write_max_lines_default() {
+    let config = EffectiveConfig::default_for_test().unwrap();
+    assert_eq!(config.runtime.safe_write_max_lines, 500);
+}
+
+#[test]
+fn safe_write_deletion_ratio_default() {
+    let config = EffectiveConfig::default_for_test().unwrap();
+    assert!((config.runtime.safe_write_deletion_ratio - 0.5).abs() < f64::EPSILON);
+}
+
+#[test]
+fn safe_write_max_lines_from_config_key() {
+    let mut config = EffectiveConfig::default_for_test().unwrap();
+    let mut map = HashMap::new();
+    map.insert("safe_write_max_lines".to_string(), "100".to_string());
+    config
+        .apply_overrides_for_test(&map, &HashMap::new(), &HashMap::new())
+        .expect("should apply");
+    assert_eq!(config.runtime.safe_write_max_lines, 100);
+}
+
+#[test]
+fn safe_write_max_lines_from_env_key() {
+    let mut config = EffectiveConfig::default_for_test().unwrap();
+    let mut map = HashMap::new();
+    map.insert("ANVIL_SAFE_WRITE_MAX_LINES".to_string(), "200".to_string());
+    config
+        .apply_overrides_for_test(&HashMap::new(), &map, &HashMap::new())
+        .expect("should apply");
+    assert_eq!(config.runtime.safe_write_max_lines, 200);
+}
+
+#[test]
+fn safe_write_max_lines_zero_disables() {
+    let mut config = EffectiveConfig::default_for_test().unwrap();
+    let mut map = HashMap::new();
+    map.insert("safe_write_max_lines".to_string(), "0".to_string());
+    config
+        .apply_overrides_for_test(&map, &HashMap::new(), &HashMap::new())
+        .expect("should apply");
+    assert_eq!(config.runtime.safe_write_max_lines, 0);
+}
+
+#[test]
+fn safe_write_deletion_ratio_from_config_key() {
+    let mut config = EffectiveConfig::default_for_test().unwrap();
+    let mut map = HashMap::new();
+    map.insert("safe_write_deletion_ratio".to_string(), "0.25".to_string());
+    config
+        .apply_overrides_for_test(&map, &HashMap::new(), &HashMap::new())
+        .expect("should apply");
+    assert!((config.runtime.safe_write_deletion_ratio - 0.25).abs() < f64::EPSILON);
+}
+
+#[test]
+fn safe_write_deletion_ratio_from_env_key() {
+    let mut config = EffectiveConfig::default_for_test().unwrap();
+    let mut map = HashMap::new();
+    map.insert(
+        "ANVIL_SAFE_WRITE_DELETION_RATIO".to_string(),
+        "0.75".to_string(),
+    );
+    config
+        .apply_overrides_for_test(&HashMap::new(), &map, &HashMap::new())
+        .expect("should apply");
+    assert!((config.runtime.safe_write_deletion_ratio - 0.75).abs() < f64::EPSILON);
+}
+
+#[test]
+fn safe_write_deletion_ratio_rejects_negative() {
+    let mut config = EffectiveConfig::default_for_test().unwrap();
+    let mut map = HashMap::new();
+    map.insert("safe_write_deletion_ratio".to_string(), "-0.1".to_string());
+    let result = config.apply_overrides_for_test(&map, &HashMap::new(), &HashMap::new());
+    assert!(result.is_err(), "negative deletion_ratio should fail");
+}
+
+#[test]
+fn safe_write_deletion_ratio_rejects_above_one() {
+    let mut config = EffectiveConfig::default_for_test().unwrap();
+    let mut map = HashMap::new();
+    map.insert("safe_write_deletion_ratio".to_string(), "1.5".to_string());
+    let result = config.apply_overrides_for_test(&map, &HashMap::new(), &HashMap::new());
+    assert!(result.is_err(), "deletion_ratio > 1.0 should fail");
+}
+
+#[test]
+fn safe_write_deletion_ratio_rejects_nan() {
+    let mut config = EffectiveConfig::default_for_test().unwrap();
+    let mut map = HashMap::new();
+    map.insert("safe_write_deletion_ratio".to_string(), "NaN".to_string());
+    let result = config.apply_overrides_for_test(&map, &HashMap::new(), &HashMap::new());
+    assert!(result.is_err(), "NaN deletion_ratio should fail");
+}
+
+#[test]
+fn safe_write_deletion_ratio_rejects_infinity() {
+    let mut config = EffectiveConfig::default_for_test().unwrap();
+    let mut map = HashMap::new();
+    map.insert("safe_write_deletion_ratio".to_string(), "inf".to_string());
+    let result = config.apply_overrides_for_test(&map, &HashMap::new(), &HashMap::new());
+    assert!(result.is_err(), "infinity deletion_ratio should fail");
+}
+
+#[test]
+fn safe_write_deletion_ratio_accepts_zero() {
+    let mut config = EffectiveConfig::default_for_test().unwrap();
+    let mut map = HashMap::new();
+    map.insert("safe_write_deletion_ratio".to_string(), "0.0".to_string());
+    config
+        .apply_overrides_for_test(&map, &HashMap::new(), &HashMap::new())
+        .expect("should apply");
+    assert!((config.runtime.safe_write_deletion_ratio - 0.0).abs() < f64::EPSILON);
+}
+
+#[test]
+fn safe_write_deletion_ratio_accepts_one() {
+    let mut config = EffectiveConfig::default_for_test().unwrap();
+    let mut map = HashMap::new();
+    map.insert("safe_write_deletion_ratio".to_string(), "1.0".to_string());
+    config
+        .apply_overrides_for_test(&map, &HashMap::new(), &HashMap::new())
+        .expect("should apply");
+    assert!((config.runtime.safe_write_deletion_ratio - 1.0).abs() < f64::EPSILON);
+}
+
+#[test]
+fn safe_write_max_lines_invalid_numeric() {
+    let mut config = EffectiveConfig::default_for_test().unwrap();
+    let mut map = HashMap::new();
+    map.insert(
+        "safe_write_max_lines".to_string(),
+        "not_a_number".to_string(),
+    );
+    let result = config.apply_overrides_for_test(&map, &HashMap::new(), &HashMap::new());
+    assert!(
+        result.is_err(),
+        "non-numeric safe_write_max_lines should fail"
+    );
+}
+
+#[test]
+fn safe_write_cli_args_max_lines() {
+    let mut config = EffectiveConfig::default_for_test().unwrap();
+    let cli = anvil::config::CliArgs {
+        safe_write_max_lines: Some(100),
+        ..Default::default()
+    };
+    config.apply_cli_args(&cli).expect("should apply");
+    assert_eq!(config.runtime.safe_write_max_lines, 100);
+}
+
+#[test]
+fn safe_write_cli_args_deletion_ratio() {
+    let mut config = EffectiveConfig::default_for_test().unwrap();
+    let cli = anvil::config::CliArgs {
+        safe_write_deletion_ratio: Some(0.3),
+        ..Default::default()
+    };
+    config.apply_cli_args(&cli).expect("should apply");
+    assert!((config.runtime.safe_write_deletion_ratio - 0.3).abs() < f64::EPSILON);
+}
+
+#[test]
+fn safe_write_cli_args_none_leaves_default() {
+    let mut config = EffectiveConfig::default_for_test().unwrap();
+    let cli = anvil::config::CliArgs::default();
+    config.apply_cli_args(&cli).expect("should apply");
+    assert_eq!(config.runtime.safe_write_max_lines, 500);
+    assert!((config.runtime.safe_write_deletion_ratio - 0.5).abs() < f64::EPSILON);
+}

--- a/tests/phase_estimation.rs
+++ b/tests/phase_estimation.rs
@@ -1,0 +1,132 @@
+//! Integration tests for Phase Estimator (Issue #159).
+//!
+//! Tests cover the PhaseEstimator's interaction with Config settings
+//! and its overall behavior patterns.
+
+use anvil::app::phase_estimator::{Phase, PhaseAction, PhaseEstimator};
+
+#[test]
+fn phase_estimator_default_config_values() {
+    // Default thresholds from config: N=5, M=10, K=5
+    let est = PhaseEstimator::new(5, 10, 5);
+    assert_eq!(est.current_phase(), Phase::Unknown);
+}
+
+#[test]
+fn phase_estimator_full_lifecycle() {
+    let mut est = PhaseEstimator::new(5, 10, 5);
+
+    // Phase 1: Exploring — read files
+    for _ in 0..5 {
+        let action = est.record_tool_call("file.read", true);
+        assert_eq!(action, PhaseAction::Continue);
+    }
+    assert_eq!(est.current_phase(), Phase::Exploring);
+
+    // Phase 2: Implementing — write files
+    est.record_tool_call("file.edit", true);
+    assert_eq!(est.current_phase(), Phase::Implementing);
+
+    // Phase 3: Verification reads
+    for _ in 0..5 {
+        est.record_tool_call("file.read", true);
+    }
+
+    // Fallback completion detected on empty response
+    assert_eq!(est.check_empty_response(), PhaseAction::FallbackComplete);
+}
+
+#[test]
+fn phase_estimator_anvil_final_disables_fallback() {
+    let mut est = PhaseEstimator::new(5, 10, 5);
+
+    // Write + K reads
+    est.record_tool_call("file.write", true);
+    for _ in 0..5 {
+        est.record_tool_call("file.read", true);
+    }
+
+    // Before ANVIL_FINAL: fallback should trigger
+    assert_eq!(est.check_empty_response(), PhaseAction::FallbackComplete);
+
+    // After ANVIL_FINAL: fallback disabled
+    est.observe_anvil_final();
+    assert_eq!(est.check_empty_response(), PhaseAction::Continue);
+}
+
+#[test]
+fn phase_estimator_force_transition_at_threshold() {
+    let mut est = PhaseEstimator::new(3, 6, 3);
+
+    // Read up to M-1: no force transition
+    for _ in 0..5 {
+        let action = est.record_tool_call("file.search", true);
+        assert_eq!(action, PhaseAction::Continue);
+    }
+
+    // M-th read: force transition
+    let action = est.record_tool_call("file.read", true);
+    assert!(matches!(action, PhaseAction::ForceTransition(_)));
+}
+
+#[test]
+fn phase_estimator_reset_preserves_cross_turn_state() {
+    let mut est = PhaseEstimator::new(5, 10, 5);
+
+    // Turn 1: write a file
+    est.record_tool_call("file.edit", true);
+    assert!(est.current_phase() == Phase::Implementing);
+
+    // New turn: reset
+    est.reset();
+
+    // has_written preserved, consecutive_reads reset
+    assert_eq!(est.current_phase(), Phase::Implementing);
+
+    // K reads → fallback should work (has_written preserved)
+    for _ in 0..5 {
+        est.record_tool_call("file.read", true);
+    }
+    assert_eq!(est.check_empty_response(), PhaseAction::FallbackComplete);
+}
+
+#[test]
+fn phase_estimator_model_switch_resets_anvil_final() {
+    let mut est = PhaseEstimator::new(5, 10, 5);
+
+    est.observe_anvil_final();
+    est.record_tool_call("file.write", true);
+    for _ in 0..5 {
+        est.record_tool_call("file.read", true);
+    }
+    // ANVIL_FINAL observed → no fallback
+    assert_eq!(est.check_empty_response(), PhaseAction::Continue);
+
+    // Model switch
+    est.reset_model_state();
+    // Now fallback should work again
+    assert_eq!(est.check_empty_response(), PhaseAction::FallbackComplete);
+}
+
+#[test]
+fn phase_estimator_no_fallback_without_write() {
+    let mut est = PhaseEstimator::new(5, 10, 5);
+
+    // Many reads but no writes
+    for _ in 0..10 {
+        est.record_tool_call("file.read", true);
+    }
+    // No fallback completion without has_written
+    assert_eq!(est.check_empty_response(), PhaseAction::Continue);
+}
+
+#[test]
+fn phase_estimator_other_tools_ignored() {
+    let mut est = PhaseEstimator::new(2, 4, 2);
+
+    // Sub-agent and shell calls should not affect read count
+    est.record_tool_call("agent.explore", true);
+    est.record_tool_call("shell.exec", true);
+    est.record_tool_call("agent.plan", true);
+    assert_eq!(est.current_phase(), Phase::Unknown);
+}

--- a/tests/provider_integration.rs
+++ b/tests/provider_integration.rs
@@ -3639,6 +3639,234 @@ fn anvil_final_guard_prompt_tool_rules_contains_implementation_guidance() {
     );
 }
 
+// ---------------------------------------------------------------------------
+// Issue #160: ANVIL_FINAL後のツール呼び出し除外 — 統合テスト
+// ---------------------------------------------------------------------------
+
+#[test]
+fn done_event_post_final() {
+    // TC6: Done-event path filters post-FINAL tools.
+    // LLM outputs ANVIL_TOOL(call_001) + ANVIL_FINAL + ANVIL_TOOL(call_002).
+    // Only call_001 should be executed; call_002 should be excluded by the parser.
+    let root = common::unique_test_dir("done_post_final");
+    let mut config = common::build_config_in(root.clone());
+    config.mode.approval_required = false;
+    let provider_ctx =
+        anvil::provider::ProviderRuntimeContext::bootstrap(&config).expect("provider bootstrap");
+    let mut app = anvil::app::App::new(
+        config,
+        provider_ctx,
+        std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+    )
+    .expect("app should initialize");
+    let tui = Tui::new();
+
+    std::fs::create_dir_all(root.join("src")).expect("create src dir");
+    std::fs::write(root.join("src/main.rs"), "fn main() {}").expect("write main.rs");
+
+    let seen_requests = Rc::new(RefCell::new(Vec::new()));
+
+    struct DonePostFinalProvider {
+        seen_requests: Rc<RefCell<Vec<ProviderTurnRequest>>>,
+    }
+
+    impl ProviderClient for DonePostFinalProvider {
+        fn stream_turn(
+            &self,
+            request: &ProviderTurnRequest,
+            emit: &mut dyn FnMut(ProviderEvent),
+        ) -> Result<(), ProviderTurnError> {
+            let call_index = self.seen_requests.borrow().len();
+            self.seen_requests.borrow_mut().push(request.clone());
+
+            match call_index {
+                0 => {
+                    // Done event: ANVIL_TOOL + ANVIL_FINAL + post-FINAL ANVIL_TOOL
+                    emit(ProviderEvent::Agent(AgentEvent::Done {
+                        status: "Done. session saved".to_string(),
+                        assistant_message: concat!(
+                            "```ANVIL_TOOL\n",
+                            "{\"id\":\"call_001\",\"tool\":\"file.read\",\"path\":\"./src/main.rs\"}\n",
+                            "```\n",
+                            "```ANVIL_FINAL\n",
+                            "Read the source file.\n",
+                            "```\n",
+                            "```ANVIL_TOOL\n",
+                            "{\"id\":\"call_002\",\"tool\":\"file.read\",\"path\":\"./src/lib.rs\"}\n",
+                            "```\n"
+                        )
+                        .to_string(),
+                        completion_summary: "turn 1".to_string(),
+                        saved_status: "session saved".to_string(),
+                        tool_logs: Vec::new(),
+                        elapsed_ms: 0,
+                        inference_performance: None,
+                    }));
+                }
+                1 => {
+                    // Agentic follow-up after file.read (only call_001 executed)
+                    emit(ProviderEvent::TokenDelta(
+                        "Here is the source code analysis.".to_string(),
+                    ));
+                }
+                _ => {
+                    // Guard retry: accept
+                    emit(ProviderEvent::TokenDelta(
+                        "No further changes needed.".to_string(),
+                    ));
+                }
+            }
+            Ok(())
+        }
+    }
+
+    let provider = DonePostFinalProvider {
+        seen_requests: seen_requests.clone(),
+    };
+
+    let _frames = app
+        .run_live_turn("read the source", &provider, &tui)
+        .expect("done_event_post_final should succeed");
+
+    // Verify call_001 WAS executed: main.rs tool result should appear in session
+    let has_main_rs_result = app
+        .session()
+        .messages
+        .iter()
+        .any(|m| m.content.contains("fn main()") || m.content.contains("main.rs"));
+    assert!(
+        has_main_rs_result,
+        "pre-FINAL tool call_001 (main.rs) should have been executed"
+    );
+
+    // Verify call_002 was NOT executed: lib.rs content should NOT appear
+    let has_lib_rs_result = app
+        .session()
+        .messages
+        .iter()
+        .any(|m| m.content.contains("lib.rs"));
+    assert!(
+        !has_lib_rs_result,
+        "post-FINAL tool call_002 (lib.rs) should NOT appear in session messages"
+    );
+}
+
+#[test]
+fn guard_retry_post_final() {
+    // TC7: Guard retry path filters post-FINAL tools.
+    // First response: plan-only ANVIL_FINAL (triggers guard).
+    // Guard retry response: ANVIL_TOOL(call_001) + ANVIL_FINAL + ANVIL_TOOL(call_002).
+    // Only call_001 should be executed from the retry response.
+    let root = common::unique_test_dir("guard_retry_post_final");
+    let mut config = common::build_config_in(root.clone());
+    config.mode.approval_required = false;
+    let provider_ctx =
+        anvil::provider::ProviderRuntimeContext::bootstrap(&config).expect("provider bootstrap");
+    let mut app = anvil::app::App::new(
+        config,
+        provider_ctx,
+        std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+    )
+    .expect("app should initialize");
+    let tui = Tui::new();
+
+    std::fs::create_dir_all(root.join("src")).expect("create src dir");
+    std::fs::write(root.join("src/main.rs"), "fn main() {}").expect("write main.rs");
+
+    let seen_requests = Rc::new(RefCell::new(Vec::new()));
+
+    struct GuardRetryPostFinalProvider {
+        seen_requests: Rc<RefCell<Vec<ProviderTurnRequest>>>,
+    }
+
+    impl ProviderClient for GuardRetryPostFinalProvider {
+        fn stream_turn(
+            &self,
+            request: &ProviderTurnRequest,
+            emit: &mut dyn FnMut(ProviderEvent),
+        ) -> Result<(), ProviderTurnError> {
+            let call_index = self.seen_requests.borrow().len();
+            self.seen_requests.borrow_mut().push(request.clone());
+
+            match call_index {
+                0 => {
+                    // Plan-only ANVIL_FINAL (no tool calls → guard fires)
+                    emit(ProviderEvent::Agent(AgentEvent::Done {
+                        status: "Done. session saved".to_string(),
+                        assistant_message: concat!(
+                            "```ANVIL_FINAL\n",
+                            "Here is my plan:\n1. Read the file\n2. Analyze it\n",
+                            "```\n"
+                        )
+                        .to_string(),
+                        completion_summary: "plan only".to_string(),
+                        saved_status: "session saved".to_string(),
+                        tool_logs: Vec::new(),
+                        elapsed_ms: 100,
+                        inference_performance: None,
+                    }));
+                }
+                1 => {
+                    // Guard retry response with post-FINAL tool
+                    emit(ProviderEvent::Agent(AgentEvent::Done {
+                        status: "Done. session saved".to_string(),
+                        assistant_message: concat!(
+                            "```ANVIL_TOOL\n",
+                            "{\"id\":\"call_001\",\"tool\":\"file.read\",\"path\":\"./src/main.rs\"}\n",
+                            "```\n",
+                            "```ANVIL_FINAL\n",
+                            "Reading the file now.\n",
+                            "```\n",
+                            "```ANVIL_TOOL\n",
+                            "{\"id\":\"call_002\",\"tool\":\"file.read\",\"path\":\"./src/lib.rs\"}\n",
+                            "```\n"
+                        )
+                        .to_string(),
+                        completion_summary: "retry turn".to_string(),
+                        saved_status: "session saved".to_string(),
+                        tool_logs: Vec::new(),
+                        elapsed_ms: 200,
+                        inference_performance: None,
+                    }));
+                }
+                _ => {
+                    // Follow-up after file.read (only call_001)
+                    emit(ProviderEvent::TokenDelta("Analysis complete.".to_string()));
+                }
+            }
+            Ok(())
+        }
+    }
+
+    let provider = GuardRetryPostFinalProvider {
+        seen_requests: seen_requests.clone(),
+    };
+
+    let _frames = app
+        .run_live_turn("analyze the code", &provider, &tui)
+        .expect("guard_retry_post_final should succeed");
+
+    // Verify call_002 was NOT executed: lib.rs should NOT appear in any session message
+    let has_lib_rs_result = app
+        .session()
+        .messages
+        .iter()
+        .any(|m| m.content.contains("lib.rs"));
+    assert!(
+        !has_lib_rs_result,
+        "post-FINAL tool call_002 (lib.rs) should NOT appear in session messages after guard retry"
+    );
+
+    // Verify guard DID fire (guard retry message present)
+    assert!(
+        app.session()
+            .messages
+            .iter()
+            .any(|m| m.content.contains("No file modifications detected")),
+        "guard retry message should be in session"
+    );
+}
+
 // ============================================================
 // normalize_http_timeout tests (Issue #146)
 // ============================================================

--- a/tests/provider_integration.rs
+++ b/tests/provider_integration.rs
@@ -3685,3 +3685,43 @@ fn transport_with_timeout_and_shutdown_flag_constructs_successfully() {
     let flag = Arc::new(AtomicBool::new(false));
     let _transport = ReqwestHttpTransport::with_timeout_and_shutdown_flag(120, flag);
 }
+
+#[test]
+fn prompt_tool_rules_contains_large_file_guidance() {
+    let app = common::build_app();
+    let tui = Tui::new();
+    let seen_requests = Rc::new(RefCell::new(Vec::new()));
+    let provider = RecordingProvider {
+        seen_requests: seen_requests.clone(),
+        events: vec![
+            ProviderEvent::Agent(AgentEvent::Thinking {
+                status: "Thinking".to_string(),
+                plan_items: vec![],
+                active_index: None,
+                reasoning_summary: vec![],
+                elapsed_ms: 0,
+            }),
+            ProviderEvent::Agent(AgentEvent::Done {
+                status: "Done. session saved".to_string(),
+                assistant_message: "ok".to_string(),
+                completion_summary: "done".to_string(),
+                saved_status: "session saved".to_string(),
+                tool_logs: Vec::new(),
+                elapsed_ms: 0,
+                inference_performance: None,
+            }),
+        ],
+        followup_events: Vec::new(),
+        error: None,
+    };
+
+    let mut app = app;
+    let _ = app.run_live_turn("test", &provider, &tui);
+
+    let requests = seen_requests.borrow();
+    let system_prompt = &requests[0].messages[0].content;
+    assert!(
+        system_prompt.contains("file.write may be blocked"),
+        "system prompt should contain large file write guidance from PROMPT_TOOL_RULES"
+    );
+}

--- a/tests/runtime_flow.rs
+++ b/tests/runtime_flow.rs
@@ -557,8 +557,14 @@ fn system_prompt_includes_confirm_class_guidance() {
 
 #[test]
 fn build_subagent_system_prompt_explore_contains_expected_tools() {
-    use anvil::agent::subagent::{SubAgentKind, build_subagent_system_prompt};
-    let prompt = build_subagent_system_prompt(&SubAgentKind::Explore, false);
+    use anvil::agent::subagent::{
+        SubAgentKind, SubAgentPromptOptions, build_subagent_system_prompt,
+    };
+    let opts = SubAgentPromptOptions {
+        offline: false,
+        ui_language: None,
+    };
+    let prompt = build_subagent_system_prompt(&SubAgentKind::Explore, &opts);
     assert!(
         prompt.contains("file.read"),
         "Explore prompt should include file.read"
@@ -583,8 +589,14 @@ fn build_subagent_system_prompt_explore_contains_expected_tools() {
 
 #[test]
 fn build_subagent_system_prompt_plan_contains_expected_tools() {
-    use anvil::agent::subagent::{SubAgentKind, build_subagent_system_prompt};
-    let prompt = build_subagent_system_prompt(&SubAgentKind::Plan, false);
+    use anvil::agent::subagent::{
+        SubAgentKind, SubAgentPromptOptions, build_subagent_system_prompt,
+    };
+    let opts = SubAgentPromptOptions {
+        offline: false,
+        ui_language: None,
+    };
+    let prompt = build_subagent_system_prompt(&SubAgentKind::Plan, &opts);
     assert!(
         prompt.contains("file.read"),
         "Plan prompt should include file.read"
@@ -613,9 +625,15 @@ fn build_subagent_system_prompt_plan_contains_expected_tools() {
 
 #[test]
 fn build_subagent_system_prompt_includes_json_format() {
-    use anvil::agent::subagent::{SubAgentKind, build_subagent_system_prompt};
+    use anvil::agent::subagent::{
+        SubAgentKind, SubAgentPromptOptions, build_subagent_system_prompt,
+    };
 
-    let explore = build_subagent_system_prompt(&SubAgentKind::Explore, false);
+    let opts = SubAgentPromptOptions {
+        offline: false,
+        ui_language: None,
+    };
+    let explore = build_subagent_system_prompt(&SubAgentKind::Explore, &opts);
     assert!(
         explore.contains("found_files"),
         "Explore prompt should mention found_files JSON field"
@@ -633,7 +651,7 @@ fn build_subagent_system_prompt_includes_json_format() {
         "Explore prompt should mention confidence JSON field"
     );
 
-    let plan = build_subagent_system_prompt(&SubAgentKind::Plan, false);
+    let plan = build_subagent_system_prompt(&SubAgentKind::Plan, &opts);
     assert!(
         plan.contains("found_files"),
         "Plan prompt should mention found_files JSON field"

--- a/tests/runtime_flow.rs
+++ b/tests/runtime_flow.rs
@@ -667,6 +667,121 @@ fn system_prompt_includes_web_tools_even_with_empty_used_tools() {
     );
 }
 
+// --- Issue #160: ANVIL_FINAL後のツール呼び出し除外テスト ---
+
+#[test]
+fn post_final_tool_excluded() {
+    // TC1: ANVIL_TOOL → ANVIL_FINAL → ANVIL_TOOL — only the first tool should be included
+    let response = anvil::agent::BasicAgentLoop::parse_structured_response(concat!(
+        "```ANVIL_TOOL\n",
+        "{\"id\":\"call_001\",\"tool\":\"file.read\",\"path\":\"./src/main.rs\"}\n",
+        "```\n",
+        "```ANVIL_FINAL\n",
+        "Read the file.\n",
+        "```\n",
+        "```ANVIL_TOOL\n",
+        "{\"id\":\"call_002\",\"tool\":\"file.read\",\"path\":\"./src/lib.rs\"}\n",
+        "```\n"
+    ))
+    .expect("parsing should succeed");
+
+    assert_eq!(
+        response.tool_calls.len(),
+        1,
+        "only pre-FINAL tool should remain"
+    );
+    assert_eq!(response.tool_calls[0].tool_call_id, "call_001");
+}
+
+#[test]
+fn pre_final_tools_preserved() {
+    // TC2: ANVIL_TOOL → ANVIL_TOOL → ANVIL_FINAL — both tools should be included
+    let response = anvil::agent::BasicAgentLoop::parse_structured_response(concat!(
+        "```ANVIL_TOOL\n",
+        "{\"id\":\"call_001\",\"tool\":\"file.read\",\"path\":\"./src/main.rs\"}\n",
+        "```\n",
+        "```ANVIL_TOOL\n",
+        "{\"id\":\"call_002\",\"tool\":\"file.read\",\"path\":\"./src/lib.rs\"}\n",
+        "```\n",
+        "```ANVIL_FINAL\n",
+        "Read both files.\n",
+        "```\n"
+    ))
+    .expect("parsing should succeed");
+
+    assert_eq!(
+        response.tool_calls.len(),
+        2,
+        "both pre-FINAL tools should remain"
+    );
+    assert_eq!(response.tool_calls[0].tool_call_id, "call_001");
+    assert_eq!(response.tool_calls[1].tool_call_id, "call_002");
+}
+
+#[test]
+fn no_final_existing_compat() {
+    // TC3: ANVIL_TOOL → ANVIL_TOOL, no ANVIL_FINAL — both tools should be included
+    let response = anvil::agent::BasicAgentLoop::parse_structured_response(concat!(
+        "```ANVIL_TOOL\n",
+        "{\"id\":\"call_001\",\"tool\":\"file.read\",\"path\":\"./src/main.rs\"}\n",
+        "```\n",
+        "```ANVIL_TOOL\n",
+        "{\"id\":\"call_002\",\"tool\":\"file.read\",\"path\":\"./src/lib.rs\"}\n",
+        "```\n"
+    ))
+    .expect("parsing should succeed");
+
+    assert_eq!(
+        response.tool_calls.len(),
+        2,
+        "all tools should remain without ANVIL_FINAL"
+    );
+    assert_eq!(response.tool_calls[0].tool_call_id, "call_001");
+    assert_eq!(response.tool_calls[1].tool_call_id, "call_002");
+}
+
+#[test]
+fn unclosed_final_filters() {
+    // TC4: ANVIL_TOOL → ANVIL_FINAL (unclosed) → ANVIL_TOOL — only the first tool
+    let response = anvil::agent::BasicAgentLoop::parse_structured_response(concat!(
+        "```ANVIL_TOOL\n",
+        "{\"id\":\"call_001\",\"tool\":\"file.read\",\"path\":\"./src/main.rs\"}\n",
+        "```\n",
+        "```ANVIL_FINAL\n",
+        "Read the file.\n",
+        "```ANVIL_TOOL\n",
+        "{\"id\":\"call_002\",\"tool\":\"file.read\",\"path\":\"./src/lib.rs\"}\n",
+        "```\n"
+    ))
+    .expect("parsing should succeed");
+
+    assert_eq!(
+        response.tool_calls.len(),
+        1,
+        "only pre-FINAL tool should remain with unclosed FINAL"
+    );
+    assert_eq!(response.tool_calls[0].tool_call_id, "call_001");
+}
+
+#[test]
+fn all_tools_after_final() {
+    // TC5: ANVIL_FINAL → ANVIL_TOOL — tool_calls should be empty
+    let response = anvil::agent::BasicAgentLoop::parse_structured_response(concat!(
+        "```ANVIL_FINAL\n",
+        "Done with everything.\n",
+        "```\n",
+        "```ANVIL_TOOL\n",
+        "{\"id\":\"call_001\",\"tool\":\"file.read\",\"path\":\"./src/main.rs\"}\n",
+        "```\n"
+    ))
+    .expect("parsing should succeed");
+
+    assert!(
+        response.tool_calls.is_empty(),
+        "all post-FINAL tools should be excluded"
+    );
+}
+
 // --- Issue #128: Multi-tier parsing tests ---
 
 #[test]

--- a/tests/state_session.rs
+++ b/tests/state_session.rs
@@ -1502,13 +1502,16 @@ fn working_memory_backward_compat_old_json() {
 }
 
 #[test]
-fn compact_history_preserves_working_memory() {
+fn compact_history_preserves_working_memory_except_context_notice() {
     let mut session = SessionRecord::new(PathBuf::from("/tmp/wm_compact"));
     session
         .working_memory
         .set_active_task(Some("task A".to_string()));
     session.working_memory.update_touched_files("a.rs");
     session.working_memory.add_error("some error");
+    session
+        .working_memory
+        .set_context_notice(Some("5 messages pruned".to_string()));
 
     // Add enough messages to trigger compaction
     for i in 0..20 {
@@ -1522,10 +1525,127 @@ fn compact_history_preserves_working_memory() {
         );
     }
 
-    let wm_before = session.working_memory.clone();
     let compacted = session.compact_history(10);
     assert!(compacted);
 
-    // Working memory should be unchanged after compaction
-    assert_eq!(session.working_memory, wm_before);
+    // Core working memory fields should be preserved after compaction
+    assert_eq!(
+        session.working_memory.active_task,
+        Some("task A".to_string())
+    );
+    assert!(
+        session
+            .working_memory
+            .touched_files
+            .contains(&"a.rs".to_string())
+    );
+    assert!(
+        session
+            .working_memory
+            .unresolved_errors
+            .contains(&"some error".to_string())
+    );
+
+    // context_notice should be cleared after compaction (Issue #157)
+    assert!(
+        session.working_memory.context_notice.is_none(),
+        "context_notice should be cleared after compact_history"
+    );
+}
+
+#[test]
+fn working_memory_context_notice_serialize_roundtrip() {
+    let mut session = SessionRecord::new(PathBuf::from("/tmp/wm_notice_test"));
+    session
+        .working_memory
+        .set_context_notice(Some("10 earlier messages pruned".to_string()));
+
+    let json = serde_json::to_string(&session).expect("serialize");
+    let restored: SessionRecord = serde_json::from_str(&json).expect("deserialize");
+
+    assert_eq!(
+        session.working_memory.context_notice,
+        restored.working_memory.context_notice
+    );
+}
+
+// ── WorkingMemory record_tool_result behavior tests (Issue #157) ────────────
+
+#[test]
+fn working_memory_recent_diffs_accumulates_entries() {
+    let mut wm = WorkingMemory::default();
+    // Simulate record_tool_result accumulation logic
+    let diff1 = "wrote 100 bytes to src/main.rs".to_string();
+    wm.set_recent_diffs(Some(diff1.clone()));
+    assert_eq!(
+        wm.recent_diffs.as_deref(),
+        Some("wrote 100 bytes to src/main.rs")
+    );
+
+    // Second diff appended
+    let diff2 = "src/lib.rs: replaced 10 chars with 20 chars".to_string();
+    let current = wm.recent_diffs.clone().unwrap_or_default();
+    let updated = format!("{}\n{}", current, diff2);
+    wm.set_recent_diffs(Some(updated));
+    let diffs = wm.recent_diffs.as_ref().expect("should have diffs");
+    assert!(diffs.contains(&diff1), "should still contain first diff");
+    assert!(diffs.contains(&diff2), "should contain second diff");
+}
+
+#[test]
+fn working_memory_recent_diffs_truncation_keeps_latest() {
+    let mut wm = WorkingMemory::default();
+    // Create old + new diffs where total exceeds limit
+    let old_diff = "a".repeat(3000);
+    let new_diff = "b".repeat(3000);
+    let combined = format!("{}\n{}", old_diff, new_diff);
+    wm.set_recent_diffs(Some(combined));
+    let diffs = wm.recent_diffs.as_ref().expect("should have diffs");
+    // After CB-003 fix, truncation keeps the tail (latest content)
+    assert!(
+        diffs.starts_with("[truncated]..."),
+        "should have truncation prefix"
+    );
+    // The latest content (b's) should be preserved more than old content (a's)
+    let b_count = diffs.chars().filter(|c| *c == 'b').count();
+    let a_count = diffs.chars().filter(|c| *c == 'a').count();
+    assert!(
+        b_count > a_count,
+        "latest diffs (b's) should be preserved over old diffs (a's): b={b_count}, a={a_count}"
+    );
+}
+
+#[test]
+fn working_memory_touched_files_updated_for_file_edit_anchor_pattern() {
+    let mut wm = WorkingMemory::default();
+    // Simulate what record_tool_result does for file.edit_anchor
+    // The artifacts contain the resolved path; update_touched_files takes relative path
+    wm.update_touched_files("src/tooling/mod.rs");
+    assert!(
+        wm.touched_files.contains(&"src/tooling/mod.rs".to_string()),
+        "touched_files should contain the edited file"
+    );
+    // Verify deduplication
+    wm.update_touched_files("src/tooling/mod.rs");
+    let count = wm
+        .touched_files
+        .iter()
+        .filter(|f| *f == "src/tooling/mod.rs")
+        .count();
+    assert_eq!(count, 1, "touched_files should deduplicate entries");
+}
+
+#[test]
+fn working_memory_format_includes_recent_diffs_section() {
+    let mut wm = WorkingMemory::default();
+    wm.set_recent_diffs(Some("wrote 50 bytes to test.txt".to_string()));
+    let prompt = wm.format_for_prompt().expect("should produce prompt");
+    assert!(
+        prompt.contains("**Recent diffs:**"),
+        "prompt should include recent diffs section"
+    );
+    assert!(
+        prompt.contains("wrote 50 bytes to test.txt"),
+        "prompt should include the diff content"
+    );
 }

--- a/tests/tooling_system.rs
+++ b/tests/tooling_system.rs
@@ -5309,3 +5309,75 @@ fn file_cache_update_existing_entry() {
     assert_eq!(cache.total_bytes(), 15); // "version2_longer".len()
     assert_eq!(cache.try_get(&file), Some("version2_longer".to_string()));
 }
+
+#[test]
+fn file_edit_success_payload_contains_diff() {
+    let root = std::env::temp_dir().join("anvil_file_edit_payload_diff");
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(&root).expect("dir should exist");
+    let file_path = root.join("test.txt");
+    fs::write(&file_path, "hello world").expect("write should succeed");
+
+    let mut executor = LocalToolExecutor::new_without_rate_limit(root.clone());
+    let result = executor
+        .execute(ToolExecutionRequest {
+            tool_call_id: "call_edit_payload_001".to_string(),
+            spec: build_registry()
+                .get("file.edit")
+                .expect("file.edit spec")
+                .clone(),
+            input: ToolInput::FileEdit {
+                path: "./test.txt".to_string(),
+                old_string: "hello".to_string(),
+                new_string: "goodbye".to_string(),
+            },
+        })
+        .expect("edit should succeed");
+
+    assert_eq!(result.status, ToolExecutionStatus::Completed);
+    match &result.payload {
+        ToolExecutionPayload::Text(diff_text) => {
+            assert!(
+                diff_text.contains("-hello"),
+                "diff should contain removed line: {diff_text}"
+            );
+            assert!(
+                diff_text.contains("+goodbye"),
+                "diff should contain added line: {diff_text}"
+            );
+        }
+        other => panic!("expected ToolExecutionPayload::Text, got: {other:?}"),
+    }
+}
+
+#[test]
+fn file_edit_no_changes_payload_is_none() {
+    let root = std::env::temp_dir().join("anvil_file_edit_no_changes_payload");
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(&root).expect("dir should exist");
+    let file_path = root.join("test.txt");
+    fs::write(&file_path, "hello world").expect("write should succeed");
+
+    let mut executor = LocalToolExecutor::new_without_rate_limit(root.clone());
+    let result = executor
+        .execute(ToolExecutionRequest {
+            tool_call_id: "call_edit_nochange_001".to_string(),
+            spec: build_registry()
+                .get("file.edit")
+                .expect("file.edit spec")
+                .clone(),
+            input: ToolInput::FileEdit {
+                path: "./test.txt".to_string(),
+                old_string: "hello".to_string(),
+                new_string: "hello".to_string(),
+            },
+        })
+        .expect("edit should succeed");
+
+    assert_eq!(result.status, ToolExecutionStatus::Completed);
+    assert_eq!(
+        result.payload,
+        ToolExecutionPayload::None,
+        "no-changes path should return Payload::None"
+    );
+}

--- a/tests/tooling_system.rs
+++ b/tests/tooling_system.rs
@@ -202,6 +202,7 @@ fn validated_tool_call_builds_typed_execution_request_and_result() {
         payload: ToolExecutionPayload::Text("mod app".to_string()),
         artifacts: vec!["src/app/mod.rs".to_string()],
         elapsed_ms: 12,
+        diff_summary: None,
     };
 
     assert_eq!(execution.spec.kind, ToolKind::FileRead);
@@ -374,6 +375,7 @@ fn tool_execution_result_can_bridge_into_console_tool_log_view() {
         payload: ToolExecutionPayload::Text("mod app".to_string()),
         artifacts: vec!["src/app/mod.rs".to_string()],
         elapsed_ms: 12,
+        diff_summary: None,
     };
     let log = result.to_tool_log_view();
 
@@ -2286,6 +2288,7 @@ fn format_tool_result_message_image_payload() {
         },
         artifacts: Vec::new(),
         elapsed_ms: 10,
+        diff_summary: None,
     };
     let msg = format_tool_result_message(&result, 10000);
     assert!(msg.contains("file.read"));
@@ -2312,6 +2315,7 @@ fn format_tool_result_message_truncates_multibyte_safely() {
         payload: ToolExecutionPayload::Text(cjk_content),
         artifacts: Vec::new(),
         elapsed_ms: 5,
+        diff_summary: None,
     };
 
     // Must not panic — the old byte-slicing implementation would panic here.
@@ -2334,6 +2338,7 @@ fn format_tool_result_message_ascii_truncation_still_works() {
         payload: ToolExecutionPayload::Text(ascii_content),
         artifacts: Vec::new(),
         elapsed_ms: 5,
+        diff_summary: None,
     };
 
     let msg = format_tool_result_message(&result, 100);
@@ -2359,6 +2364,7 @@ fn format_tool_result_message_boundary_char_3byte() {
         payload: ToolExecutionPayload::Text(content),
         artifacts: Vec::new(),
         elapsed_ms: 5,
+        diff_summary: None,
     };
 
     let msg = format_tool_result_message(&result, 100);
@@ -2441,6 +2447,7 @@ fn format_tool_result_message_success_head_priority() {
         payload: ToolExecutionPayload::Text(content),
         artifacts: Vec::new(),
         elapsed_ms: 5,
+        diff_summary: None,
     };
 
     let msg = format_tool_result_message(&result, 100);
@@ -2466,6 +2473,7 @@ fn format_tool_result_message_failure_tail_priority() {
         payload: ToolExecutionPayload::Text(content),
         artifacts: Vec::new(),
         elapsed_ms: 5,
+        diff_summary: None,
     };
 
     let msg = format_tool_result_message(&result, 100);
@@ -2491,6 +2499,7 @@ fn format_tool_result_message_interrupted_tail_priority() {
         payload: ToolExecutionPayload::Text(content),
         artifacts: Vec::new(),
         elapsed_ms: 5,
+        diff_summary: None,
     };
 
     let msg = format_tool_result_message(&result, 100);
@@ -4646,6 +4655,142 @@ mod captcha_blocked_error {
 // --- Issue #128: file.edit_anchor and fallback tests ---
 
 use anvil::tooling::AnchorEditParams;
+
+// ── diff_summary generation tests (Issue #157) ──────────────────────────────
+
+#[test]
+fn file_write_produces_diff_summary() {
+    let root = std::env::temp_dir().join("anvil_diff_summary_write");
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(&root).expect("dir should exist");
+
+    let mut executor = LocalToolExecutor::new_without_rate_limit(root.clone());
+    let result = executor
+        .execute(ToolExecutionRequest {
+            tool_call_id: "call_ds_write_001".to_string(),
+            spec: build_registry()
+                .get("file.write")
+                .expect("file.write spec")
+                .clone(),
+            input: ToolInput::FileWrite {
+                path: "./new_file.txt".to_string(),
+                content: "hello world".to_string(),
+            },
+        })
+        .expect("write should succeed");
+
+    assert_eq!(result.status, ToolExecutionStatus::Completed);
+    assert!(
+        result.diff_summary.is_some(),
+        "file.write should produce a diff_summary"
+    );
+    let diff = result.diff_summary.unwrap();
+    assert!(
+        diff.contains("wrote") && diff.contains("bytes"),
+        "diff_summary should describe the write, got: {diff}"
+    );
+}
+
+#[test]
+fn file_edit_produces_diff_summary() {
+    let root = std::env::temp_dir().join("anvil_diff_summary_edit");
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(&root).expect("dir should exist");
+    fs::write(root.join("target.txt"), "hello world").expect("write should succeed");
+
+    let mut executor = LocalToolExecutor::new_without_rate_limit(root.clone());
+    let result = executor
+        .execute(ToolExecutionRequest {
+            tool_call_id: "call_ds_edit_001".to_string(),
+            spec: build_registry()
+                .get("file.edit")
+                .expect("file.edit spec")
+                .clone(),
+            input: ToolInput::FileEdit {
+                path: "./target.txt".to_string(),
+                old_string: "hello".to_string(),
+                new_string: "goodbye".to_string(),
+            },
+        })
+        .expect("edit should succeed");
+
+    assert_eq!(result.status, ToolExecutionStatus::Completed);
+    assert!(
+        result.diff_summary.is_some(),
+        "file.edit should produce a diff_summary"
+    );
+    let diff = result.diff_summary.unwrap();
+    assert!(
+        diff.contains("replaced") && diff.contains("chars"),
+        "diff_summary should describe the edit, got: {diff}"
+    );
+}
+
+#[test]
+fn file_edit_anchor_produces_diff_summary() {
+    let root = std::env::temp_dir().join("anvil_diff_summary_anchor");
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(&root).expect("dir should exist");
+    fs::write(root.join("test.rs"), "fn main() {\n    let x = 1;\n}\n")
+        .expect("write should succeed");
+
+    let mut executor = LocalToolExecutor::new_without_rate_limit(root.clone());
+    let result = executor
+        .execute(ToolExecutionRequest {
+            tool_call_id: "call_ds_anchor_001".to_string(),
+            spec: build_registry()
+                .get("file.edit_anchor")
+                .expect("file.edit_anchor spec")
+                .clone(),
+            input: ToolInput::FileEditAnchor {
+                path: "./test.rs".to_string(),
+                params: AnchorEditParams {
+                    old_content: "let x = 1;".to_string(),
+                    new_content: "let x = 42;".to_string(),
+                },
+            },
+        })
+        .expect("anchor edit should succeed");
+
+    assert_eq!(result.status, ToolExecutionStatus::Completed);
+    assert!(
+        result.diff_summary.is_some(),
+        "file.edit_anchor should produce a diff_summary"
+    );
+    let diff = result.diff_summary.unwrap();
+    assert!(
+        diff.contains("replaced") && diff.contains("chars"),
+        "diff_summary should describe the anchor edit, got: {diff}"
+    );
+}
+
+#[test]
+fn file_read_has_no_diff_summary() {
+    let root = std::env::temp_dir().join("anvil_diff_summary_read");
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(&root).expect("dir should exist");
+    fs::write(root.join("test.txt"), "content").expect("write should succeed");
+
+    let mut executor = LocalToolExecutor::new_without_rate_limit(root.clone());
+    let result = executor
+        .execute(ToolExecutionRequest {
+            tool_call_id: "call_ds_read_001".to_string(),
+            spec: build_registry()
+                .get("file.read")
+                .expect("file.read spec")
+                .clone(),
+            input: ToolInput::FileRead {
+                path: "./test.txt".to_string(),
+            },
+        })
+        .expect("read should succeed");
+
+    assert_eq!(result.status, ToolExecutionStatus::Completed);
+    assert!(
+        result.diff_summary.is_none(),
+        "file.read should NOT produce a diff_summary"
+    );
+}
 
 #[test]
 fn file_edit_anchor_registered_in_registry() {

--- a/tests/tooling_system.rs
+++ b/tests/tooling_system.rs
@@ -1802,7 +1802,7 @@ fn file_edit_sandbox_escape_rejected() {
 
 // ---- Diff preview tests ----
 
-use anvil::tooling::diff::{generate_diff_preview, is_binary_content};
+use anvil::tooling::diff::{DiffOptions, generate_diff_preview, is_binary_content};
 
 #[test]
 fn test_diff_preview_existing_file() {
@@ -1814,7 +1814,7 @@ fn test_diff_preview_existing_file() {
         path: "hello.txt".to_string(),
         content: "line1\nline2 modified\nline3\nline4\n".to_string(),
     };
-    let result = generate_diff_preview(dir.path(), &input);
+    let result = generate_diff_preview(dir.path(), &input, &DiffOptions::default());
     assert!(result.is_some());
     let diff = result.unwrap();
     assert!(diff.contains("-line2"));
@@ -1829,7 +1829,7 @@ fn test_diff_preview_new_file() {
         path: "brand_new.txt".to_string(),
         content: "first line\nsecond line\n".to_string(),
     };
-    let result = generate_diff_preview(dir.path(), &input);
+    let result = generate_diff_preview(dir.path(), &input, &DiffOptions::default());
     assert!(result.is_some());
     let preview = result.unwrap();
     assert!(preview.contains("(new file)"));
@@ -1849,7 +1849,7 @@ fn test_diff_preview_binary_file() {
         path: "binary.bin".to_string(),
         content: "new content".to_string(),
     };
-    let result = generate_diff_preview(dir.path(), &input);
+    let result = generate_diff_preview(dir.path(), &input, &DiffOptions::default());
     assert!(result.is_some());
     assert!(result.unwrap().contains("binary file"));
 }
@@ -1866,7 +1866,7 @@ fn test_diff_preview_large_file() {
         path: "big.txt".to_string(),
         content: "replacement".to_string(),
     };
-    let result = generate_diff_preview(dir.path(), &input);
+    let result = generate_diff_preview(dir.path(), &input, &DiffOptions::default());
     assert!(result.is_some());
     assert!(result.unwrap().contains("file too large"));
 }
@@ -1884,7 +1884,7 @@ fn test_diff_preview_large_diff() {
         path: "many_lines.txt".to_string(),
         content: new_lines.join("\n"),
     };
-    let result = generate_diff_preview(dir.path(), &input);
+    let result = generate_diff_preview(dir.path(), &input, &DiffOptions::default());
     assert!(result.is_some());
     let diff = result.unwrap();
     // Should be truncated
@@ -1901,7 +1901,7 @@ fn test_diff_preview_file_edit() {
         old_string: "fn old_function() {}".to_string(),
         new_string: "fn new_function() {\n    println!(\"hello\");\n}".to_string(),
     };
-    let result = generate_diff_preview(dir.path(), &input);
+    let result = generate_diff_preview(dir.path(), &input, &DiffOptions::default());
     assert!(result.is_some());
     let diff = result.unwrap();
     assert!(diff.contains("-fn old_function() {}"));
@@ -1915,7 +1915,7 @@ fn test_diff_preview_nonexistent_file() {
         path: "does_not_exist.txt".to_string(),
         content: "hello world\n".to_string(),
     };
-    let result = generate_diff_preview(dir.path(), &input);
+    let result = generate_diff_preview(dir.path(), &input, &DiffOptions::default());
     assert!(result.is_some());
     let preview = result.unwrap();
     assert!(preview.contains("(new file)"));
@@ -1931,7 +1931,7 @@ fn test_diff_preview_line_truncation() {
         path: "long_line.txt".to_string(),
         content: format!("{long_line}\nshort\n"),
     };
-    let result = generate_diff_preview(dir.path(), &input);
+    let result = generate_diff_preview(dir.path(), &input, &DiffOptions::default());
     assert!(result.is_some());
     let preview = result.unwrap();
     assert!(preview.contains("(new file)"));
@@ -1964,7 +1964,7 @@ fn test_file_edit_diff_no_file_access() {
         old_string: "old code".to_string(),
         new_string: "new code".to_string(),
     };
-    let result = generate_diff_preview(dir.path(), &input);
+    let result = generate_diff_preview(dir.path(), &input, &DiffOptions::default());
     assert!(result.is_some());
     let diff = result.unwrap();
     assert!(diff.contains("-old code"));
@@ -1977,12 +1977,12 @@ fn test_diff_preview_other_tool_input_returns_none() {
     let input = ToolInput::FileRead {
         path: "foo.txt".to_string(),
     };
-    assert!(generate_diff_preview(dir.path(), &input).is_none());
+    assert!(generate_diff_preview(dir.path(), &input, &DiffOptions::default()).is_none());
 
     let input = ToolInput::ShellExec {
         command: "ls".to_string(),
     };
-    assert!(generate_diff_preview(dir.path(), &input).is_none());
+    assert!(generate_diff_preview(dir.path(), &input, &DiffOptions::default()).is_none());
 }
 
 // --- Parallel execution grouping tests ---
@@ -5308,4 +5308,281 @@ fn file_cache_update_existing_entry() {
     assert_eq!(cache.len(), 1);
     assert_eq!(cache.total_bytes(), 15); // "version2_longer".len()
     assert_eq!(cache.try_get(&file), Some("version2_longer".to_string()));
+}
+
+// ============================================================
+// Large file write block tests (Issue #156)
+// ============================================================
+
+/// Helper to build a file.write ToolExecutionRequest.
+fn build_file_write_request(
+    registry: &ToolRegistry,
+    path: &str,
+    content: &str,
+) -> ToolExecutionRequest {
+    registry
+        .validate(ToolCallRequest::new(
+            "call_write_large",
+            "file.write",
+            ToolInput::FileWrite {
+                path: path.to_string(),
+                content: content.to_string(),
+            },
+        ))
+        .expect("should validate")
+        .approve()
+        .into_execution_request(ToolExecutionPolicy {
+            approval_required: false,
+            ..Default::default()
+        })
+        .expect("policy should allow")
+}
+
+#[test]
+fn large_file_write_blocked_over_threshold() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().to_path_buf();
+    let file = root.join("big.txt");
+    // Create a 501-line file (exceeds default 500)
+    let lines: Vec<String> = (0..501).map(|i| format!("line {i}")).collect();
+    fs::write(&file, lines.join("\n")).unwrap();
+
+    let registry = build_registry();
+    let mut executor = LocalToolExecutor::new_without_rate_limit(&root);
+    executor.set_safe_write_max_lines(500);
+    let request = build_file_write_request(&registry, "big.txt", "replacement");
+    let result = executor.execute(request);
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("Large existing files cannot be overwritten"),
+        "error: {msg}"
+    );
+    assert!(msg.contains("file.edit"), "should suggest file.edit: {msg}");
+}
+
+#[test]
+fn small_file_write_allowed_under_threshold() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().to_path_buf();
+    let file = root.join("small.txt");
+    // Create a 100-line file (under 500)
+    let lines: Vec<String> = (0..100).map(|i| format!("line {i}")).collect();
+    fs::write(&file, lines.join("\n")).unwrap();
+
+    let registry = build_registry();
+    let mut executor = LocalToolExecutor::new_without_rate_limit(&root);
+    executor.set_safe_write_max_lines(500);
+    let request = build_file_write_request(&registry, "small.txt", "replacement");
+    let result = executor.execute(request);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn new_file_write_allowed_regardless_of_threshold() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().to_path_buf();
+
+    let registry = build_registry();
+    let mut executor = LocalToolExecutor::new_without_rate_limit(&root);
+    executor.set_safe_write_max_lines(500);
+    // Write a new file with 600 lines
+    let lines: Vec<String> = (0..600).map(|i| format!("line {i}")).collect();
+    let request = build_file_write_request(&registry, "new_file.txt", &lines.join("\n"));
+    let result = executor.execute(request);
+    assert!(result.is_ok(), "new file creation should not be blocked");
+}
+
+#[test]
+fn large_file_write_allowed_when_disabled() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().to_path_buf();
+    let file = root.join("big.txt");
+    let lines: Vec<String> = (0..501).map(|i| format!("line {i}")).collect();
+    fs::write(&file, lines.join("\n")).unwrap();
+
+    let registry = build_registry();
+    // safe_write_max_lines = 0 (disabled, default for new_without_rate_limit)
+    let mut executor = LocalToolExecutor::new_without_rate_limit(&root);
+    let request = build_file_write_request(&registry, "big.txt", "replacement");
+    let result = executor.execute(request);
+    assert!(result.is_ok(), "should succeed when safe_write_max_lines=0");
+}
+
+#[test]
+fn large_file_write_custom_threshold() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().to_path_buf();
+    let file = root.join("medium.txt");
+    // Create a 101-line file
+    let lines: Vec<String> = (0..101).map(|i| format!("line {i}")).collect();
+    fs::write(&file, lines.join("\n")).unwrap();
+
+    let registry = build_registry();
+    let mut executor = LocalToolExecutor::new_without_rate_limit(&root);
+    executor.set_safe_write_max_lines(100);
+    let request = build_file_write_request(&registry, "medium.txt", "replacement");
+    let result = executor.execute(request);
+    assert!(result.is_err(), "should block with custom threshold of 100");
+}
+
+#[test]
+fn large_file_write_exactly_at_threshold_allowed() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().to_path_buf();
+    let file = root.join("exact.txt");
+    // Create a file with exactly 500 lines (500 newlines = 500+1=501? No, 499 newlines + content = 500 lines)
+    // line_count = newlines + 1, so we need 499 newlines for 500 lines
+    let lines: Vec<String> = (0..500).map(|i| format!("line {i}")).collect();
+    let content = lines.join("\n"); // 499 newlines = 500 lines
+    fs::write(&file, &content).unwrap();
+
+    let registry = build_registry();
+    let mut executor = LocalToolExecutor::new_without_rate_limit(&root);
+    executor.set_safe_write_max_lines(500);
+    let request = build_file_write_request(&registry, "exact.txt", "replacement");
+    let result = executor.execute(request);
+    assert!(
+        result.is_ok(),
+        "file with exactly 500 lines should be allowed"
+    );
+}
+
+#[test]
+fn large_file_blocked_error_display_format() {
+    use anvil::tooling::ToolRuntimeError;
+    let err = ToolRuntimeError::LargeFileBlocked {
+        path: "src/main.rs".to_string(),
+        line_count: 600,
+        threshold: 500,
+    };
+    let msg = err.to_string();
+    assert!(msg.contains("600 lines"));
+    assert!(msg.contains("threshold: 500"));
+    assert!(msg.contains("file.edit"));
+    assert!(msg.contains("file.edit_anchor"));
+}
+
+#[test]
+fn large_file_blocked_error_sanitizes_control_chars() {
+    use anvil::tooling::ToolRuntimeError;
+    let err = ToolRuntimeError::LargeFileBlocked {
+        path: "src/\nmain\x00.rs".to_string(),
+        line_count: 600,
+        threshold: 500,
+    };
+    let msg = err.to_string();
+    assert!(!msg.contains('\n') || msg.starts_with("File"));
+    assert!(!msg.contains('\x00'));
+    assert!(msg.contains("src/main.rs"));
+}
+
+// ============================================================
+// Diff deletion warning tests (Issue #156)
+// ============================================================
+
+#[test]
+fn diff_preview_deletion_warning_when_threshold_exceeded() {
+    let dir = tempfile::tempdir().unwrap();
+    let file_path = dir.path().join("original.txt");
+    // Create a file with 100 lines
+    let original_lines: Vec<String> = (0..100).map(|i| format!("line {i}")).collect();
+    fs::write(&file_path, original_lines.join("\n")).unwrap();
+
+    // New content replaces most lines (high deletion ratio)
+    let input = ToolInput::FileWrite {
+        path: "original.txt".to_string(),
+        content: "only one line\n".to_string(),
+    };
+    let options = DiffOptions {
+        deletion_ratio_threshold: 0.5,
+    };
+    let result = generate_diff_preview(dir.path(), &input, &options);
+    assert!(result.is_some());
+    let diff = result.unwrap();
+    assert!(
+        diff.contains("WARNING"),
+        "should contain deletion warning: {diff}"
+    );
+    assert!(
+        diff.contains("lines deleted"),
+        "should mention lines deleted: {diff}"
+    );
+}
+
+#[test]
+fn diff_preview_no_warning_when_below_threshold() {
+    let dir = tempfile::tempdir().unwrap();
+    let file_path = dir.path().join("small_change.txt");
+    // Create a file with 10 lines
+    let original_lines: Vec<String> = (0..10).map(|i| format!("line {i}")).collect();
+    fs::write(&file_path, original_lines.join("\n")).unwrap();
+
+    // Change only 2 lines (low deletion ratio)
+    let mut new_lines = original_lines.clone();
+    new_lines[0] = "modified line 0".to_string();
+    new_lines[1] = "modified line 1".to_string();
+    let input = ToolInput::FileWrite {
+        path: "small_change.txt".to_string(),
+        content: new_lines.join("\n"),
+    };
+    let options = DiffOptions {
+        deletion_ratio_threshold: 0.5,
+    };
+    let result = generate_diff_preview(dir.path(), &input, &options);
+    assert!(result.is_some());
+    let diff = result.unwrap();
+    assert!(
+        !diff.contains("WARNING"),
+        "should not contain deletion warning for small change: {diff}"
+    );
+}
+
+#[test]
+fn diff_preview_no_warning_when_disabled() {
+    let dir = tempfile::tempdir().unwrap();
+    let file_path = dir.path().join("delete_all.txt");
+    let original_lines: Vec<String> = (0..100).map(|i| format!("line {i}")).collect();
+    fs::write(&file_path, original_lines.join("\n")).unwrap();
+
+    let input = ToolInput::FileWrite {
+        path: "delete_all.txt".to_string(),
+        content: "replacement\n".to_string(),
+    };
+    let options = DiffOptions {
+        deletion_ratio_threshold: 0.0, // disabled
+    };
+    let result = generate_diff_preview(dir.path(), &input, &options);
+    assert!(result.is_some());
+    let diff = result.unwrap();
+    assert!(
+        !diff.contains("WARNING"),
+        "should not contain warning when disabled: {diff}"
+    );
+}
+
+#[test]
+fn diff_preview_no_warning_for_new_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let input = ToolInput::FileWrite {
+        path: "brand_new.txt".to_string(),
+        content: "new content\n".to_string(),
+    };
+    let options = DiffOptions {
+        deletion_ratio_threshold: 0.5,
+    };
+    let result = generate_diff_preview(dir.path(), &input, &options);
+    assert!(result.is_some());
+    let diff = result.unwrap();
+    assert!(
+        !diff.contains("WARNING"),
+        "new file should not have deletion warning: {diff}"
+    );
+}
+
+#[test]
+fn diff_options_default_values() {
+    let opts = DiffOptions::default();
+    assert!((opts.deletion_ratio_threshold - 0.5).abs() < f64::EPSILON);
 }

--- a/tests/tooling_system.rs
+++ b/tests/tooling_system.rs
@@ -3132,8 +3132,14 @@ fn subagent_payload_size_limits_applied() {
 
 #[test]
 fn build_subagent_system_prompt_plan_offline_excludes_web_fetch() {
-    use anvil::agent::subagent::{SubAgentKind, build_subagent_system_prompt};
-    let prompt = build_subagent_system_prompt(&SubAgentKind::Plan, true);
+    use anvil::agent::subagent::{
+        SubAgentKind, SubAgentPromptOptions, build_subagent_system_prompt,
+    };
+    let opts = SubAgentPromptOptions {
+        offline: true,
+        ui_language: None,
+    };
+    let prompt = build_subagent_system_prompt(&SubAgentKind::Plan, &opts);
     assert!(
         !prompt.contains("web.fetch"),
         "offline Plan prompt should not contain web.fetch tool description"
@@ -3150,8 +3156,14 @@ fn build_subagent_system_prompt_plan_offline_excludes_web_fetch() {
 
 #[test]
 fn build_subagent_system_prompt_plan_online_includes_web_fetch() {
-    use anvil::agent::subagent::{SubAgentKind, build_subagent_system_prompt};
-    let prompt = build_subagent_system_prompt(&SubAgentKind::Plan, false);
+    use anvil::agent::subagent::{
+        SubAgentKind, SubAgentPromptOptions, build_subagent_system_prompt,
+    };
+    let opts = SubAgentPromptOptions {
+        offline: false,
+        ui_language: None,
+    };
+    let prompt = build_subagent_system_prompt(&SubAgentKind::Plan, &opts);
     assert!(
         prompt.contains("web.fetch"),
         "online Plan prompt should contain web.fetch tool description"
@@ -3168,9 +3180,19 @@ fn build_subagent_system_prompt_plan_online_includes_web_fetch() {
 
 #[test]
 fn build_subagent_system_prompt_explore_unaffected_by_offline() {
-    use anvil::agent::subagent::{SubAgentKind, build_subagent_system_prompt};
-    let online_prompt = build_subagent_system_prompt(&SubAgentKind::Explore, false);
-    let offline_prompt = build_subagent_system_prompt(&SubAgentKind::Explore, true);
+    use anvil::agent::subagent::{
+        SubAgentKind, SubAgentPromptOptions, build_subagent_system_prompt,
+    };
+    let online_opts = SubAgentPromptOptions {
+        offline: false,
+        ui_language: None,
+    };
+    let offline_opts = SubAgentPromptOptions {
+        offline: true,
+        ui_language: None,
+    };
+    let online_prompt = build_subagent_system_prompt(&SubAgentKind::Explore, &online_opts);
+    let offline_prompt = build_subagent_system_prompt(&SubAgentKind::Explore, &offline_opts);
     assert_eq!(
         online_prompt, offline_prompt,
         "Explore prompt should be identical regardless of offline flag"


### PR DESCRIPTION
## Summary
Issue #142〜#162 のランタイム堅牢性改善をmainにマージするリリースPRです。3バッチの開発成果を統合。

### Batch 1 (#142-#147): 基本的なランタイム改善
- **#142**: ファイル読み取りキャッシュ（mtime検知、LRU eviction）
- **#143**: file.edit 3段階フォールバック（コンテキストヒント→anchor→file.write）
- **#144**: ANVIL_FINAL早期発火防止ガード
- **#145**: 反復ループ検出と自己修正（Warn→StrongWarn→Break）
- **#146**: --timeout CLIオプション（10〜3600秒、環境変数対応）
- **#147**: --max-iterations デフォルト値引き上げ

### Batch 2 (#155-#162): ツール実行品質とUX改善
- **#155**: file.edit成功後のdiffフィードバック
- **#156**: 大ファイルへのfile.write全体書き換え制限
- **#157**: コンテキストリセット時の前回状態引き継ぎ（working memory注入）
- **#158**: file.edit/file.writeフォールバック戦略の統一
- **#159**: モデル非依存のフェーズ制御（構造化マーカーフォールバック）
- **#160**: ANVIL_FINAL後のツール呼び出し続行防止（フィルタリング）
- **#161**: file.write連続失敗時のリトライループ防止
- **#162**: LLM応答の言語安定性向上（言語コード設定）

## 品質チェック
- cargo build: Pass
- cargo clippy --all-targets: Pass（警告0件）
- cargo test: Pass（22テストスイート全パス）
- cargo fmt --check: Pass

## UAT結果
全14 Issue、29テスト項目が **ALL PASS (100%)** で ACCEPTED（実機起動確認済み）

| Batch | Issues | テスト | 判定 |
|-------|--------|--------|------|
| 1 | #142-#147 | 13/13 PASS | ALL ACCEPTED |
| 2 | #155-#162 | 16/16 PASS | ALL ACCEPTED |

## 変更統計
- 29ファイル変更、+5,414行、-254行
- 新規ファイル: file_cache.rs, edit_fail_tracker.rs, loop_detector.rs, write_fail_tracker.rs, phase_estimator.rs, loop_detection.rs, phase_estimation.rs

Closes #142, Closes #143, Closes #144, Closes #145, Closes #146, Closes #147
Closes #155, Closes #156, Closes #157, Closes #158, Closes #159, Closes #160, Closes #161, Closes #162

## Test plan
- [x] cargo build / clippy / test / fmt: 全パス
- [x] UAT全29テスト項目PASS（実機起動確認済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)