### PR TITLE
fix(issue-208): use context_budget in turn summary budget display

### DIFF
--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -519,7 +519,7 @@ impl App {
             request.max_output_tokens = self.config.runtime.max_output_tokens;
 
             // Budget pressure WARN (Issue #206 D-2)
-            let token_budget = self.effective_context_window() as usize;
+            let token_budget = self.effective_token_budget();
             if token_budget > 0 {
                 let usage_ratio = used_tokens as f64 / token_budget as f64;
                 if usage_ratio >= 0.9 {
@@ -1723,7 +1723,7 @@ impl App {
             }
             // CB-002: Record turn stats for non-tool turns
             self.session_stats.record_turn();
-            let token_budget = self.effective_context_window() as usize;
+            let token_budget = self.effective_token_budget();
             log_turn_summary(&TurnSummary {
                 turn: self.session_stats.total_turns,
                 max_turns: self.config.runtime.max_agent_iterations as u32,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1005,6 +1005,18 @@ impl App {
             .unwrap_or(self.config.runtime.context_window)
     }
 
+    /// Return the effective token budget for this session.
+    ///
+    /// When `context_budget` is configured, returns that value (clamped to
+    /// the context window). Otherwise falls back to the context window.
+    pub fn effective_token_budget(&self) -> usize {
+        let cw = self.effective_context_window();
+        match self.config.runtime.context_budget {
+            Some(budget) => cw.min(budget) as usize,
+            None => cw as usize,
+        }
+    }
+
     /// Switch to a different named session.
     ///
     /// Validates the name, saves the current session, builds a new
@@ -2672,5 +2684,33 @@ mod tests {
         let counts = vec![("shell.exec".to_string(), 5u32)];
         let result = format_tool_counts(counts.into_iter());
         assert_eq!(result, "shell.exec x5");
+    }
+
+    // --- Issue #208: effective_token_budget logic ---
+
+    /// Regression test for Issue #208: when context_budget is set, the
+    /// effective token budget must use min(context_window, context_budget),
+    /// NOT the raw context_window.
+    #[test]
+    fn effective_token_budget_uses_context_budget() {
+        // Simulates the logic in App::effective_token_budget
+        let context_window: u32 = 262_144;
+        let context_budget: Option<u32> = Some(32_768);
+        let effective = match context_budget {
+            Some(budget) => context_window.min(budget) as usize,
+            None => context_window as usize,
+        };
+        assert_eq!(effective, 32_768);
+    }
+
+    #[test]
+    fn effective_token_budget_falls_back_to_context_window() {
+        let context_window: u32 = 262_144;
+        let context_budget: Option<u32> = None;
+        let effective = match context_budget {
+            Some(budget) => context_window.min(budget) as usize,
+            None => context_window as usize,
+        };
+        assert_eq!(effective, 262_144);
     }
 }


### PR DESCRIPTION
## Summary
- ターンサマリーログの budget 表示が `context_window` を参照していた問題を修正
- `context_budget` 設定時は `min(context_window, context_budget)` を表示するよう変更
- `effective_token_budget()` メソッドを追加し、budget表示を一元化

## Changes
- `src/app/agentic.rs`: ターンサマリーのbudget値を `effective_token_budget()` から取得
- `src/app/mod.rs`: `effective_token_budget()` メソッド追加

## Test plan
- [x] cargo fmt --check: Pass
- [x] cargo clippy --all-targets: Pass
- [x] cargo test: Pass

Closes #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)