### PR TITLE
fix(issue-204): add max_output_tokens to prevent infinite LLM stream

### DIFF
--- a/src/agent/subagent.rs
+++ b/src/agent/subagent.rs
@@ -477,7 +477,7 @@ impl<'a, C: ProviderClient> SubAgentSession<'a, C> {
     /// Execute one LLM turn: request -> stream -> parse -> validate -> execute -> record.
     fn run_turn(&mut self) -> Result<TurnOutcome, SubAgentError> {
         // Build the provider request
-        let request = BasicAgentLoop::build_turn_request(
+        let mut request = BasicAgentLoop::build_turn_request(
             self.effective_model(),
             &self.session,
             true,
@@ -485,6 +485,7 @@ impl<'a, C: ProviderClient> SubAgentSession<'a, C> {
             &self.system_prompt,
             self.config.runtime.context_budget,
         );
+        request.max_output_tokens = self.config.runtime.max_output_tokens;
 
         // Stream the LLM response, collecting token deltas
         let mut token_buffer = String::new();

--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -449,7 +449,7 @@ impl App {
             );
 
             let (system_prompt, calibration_ratio) = self.prepare_turn_context();
-            let (request, _) = BasicAgentLoop::build_turn_request_calibrated(
+            let (mut request, _) = BasicAgentLoop::build_turn_request_calibrated(
                 self.effective_model().to_string(),
                 &self.session,
                 self.provider.capabilities.streaming && self.config.runtime.stream,
@@ -458,6 +458,7 @@ impl App {
                 calibration_ratio,
                 self.config.runtime.context_budget,
             );
+            request.max_output_tokens = self.config.runtime.max_output_tokens;
 
             let mut next_token_buffer = String::new();
             let mut first_token = true;
@@ -1429,7 +1430,7 @@ impl App {
     ) -> Result<Vec<String>, AppError> {
         // Build request and call LLM for one more turn
         let (system_prompt, calibration_ratio) = self.prepare_turn_context();
-        let (request, _) = BasicAgentLoop::build_turn_request_calibrated(
+        let (mut request, _) = BasicAgentLoop::build_turn_request_calibrated(
             self.effective_model().to_string(),
             &self.session,
             self.provider.capabilities.streaming && self.config.runtime.stream,
@@ -1438,6 +1439,7 @@ impl App {
             calibration_ratio,
             self.config.runtime.context_budget,
         );
+        request.max_output_tokens = self.config.runtime.max_output_tokens;
 
         let spinner = Spinner::start(
             format!("ANVIL_FINAL guard retry. model={}", self.effective_model()),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1044,7 +1044,7 @@ impl App {
         self.begin_live_turn_state()?;
 
         let (system_prompt, calibration_ratio) = self.prepare_turn_context();
-        let (request, estimated_prompt_tokens) = BasicAgentLoop::build_turn_request_calibrated(
+        let (mut request, estimated_prompt_tokens) = BasicAgentLoop::build_turn_request_calibrated(
             self.effective_model().to_string(),
             &self.session,
             self.provider.capabilities.streaming && self.config.runtime.stream,
@@ -1053,6 +1053,7 @@ impl App {
             calibration_ratio,
             self.config.runtime.context_budget,
         );
+        request.max_output_tokens = self.config.runtime.max_output_tokens;
         self.last_estimated_prompt_tokens = Some(estimated_prompt_tokens);
 
         // Phase 1: Collect events from provider with spinner + streaming output.

--- a/src/config/cli_args.rs
+++ b/src/config/cli_args.rs
@@ -120,6 +120,10 @@ pub struct CliArgs {
     /// Maximum total tool calls per agentic turn [default: 200]
     #[arg(long = "max-tool-calls")]
     pub max_tool_calls: Option<usize>,
+
+    /// Maximum output tokens per LLM turn [default: 16384]
+    #[arg(long = "max-output-tokens")]
+    pub max_output_tokens: Option<u32>,
 }
 
 impl CliArgs {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -150,6 +150,9 @@ pub struct RuntimeConfig {
     pub ui_language: Option<String>,
     /// Maximum total tool calls per agentic turn (Issue #172).
     pub max_tool_calls: usize,
+    /// Maximum output tokens per LLM turn (Issue #204).
+    /// Translated to provider-specific limits (Ollama `num_predict`, OpenAI `max_tokens`).
+    pub max_output_tokens: Option<u32>,
 }
 
 #[derive(Debug, Clone)]
@@ -324,6 +327,7 @@ impl EffectiveConfig {
                 read_repeat_strong_warn_threshold: 6,
                 ui_language: None,
                 max_tool_calls: DEFAULT_MAX_TOOL_CALLS,
+                max_output_tokens: Some(DEFAULT_MAX_OUTPUT_TOKENS),
             },
             mode: ModeConfig {
                 prompt_source: PromptSource::Interactive,
@@ -555,6 +559,11 @@ impl EffectiveConfig {
         // Max tool calls (Issue #172)
         if let Some(v) = cli.max_tool_calls {
             self.runtime.max_tool_calls = v;
+        }
+
+        // Max output tokens (Issue #204)
+        if let Some(v) = cli.max_output_tokens {
+            self.runtime.max_output_tokens = if v == 0 { None } else { Some(v) };
         }
 
         // --session flag: override session file path
@@ -799,6 +808,12 @@ impl EffectiveConfig {
                     self.runtime.max_tool_calls = value
                         .parse()
                         .map_err(|_| ConfigError::InvalidNumericValue(value.clone()))?;
+                }
+                "max_output_tokens" | "ANVIL_MAX_OUTPUT_TOKENS" => {
+                    let v: u32 = value
+                        .parse()
+                        .map_err(|_| ConfigError::InvalidNumericValue(value.clone()))?;
+                    self.runtime.max_output_tokens = if v == 0 { None } else { Some(v) };
                 }
                 _ => {}
             }
@@ -1096,6 +1111,8 @@ const MAX_AGENT_ITERATIONS: usize = 100;
 pub const DEFAULT_MAX_TOOL_CALLS: usize = 200;
 /// Hard upper limit for max_tool_calls (Issue #172).
 pub const MAX_TOOL_CALLS_LIMIT: usize = 10000;
+/// Default maximum output tokens per LLM turn (Issue #204).
+pub const DEFAULT_MAX_OUTPUT_TOKENS: u32 = 16384;
 
 /// Sensitive keys and their recommended environment variable names.
 /// To add a new sensitive key, simply add an entry to this array.

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -18,9 +18,10 @@ use std::sync::atomic::AtomicBool;
 // Re-export key types so existing `use crate::provider::*` continues to work.
 pub use ollama::{
     OllamaChatMessage, OllamaChatRequest, OllamaModelEntry, OllamaModelInfo, OllamaProviderClient,
-    fetch_context_length_from_ollama, fetch_model_info_from_ollama, fetch_model_list_from_ollama,
-    parse_context_length_from_show_response, parse_model_info_from_show_response,
-    parse_model_list_from_tags_response, resolve_ollama_model_alias,
+    OllamaRequestOptions, fetch_context_length_from_ollama, fetch_model_info_from_ollama,
+    fetch_model_list_from_ollama, parse_context_length_from_show_response,
+    parse_model_info_from_show_response, parse_model_list_from_tags_response,
+    resolve_ollama_model_alias,
 };
 pub use transport::{
     DEFAULT_HTTP_TIMEOUT_SECS, HttpResponse, HttpTransport, ReqwestHttpTransport, RetryConfig,
@@ -104,6 +105,10 @@ pub struct ProviderTurnRequest {
     pub model: String,
     pub messages: Vec<ProviderMessage>,
     pub stream: bool,
+    /// Maximum number of tokens the LLM may generate in this turn.
+    /// When set, providers translate this to their native limit parameter
+    /// (e.g. Ollama `num_predict`, OpenAI `max_tokens`).
+    pub max_output_tokens: Option<u32>,
 }
 
 impl ProviderTurnRequest {
@@ -112,6 +117,7 @@ impl ProviderTurnRequest {
             model,
             messages,
             stream,
+            max_output_tokens: None,
         }
     }
 }

--- a/src/provider/ollama.rs
+++ b/src/provider/ollama.rs
@@ -32,6 +32,14 @@ pub struct OllamaChatMessage {
     pub images: Option<Vec<String>>,
 }
 
+/// Ollama request options (e.g. `num_predict` for output token limit).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct OllamaRequestOptions {
+    /// Maximum number of tokens to generate (maps to Ollama `num_predict`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub num_predict: Option<u32>,
+}
+
 /// Wire format for an Ollama `/api/chat` request.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct OllamaChatRequest {
@@ -40,6 +48,8 @@ pub struct OllamaChatRequest {
     pub stream: bool,
     #[serde(default)]
     pub think: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub options: Option<OllamaRequestOptions>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -136,6 +146,9 @@ impl<T> OllamaProviderClient<T> {
                 .collect(),
             stream: request.stream,
             think: false,
+            options: request.max_output_tokens.map(|n| OllamaRequestOptions {
+                num_predict: Some(n),
+            }),
         }
     }
 
@@ -250,6 +263,7 @@ impl<T: HttpTransport> OllamaProviderClient<T> {
             ],
             stream: false,
             think: false,
+            options: None,
         };
 
         let body = serde_json::to_vec(&request).ok()?;

--- a/src/provider/openai.rs
+++ b/src/provider/openai.rs
@@ -31,6 +31,8 @@ struct OpenAiChatRequest {
     stream: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     stream_options: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    max_tokens: Option<u32>,
 }
 
 /// Request message: content is `Value` to support both plain text and
@@ -193,6 +195,7 @@ impl<T> OpenAiCompatibleProviderClient<T> {
                 .collect(),
             stream: request.stream,
             stream_options,
+            max_tokens: request.max_output_tokens,
         }
     }
 }

--- a/tests/provider_integration.rs
+++ b/tests/provider_integration.rs
@@ -3989,6 +3989,7 @@ fn sidecar_summarize_success_with_mock_server() {
         ],
         stream: false,
         think: false,
+        options: None,
     };
     let json = serde_json::to_string(&request).expect("should serialize");
     assert!(json.contains("qwen2.5:3b"));
@@ -4007,5 +4008,154 @@ fn error_guidance_mentions_sidecar_keys() {
     assert!(
         guidance.contains("sidecar_provider_url"),
         "error guidance should mention sidecar_provider_url: {guidance}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Issue #204: max_output_tokens / infinite stream guard
+// ---------------------------------------------------------------------------
+
+#[test]
+fn ollama_request_includes_num_predict_when_max_output_tokens_set() {
+    let mut request = ProviderTurnRequest::new(
+        "test-model".to_string(),
+        vec![anvil::provider::ProviderMessage::new(
+            ProviderMessageRole::User,
+            "hello",
+        )],
+        true,
+    );
+    request.max_output_tokens = Some(16384);
+
+    let ollama_request =
+        OllamaProviderClient::<anvil::provider::ReqwestHttpTransport>::build_chat_request(&request);
+
+    let options = ollama_request
+        .options
+        .expect("options should be set when max_output_tokens is Some");
+    assert_eq!(options.num_predict, Some(16384));
+}
+
+#[test]
+fn ollama_request_omits_options_when_max_output_tokens_none() {
+    let request = ProviderTurnRequest::new(
+        "test-model".to_string(),
+        vec![anvil::provider::ProviderMessage::new(
+            ProviderMessageRole::User,
+            "hello",
+        )],
+        true,
+    );
+
+    let ollama_request =
+        OllamaProviderClient::<anvil::provider::ReqwestHttpTransport>::build_chat_request(&request);
+
+    assert!(
+        ollama_request.options.is_none(),
+        "options should be None when max_output_tokens is not set"
+    );
+}
+
+#[test]
+fn ollama_request_serializes_num_predict_correctly() {
+    let mut request = ProviderTurnRequest::new(
+        "test-model".to_string(),
+        vec![anvil::provider::ProviderMessage::new(
+            ProviderMessageRole::User,
+            "hello",
+        )],
+        true,
+    );
+    request.max_output_tokens = Some(8192);
+
+    let ollama_request =
+        OllamaProviderClient::<anvil::provider::ReqwestHttpTransport>::build_chat_request(&request);
+    let json = serde_json::to_string(&ollama_request).expect("should serialize");
+    assert!(
+        json.contains("\"num_predict\":8192"),
+        "serialized request should contain num_predict: {json}"
+    );
+}
+
+#[test]
+fn openai_request_includes_max_tokens_when_set() {
+    let mut request = ProviderTurnRequest::new(
+        "test-model".to_string(),
+        vec![anvil::provider::ProviderMessage::new(
+            ProviderMessageRole::User,
+            "hello",
+        )],
+        false,
+    );
+    request.max_output_tokens = Some(16384);
+
+    // Use mock transport to capture the serialized request body
+    let seen_bodies = Rc::new(RefCell::new(Vec::new()));
+    let transport = MockHttpTransport {
+        seen_urls: Rc::new(RefCell::new(Vec::new())),
+        seen_bodies: seen_bodies.clone(),
+        seen_headers: Rc::new(RefCell::new(Vec::new())),
+        response: HttpResponse {
+            status_code: 200,
+            body: br#"{"choices":[{"message":{"role":"assistant","content":"ok"}}]}"#.to_vec(),
+        },
+        get_response: None,
+    };
+    let client = anvil::provider::openai::OpenAiCompatibleProviderClient::with_transport(
+        "http://localhost:1234",
+        transport,
+    );
+
+    let mut events = Vec::new();
+    client
+        .stream_turn(&request, &mut |event| events.push(event))
+        .expect("should succeed");
+
+    let bodies = seen_bodies.borrow();
+    assert!(!bodies.is_empty(), "should have sent a request");
+    let body_str = String::from_utf8_lossy(&bodies[0]);
+    assert!(
+        body_str.contains("\"max_tokens\":16384"),
+        "request body should contain max_tokens: {body_str}"
+    );
+}
+
+#[test]
+fn openai_request_omits_max_tokens_when_none() {
+    let request = ProviderTurnRequest::new(
+        "test-model".to_string(),
+        vec![anvil::provider::ProviderMessage::new(
+            ProviderMessageRole::User,
+            "hello",
+        )],
+        false,
+    );
+
+    let seen_bodies = Rc::new(RefCell::new(Vec::new()));
+    let transport = MockHttpTransport {
+        seen_urls: Rc::new(RefCell::new(Vec::new())),
+        seen_bodies: seen_bodies.clone(),
+        seen_headers: Rc::new(RefCell::new(Vec::new())),
+        response: HttpResponse {
+            status_code: 200,
+            body: br#"{"choices":[{"message":{"role":"assistant","content":"ok"}}]}"#.to_vec(),
+        },
+        get_response: None,
+    };
+    let client = anvil::provider::openai::OpenAiCompatibleProviderClient::with_transport(
+        "http://localhost:1234",
+        transport,
+    );
+
+    let mut events = Vec::new();
+    client
+        .stream_turn(&request, &mut |event| events.push(event))
+        .expect("should succeed");
+
+    let bodies = seen_bodies.borrow();
+    let body_str = String::from_utf8_lossy(&bodies[0]);
+    assert!(
+        !body_str.contains("max_tokens"),
+        "request body should NOT contain max_tokens when None: {body_str}"
     );
 }


### PR DESCRIPTION
## Summary
- LLMが壊れたトークンを無限生成する場合のハング防止策を追加
- `--max-output-tokens` CLIオプション追加（デフォルト16384）
- Ollama `num_predict`、OpenAI `max_tokens` パラメータに反映
- `ProviderTurnRequest` に `max_output_tokens` フィールド追加

## Changes
- `src/config/mod.rs`, `src/config/cli_args.rs`: `max_output_tokens` 設定追加
- `src/provider/mod.rs`: `ProviderTurnRequest` に `max_output_tokens` フィールド追加
- `src/provider/ollama.rs`: `OllamaChatRequest` に `options.num_predict` 設定
- `src/provider/openai.rs`: `OpenAiChatRequest` に `max_tokens` 設定
- `src/app/agentic.rs`, `src/app/mod.rs`, `src/agent/subagent.rs`: リクエスト構築時に `max_output_tokens` を設定
- `tests/provider_integration.rs`: テスト追加

## Test plan
- [x] cargo fmt --check: Pass
- [x] cargo clippy --all-targets: Pass
- [x] cargo test: Pass（全テスト通過）

Closes #204

🤖 Generated with [Claude Code](https://claude.com/claude-code)