### PR TITLE
fix: +CI群の実装量低下を緩和する閾値調整 (#187)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -434,6 +434,8 @@ impl App {
         let phase_completion = config.runtime.phase_completion_read_threshold;
         let edit_reread_threshold = config.runtime.edit_reread_threshold;
         let edit_write_fallback_threshold = config.runtime.edit_write_fallback_threshold;
+        let read_repeat_warn = config.runtime.read_repeat_warn_threshold;
+        let read_repeat_strong_warn = config.runtime.read_repeat_strong_warn_threshold;
 
         Ok(Self {
             tools,
@@ -473,7 +475,10 @@ impl App {
                 phase_completion,
             ),
             write_fail_tracker: write_fail_tracker::WriteFailTracker::new(2),
-            read_repeat_tracker: read_repeat_tracker::ReadRepeatTracker::new(2, 4),
+            read_repeat_tracker: read_repeat_tracker::ReadRepeatTracker::new(
+                read_repeat_warn,
+                read_repeat_strong_warn,
+            ),
             write_repeat_tracker: write_repeat_tracker::WriteRepeatTracker::new(3, 4),
             file_read_cache,
         })

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -133,6 +133,10 @@ pub struct RuntimeConfig {
     pub safe_write_max_lines: usize,
     /// Deletion ratio threshold for diff warning (0.0-1.0, Issue #156).
     pub safe_write_deletion_ratio: f64,
+    /// ReadRepeatTracker: per-path read count to trigger warn hint (Issue #187).
+    pub read_repeat_warn_threshold: u32,
+    /// ReadRepeatTracker: per-path read count to trigger strong-warn hint (Issue #187).
+    pub read_repeat_strong_warn_threshold: u32,
     /// UI language for LLM responses (Issue #162).
     /// `None` means "use default language via effective_ui_language_code()".
     /// Supported: "ja", "en".
@@ -293,13 +297,15 @@ impl EffectiveConfig {
                 loop_detection_threshold: 3,
                 http_timeout_secs: DEFAULT_HTTP_TIMEOUT_SECS,
                 phase_explore_threshold: 5,
-                phase_force_transition_threshold: 10,
+                phase_force_transition_threshold: 15,
                 phase_completion_read_threshold: 5,
                 edit_strategy: crate::app::edit_fail_tracker::EditStrategy::EditFirst,
                 edit_reread_threshold: 3,
                 edit_write_fallback_threshold: 5,
                 safe_write_max_lines: 500,
                 safe_write_deletion_ratio: 0.5,
+                read_repeat_warn_threshold: 3,
+                read_repeat_strong_warn_threshold: 6,
                 ui_language: None,
                 max_tool_calls: DEFAULT_MAX_TOOL_CALLS,
             },
@@ -722,6 +728,24 @@ impl EffectiveConfig {
                     }
                     self.runtime.edit_write_fallback_threshold = v;
                 }
+                "read_repeat_warn_threshold" | "ANVIL_READ_REPEAT_WARN_THRESHOLD" => {
+                    let v: u32 = value
+                        .parse()
+                        .map_err(|_| ConfigError::InvalidNumericValue(value.clone()))?;
+                    if !(1..=20).contains(&v) {
+                        return Err(ConfigError::InvalidNumericValue(value.clone()));
+                    }
+                    self.runtime.read_repeat_warn_threshold = v;
+                }
+                "read_repeat_strong_warn_threshold" | "ANVIL_READ_REPEAT_STRONG_WARN_THRESHOLD" => {
+                    let v: u32 = value
+                        .parse()
+                        .map_err(|_| ConfigError::InvalidNumericValue(value.clone()))?;
+                    if !(2..=40).contains(&v) {
+                        return Err(ConfigError::InvalidNumericValue(value.clone()));
+                    }
+                    self.runtime.read_repeat_strong_warn_threshold = v;
+                }
                 "safe_write_max_lines" | "ANVIL_SAFE_WRITE_MAX_LINES" => {
                     self.runtime.safe_write_max_lines = value
                         .parse()
@@ -777,6 +801,7 @@ impl EffectiveConfig {
         self.clamp_loop_detection_threshold();
         self.clamp_phase_thresholds();
         self.clamp_edit_thresholds();
+        self.clamp_read_repeat_thresholds();
         self.clamp_http_timeout();
         self.clamp_max_tool_calls();
         self.sanitize_ui_language();
@@ -937,6 +962,20 @@ impl EffectiveConfig {
         if self.runtime.phase_explore_threshold >= self.runtime.phase_force_transition_threshold {
             self.runtime.phase_force_transition_threshold =
                 (self.runtime.phase_explore_threshold + 5).min(30);
+        }
+    }
+
+    /// Clamp read-repeat tracker thresholds and enforce warn < strong_warn (Issue #187).
+    fn clamp_read_repeat_thresholds(&mut self) {
+        self.runtime.read_repeat_warn_threshold =
+            self.runtime.read_repeat_warn_threshold.clamp(1, 20);
+        self.runtime.read_repeat_strong_warn_threshold =
+            self.runtime.read_repeat_strong_warn_threshold.clamp(2, 40);
+        // Enforce warn < strong_warn
+        if self.runtime.read_repeat_warn_threshold >= self.runtime.read_repeat_strong_warn_threshold
+        {
+            self.runtime.read_repeat_strong_warn_threshold =
+                self.runtime.read_repeat_warn_threshold + 3;
         }
     }
 

--- a/tests/config_bootstrap.rs
+++ b/tests/config_bootstrap.rs
@@ -1077,3 +1077,78 @@ fn safe_write_cli_args_none_leaves_default() {
     assert_eq!(config.runtime.safe_write_max_lines, 500);
     assert!((config.runtime.safe_write_deletion_ratio - 0.5).abs() < f64::EPSILON);
 }
+
+// --- Issue #187: CI implementation reduction fixes ---
+
+#[test]
+fn issue187_read_repeat_default_thresholds_raised() {
+    let config = EffectiveConfig::default_for_test().unwrap();
+    // Issue #187: warn=2 was too aggressive, raised to 3
+    assert_eq!(config.runtime.read_repeat_warn_threshold, 3);
+    // Issue #187: strong_warn raised from 4 to 6
+    assert_eq!(config.runtime.read_repeat_strong_warn_threshold, 6);
+}
+
+#[test]
+fn issue187_phase_force_transition_default_raised() {
+    let config = EffectiveConfig::default_for_test().unwrap();
+    // Issue #187: force_transition_threshold raised from 10 to 15
+    assert_eq!(config.runtime.phase_force_transition_threshold, 15);
+}
+
+#[test]
+fn issue187_read_repeat_thresholds_configurable_via_file() {
+    let mut config = EffectiveConfig::default_for_test().unwrap();
+    let mut file_values = HashMap::new();
+    file_values.insert("read_repeat_warn_threshold".to_string(), "5".to_string());
+    file_values.insert(
+        "read_repeat_strong_warn_threshold".to_string(),
+        "10".to_string(),
+    );
+    config
+        .apply_overrides_for_test(&file_values, &HashMap::new(), &HashMap::new())
+        .expect("should apply");
+    assert_eq!(config.runtime.read_repeat_warn_threshold, 5);
+    assert_eq!(config.runtime.read_repeat_strong_warn_threshold, 10);
+}
+
+#[test]
+fn issue187_read_repeat_thresholds_configurable_via_env() {
+    let mut config = EffectiveConfig::default_for_test().unwrap();
+    let mut env_values = HashMap::new();
+    env_values.insert(
+        "ANVIL_READ_REPEAT_WARN_THRESHOLD".to_string(),
+        "4".to_string(),
+    );
+    env_values.insert(
+        "ANVIL_READ_REPEAT_STRONG_WARN_THRESHOLD".to_string(),
+        "8".to_string(),
+    );
+    config
+        .apply_overrides_for_test(&HashMap::new(), &env_values, &HashMap::new())
+        .expect("should apply");
+    assert_eq!(config.runtime.read_repeat_warn_threshold, 4);
+    assert_eq!(config.runtime.read_repeat_strong_warn_threshold, 8);
+}
+
+#[test]
+fn issue187_read_repeat_clamp_enforces_warn_less_than_strong_warn() {
+    let mut config = EffectiveConfig::default_for_test().unwrap();
+    config.runtime.read_repeat_warn_threshold = 10;
+    config.runtime.read_repeat_strong_warn_threshold = 10;
+    config.validate_for_test().expect("should validate");
+    // warn < strong_warn enforced
+    assert!(
+        config.runtime.read_repeat_warn_threshold
+            < config.runtime.read_repeat_strong_warn_threshold
+    );
+}
+
+#[test]
+fn issue187_read_repeat_invalid_value_rejected() {
+    let mut config = EffectiveConfig::default_for_test().unwrap();
+    let mut file_values = HashMap::new();
+    file_values.insert("read_repeat_warn_threshold".to_string(), "0".to_string());
+    let result = config.apply_overrides_for_test(&file_values, &HashMap::new(), &HashMap::new());
+    assert!(result.is_err());
+}

--- a/tests/phase_estimation.rs
+++ b/tests/phase_estimation.rs
@@ -7,8 +7,8 @@ use anvil::app::phase_estimator::{Phase, PhaseAction, PhaseEstimator};
 
 #[test]
 fn phase_estimator_default_config_values() {
-    // Default thresholds from config: N=5, M=10, K=5
-    let est = PhaseEstimator::new(5, 10, 5);
+    // Default thresholds from config: N=5, M=15, K=5 (Issue #187: M raised from 10 to 15)
+    let est = PhaseEstimator::new(5, 15, 5);
     assert_eq!(est.current_phase(), Phase::Unknown);
 }
 


### PR DESCRIPTION
## Summary
+CI群（CommandIndexコンテキスト付きプロンプト）で実装量が���体群の1/4に低下する問題の恒久対策。

### 根本原因（Opus 4.6 分析）
- 主因: LLMの慎重モード化（before-change出力による現状維持バイアス）
- 寄与因子: ReadRepeatTracker warn=2 が低すぎ、正当な再読をヒントで抑制
- 寄与因子: PhaseEstimator force_transition_threshold=10 が設計制約確認のreadで誤発火

### 対策
- ReadRepeatTracker warn閾値を引き上げ
- PhaseEstimator force_transition_threshold を引き上げ
- 対応テスト追加

Closes #187

## Test plan
- [x] cargo test: 全テストパス
- [x] cargo clippy: 警告0件

🤖 Generated with [Claude Code](https://claude.com/claude-code)