### PR TITLE
fix(issue-200): use min(context_window, context_budget) for auto-compact threshold

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -273,16 +273,25 @@ struct CompactParams {
 
 /// Compute compaction parameters from session state and context window.
 /// Returns None if neither token-based nor message-based threshold is exceeded.
-fn compute_compact_params(session: &SessionRecord, context_window: u32) -> Option<CompactParams> {
-    let token_triggered = session.should_smart_compact(context_window);
+/// When `context_budget` is set, uses `min(context_window, context_budget)` for thresholds.
+fn compute_compact_params(
+    session: &SessionRecord,
+    context_window: u32,
+    context_budget: Option<u32>,
+) -> Option<CompactParams> {
+    let token_triggered = session.should_smart_compact(context_window, context_budget);
     let msg_triggered = session.should_compact();
 
     if !token_triggered && !msg_triggered {
         return None;
     }
 
+    let effective_limit = match context_budget {
+        Some(budget) => context_window.min(budget),
+        None => context_window,
+    };
     let token_based = if token_triggered {
-        let target_tokens = (context_window as f64 * crate::session::TARGET_TOKEN_RATIO) as usize;
+        let target_tokens = (effective_limit as f64 * crate::session::TARGET_TOKEN_RATIO) as usize;
         crate::session::compute_token_based_keep_recent(&session.messages, target_tokens)
     } else {
         usize::MAX
@@ -743,7 +752,9 @@ impl App {
     fn compact_with_hooks(&mut self, trigger: &str) -> bool {
         let keep_recent = if trigger == "auto" {
             let context_window = self.effective_context_window();
-            let params = match compute_compact_params(&self.session, context_window) {
+            let context_budget = self.config.runtime.context_budget;
+            let params = match compute_compact_params(&self.session, context_window, context_budget)
+            {
                 Some(p) => p,
                 None => return false,
             };

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -401,11 +401,17 @@ impl SessionRecord {
     }
 
     /// Token-based compaction check.
-    /// Returns true when estimated tokens exceed context_window * ratio.
-    pub fn should_smart_compact(&self, context_window: u32) -> bool {
+    /// Returns true when estimated tokens exceed effective_limit * ratio.
+    /// When `context_budget` is set, uses `min(context_window, context_budget)`
+    /// as the effective limit so that compact triggers within the budget.
+    pub fn should_smart_compact(&self, context_window: u32, context_budget: Option<u32>) -> bool {
+        let effective_limit = match context_budget {
+            Some(budget) => context_window.min(budget),
+            None => context_window,
+        };
         self.smart_compact_threshold_ratio > 0.0
             && self.estimated_token_count()
-                > (context_window as f64 * self.smart_compact_threshold_ratio) as usize
+                > (effective_limit as f64 * self.smart_compact_threshold_ratio) as usize
     }
 
     /// Run auto-compaction if message count exceeds the threshold.

--- a/tests/state_session.rs
+++ b/tests/state_session.rs
@@ -1136,7 +1136,7 @@ fn should_smart_compact_below_threshold() {
     session.smart_compact_threshold_ratio = 0.75;
     session.push_message(new_user_message("m1", "hello"));
     // 1 message, far below any threshold
-    assert!(!session.should_smart_compact(200_000));
+    assert!(!session.should_smart_compact(200_000, None));
 }
 
 #[test]
@@ -1152,7 +1152,7 @@ fn should_smart_compact_above_threshold() {
     }
     // With context_window=1000, threshold = 750 tokens
     // 100 messages * ~50 tokens = ~5000 tokens > 750
-    assert!(session.should_smart_compact(1000));
+    assert!(session.should_smart_compact(1000, None));
 }
 
 #[test]
@@ -1163,7 +1163,7 @@ fn should_smart_compact_ratio_zero_disabled() {
         session.push_message(new_user_message(format!("m{i}"), "a".repeat(200)));
     }
     // ratio=0.0 means smart compact is disabled
-    assert!(!session.should_smart_compact(1000));
+    assert!(!session.should_smart_compact(1000, None));
 }
 
 #[test]
@@ -1173,7 +1173,27 @@ fn should_smart_compact_small_context_window() {
     // MIN_CONTEXT_WINDOW = 1000, threshold = 750
     session.push_message(new_user_message("m1", "a".repeat(400)));
     // ~100 tokens, below 750
-    assert!(!session.should_smart_compact(1000));
+    assert!(!session.should_smart_compact(1000, None));
+}
+
+/// Issue #200: should_smart_compact respects context_budget
+#[test]
+fn should_smart_compact_respects_context_budget() {
+    let mut session = SessionRecord::new(PathBuf::from("/tmp/test"));
+    session.smart_compact_threshold_ratio = 0.75;
+    // Fill with messages to get ~5000 tokens
+    for i in 0..100 {
+        session.push_message(new_user_message(
+            format!("m{i}"),
+            "a".repeat(200), // ~50 tokens each
+        ));
+    }
+    // context_window=262144 alone → threshold=196608, won't trigger
+    assert!(!session.should_smart_compact(262_144, None));
+    // With context_budget=4000 → effective=4000, threshold=3000 → 5000>3000 triggers
+    assert!(session.should_smart_compact(262_144, Some(4000)));
+    // context_budget larger than context_window → effective=context_window, no change
+    assert!(!session.should_smart_compact(262_144, Some(300_000)));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- auto-compact閾値計算で `context_budget` を考慮するよう修正
- `should_smart_compact()` と `compute_compact_params()` に `context_budget: Option<u32>` を追加
- `context_budget` 設定時は `min(context_window, context_budget)` を基準にcompact発動を判定

## Changes
- `src/session/mod.rs`: `should_smart_compact()` に `context_budget` パラメータ追加
- `src/app/mod.rs`: `compute_compact_params()` で `context_budget` を渡す
- `tests/state_session.rs`: `context_budget` 設定時のcompact発動テスト追加

## Test plan
- [x] cargo fmt --check: Pass
- [x] cargo clippy --all-targets: Pass（警告0件）
- [x] cargo test: Pass（全テスト通過）

Closes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)