### PR TITLE
fix(issue-198): use config.runtime.context_budget in derive_context_budget()

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -164,8 +164,9 @@ impl BasicAgentLoop {
         stream: bool,
         context_window: u32,
         system_prompt: &str,
+        context_budget_override: Option<u32>,
     ) -> ProviderTurnRequest {
-        let token_budget = derive_context_budget(context_window);
+        let token_budget = derive_context_budget(context_window, context_budget_override);
         Self::build_turn_request_with_token_budget(
             model,
             session,
@@ -229,8 +230,9 @@ impl BasicAgentLoop {
         context_window: u32,
         system_prompt: &str,
         calibration_ratio: f64,
+        context_budget_override: Option<u32>,
     ) -> (ProviderTurnRequest, usize) {
-        let token_budget = derive_context_budget(context_window);
+        let token_budget = derive_context_budget(context_window, context_budget_override);
         build_turn_request_with_calibration(
             model,
             session,
@@ -249,8 +251,9 @@ impl BasicAgentLoop {
         context_window: u32,
         system_prompt_tokens: usize,
         calibration_ratio: f64,
+        context_budget_override: Option<u32>,
     ) -> (usize, usize) {
-        let token_budget = derive_context_budget(context_window);
+        let token_budget = derive_context_budget(context_window, context_budget_override);
         let budget_for_messages = token_budget
             .saturating_sub(system_prompt_tokens)
             .max(MINIMUM_MESSAGE_BUDGET);
@@ -645,11 +648,14 @@ fn build_turn_request_with_calibration(
     )
 }
 
-fn derive_context_budget(context_window: u32) -> usize {
-    if let Ok(override_val) = std::env::var("ANVIL_CONTEXT_BUDGET")
-        && let Ok(budget) = override_val.parse::<usize>()
-    {
-        return budget;
+fn derive_context_budget(context_window: u32, context_budget_override: Option<u32>) -> usize {
+    if let Some(budget) = context_budget_override {
+        tracing::debug!(
+            budget = budget,
+            context_window = context_window,
+            "context budget from config override"
+        );
+        return budget as usize;
     }
     let quarter = (context_window / 4) as usize;
     let half = (context_window / 2) as usize;
@@ -1349,7 +1355,7 @@ mod tests {
         }
         // Large context window, small messages => no pruning
         let (pruned, _tokens) =
-            BasicAgentLoop::estimate_pruned_message_count(&session, 128_000, 100, 1.0);
+            BasicAgentLoop::estimate_pruned_message_count(&session, 128_000, 100, 1.0, None);
         assert_eq!(pruned, 0);
     }
 
@@ -1369,7 +1375,7 @@ mod tests {
         }
         // Very small context window to force pruning
         let (pruned, _tokens) =
-            BasicAgentLoop::estimate_pruned_message_count(&session, 512, 50, 1.0);
+            BasicAgentLoop::estimate_pruned_message_count(&session, 512, 50, 1.0, None);
         assert!(pruned > 0, "should prune some messages with tiny budget");
         assert!(pruned < 50, "should keep at least one message");
     }
@@ -1378,8 +1384,34 @@ mod tests {
     fn estimate_pruned_zero_for_empty_session() {
         let session = SessionRecord::new(std::path::PathBuf::from("/tmp/test"));
         let (pruned, tokens) =
-            BasicAgentLoop::estimate_pruned_message_count(&session, 128_000, 100, 1.0);
+            BasicAgentLoop::estimate_pruned_message_count(&session, 128_000, 100, 1.0, None);
         assert_eq!(pruned, 0);
         assert_eq!(tokens, 0);
+    }
+
+    #[test]
+    fn derive_context_budget_uses_override() {
+        // When context_budget_override is Some, it should be used directly
+        let budget = derive_context_budget(128_000, Some(4096));
+        assert_eq!(budget, 4096);
+    }
+
+    #[test]
+    fn derive_context_budget_falls_back_to_default() {
+        // When context_budget_override is None, derive from context_window
+        let budget = derive_context_budget(128_000, None);
+        let expected = (128_000u32 / 4) as usize; // quarter of context_window
+        assert_eq!(budget, expected);
+    }
+
+    #[test]
+    fn derive_context_budget_default_clamps_minimum() {
+        // context_window=2048: quarter=512, half=1024, clamp(256,1024) => 512
+        let budget = derive_context_budget(2048, None);
+        assert_eq!(budget, 512);
+
+        // context_window=512: quarter=128, half=256, clamp(256,256) => 256
+        let budget = derive_context_budget(512, None);
+        assert_eq!(budget, 256);
     }
 }

--- a/src/agent/subagent.rs
+++ b/src/agent/subagent.rs
@@ -483,6 +483,7 @@ impl<'a, C: ProviderClient> SubAgentSession<'a, C> {
             true,
             self.effective_context_window(),
             &self.system_prompt,
+            self.config.runtime.context_budget,
         );
 
         // Stream the LLM response, collecting token deltas

--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -456,6 +456,7 @@ impl App {
                 self.effective_context_window(),
                 &system_prompt,
                 calibration_ratio,
+                self.config.runtime.context_budget,
             );
 
             let mut next_token_buffer = String::new();
@@ -1435,6 +1436,7 @@ impl App {
             self.effective_context_window(),
             &system_prompt,
             calibration_ratio,
+            self.config.runtime.context_budget,
         );
 
         let spinner = Spinner::start(

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -545,6 +545,7 @@ impl App {
             context_window,
             system_prompt_tokens,
             calibration_ratio,
+            self.config.runtime.context_budget,
         );
 
         // 3. Update context_notice
@@ -1039,6 +1040,7 @@ impl App {
             self.effective_context_window(),
             &system_prompt,
             calibration_ratio,
+            self.config.runtime.context_budget,
         );
         self.last_estimated_prompt_tokens = Some(estimated_prompt_tokens);
 

--- a/tests/provider_integration.rs
+++ b/tests/provider_integration.rs
@@ -687,6 +687,7 @@ fn basic_agent_loop_derives_context_budget_from_context_window() {
         true,
         8_000,
         &system_prompt,
+        None,
     );
     let large = anvil::agent::BasicAgentLoop::build_turn_request(
         "local-default",
@@ -694,6 +695,7 @@ fn basic_agent_loop_derives_context_budget_from_context_window() {
         true,
         200_000,
         &system_prompt,
+        None,
     );
 
     assert!(small.messages.len() < large.messages.len());
@@ -1517,6 +1519,7 @@ fn system_prompt_includes_web_fetch_tool() {
         false,
         4096,
         &system_prompt,
+        None,
     );
     assert!(
         request.messages[0].content.contains("web.fetch"),
@@ -1599,6 +1602,7 @@ fn system_prompt_includes_web_search_tool() {
         false,
         4096,
         &system_prompt,
+        None,
     );
     assert!(
         request.messages[0].content.contains("web.search"),
@@ -1616,6 +1620,7 @@ fn system_prompt_includes_github_insights() {
         false,
         4096,
         &system_prompt,
+        None,
     );
     assert!(
         request.messages[0].content.contains("GitHub Insights"),
@@ -1776,6 +1781,7 @@ fn system_prompt_includes_file_edit_tool() {
         false,
         4096,
         &system_prompt,
+        None,
     );
     assert!(
         request.messages[0].content.contains("file.edit"),
@@ -1800,6 +1806,7 @@ fn system_prompt_includes_project_instructions() {
         false,
         4096,
         &system_prompt,
+        None,
     );
 
     assert!(
@@ -1828,6 +1835,7 @@ fn system_prompt_without_project_instructions() {
         false,
         4096,
         &system_prompt,
+        None,
     );
 
     assert!(


### PR DESCRIPTION
## Summary
- `derive_context_budget()` が `config.runtime.context_budget` を参照するよう修正
- CLI引数 `--context-budget`・設定ファイル・環境変数すべてが統一パスで反映される
- `std::env::var("ANVIL_CONTEXT_BUDGET")` の直接参照を削除し、config経由に一本化

## Changes
- `src/agent/mod.rs`: `derive_context_budget()` に `Option<u32>` パラメータ追加、config優先ロジック実装
- `src/agent/subagent.rs`, `src/app/agentic.rs`, `src/app/mod.rs`: 呼び出し箇所でconfigからcontext_budgetを渡すよう修正
- `tests/provider_integration.rs`: context_budget設定時のテスト追加

## Test plan
- [x] cargo fmt --check: Pass
- [x] cargo clippy --all-targets: Pass（警告0件）
- [x] cargo test: Pass（全テスト通過）

Closes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)