### PR TITLE
feat(issue-195): サイドカーモデルによるコンテキスト圧縮

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -765,7 +765,15 @@ impl App {
             }
         }
 
-        let compacted = self.session.compact_history(keep_recent);
+        // Try LLM-based summarization via sidecar model (Issue #195)
+        let llm_summary = self.try_sidecar_summarize(keep_recent);
+
+        let compacted = if let Some(summary) = llm_summary {
+            self.session
+                .compact_history_with_llm_summary(keep_recent, summary)
+        } else {
+            self.session.compact_history(keep_recent)
+        };
 
         // Reset context warning tracker after successful compaction (auto/manual)
         if compacted {
@@ -777,6 +785,62 @@ impl App {
         }
 
         compacted
+    }
+
+    /// Attempt LLM-based summarization via the sidecar model (Issue #195).
+    ///
+    /// Returns `Some(summary)` if the sidecar model is available and produces
+    /// a non-empty summary.  Returns `None` on any failure, signalling the
+    /// caller to fall back to rule-based summarization.
+    fn try_sidecar_summarize(&self, keep_recent: usize) -> Option<String> {
+        use crate::provider::ollama::{
+            DEFAULT_SIDECAR_MODEL, OllamaChatMessage, build_conversation_text_for_summary,
+            sidecar_summarize,
+        };
+
+        let sidecar_model = self
+            .config
+            .runtime
+            .sidecar_model
+            .as_deref()
+            .unwrap_or(DEFAULT_SIDECAR_MODEL);
+
+        // Only attempt if provider is Ollama
+        if self.config.runtime.provider != "ollama" {
+            return None;
+        }
+
+        let msg_count = self.session.messages.len();
+        if msg_count <= keep_recent {
+            return None;
+        }
+        let split_at = msg_count - keep_recent;
+
+        // Convert session messages to OllamaChatMessage for the helper
+        let ollama_msgs: Vec<OllamaChatMessage> = self.session.messages[..split_at]
+            .iter()
+            .map(|m| OllamaChatMessage {
+                role: match m.role {
+                    crate::session::MessageRole::System => "system".to_string(),
+                    crate::session::MessageRole::User => "user".to_string(),
+                    crate::session::MessageRole::Assistant => "assistant".to_string(),
+                    crate::session::MessageRole::Tool => "tool".to_string(),
+                },
+                content: m.content.clone(),
+                images: None,
+            })
+            .collect();
+
+        let conversation_text = build_conversation_text_for_summary(&ollama_msgs);
+        if conversation_text.trim().is_empty() {
+            return None;
+        }
+
+        sidecar_summarize(
+            &self.config.runtime.provider_url,
+            sidecar_model,
+            &conversation_text,
+        )
     }
 
     /// Get a clone of the shutdown flag for injection into sub-components.

--- a/src/provider/ollama.rs
+++ b/src/provider/ollama.rs
@@ -491,6 +491,123 @@ pub fn fetch_model_info_from_ollama(provider_url: &str, model: &str) -> Option<O
 // fetch_model_info_from_ollamaをOllamaProviderClient::メソッドに統合し、
 // HttpTransport経由で実装するリファクタリング（別Issue）
 
+/// Default sidecar model name used when none is explicitly configured.
+pub const DEFAULT_SIDECAR_MODEL: &str = "qwen3.5:9b";
+
+/// Summarization prompt sent to the sidecar model during context compaction.
+const SIDECAR_SUMMARIZE_PROMPT: &str = "\
+You are a concise summarizer. Respond ONLY with bullet points.\n\
+Summarize this conversation so far in 3-5 bullet points, focusing on:\n\
+what was discussed, what files were modified, what decisions were made.";
+
+/// Summarize a conversation using a sidecar (small) model via Ollama `/api/chat`.
+///
+/// Returns `Some(summary_text)` on success, or `None` if the model is
+/// unavailable, the request fails, or the response is empty.  The caller
+/// should fall back to rule-based summarization on `None`.
+pub fn sidecar_summarize(
+    provider_url: &str,
+    sidecar_model: &str,
+    conversation_text: &str,
+) -> Option<String> {
+    if conversation_text.trim().is_empty() {
+        return None;
+    }
+
+    let url = format!("{}/api/chat", provider_url.trim_end_matches('/'));
+    let request_body = serde_json::json!({
+        "model": sidecar_model,
+        "messages": [
+            {"role": "system", "content": SIDECAR_SUMMARIZE_PROMPT},
+            {"role": "user", "content": conversation_text}
+        ],
+        "stream": false
+    });
+
+    let client = ollama_metadata_client();
+    let response = match client.post(&url).json(&request_body).send() {
+        Ok(r) => r,
+        Err(err) => {
+            tracing::debug!(error = %err, model = sidecar_model, "sidecar summarize request failed");
+            return None;
+        }
+    };
+
+    if !response.status().is_success() {
+        tracing::debug!(
+            status = %response.status(),
+            model = sidecar_model,
+            "sidecar summarize: non-success status"
+        );
+        return None;
+    }
+
+    let body: Value = match response.json() {
+        Ok(v) => v,
+        Err(err) => {
+            tracing::debug!(error = %err, "sidecar summarize: failed to parse response");
+            return None;
+        }
+    };
+
+    // Check for model-not-found error
+    if let Some(error) = body.get("error").and_then(Value::as_str) {
+        if MODEL_NOT_FOUND_PATTERNS.iter().any(|p| error.contains(p)) {
+            tracing::info!(
+                model = sidecar_model,
+                "sidecar model not found, falling back to rule-based summary"
+            );
+        } else {
+            tracing::debug!(error = error, "sidecar summarize: API error");
+        }
+        return None;
+    }
+
+    let content = body
+        .get("message")
+        .and_then(|m| m.get("content"))
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .trim()
+        .to_string();
+
+    if content.is_empty() {
+        tracing::debug!("sidecar summarize: empty response content");
+        return None;
+    }
+
+    tracing::info!(
+        model = sidecar_model,
+        summary_len = content.len(),
+        "sidecar model generated context summary"
+    );
+    Some(content)
+}
+
+/// Build a plain-text conversation representation for summarization.
+///
+/// Each message is formatted as `role: content` (truncated to avoid
+/// sending excessively large payloads to a small model).
+pub fn build_conversation_text_for_summary(messages: &[OllamaChatMessage]) -> String {
+    const MAX_MSG_CHARS: usize = 500;
+    const MAX_TOTAL_CHARS: usize = 8000;
+
+    let mut text = String::new();
+    for msg in messages {
+        let preview = if msg.content.len() > MAX_MSG_CHARS {
+            format!("{}...", &msg.content[..MAX_MSG_CHARS])
+        } else {
+            msg.content.clone()
+        };
+        let line = format!("{}: {}\n", msg.role, preview);
+        if text.len() + line.len() > MAX_TOTAL_CHARS {
+            break;
+        }
+        text.push_str(&line);
+    }
+    text
+}
+
 fn resolve_model_with_ollama_tags(base_url: &str, requested: &str) -> String {
     let url = format!("{}/api/tags", base_url.trim_end_matches('/'));
     let client = ollama_metadata_client();

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -543,6 +543,21 @@ impl SessionRecord {
     }
 
     pub fn compact_history(&mut self, keep_recent: usize) -> bool {
+        self.compact_history_impl(keep_recent, None)
+    }
+
+    /// Compact history using an externally-provided LLM summary instead of
+    /// the rule-based summarizer.  Falls back to rule-based if `llm_summary`
+    /// is `None`.
+    pub fn compact_history_with_llm_summary(
+        &mut self,
+        keep_recent: usize,
+        llm_summary: String,
+    ) -> bool {
+        self.compact_history_impl(keep_recent, Some(llm_summary))
+    }
+
+    fn compact_history_impl(&mut self, keep_recent: usize, llm_summary: Option<String>) -> bool {
         if self.messages.len() <= keep_recent {
             return false;
         }
@@ -551,17 +566,23 @@ impl SessionRecord {
         tracing::debug!(
             compacted = split_at,
             kept = keep_recent,
+            llm_summary = llm_summary.is_some(),
             "compacting session history"
         );
 
-        // Step 1: Replace large tool results with summaries
-        replace_tool_results_with_summaries(&mut self.messages[..split_at]);
+        let summary = if let Some(llm_text) = llm_summary {
+            format!("[compacted session summary (LLM)]\n{llm_text}")
+        } else {
+            // Rule-based fallback
+            // Step 1: Replace large tool results with summaries
+            replace_tool_results_with_summaries(&mut self.messages[..split_at]);
 
-        // Step 2: Compute importance scores
-        let scores = compute_importance_scores(&self.messages, split_at);
+            // Step 2: Compute importance scores
+            let scores = compute_importance_scores(&self.messages, split_at);
 
-        // Step 3: Generate summary using scores
-        let summary = generate_compact_summary(&self.messages[..split_at], &scores);
+            // Step 3: Generate summary using scores
+            generate_compact_summary(&self.messages[..split_at], &scores)
+        };
 
         // Step 4: Drain old messages and insert summary
         self.messages.drain(..split_at);

--- a/tests/state_session.rs
+++ b/tests/state_session.rs
@@ -1649,3 +1649,136 @@ fn working_memory_format_includes_recent_diffs_section() {
         "prompt should include the diff content"
     );
 }
+
+// ── Sidecar model / LLM summary compaction tests (Issue #195) ────────
+
+#[test]
+fn compact_history_with_llm_summary_uses_provided_text() {
+    let mut session = SessionRecord::new(PathBuf::from("/tmp/sidecar-test"));
+    for i in 0..20 {
+        session.push_message(
+            SessionMessage::new(MessageRole::User, "you", format!("msg {i}"))
+                .with_id(format!("u_{i}")),
+        );
+        session.push_message(
+            SessionMessage::new(MessageRole::Assistant, "anvil", format!("reply {i}"))
+                .with_id(format!("a_{i}")),
+        );
+    }
+
+    let llm_summary =
+        "- Discussed project architecture\n- Modified src/main.rs\n- Decided to use TDD approach"
+            .to_string();
+    let changed = session.compact_history_with_llm_summary(8, llm_summary.clone());
+
+    assert!(changed);
+    assert!(
+        session.messages[0]
+            .content
+            .contains("[compacted session summary (LLM)]"),
+        "summary should contain LLM marker"
+    );
+    assert!(
+        session.messages[0]
+            .content
+            .contains("Discussed project architecture"),
+        "summary should contain the LLM-provided text"
+    );
+    // Recent messages should be preserved
+    assert!(session.messages.len() <= 9, "should keep recent + summary");
+}
+
+#[test]
+fn compact_history_with_llm_summary_preserves_working_memory() {
+    let mut session = SessionRecord::new(PathBuf::from("/tmp/sidecar-wm"));
+    session
+        .working_memory
+        .set_active_task(Some("implement feature".to_string()));
+    session
+        .working_memory
+        .set_context_notice(Some("old notice".to_string()));
+
+    for i in 0..20 {
+        session.push_message(
+            SessionMessage::new(MessageRole::User, "you", format!("msg {i}"))
+                .with_id(format!("u_{i}")),
+        );
+        session.push_message(
+            SessionMessage::new(MessageRole::Assistant, "anvil", format!("reply {i}"))
+                .with_id(format!("a_{i}")),
+        );
+    }
+
+    session.compact_history_with_llm_summary(8, "- summary".to_string());
+
+    assert_eq!(
+        session.working_memory.active_task,
+        Some("implement feature".to_string()),
+        "active_task should be preserved"
+    );
+    assert!(
+        session.working_memory.context_notice.is_none(),
+        "context_notice should be cleared after compaction"
+    );
+}
+
+#[test]
+fn compact_history_with_llm_summary_no_op_when_too_few_messages() {
+    let mut session = SessionRecord::new(PathBuf::from("/tmp/sidecar-noop"));
+    session.push_message(
+        SessionMessage::new(MessageRole::User, "you", "hello".to_string()).with_id("u_1"),
+    );
+
+    let changed = session.compact_history_with_llm_summary(8, "- summary".to_string());
+    assert!(!changed, "should not compact when messages <= keep_recent");
+}
+
+#[test]
+fn build_conversation_text_for_summary_truncates_long_messages() {
+    use anvil::provider::ollama::{OllamaChatMessage, build_conversation_text_for_summary};
+
+    let msgs = vec![
+        OllamaChatMessage {
+            role: "user".to_string(),
+            content: "x".repeat(1000),
+            images: None,
+        },
+        OllamaChatMessage {
+            role: "assistant".to_string(),
+            content: "short reply".to_string(),
+            images: None,
+        },
+    ];
+
+    let text = build_conversation_text_for_summary(&msgs);
+    assert!(text.contains("user: "));
+    assert!(text.contains("assistant: short reply"));
+    // First message should be truncated (500 chars + "...")
+    assert!(text.len() < 1200, "total text should be bounded");
+}
+
+#[test]
+fn build_conversation_text_for_summary_respects_total_limit() {
+    use anvil::provider::ollama::{OllamaChatMessage, build_conversation_text_for_summary};
+
+    let msgs: Vec<OllamaChatMessage> = (0..100)
+        .map(|i| OllamaChatMessage {
+            role: "user".to_string(),
+            content: format!("message number {i} with some padding text to fill space"),
+            images: None,
+        })
+        .collect();
+
+    let text = build_conversation_text_for_summary(&msgs);
+    assert!(
+        text.len() <= 8200,
+        "should respect MAX_TOTAL_CHARS limit, got {}",
+        text.len()
+    );
+}
+
+#[test]
+fn default_sidecar_model_constant() {
+    use anvil::provider::ollama::DEFAULT_SIDECAR_MODEL;
+    assert_eq!(DEFAULT_SIDECAR_MODEL, "qwen3.5:9b");
+}


### PR DESCRIPTION
## Summary
- `--sidecar-model` CLIオプション追加（デフォルト: qwen3.5:9b）
- compact_history実行時にサイドカーモデルへOllama APIで要約リクエストを送信するLLMベース圧縮を実装
- サイドカーモデル利用不可時は既存ルールベース要約にフォールバック
- 設定優先順位: CLI引数 > 環境変数 > 設定ファイル > デフォルト値

## Test plan
- [x] cargo fmt --check: 差分なし
- [x] cargo clippy --all-targets: 警告0件
- [x] cargo test: 全テストパス
- [x] サイドカーモデル要約のユニットテスト追加済み

Closes #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)