### PR TITLE
chore: release v0.0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 ## [Unreleased]
 
+## [0.0.8] - 2026-03-31
+
+### Added
+- ANVIL.md custom tool registration with `## tools` section (#193)
+- Sidecar model LLM-based context summarization (#195)
+- Read repeat tracker to detect and warn repeated file.read (#185)
+- Write repeat tracker to prevent file.edit→file.write loop (#184)
+- Duplicate tool call deduplication in single turn (#186)
+- Debug observability with turn summaries, file.edit details, and session metrics (#206)
+- Cause-analysis and current-situation slash commands
+
+### Fixed
+- Raise thresholds to reduce CI-induced implementation suppression (#187)
+- Use `min(context_window, context_budget)` for auto-compact threshold (#200)
+- Use `config.runtime.context_budget` in `derive_context_budget()` (#198)
+- Run auto-compact in non-interactive mode (`--exec-file`/`--exec`/`--oneshot`) (#202)
+- Add `max_output_tokens` to prevent infinite LLM stream (#204)
+- Use `context_budget` instead of `context_window` in turn summary budget display (#208)
+
+### Changed
+- Improve sidecar summarization prompt for coding tasks (#209)
+- Enforce Codex reviewer via `--agent codex` in multi-stage review commands
+
 ## [0.0.7] - 2026-03-27
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,7 +72,7 @@ dependencies = [
 
 [[package]]
 name = "anvil"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anvil"
-version = "0.0.7"
+version = "0.0.8"
 edition = "2024"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ```bash
 # macOS (Apple Silicon)
-curl -L https://github.com/Kewton/Anvil/releases/download/v0.0.7/anvil-darwin-arm64.gz -o anvil.gz
+curl -L https://github.com/Kewton/Anvil/releases/download/v0.0.8/anvil-darwin-arm64.gz -o anvil.gz
 gunzip anvil.gz
 chmod +x anvil
 sudo mv anvil /usr/local/bin/


### PR DESCRIPTION
## Summary
- Bump version from 0.0.7 to 0.0.8
- Update CHANGELOG.md with all changes since v0.0.7
- Update README.md download link to v0.0.8

### Highlights
- ANVIL.md custom tool registration (#193)
- Sidecar model LLM-based context summarization (#195)
- Read/write repeat trackers (#184, #185)
- Multiple context budget and auto-compact fixes (#198, #200, #202, #204, #208)
- Debug observability improvements (#206)

🤖 Generated with [Claude Code](https://claude.com/claude-code)