### PR TITLE
release: develop → main (Issues #214, #215 + read_transition_guard)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ ollama pull qwen3.5:latest       # モデル取得（例）
 
 ```bash
 # LM Studio 等でサーバーを起動し、URL とモデル名を指定
+# provider-url は http://localhost:1234 と http://localhost:1234/v1 のどちらでも利用できます
 anvil --provider openai --provider-url http://localhost:1234 --model your-model
 ```
 
@@ -273,7 +274,7 @@ export SERPER_API_KEY=...          # Serper Web検索APIキー
 | プロバイダー | 設定例 |
 |-------------|--------|
 | Ollama | `anvil --model qwen3.5:35b` (デフォルト) |
-| OpenAI互換 | `anvil --provider openai --provider-url http://localhost:1234 --model your-model` |
+| OpenAI互換 | `anvil --provider openai --provider-url http://localhost:1234 --model your-model` (`/v1` 付きURLも可) |
 | API キー認証 | `ANVIL_API_KEY=Bearer sk-...` を環境変数に設定 |
 
 ---

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ ollama pull qwen3.5:latest       # モデル取得（例）
 # LM Studio 等でサーバーを起動し、URL とモデル名を指定
 # provider-url は http://localhost:1234 と http://localhost:1234/v1 のどちらでも利用できます
 anvil --provider openai --provider-url http://localhost:1234 --model your-model
+
+# LM Studio を使うだけなら lmstudio エイリアスも利用できます
+anvil --provider lmstudio --model your-model
 ```
 
 ### 3. 起動
@@ -216,7 +219,7 @@ ANVIL_API_KEY=sk-...              # OpenAI互換APIキー
 ```
 anvil [OPTIONS]
 
-  -p, --provider <PROVIDER>              プロバイダー (ollama|openai)
+  -p, --provider <PROVIDER>              プロバイダー (ollama|openai|lmstudio)
   -m, --model <MODEL>                    モデル名
   -u, --provider-url <URL>               プロバイダーURL
       --sidecar-model <MODEL>            サイドカーモデル名
@@ -274,6 +277,7 @@ export SERPER_API_KEY=...          # Serper Web検索APIキー
 | プロバイダー | 設定例 |
 |-------------|--------|
 | Ollama | `anvil --model qwen3.5:35b` (デフォルト) |
+| LM Studio | `anvil --provider lmstudio --model your-model` |
 | OpenAI互換 | `anvil --provider openai --provider-url http://localhost:1234 --model your-model` (`/v1` 付きURLも可) |
 | API キー認証 | `ANVIL_API_KEY=Bearer sk-...` を環境変数に設定 |
 

--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -25,6 +25,7 @@ use crate::tooling::{PermissionClass, effective_permission_class};
 
 use super::policy::{OFFLINE_BLOCK_PAYLOAD, check_offline_blocked};
 use super::read_repeat_tracker::ReadRepeatAction;
+use super::read_transition_guard::ReadTransitionAction;
 use super::write_repeat_tracker::WriteRepeatAction;
 use super::{App, AppError, CompactInfo, format_tool_counts};
 
@@ -233,11 +234,21 @@ fn execute_parallel_group_standalone(
 
 /// Maximum number of ANVIL_FINAL guard retries (no-file-modification detection).
 const MAX_FINAL_GUARD_RETRIES: u8 = 1;
+const FILE_READ_RESULT_MAX_CHARS: usize = 2_000;
+const SYNTHETIC_GUIDANCE_RESULT_MAX_CHARS: usize = 1_200;
 
 /// Message sent to LLM when ANVIL_FINAL fires without file modifications.
 const FINAL_GUARD_RETRY_MESSAGE: &str = "No file modifications detected (file.write/file.edit not called). \
      Please implement the changes rather than just planning them. \
      Use file.write or file.edit to make the necessary code changes.";
+
+/// Synthetic guidance tools that must be shown to the model before accepting
+/// an ANVIL_FINAL termination.
+const GUIDANCE_TOOL_NAMES: &[&str] = &[
+    "system.read_guard",
+    "system.loop_detector",
+    "system.phase_estimator",
+];
 
 /// Maximum number of sub-agent calls allowed in a single turn (SR4-006).
 const MAX_SUBAGENT_CALLS_PER_TURN: usize = 3;
@@ -347,6 +358,20 @@ impl App {
         retries < MAX_FINAL_GUARD_RETRIES && self.session.working_memory.touched_files.is_empty()
     }
 
+    /// Check whether synthetic guidance was injected in the current turn and
+    /// should be shown to the model before honoring ANVIL_FINAL.
+    fn should_activate_guidance_retry(
+        &self,
+        already_used: bool,
+        results: &[ToolExecutionResult],
+    ) -> bool {
+        !already_used
+            && self.session.working_memory.touched_files.is_empty()
+            && results
+                .iter()
+                .any(|r| GUIDANCE_TOOL_NAMES.contains(&r.tool_name.as_str()))
+    }
+
     /// Inject a retry message into the session to prompt the LLM for actual implementation.
     /// See also: PROMPT_TOOL_RULES in src/agent/mod.rs for preventive guidance.
     fn inject_final_guard_retry(&mut self) {
@@ -387,6 +412,8 @@ impl App {
         let mut all_tool_log_views: Vec<ToolLogView> = Vec::new();
         let mut final_guard_retries: u8 = 0;
         let mut fallback_completed = false;
+        let mut guidance_retry_used = false;
+        let mut awaiting_guidance_followup = false;
         // Issue #173: Track whether ANVIL_FINAL has been seen in this session.
         // When true, the loop will terminate after executing the current batch
         // of tool calls (no further LLM round-trips).
@@ -398,6 +425,8 @@ impl App {
         self.alternating_loop_detector.reset();
         // Reset phase estimator per-turn counters (Issue #159)
         self.phase_estimator.reset();
+        // Reset read transition guard per-turn counters (Issue #216)
+        self.read_transition_guard.reset();
 
         for iteration in 0..max_iterations {
             let iteration_started = std::time::Instant::now();
@@ -477,8 +506,17 @@ impl App {
             // Issue #173: If ANVIL_FINAL was already seen, terminate after
             // executing the current tool batch (no further LLM round-trips).
             if anvil_final_seen {
-                tracing::info!("ANVIL_FINAL detected; terminating after tool execution");
-                break;
+                if self.should_activate_guidance_retry(guidance_retry_used, &results) {
+                    tracing::info!(
+                        "ANVIL_FINAL delayed: synthetic guidance injected, sending one follow-up turn"
+                    );
+                    guidance_retry_used = true;
+                    awaiting_guidance_followup = true;
+                    anvil_final_seen = false;
+                } else {
+                    tracing::info!("ANVIL_FINAL detected; terminating after tool execution");
+                    break;
+                }
             }
 
             // Max tool calls check (Issue #172)
@@ -632,6 +670,27 @@ impl App {
             }
 
             if next_structured.tool_calls.is_empty() {
+                if awaiting_guidance_followup {
+                    awaiting_guidance_followup = false;
+                    if self.should_activate_final_guard(final_guard_retries) {
+                        tracing::info!(
+                            "Guidance follow-up ended without edits; escalating to final guard retry"
+                        );
+                        if !next_structured.anvil_final_detected {
+                            self.phase_estimator.observe_anvil_final();
+                        }
+                        self.inject_final_guard_retry();
+                        final_guard_retries += 1;
+                        current = next_structured;
+                        continue;
+                    }
+                    tracing::info!("Guidance follow-up completed; accepting response");
+                    self.record_assistant_output(
+                        self.next_message_id("assistant"),
+                        next_structured.final_response,
+                    )?;
+                    break;
+                }
                 // ANVIL_FINAL guard: check if any file modifications were made
                 if self.should_activate_final_guard(final_guard_retries) {
                     // ANVIL_FINAL was detected → record observation (Issue #159)
@@ -668,6 +727,9 @@ impl App {
             }
 
             // More tool calls — continue the loop
+            if awaiting_guidance_followup {
+                awaiting_guidance_followup = false;
+            }
             current = next_structured;
         }
 
@@ -1162,6 +1224,7 @@ impl App {
         indexed_results.sort_by_key(|(idx, _)| *idx);
         let mut results: Vec<ToolExecutionResult> = Vec::with_capacity(indexed_results.len());
         let mut phase_action = super::phase_estimator::PhaseAction::Continue;
+        let mut read_transition_message: Option<String> = None;
         for (_, result) in indexed_results {
             self.record_tool_result(&result);
             // Phase estimator: record tool call pattern (Issue #159)
@@ -1171,6 +1234,12 @@ impl App {
                 .record_tool_call(&result.tool_name, success);
             if !matches!(pa, super::phase_estimator::PhaseAction::Continue) {
                 phase_action = pa;
+            }
+            let transition_action = self
+                .read_transition_guard
+                .record_tool_call(&result.tool_name, success);
+            if let ReadTransitionAction::Inject(msg) = transition_action {
+                read_transition_message = Some(msg);
             }
 
             // Emit folded tool result to stderr for interactive sessions
@@ -1226,12 +1295,29 @@ impl App {
             results.push(warning_result);
         }
 
+        if let Some(ref msg) = read_transition_message {
+            let transition_result = ToolExecutionResult {
+                tool_call_id: "read_transition_guard".to_string(),
+                tool_name: "system.read_guard".to_string(),
+                status: ToolExecutionStatus::Completed,
+                summary: msg.clone(),
+                payload: ToolExecutionPayload::Text(msg.clone()),
+                artifacts: vec![],
+                elapsed_ms: 0,
+                diff_summary: None,
+                edit_detail: None,
+            };
+            self.record_tool_result(&transition_result);
+            results.push(transition_result);
+        }
+
         // Phase estimator: inject force-transition message if needed (Issue #159).
-        // Skip if LoopDetector already issued a warning (priority: LoopDetector > PhaseEstimator).
+        // Skip if LoopDetector or read transition guard already issued a warning.
         if matches!(
             worst_loop_action,
             super::loop_detector::LoopAction::Continue
-        ) && let super::phase_estimator::PhaseAction::ForceTransition(msg) = phase_action
+        ) && read_transition_message.is_none()
+            && let super::phase_estimator::PhaseAction::ForceTransition(msg) = phase_action
         {
             // Context window protection: skip if usage >= 90%
             let usage = crate::contracts::ContextUsageView {
@@ -1894,6 +1980,7 @@ fn extract_write_path_from_summary(summary: &str) -> Option<String> {
 /// Includes the actual payload (file content, search matches) so the LLM
 /// can reason about the results in subsequent turns.
 pub fn format_tool_result_message(result: &ToolExecutionResult, max_chars: usize) -> String {
+    let max_chars = effective_tool_result_max_chars(result.tool_name.as_str(), max_chars);
     match &result.payload {
         ToolExecutionPayload::None => {
             format!("[tool result: {}] {}", result.tool_name, result.summary)
@@ -1904,6 +1991,15 @@ pub fn format_tool_result_message(result: &ToolExecutionResult, max_chars: usize
                 ToolExecutionStatus::Failed | ToolExecutionStatus::Interrupted => 20,
             };
             let truncated = truncate_with_head_tail(content, max_chars, head_pct);
+            if result.tool_name == "file.read"
+                && result.status == ToolExecutionStatus::Completed
+                && let Some(path) = result.artifacts.first()
+            {
+                return format!(
+                    "[tool result: {}] {}\nPath: {}\n{}",
+                    result.tool_name, result.summary, path, truncated
+                );
+            }
             format!(
                 "[tool result: {}] {}\n{}",
                 result.tool_name, result.summary, truncated
@@ -1925,6 +2021,16 @@ pub fn format_tool_result_message(result: &ToolExecutionResult, max_chars: usize
                 result.tool_name, source_path
             )
         }
+    }
+}
+
+fn effective_tool_result_max_chars(tool_name: &str, default_max_chars: usize) -> usize {
+    match tool_name {
+        "file.read" => default_max_chars.min(FILE_READ_RESULT_MAX_CHARS),
+        name if name.starts_with("system.") => {
+            default_max_chars.min(SYNTHETIC_GUIDANCE_RESULT_MAX_CHARS)
+        }
+        _ => default_max_chars,
     }
 }
 
@@ -2185,5 +2291,29 @@ mod trust_tests {
         assert!(result.contains("file.read"));
         assert!(result.contains("file.edit"));
         assert!(result.contains("shell.exec"));
+    }
+
+    #[test]
+    fn format_tool_result_message_caps_file_read_payload_more_aggressively() {
+        let result = ToolExecutionResult {
+            tool_call_id: "call_001".to_string(),
+            tool_name: "file.read".to_string(),
+            status: ToolExecutionStatus::Completed,
+            summary: "read ok".to_string(),
+            payload: ToolExecutionPayload::Text("A".repeat(3_000)),
+            artifacts: vec!["./src/main.rs".to_string()],
+            elapsed_ms: 0,
+            diff_summary: None,
+            edit_detail: None,
+        };
+
+        let formatted = format_tool_result_message(&result, 8_000);
+
+        assert!(formatted.contains("Path: ./src/main.rs"));
+        assert!(formatted.contains("[1000 chars truncated, 3000 chars total]"));
+        assert!(
+            !formatted.contains("[0 chars truncated"),
+            "file.read should use the tighter per-tool cap"
+        );
     }
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -14,6 +14,7 @@ pub mod phase_estimator;
 pub mod plan;
 pub mod policy;
 pub(crate) mod read_repeat_tracker;
+pub(crate) mod read_transition_guard;
 pub mod render;
 pub(crate) mod write_fail_tracker;
 pub(crate) mod write_repeat_tracker;
@@ -256,6 +257,8 @@ pub struct App {
     edit_fail_tracker: edit_fail_tracker::EditFailTracker,
     /// Phase estimator for fallback phase control (Issue #159).
     phase_estimator: phase_estimator::PhaseEstimator,
+    /// Guard that forces a transition from exploration to implementation.
+    read_transition_guard: read_transition_guard::ReadTransitionGuard,
     /// Tracks consecutive file.write failures per path for recovery hints.
     write_fail_tracker: write_fail_tracker::WriteFailTracker,
     /// Tracks repeated file.read calls per path for hint injection (Issue #185).
@@ -540,6 +543,8 @@ impl App {
         let phase_explore = config.runtime.phase_explore_threshold;
         let phase_force = config.runtime.phase_force_transition_threshold;
         let phase_completion = config.runtime.phase_completion_read_threshold;
+        let read_transition_threshold = config.runtime.read_transition_threshold;
+        let read_transition_reinject_interval = config.runtime.read_transition_reinject_interval;
         let edit_reread_threshold = config.runtime.edit_reread_threshold;
         let edit_write_fallback_threshold = config.runtime.edit_write_fallback_threshold;
         let read_repeat_warn = config.runtime.read_repeat_warn_threshold;
@@ -581,6 +586,10 @@ impl App {
                 phase_explore,
                 phase_force,
                 phase_completion,
+            ),
+            read_transition_guard: read_transition_guard::ReadTransitionGuard::new(
+                read_transition_threshold,
+                read_transition_reinject_interval,
             ),
             write_fail_tracker: write_fail_tracker::WriteFailTracker::new(2),
             read_repeat_tracker: read_repeat_tracker::ReadRepeatTracker::new(
@@ -1111,6 +1120,8 @@ impl App {
         message_id: impl Into<String>,
         content: impl Into<String>,
     ) -> Result<(), AppError> {
+        let content = content.into();
+        self.update_active_task_from_user_input(&content);
         self.session
             .push_message(new_user_message(message_id, content));
         self.persist_session(AppEvent::SessionSaved)?;
@@ -1128,6 +1139,7 @@ impl App {
         user_input: &str,
         expanded_content: Option<String>,
     ) -> Result<(), AppError> {
+        self.update_active_task_from_user_input(user_input);
         let mut message = new_user_message(msg_id, user_input);
         message.expanded_content = expanded_content;
         self.session.push_message(message);
@@ -1149,6 +1161,16 @@ impl App {
             eprintln!("@file展開エラー: {}", err);
         }
         expanded
+    }
+
+    fn update_active_task_from_user_input(&mut self, user_input: &str) {
+        let trimmed = user_input.trim();
+        if trimmed.is_empty() {
+            return;
+        }
+        self.session
+            .working_memory
+            .set_active_task(Some(trimmed.to_string()));
     }
 
     pub fn record_assistant_output(
@@ -2382,6 +2404,7 @@ pub fn error_guidance(err: &AppError) -> String {
                     "Hint: provider could not be reached\n",
                     "  - For Ollama: ensure `ollama serve` is running\n",
                     "  - For OpenAI-compatible: --provider openai --provider-url <url>\n",
+                    "  - For LM Studio: --provider lmstudio\n",
                     "  - Set API key with ANVIL_API_KEY if required"
                 )
                 .to_string()

--- a/src/app/phase_estimator.rs
+++ b/src/app/phase_estimator.rs
@@ -7,7 +7,7 @@
 /// Read-category tool names.
 const READ_TOOLS: &[&str] = &["file.read", "file.search", "web.fetch"];
 /// Write-category tool names.
-const WRITE_TOOLS: &[&str] = &["file.edit", "file.write"];
+const WRITE_TOOLS: &[&str] = &["file.edit", "file.edit_anchor", "file.write"];
 
 /// Action recommended by the phase estimator.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/app/read_transition_guard.rs
+++ b/src/app/read_transition_guard.rs
@@ -1,0 +1,169 @@
+/// Action recommended when exploration has continued for too long.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ReadTransitionAction {
+    /// No action needed.
+    Continue,
+    /// Inject a system message urging the model to transition to implementation.
+    Inject(String),
+}
+
+/// Guards against over-exploration by tracking consecutive read/search calls.
+///
+/// Unlike `LoopDetector`, this policy intentionally triggers even when the
+/// agent reads different files each time. The goal is to force the transition
+/// from exploration to implementation once enough context has been gathered.
+pub(crate) struct ReadTransitionGuard {
+    consecutive_exploration_calls: usize,
+    consecutive_file_reads: usize,
+    transition_threshold: usize,
+    reinject_interval: usize,
+    last_injected_at: Option<usize>,
+}
+
+impl ReadTransitionGuard {
+    pub(crate) fn new(transition_threshold: usize, reinject_interval: usize) -> Self {
+        Self {
+            consecutive_exploration_calls: 0,
+            consecutive_file_reads: 0,
+            transition_threshold,
+            reinject_interval,
+            last_injected_at: None,
+        }
+    }
+
+    pub(crate) fn reset(&mut self) {
+        self.consecutive_exploration_calls = 0;
+        self.consecutive_file_reads = 0;
+        self.last_injected_at = None;
+    }
+
+    pub(crate) fn record_tool_call(
+        &mut self,
+        tool_name: &str,
+        success: bool,
+    ) -> ReadTransitionAction {
+        if !success {
+            return ReadTransitionAction::Continue;
+        }
+
+        match tool_name {
+            "file.read" => {
+                self.consecutive_exploration_calls += 1;
+                self.consecutive_file_reads += 1;
+            }
+            "file.search" | "web.fetch" => {
+                self.consecutive_exploration_calls += 1;
+            }
+            "file.edit" | "file.edit_anchor" | "file.write" => {
+                self.reset();
+                return ReadTransitionAction::Continue;
+            }
+            _ => {
+                self.consecutive_exploration_calls = 0;
+                self.consecutive_file_reads = 0;
+                self.last_injected_at = None;
+                return ReadTransitionAction::Continue;
+            }
+        }
+
+        if self.consecutive_exploration_calls < self.transition_threshold {
+            return ReadTransitionAction::Continue;
+        }
+
+        let should_inject = match self.last_injected_at {
+            None => true,
+            Some(last) => {
+                self.consecutive_exploration_calls.saturating_sub(last) >= self.reinject_interval
+            }
+        };
+        if !should_inject {
+            return ReadTransitionAction::Continue;
+        }
+
+        self.last_injected_at = Some(self.consecutive_exploration_calls);
+        ReadTransitionAction::Inject(format!(
+            "[System] You have already spent {} consecutive tool calls exploring \
+             (including {} file.read calls). You have enough context. \
+             Start implementing now using file.edit, file.edit_anchor, or file.write. \
+             Do NOT call file.read again unless a previous edit failed and you need one \
+             targeted verification read.",
+            self.consecutive_exploration_calls, self.consecutive_file_reads
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn injects_at_threshold() {
+        let mut guard = ReadTransitionGuard::new(4, 2);
+        for _ in 0..3 {
+            assert_eq!(
+                guard.record_tool_call("file.read", true),
+                ReadTransitionAction::Continue
+            );
+        }
+        let action = guard.record_tool_call("file.read", true);
+        assert!(matches!(action, ReadTransitionAction::Inject(_)));
+    }
+
+    #[test]
+    fn reinjects_on_interval() {
+        let mut guard = ReadTransitionGuard::new(4, 2);
+        for _ in 0..4 {
+            guard.record_tool_call("file.read", true);
+        }
+        assert_eq!(
+            guard.record_tool_call("file.read", true),
+            ReadTransitionAction::Continue
+        );
+        let action = guard.record_tool_call("file.search", true);
+        assert!(matches!(action, ReadTransitionAction::Inject(_)));
+    }
+
+    #[test]
+    fn successful_write_resets_guard() {
+        let mut guard = ReadTransitionGuard::new(3, 2);
+        for _ in 0..3 {
+            guard.record_tool_call("file.read", true);
+        }
+        assert_eq!(
+            guard.record_tool_call("file.edit", true),
+            ReadTransitionAction::Continue
+        );
+        assert_eq!(
+            guard.record_tool_call("file.read", true),
+            ReadTransitionAction::Continue
+        );
+    }
+
+    #[test]
+    fn non_exploration_tools_clear_streak() {
+        let mut guard = ReadTransitionGuard::new(3, 2);
+        guard.record_tool_call("file.read", true);
+        guard.record_tool_call("file.search", true);
+        assert_eq!(
+            guard.record_tool_call("shell.exec", true),
+            ReadTransitionAction::Continue
+        );
+        assert_eq!(
+            guard.record_tool_call("file.read", true),
+            ReadTransitionAction::Continue
+        );
+    }
+
+    #[test]
+    fn failed_calls_do_not_advance_guard() {
+        let mut guard = ReadTransitionGuard::new(2, 1);
+        assert_eq!(
+            guard.record_tool_call("file.read", false),
+            ReadTransitionAction::Continue
+        );
+        assert_eq!(
+            guard.record_tool_call("file.read", true),
+            ReadTransitionAction::Continue
+        );
+    }
+}

--- a/src/config/cli_args.rs
+++ b/src/config/cli_args.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 #[derive(Parser, Debug, Default)]
 #[command(name = "anvil", version, about = "Local coding agent powered by LLM")]
 pub struct CliArgs {
-    /// Provider (ollama|openai)
+    /// Provider (ollama|openai|lmstudio)
     #[arg(short = 'p', long)]
     pub provider: Option<String>,
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -90,6 +90,10 @@ pub enum WebSearchProvider {
 pub struct RuntimeConfig {
     pub provider: String,
     pub provider_url: String,
+    /// `true` when the user explicitly set `provider_url` via config file,
+    /// environment variable, or CLI flag. When `false`, provider-specific
+    /// default URL resolution may override `provider_url`.
+    pub provider_url_explicitly_set: bool,
     pub model: String,
     pub sidecar_model: Option<String>,
     pub sidecar_provider_url: Option<String>,
@@ -130,6 +134,10 @@ pub struct RuntimeConfig {
     pub phase_force_transition_threshold: usize,
     /// Phase estimator: consecutive reads after last write for fallback completion (Issue #159).
     pub phase_completion_read_threshold: usize,
+    /// Force transition guard: consecutive exploration calls before a strong message is injected.
+    pub read_transition_threshold: usize,
+    /// Force transition guard: reinject interval after the first forced transition.
+    pub read_transition_reinject_interval: usize,
     /// Edit/write fallback strategy: edit-first or write-first (Issue #158).
     pub edit_strategy: crate::app::edit_fail_tracker::EditStrategy,
     /// Consecutive edit failures before re-read hint (Issue #158).
@@ -296,6 +304,7 @@ impl EffectiveConfig {
             runtime: RuntimeConfig {
                 provider: "ollama".to_string(),
                 provider_url: DEFAULT_OLLAMA_URL.to_string(),
+                provider_url_explicitly_set: false,
                 model: "local-default".to_string(),
                 sidecar_model: None,
                 sidecar_provider_url: None,
@@ -320,6 +329,8 @@ impl EffectiveConfig {
                 phase_explore_threshold: 5,
                 phase_force_transition_threshold: 15,
                 phase_completion_read_threshold: 5,
+                read_transition_threshold: 8,
+                read_transition_reinject_interval: 2,
                 edit_strategy: crate::app::edit_fail_tracker::EditStrategy::EditFirst,
                 edit_reread_threshold: 3,
                 edit_write_fallback_threshold: 5,
@@ -363,6 +374,18 @@ impl EffectiveConfig {
     fn set_context_window(&mut self, value: u32) {
         self.runtime.context_window = value;
         self.runtime.context_window_explicitly_set = true;
+    }
+
+    fn set_provider_url(&mut self, value: impl Into<String>) {
+        self.runtime.provider_url = value.into();
+        self.runtime.provider_url_explicitly_set = true;
+    }
+
+    fn resolve_provider_url_default(&mut self) {
+        if self.runtime.provider_url_explicitly_set {
+            return;
+        }
+        self.runtime.provider_url = default_provider_url(&self.runtime.provider).to_string();
     }
 
     fn apply_file_and_env_overrides(&mut self) -> Result<(), ConfigError> {
@@ -477,7 +500,7 @@ impl EffectiveConfig {
             self.runtime.model = v.clone();
         }
         if let Some(ref v) = cli.provider_url {
-            self.runtime.provider_url = v.clone();
+            self.set_provider_url(v.clone());
         }
         if let Some(ref v) = cli.sidecar_model {
             validate_sidecar_model(v)?;
@@ -588,7 +611,7 @@ impl EffectiveConfig {
         for (key, value) in map {
             match key.as_str() {
                 "provider" | "ANVIL_PROVIDER" => self.runtime.provider = value.clone(),
-                "provider_url" | "ANVIL_PROVIDER_URL" => self.runtime.provider_url = value.clone(),
+                "provider_url" | "ANVIL_PROVIDER_URL" => self.set_provider_url(value.clone()),
                 "model" | "ANVIL_MODEL" => self.runtime.model = value.clone(),
                 "sidecar_model" | "ANVIL_SIDECAR_MODEL" => {
                     if value.is_empty() {
@@ -750,6 +773,24 @@ impl EffectiveConfig {
                     }
                     self.runtime.phase_completion_read_threshold = v;
                 }
+                "read_transition_threshold" | "ANVIL_READ_TRANSITION_THRESHOLD" => {
+                    let v: usize = value
+                        .parse()
+                        .map_err(|_| ConfigError::InvalidNumericValue(value.clone()))?;
+                    if !(3..=30).contains(&v) {
+                        return Err(ConfigError::InvalidNumericValue(value.clone()));
+                    }
+                    self.runtime.read_transition_threshold = v;
+                }
+                "read_transition_reinject_interval" | "ANVIL_READ_TRANSITION_REINJECT_INTERVAL" => {
+                    let v: usize = value
+                        .parse()
+                        .map_err(|_| ConfigError::InvalidNumericValue(value.clone()))?;
+                    if !(1..=10).contains(&v) {
+                        return Err(ConfigError::InvalidNumericValue(value.clone()));
+                    }
+                    self.runtime.read_transition_reinject_interval = v;
+                }
                 "edit_strategy" | "ANVIL_EDIT_STRATEGY" => {
                     self.runtime.edit_strategy = value
                         .parse::<crate::app::edit_fail_tracker::EditStrategy>()
@@ -842,6 +883,7 @@ impl EffectiveConfig {
     }
 
     fn validate(&mut self) -> Result<(), ConfigError> {
+        self.resolve_provider_url_default();
         self.check_provider_url()?;
         self.check_model()?;
         self.clamp_context_window();
@@ -851,6 +893,7 @@ impl EffectiveConfig {
         self.clamp_subagent_settings();
         self.clamp_loop_detection_threshold();
         self.clamp_phase_thresholds();
+        self.clamp_read_transition_thresholds();
         self.clamp_edit_thresholds();
         self.clamp_read_repeat_thresholds();
         self.clamp_http_timeout();
@@ -1030,6 +1073,21 @@ impl EffectiveConfig {
         }
     }
 
+    fn clamp_read_transition_thresholds(&mut self) {
+        self.runtime.read_transition_threshold =
+            self.runtime.read_transition_threshold.clamp(3, 30);
+        self.runtime.read_transition_reinject_interval =
+            self.runtime.read_transition_reinject_interval.clamp(1, 10);
+        if self.runtime.read_transition_reinject_interval >= self.runtime.read_transition_threshold
+        {
+            self.runtime.read_transition_reinject_interval = self
+                .runtime
+                .read_transition_threshold
+                .saturating_sub(1)
+                .max(1);
+        }
+    }
+
     fn clamp_edit_thresholds(&mut self) {
         self.runtime.edit_reread_threshold = self.runtime.edit_reread_threshold.clamp(1, 20);
         self.runtime.edit_write_fallback_threshold =
@@ -1067,6 +1125,8 @@ const MIN_CONTEXT_WINDOW: u32 = 1000;
 
 /// Default Ollama server URL used as fallback for sidecar provider.
 pub const DEFAULT_OLLAMA_URL: &str = "http://127.0.0.1:11434";
+pub const DEFAULT_OPENAI_URL: &str = "https://api.openai.com/v1";
+pub const DEFAULT_LMSTUDIO_URL: &str = "http://localhost:1234/v1";
 const DEFAULT_MAX_AGENT_ITERATIONS: usize = 30;
 const DEFAULT_SUBAGENT_MAX_ITERATIONS: u32 = 20;
 const DEFAULT_SUBAGENT_TIMEOUT_SECS: u64 = 120;
@@ -1347,11 +1407,24 @@ fn parse_reasoning_visibility(value: &str) -> Result<ReasoningVisibility, Config
     }
 }
 
+fn default_provider_url(provider: &str) -> &'static str {
+    match provider {
+        "ollama" => DEFAULT_OLLAMA_URL,
+        "openai" => DEFAULT_OPENAI_URL,
+        "lmstudio" => DEFAULT_LMSTUDIO_URL,
+        _ => DEFAULT_OLLAMA_URL,
+    }
+}
+
 impl std::fmt::Debug for RuntimeConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("RuntimeConfig")
             .field("provider", &self.provider)
             .field("provider_url", &self.provider_url)
+            .field(
+                "provider_url_explicitly_set",
+                &self.provider_url_explicitly_set,
+            )
             .field("model", &self.model)
             .field("sidecar_model", &self.sidecar_model)
             .field("sidecar_provider_url", &self.sidecar_provider_url)

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -351,7 +351,7 @@ impl ProviderRuntimeContext {
     pub fn bootstrap(config: &EffectiveConfig) -> Result<Self, ProviderBootstrapError> {
         let backend = match config.runtime.provider.as_str() {
             "ollama" => ProviderBackend::Ollama,
-            "openai" => ProviderBackend::OpenAi,
+            "openai" | "lmstudio" => ProviderBackend::OpenAi,
             other => {
                 return Err(ProviderBootstrapError::UnsupportedBackend(
                     other.to_string(),
@@ -438,6 +438,12 @@ pub fn build_local_provider_client(
             }
             Ok(LocalProviderClient::OpenAi(client))
         }
+        "lmstudio" => Ok(LocalProviderClient::OpenAi(
+            openai::OpenAiCompatibleProviderClient::with_transport(
+                config.runtime.provider_url.clone(),
+                transport,
+            ),
+        )),
         other => Err(ProviderBootstrapError::UnsupportedBackend(
             other.to_string(),
         )),

--- a/src/provider/openai.rs
+++ b/src/provider/openai.rs
@@ -14,6 +14,7 @@ use crate::config::EffectiveConfig;
 use crate::contracts::InferencePerformanceView;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::collections::BTreeMap;
 
 /// Client for OpenAI-compatible chat completion APIs.
 ///
@@ -48,7 +49,10 @@ struct OpenAiChatMessage {
 struct OpenAiResponseMessage {
     #[allow(dead_code)]
     role: String,
+    #[serde(default)]
     content: Option<String>,
+    #[serde(default)]
+    tool_calls: Vec<OpenAiToolCall>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -88,6 +92,46 @@ struct OpenAiDeltaChoice {
 struct OpenAiDeltaMessage {
     #[serde(default)]
     content: Option<String>,
+    #[serde(default)]
+    tool_calls: Vec<OpenAiDeltaToolCall>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct OpenAiToolCall {
+    #[serde(default)]
+    id: String,
+    function: OpenAiToolFunction,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct OpenAiToolFunction {
+    name: String,
+    arguments: String,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+struct OpenAiDeltaToolCall {
+    #[serde(default)]
+    index: usize,
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    function: Option<OpenAiDeltaToolFunction>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+struct OpenAiDeltaToolFunction {
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    arguments: Option<String>,
+}
+
+#[derive(Debug, Clone, Default)]
+struct StreamingToolCallAccumulator {
+    id: String,
+    name: String,
+    arguments: String,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -139,6 +183,144 @@ fn extract_openai_performance(usage: &Option<OpenAiUsage>) -> Option<InferencePe
         prompt_tokens: usage.prompt_tokens,
         ..Default::default()
     })
+}
+
+fn normalize_openai_tool_name(name: &str) -> String {
+    match name {
+        "file_read" => "file.read".to_string(),
+        "file_write" => "file.write".to_string(),
+        "file_edit" => "file.edit".to_string(),
+        "file_search" => "file.search".to_string(),
+        "file_edit_anchor" => "file.edit_anchor".to_string(),
+        "shell_exec" => "shell.exec".to_string(),
+        "web_fetch" => "web.fetch".to_string(),
+        "web_search" => "web.search".to_string(),
+        "agent_explore" => "agent.explore".to_string(),
+        "agent_plan" => "agent.plan".to_string(),
+        "git_status" => "git.status".to_string(),
+        "git_diff" => "git.diff".to_string(),
+        "git_log" => "git.log".to_string(),
+        _ => name.to_string(),
+    }
+}
+
+fn default_tool_call_id(tool_name: &str, index: usize) -> String {
+    format!("call_{}_{}", tool_name.replace('.', "_"), index)
+}
+
+fn openai_tool_call_to_anvil_block(
+    tool_call: &OpenAiToolCall,
+    index: usize,
+) -> Result<String, ProviderTurnError> {
+    let raw_name = tool_call.function.name.trim();
+    if raw_name.is_empty() {
+        return Err(ProviderTurnError::Backend(format!(
+            "openai tool_call at index {index} is missing function.name"
+        )));
+    }
+
+    let tool_name = normalize_openai_tool_name(raw_name);
+    let args_value: Value = serde_json::from_str(&tool_call.function.arguments).map_err(|err| {
+        ProviderTurnError::Backend(format!(
+            "invalid openai tool_call arguments for '{tool_name}': {err}"
+        ))
+    })?;
+
+    let Some(args_object) = args_value.as_object() else {
+        return Err(ProviderTurnError::Backend(format!(
+            "openai tool_call arguments for '{tool_name}' must be a JSON object"
+        )));
+    };
+
+    let mut payload = serde_json::Map::new();
+    let tool_call_id = if tool_call.id.trim().is_empty() {
+        default_tool_call_id(&tool_name, index)
+    } else {
+        tool_call.id.clone()
+    };
+
+    payload.insert("id".to_string(), Value::String(tool_call_id));
+    payload.insert("tool".to_string(), Value::String(tool_name));
+    for (key, value) in args_object {
+        payload.insert(key.clone(), value.clone());
+    }
+
+    let json = serde_json::to_string(&Value::Object(payload)).map_err(|err| {
+        ProviderTurnError::Backend(format!(
+            "failed to encode synthetic ANVIL_TOOL block: {err}"
+        ))
+    })?;
+
+    Ok(format!("```ANVIL_TOOL\n{json}\n```"))
+}
+
+fn build_native_tool_calls_content(
+    content: Option<&str>,
+    tool_calls: &[OpenAiToolCall],
+) -> Result<String, ProviderTurnError> {
+    let mut parts = Vec::new();
+    if let Some(content) = content
+        && !content.trim().is_empty()
+    {
+        parts.push(content.to_string());
+    }
+
+    for (index, tool_call) in tool_calls.iter().enumerate() {
+        parts.push(openai_tool_call_to_anvil_block(tool_call, index)?);
+    }
+
+    Ok(parts.join("\n"))
+}
+
+fn merge_delta_tool_calls(
+    accumulators: &mut BTreeMap<usize, StreamingToolCallAccumulator>,
+    delta_tool_calls: &[OpenAiDeltaToolCall],
+) {
+    for delta_tool_call in delta_tool_calls {
+        let accumulator = accumulators.entry(delta_tool_call.index).or_default();
+        if let Some(id) = &delta_tool_call.id {
+            accumulator.id.push_str(id);
+        }
+        if let Some(function) = &delta_tool_call.function {
+            if let Some(name) = &function.name {
+                accumulator.name.push_str(name);
+            }
+            if let Some(arguments) = &function.arguments {
+                accumulator.arguments.push_str(arguments);
+            }
+        }
+    }
+}
+
+fn finalize_streaming_tool_calls(
+    accumulators: BTreeMap<usize, StreamingToolCallAccumulator>,
+) -> Result<Vec<OpenAiToolCall>, ProviderTurnError> {
+    let mut finalized = Vec::with_capacity(accumulators.len());
+    for (index, accumulator) in accumulators {
+        if accumulator.name.trim().is_empty() {
+            return Err(ProviderTurnError::Backend(format!(
+                "openai streaming tool_call at index {index} is missing function.name"
+            )));
+        }
+        finalized.push(OpenAiToolCall {
+            id: accumulator.id,
+            function: OpenAiToolFunction {
+                name: accumulator.name,
+                arguments: accumulator.arguments,
+            },
+        });
+    }
+    Ok(finalized)
+}
+
+fn build_openai_api_url(base_url: &str, endpoint: &str) -> String {
+    let normalized_base = base_url.trim_end_matches('/');
+    let normalized_endpoint = endpoint.trim_start_matches('/');
+    if normalized_base.ends_with("/v1") {
+        format!("{normalized_base}/{normalized_endpoint}")
+    } else {
+        format!("{normalized_base}/v1/{normalized_endpoint}")
+    }
 }
 
 impl OpenAiCompatibleProviderClient {
@@ -207,7 +389,7 @@ impl<T: HttpTransport> OpenAiCompatibleProviderClient<T> {
     /// (without `Bearer` prefix, matching the existing code pattern in
     /// `send_chat_request`).
     pub fn health_check(&self) -> Result<(), ProviderTurnError> {
-        let url = format!("{}/v1/models", self.base_url.trim_end_matches('/'));
+        let url = build_openai_api_url(&self.base_url, "models");
         let headers: Vec<(&str, &str)> = self
             .api_key
             .as_deref()
@@ -247,10 +429,7 @@ impl<T: HttpTransport> OpenAiCompatibleProviderClient<T> {
         let request_body = serde_json::to_vec(&chat_request).map_err(|err| {
             ProviderTurnError::Backend(format!("failed to encode openai request: {err}"))
         })?;
-        let url = format!(
-            "{}/v1/chat/completions",
-            self.base_url.trim_end_matches('/')
-        );
+        let url = build_openai_api_url(&self.base_url, "chat/completions");
 
         let mut headers = Vec::new();
         if let Some(api_key) = &self.api_key {
@@ -283,13 +462,18 @@ impl<T: HttpTransport> OpenAiCompatibleProviderClient<T> {
             .map_err(|err| ProviderTurnError::Backend(format!("invalid openai response: {err}")))?;
 
         let perf = extract_openai_performance(&parsed.usage);
-        let content = parsed
-            .choices
-            .first()
-            .and_then(|choice| choice.message.content.clone())
-            .ok_or_else(|| {
-                ProviderTurnError::Backend("openai response contained no choices".to_string())
-            })?;
+        let choice = parsed.choices.first().ok_or_else(|| {
+            ProviderTurnError::Backend("openai response contained no choices".to_string())
+        })?;
+        let content = choice.message.content.clone().unwrap_or_default();
+        if !choice.message.tool_calls.is_empty() {
+            let assistant_message =
+                build_native_tool_calls_content(Some(&content), &choice.message.tool_calls)?;
+            return Ok(vec![ProviderEvent::Agent(build_provider_done_event(
+                &assistant_message,
+                perf,
+            ))]);
+        }
 
         Ok(vec![
             ProviderEvent::TokenDelta(content.clone()),
@@ -326,10 +510,7 @@ impl<T: HttpTransport> OpenAiCompatibleProviderClient<T> {
         let request_body = serde_json::to_vec(&chat_request).map_err(|err| {
             ProviderTurnError::Backend(format!("failed to encode openai request: {err}"))
         })?;
-        let url = format!(
-            "{}/v1/chat/completions",
-            self.base_url.trim_end_matches('/')
-        );
+        let url = build_openai_api_url(&self.base_url, "chat/completions");
         tracing::debug!(
             model = %request.model,
             messages = request.messages.len(),
@@ -346,6 +527,8 @@ impl<T: HttpTransport> OpenAiCompatibleProviderClient<T> {
         let mut emitted_done = false;
         let mut had_error: Option<ProviderTurnError> = None;
         let mut stream_usage: Option<OpenAiUsage> = None;
+        let mut streaming_tool_calls = BTreeMap::new();
+        let mut saw_native_tool_calls = false;
 
         self.transport
             .stream_lines(&url, &request_body, &headers, &mut |line| {
@@ -362,10 +545,28 @@ impl<T: HttpTransport> OpenAiCompatibleProviderClient<T> {
                         if let Some(choice) = parsed.choices.first() {
                             let perf = extract_openai_performance(&parsed.usage);
                             let msg_content = choice.message.content.clone().unwrap_or_default();
-                            content.push_str(&msg_content);
-                            emit(ProviderEvent::TokenDelta(msg_content));
+                            let assistant_message = if !choice.message.tool_calls.is_empty() {
+                                match build_native_tool_calls_content(
+                                    Some(&msg_content),
+                                    &choice.message.tool_calls,
+                                ) {
+                                    Ok(message) => {
+                                        saw_native_tool_calls = true;
+                                        message
+                                    }
+                                    Err(err) => {
+                                        had_error = Some(err);
+                                        return;
+                                    }
+                                }
+                            } else {
+                                content.push_str(&msg_content);
+                                emit(ProviderEvent::TokenDelta(msg_content));
+                                content.clone()
+                            };
                             emit(ProviderEvent::Agent(build_provider_done_event(
-                                &content, perf,
+                                &assistant_message,
+                                perf,
                             )));
                             emitted_done = true;
                         }
@@ -381,8 +582,25 @@ impl<T: HttpTransport> OpenAiCompatibleProviderClient<T> {
                 if payload == "[DONE]" {
                     if !emitted_done {
                         let perf = extract_openai_performance(&stream_usage);
+                        let assistant_message = if saw_native_tool_calls {
+                            match finalize_streaming_tool_calls(std::mem::take(
+                                &mut streaming_tool_calls,
+                            ))
+                            .and_then(|finalized| {
+                                build_native_tool_calls_content(Some(&content), &finalized)
+                            }) {
+                                Ok(message) => message,
+                                Err(err) => {
+                                    had_error = Some(err);
+                                    return;
+                                }
+                            }
+                        } else {
+                            content.clone()
+                        };
                         emit(ProviderEvent::Agent(build_provider_done_event(
-                            &content, perf,
+                            &assistant_message,
+                            perf,
                         )));
                         emitted_done = true;
                     }
@@ -400,10 +618,34 @@ impl<T: HttpTransport> OpenAiCompatibleProviderClient<T> {
                                 content.push_str(&delta);
                                 emit(ProviderEvent::TokenDelta(delta));
                             }
+                            if !choice.delta.tool_calls.is_empty() {
+                                saw_native_tool_calls = true;
+                                merge_delta_tool_calls(
+                                    &mut streaming_tool_calls,
+                                    &choice.delta.tool_calls,
+                                );
+                            }
                             if choice.finish_reason.is_some() && !emitted_done {
                                 let perf = extract_openai_performance(&stream_usage);
+                                let assistant_message = if saw_native_tool_calls {
+                                    match finalize_streaming_tool_calls(std::mem::take(
+                                        &mut streaming_tool_calls,
+                                    ))
+                                    .and_then(|finalized| {
+                                        build_native_tool_calls_content(Some(&content), &finalized)
+                                    }) {
+                                        Ok(message) => message,
+                                        Err(err) => {
+                                            had_error = Some(err);
+                                            return;
+                                        }
+                                    }
+                                } else {
+                                    content.clone()
+                                };
                                 emit(ProviderEvent::Agent(build_provider_done_event(
-                                    &content, perf,
+                                    &assistant_message,
+                                    perf,
                                 )));
                                 emitted_done = true;
                             }
@@ -423,8 +665,15 @@ impl<T: HttpTransport> OpenAiCompatibleProviderClient<T> {
         }
         if !emitted_done {
             let perf = extract_openai_performance(&stream_usage);
+            let assistant_message = if saw_native_tool_calls {
+                let finalized = finalize_streaming_tool_calls(streaming_tool_calls)?;
+                build_native_tool_calls_content(Some(&content), &finalized)?
+            } else {
+                content.clone()
+            };
             emit(ProviderEvent::Agent(build_provider_done_event(
-                &content, perf,
+                &assistant_message,
+                perf,
             )));
         }
         Ok(())
@@ -435,6 +684,8 @@ fn parse_openai_sse_response(body: &[u8]) -> Result<Vec<ProviderEvent>, Provider
     let text = String::from_utf8_lossy(body);
     let mut content = String::new();
     let mut events = Vec::new();
+    let mut streaming_tool_calls = BTreeMap::new();
+    let mut saw_native_tool_calls = false;
 
     for line in text.lines() {
         let trimmed = line.trim();
@@ -455,9 +706,21 @@ fn parse_openai_sse_response(body: &[u8]) -> Result<Vec<ProviderEvent>, Provider
                 content.push_str(&delta);
                 events.push(ProviderEvent::TokenDelta(delta));
             }
+            if !choice.delta.tool_calls.is_empty() {
+                saw_native_tool_calls = true;
+                merge_delta_tool_calls(&mut streaming_tool_calls, &choice.delta.tool_calls);
+            }
             if choice.finish_reason.is_some() {
+                let assistant_message = if saw_native_tool_calls {
+                    let finalized =
+                        finalize_streaming_tool_calls(std::mem::take(&mut streaming_tool_calls))?;
+                    build_native_tool_calls_content(Some(&content), &finalized)?
+                } else {
+                    content.clone()
+                };
                 events.push(ProviderEvent::Agent(build_provider_done_event(
-                    &content, None,
+                    &assistant_message,
+                    None,
                 )));
             }
         }
@@ -467,8 +730,15 @@ fn parse_openai_sse_response(body: &[u8]) -> Result<Vec<ProviderEvent>, Provider
         .iter()
         .all(|event| !matches!(event, ProviderEvent::Agent(AgentEvent::Done { .. })))
     {
+        let assistant_message = if saw_native_tool_calls {
+            let finalized = finalize_streaming_tool_calls(streaming_tool_calls)?;
+            build_native_tool_calls_content(Some(&content), &finalized)?
+        } else {
+            content
+        };
         events.push(ProviderEvent::Agent(build_provider_done_event(
-            &content, None,
+            &assistant_message,
+            None,
         )));
     }
 

--- a/src/provider/openai.rs
+++ b/src/provider/openai.rs
@@ -175,6 +175,34 @@ fn build_openai_content(text: &str, images: Option<&[ImageContent]>) -> Value {
     }
 }
 
+fn openai_message_role_and_content(message: &super::ProviderMessage) -> (String, Value) {
+    match message.role {
+        super::ProviderMessageRole::System => (
+            "system".to_string(),
+            build_openai_content(&message.content, message.images.as_deref()),
+        ),
+        super::ProviderMessageRole::User => (
+            "user".to_string(),
+            build_openai_content(&message.content, message.images.as_deref()),
+        ),
+        super::ProviderMessageRole::Assistant => (
+            "assistant".to_string(),
+            build_openai_content(&message.content, message.images.as_deref()),
+        ),
+        super::ProviderMessageRole::Tool => (
+            // We do not send native tool_call/tool_call_id pairs on follow-up
+            // turns, so OpenAI-compatible backends can underweight orphaned
+            // `tool` role messages. Flatten tool outputs into explicit user
+            // context instead.
+            "user".to_string(),
+            build_openai_content(
+                &format!("Tool result:\n{}", message.content),
+                message.images.as_deref(),
+            ),
+        ),
+    }
+}
+
 /// Extract InferencePerformanceView from OpenAI usage.
 fn extract_openai_performance(usage: &Option<OpenAiUsage>) -> Option<InferencePerformanceView> {
     let usage = usage.as_ref()?;
@@ -365,14 +393,9 @@ impl<T> OpenAiCompatibleProviderClient<T> {
             messages: request
                 .messages
                 .iter()
-                .map(|m| OpenAiChatMessage {
-                    role: match m.role {
-                        super::ProviderMessageRole::System => "system".to_string(),
-                        super::ProviderMessageRole::User => "user".to_string(),
-                        super::ProviderMessageRole::Assistant => "assistant".to_string(),
-                        super::ProviderMessageRole::Tool => "tool".to_string(),
-                    },
-                    content: build_openai_content(&m.content, m.images.as_deref()),
+                .map(|m| {
+                    let (role, content) = openai_message_role_and_content(m);
+                    OpenAiChatMessage { role, content }
                 })
                 .collect(),
             stream: request.stream,
@@ -755,4 +778,33 @@ fn looks_like_sse_stream(body: &[u8]) -> bool {
     String::from_utf8_lossy(body)
         .lines()
         .any(|line| line.trim_start().starts_with("data: "))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::provider::{ProviderMessage, ProviderMessageRole};
+
+    #[test]
+    fn build_chat_request_flattens_tool_messages_into_user_context() {
+        let request = ProviderTurnRequest::new(
+            "test-model".to_string(),
+            vec![
+                ProviderMessage::new(ProviderMessageRole::System, "system prompt"),
+                ProviderMessage::new(
+                    ProviderMessageRole::Tool,
+                    "[tool result: file.read] read ok",
+                ),
+            ],
+            false,
+        );
+
+        let chat_request = OpenAiCompatibleProviderClient::<()>::build_chat_request(&request, None);
+
+        assert_eq!(chat_request.messages[1].role, "user");
+        assert_eq!(
+            chat_request.messages[1].content,
+            Value::String("Tool result:\n[tool result: file.read] read ok".to_string())
+        );
+    }
 }

--- a/tests/cli_args.rs
+++ b/tests/cli_args.rs
@@ -1,7 +1,7 @@
 mod common;
 
 use anvil::config::{CliArgs, EffectiveConfig, PromptSource, ReasoningVisibility};
-use clap::Parser;
+use clap::{CommandFactory, Parser};
 use std::path::PathBuf;
 
 // --- CliArgs parsing tests ---
@@ -43,6 +43,12 @@ fn cli_args_parse_model_short() {
 fn cli_args_parse_provider_long() {
     let args = CliArgs::try_parse_from(["anvil", "--provider", "openai"]).unwrap();
     assert_eq!(args.provider.as_deref(), Some("openai"));
+}
+
+#[test]
+fn cli_args_parse_lmstudio_provider() {
+    let args = CliArgs::try_parse_from(["anvil", "--provider", "lmstudio"]).unwrap();
+    assert_eq!(args.provider.as_deref(), Some("lmstudio"));
 }
 
 #[test]
@@ -155,6 +161,15 @@ fn cli_args_parse_multiple_options() {
     assert_eq!(args.provider_url.as_deref(), Some("https://api.openai.com"));
     assert!(args.no_stream);
     assert!(args.debug);
+}
+
+#[test]
+fn cli_help_mentions_lmstudio_provider() {
+    let mut command = CliArgs::command();
+    let mut help = Vec::new();
+    command.write_long_help(&mut help).unwrap();
+    let help = String::from_utf8(help).unwrap();
+    assert!(help.contains("ollama|openai|lmstudio"));
 }
 
 // --- apply_cli_args tests ---

--- a/tests/config_bootstrap.rs
+++ b/tests/config_bootstrap.rs
@@ -91,6 +91,27 @@ fn openai_provider_bootstraps_from_config() {
 }
 
 #[test]
+fn lmstudio_provider_bootstraps_from_config() {
+    let mut config = EffectiveConfig::load().expect("config should load");
+    config.runtime.provider = "lmstudio".to_string();
+    config.runtime.provider_url = "http://localhost:1234/v1".to_string();
+
+    let provider = ProviderRuntimeContext::bootstrap(&config).expect("lmstudio should bootstrap");
+    let client = build_local_provider_client(
+        &config,
+        std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+    )
+    .expect("lmstudio client should build");
+
+    assert_eq!(provider.backend, anvil::provider::ProviderBackend::OpenAi);
+    assert!(provider.capabilities.streaming);
+    assert!(matches!(
+        client,
+        anvil::provider::LocalProviderClient::OpenAi(_)
+    ));
+}
+
+#[test]
 fn provider_bootstrap_rejects_unknown_backend() {
     let mut config = EffectiveConfig::load().expect("config should load");
     config.runtime.provider = "unknown".to_string();
@@ -142,9 +163,66 @@ fn override_precedence_is_file_then_env_then_cli() {
 }
 
 #[test]
+fn provider_defaults_switch_to_lmstudio_url_when_provider_changes() {
+    let mut config = EffectiveConfig::default_for_test().expect("config should load");
+    config.runtime.provider = "lmstudio".to_string();
+
+    config
+        .validate_for_test()
+        .expect("lmstudio default url should validate");
+
+    assert_eq!(config.runtime.provider_url, "http://localhost:1234/v1");
+    assert!(!config.runtime.provider_url_explicitly_set);
+}
+
+#[test]
+fn provider_defaults_switch_to_openai_url_when_provider_changes() {
+    let mut config = EffectiveConfig::default_for_test().expect("config should load");
+    config.runtime.provider = "openai".to_string();
+
+    config
+        .validate_for_test()
+        .expect("openai default url should validate");
+
+    assert_eq!(config.runtime.provider_url, "https://api.openai.com/v1");
+    assert!(!config.runtime.provider_url_explicitly_set);
+}
+
+#[test]
+fn explicit_provider_url_is_preserved_for_lmstudio() {
+    let mut config = EffectiveConfig::default_for_test().expect("config should load");
+    let mut cli_values = HashMap::new();
+    cli_values.insert("provider".to_string(), "lmstudio".to_string());
+    cli_values.insert(
+        "provider_url".to_string(),
+        "http://custom-lmstudio:9999/v1".to_string(),
+    );
+
+    config
+        .apply_overrides_for_test(&HashMap::new(), &HashMap::new(), &cli_values)
+        .expect("overrides should apply");
+    config
+        .validate_for_test()
+        .expect("explicit provider url should validate");
+
+    assert_eq!(
+        config.runtime.provider_url,
+        "http://custom-lmstudio:9999/v1"
+    );
+    assert!(config.runtime.provider_url_explicitly_set);
+}
+
+#[test]
 fn max_agent_iterations_defaults_to_thirty() {
     let config = EffectiveConfig::default_for_test().expect("config should load");
     assert_eq!(config.runtime.max_agent_iterations, 30);
+}
+
+#[test]
+fn read_transition_guard_defaults_are_configured() {
+    let config = EffectiveConfig::default_for_test().expect("config should load");
+    assert_eq!(config.runtime.read_transition_threshold, 8);
+    assert_eq!(config.runtime.read_transition_reinject_interval, 2);
 }
 
 #[test]
@@ -374,6 +452,7 @@ fn validate_default_config_passes() {
 fn validate_rejects_empty_provider_url() {
     let mut config = EffectiveConfig::default_for_test().unwrap();
     config.runtime.provider_url = String::new();
+    config.runtime.provider_url_explicitly_set = true;
     let result = config.validate_for_test();
     assert!(result.is_err());
     assert!(
@@ -388,6 +467,7 @@ fn validate_rejects_empty_provider_url() {
 fn validate_rejects_invalid_provider_url_scheme() {
     let mut config = EffectiveConfig::default_for_test().unwrap();
     config.runtime.provider_url = "ftp://example.com".to_string();
+    config.runtime.provider_url_explicitly_set = true;
     let result = config.validate_for_test();
     assert!(result.is_err());
     assert!(

--- a/tests/provider_integration.rs
+++ b/tests/provider_integration.rs
@@ -3713,6 +3713,147 @@ fn anvil_final_guard_does_not_fire_when_file_write_was_executed() {
 }
 
 #[test]
+fn synthetic_guidance_followup_without_edits_triggers_final_guard_retry() {
+    let root = common::unique_test_dir("guidance_retry");
+    let mut config = common::build_config_in(root.clone());
+    config.mode.approval_required = false;
+    let provider_ctx =
+        anvil::provider::ProviderRuntimeContext::bootstrap(&config).expect("provider bootstrap");
+    let mut app = anvil::app::App::new(
+        config,
+        provider_ctx,
+        std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+    )
+    .expect("app should initialize");
+    let tui = Tui::new();
+
+    std::fs::create_dir_all(root.join("src")).expect("create src dir");
+    for i in 0..8 {
+        std::fs::write(
+            root.join(format!("src/file_{i}.rs")),
+            format!("fn f{i}() {{}}\n"),
+        )
+        .expect("write fixture file");
+    }
+
+    let seen_requests = Rc::new(RefCell::new(Vec::new()));
+
+    struct GuidanceRetryProvider {
+        seen_requests: Rc<RefCell<Vec<ProviderTurnRequest>>>,
+    }
+
+    impl ProviderClient for GuidanceRetryProvider {
+        fn stream_turn(
+            &self,
+            request: &ProviderTurnRequest,
+            emit: &mut dyn FnMut(ProviderEvent),
+        ) -> Result<(), ProviderTurnError> {
+            let call_index = self.seen_requests.borrow().len();
+            self.seen_requests.borrow_mut().push(request.clone());
+
+            match call_index {
+                0 => {
+                    let mut assistant_message = String::new();
+                    for i in 0..8 {
+                        assistant_message.push_str("```ANVIL_TOOL\n");
+                        assistant_message.push_str(&format!(
+                            "{{\"id\":\"call_{i:03}\",\"tool\":\"file.read\",\"path\":\"./src/file_{i}.rs\"}}\n"
+                        ));
+                        assistant_message.push_str("```\n");
+                    }
+                    assistant_message.push_str("```ANVIL_FINAL\n");
+                    assistant_message.push_str("Finished reading the repository.\n");
+                    assistant_message.push_str("```\n");
+
+                    emit(ProviderEvent::Agent(AgentEvent::Done {
+                        status: "Done. session saved".to_string(),
+                        assistant_message,
+                        completion_summary: "turn 1".to_string(),
+                        saved_status: "session saved".to_string(),
+                        tool_logs: Vec::new(),
+                        elapsed_ms: 0,
+                        inference_performance: None,
+                    }));
+                }
+                _ => {
+                    emit(ProviderEvent::TokenDelta(
+                        "I will now implement the change.".to_string(),
+                    ));
+                }
+            }
+            Ok(())
+        }
+    }
+
+    let provider = GuidanceRetryProvider {
+        seen_requests: seen_requests.clone(),
+    };
+
+    let _frames = app
+        .run_live_turn("implement the feature", &provider, &tui)
+        .expect("guidance retry scenario should succeed");
+
+    let requests = seen_requests.borrow();
+    assert_eq!(
+        requests.len(),
+        3,
+        "expected 3 provider calls: initial turn + guidance follow-up + final guard retry"
+    );
+    assert!(
+        app.session()
+            .messages
+            .iter()
+            .any(|m| m.role == anvil::session::MessageRole::Tool && m.author == "system.read_guard"),
+        "system.read_guard should be recorded in the session"
+    );
+    assert!(
+        app.session()
+            .messages
+            .iter()
+            .any(|m| m.content.contains("No file modifications detected")),
+        "guidance follow-up with no edits should escalate to the final guard retry"
+    );
+}
+
+#[test]
+fn live_turn_pins_latest_user_task_into_working_memory_prompt() {
+    let mut app = common::build_app();
+    let tui = Tui::new();
+    let seen_requests = Rc::new(RefCell::new(Vec::new()));
+    let provider = RecordingProvider {
+        seen_requests: seen_requests.clone(),
+        events: vec![ProviderEvent::Agent(AgentEvent::Done {
+            status: "Done. session saved".to_string(),
+            assistant_message: "done".to_string(),
+            completion_summary: "done".to_string(),
+            saved_status: "session saved".to_string(),
+            tool_logs: Vec::new(),
+            elapsed_ms: 0,
+            inference_performance: None,
+        })],
+        followup_events: Vec::new(),
+        error: None,
+    };
+
+    let task = "fix the read-to-edit transition";
+    let _ = app
+        .run_live_turn(task, &provider, &tui)
+        .expect("turn should succeed");
+
+    assert_eq!(
+        app.session().working_memory.active_task.as_deref(),
+        Some(task)
+    );
+
+    let requests = seen_requests.borrow();
+    let system_prompt = &requests[0].messages[0].content;
+    assert!(
+        system_prompt.contains("**Active task:** fix the read-to-edit transition"),
+        "system prompt should pin the latest user task for follow-up turns"
+    );
+}
+
+#[test]
 fn anvil_final_guard_handle_structured_done_fires_for_plan_only_response() {
     // Scenario: Done event with ANVIL_FINAL but no tool calls (plan only).
     // Guard should fire via handle_structured_done path.

--- a/tests/provider_integration.rs
+++ b/tests/provider_integration.rs
@@ -597,6 +597,68 @@ fn openai_compatible_provider_forwards_authorization_header() {
 }
 
 #[test]
+fn openai_compatible_provider_accepts_base_url_with_v1_suffix() {
+    let request = ProviderTurnRequest::new(
+        "local-openai".to_string(),
+        vec![anvil::provider::ProviderMessage::new(
+            ProviderMessageRole::User,
+            "inspect src/provider",
+        )],
+        false,
+    );
+
+    let seen_urls = Rc::new(RefCell::new(Vec::new()));
+    let transport = MockHttpTransport {
+        seen_urls: seen_urls.clone(),
+        seen_bodies: Rc::new(RefCell::new(Vec::new())),
+        seen_headers: Rc::new(RefCell::new(Vec::new())),
+        response: HttpResponse {
+            status_code: 200,
+            body: br#"{"choices":[{"message":{"role":"assistant","content":"ok"}}]}"#.to_vec(),
+        },
+        get_response: None,
+    };
+    let client = anvil::provider::openai::OpenAiCompatibleProviderClient::with_transport(
+        "http://localhost:1234/v1",
+        transport,
+    );
+
+    client
+        .stream_turn(&request, &mut |_event| {})
+        .expect("request with /v1 base url should succeed");
+
+    assert_eq!(
+        seen_urls.borrow()[0],
+        "http://localhost:1234/v1/chat/completions"
+    );
+}
+
+#[test]
+fn openai_health_check_accepts_base_url_with_v1_suffix() {
+    let seen_urls = Rc::new(RefCell::new(Vec::new()));
+    let transport = MockHttpTransport {
+        seen_urls: seen_urls.clone(),
+        seen_bodies: Rc::new(RefCell::new(Vec::new())),
+        seen_headers: Rc::new(RefCell::new(Vec::new())),
+        response: HttpResponse {
+            status_code: 200,
+            body: br#"{"data":[]}"#.to_vec(),
+        },
+        get_response: None,
+    };
+    let client = anvil::provider::openai::OpenAiCompatibleProviderClient::with_transport(
+        "http://localhost:1234/v1",
+        transport,
+    );
+
+    client
+        .health_check()
+        .expect("health check with /v1 base url should succeed");
+
+    assert_eq!(seen_urls.borrow()[0], "http://localhost:1234/v1/models");
+}
+
+#[test]
 fn live_turn_executes_structured_response_from_openai_compatible_provider() {
     let root = common::unique_test_dir("openai_structured_write");
     let mut config = common::build_config_in(root.clone());
@@ -639,6 +701,144 @@ fn live_turn_executes_structured_response_from_openai_compatible_provider() {
         frames
             .iter()
             .any(|frame| frame.contains("file.write completed ./sandbox/openai/index.html"))
+    );
+}
+
+#[test]
+fn live_turn_executes_native_tool_calls_response_from_openai_compatible_provider() {
+    let root = common::unique_test_dir("openai_native_tool_calls_write");
+    fs::create_dir_all(&root).expect("test root should be created");
+    let mut config = common::build_config_in(root.clone());
+    config.mode.approval_required = false;
+    config.runtime.provider = "openai".to_string();
+    config.runtime.provider_url = "http://localhost:1234".to_string();
+    config.runtime.stream = false;
+    let provider_ctx =
+        anvil::provider::ProviderRuntimeContext::bootstrap(&config).expect("provider bootstrap");
+    let mut app = anvil::app::App::new(
+        config,
+        provider_ctx,
+        std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+    )
+    .expect("app should initialize");
+    let tui = Tui::new();
+
+    let transport = MockHttpTransport {
+        seen_urls: Rc::new(RefCell::new(Vec::new())),
+        seen_bodies: Rc::new(RefCell::new(Vec::new())),
+        seen_headers: Rc::new(RefCell::new(Vec::new())),
+        response: HttpResponse {
+            status_code: 200,
+            body: br#"{"choices":[{"message":{"role":"assistant","content":"","tool_calls":[{"id":"call_native_write_001","type":"function","function":{"name":"file_write","arguments":"{\"path\":\"./sandbox/native/nonstream.html\",\"content\":\"<html><body>native non-stream</body></html>\"}"}}]}}],"stats":{},"system_fingerprint":"qwen3.5"}"#.to_vec(),
+        },
+        get_response: None,
+    };
+    let client = anvil::provider::openai::OpenAiCompatibleProviderClient::with_transport(
+        "http://localhost:1234",
+        transport,
+    );
+
+    let frames = app
+        .run_live_turn("build via native tool_calls", &client, &tui)
+        .expect("native tool_calls response should execute");
+
+    let written = fs::read_to_string(root.join("sandbox/native/nonstream.html"))
+        .expect("file should be written from native tool_calls");
+    assert!(written.contains("native non-stream"));
+    assert!(
+        frames
+            .iter()
+            .any(|frame| frame.contains("file.write completed ./sandbox/native/nonstream.html"))
+    );
+}
+
+#[test]
+fn live_turn_executes_streaming_native_tool_calls_response_from_openai_compatible_provider() {
+    let root = common::unique_test_dir("openai_streaming_native_tool_calls_write");
+    fs::create_dir_all(&root).expect("test root should be created");
+    let mut config = common::build_config_in(root.clone());
+    config.mode.approval_required = false;
+    config.runtime.provider = "openai".to_string();
+    config.runtime.provider_url = "http://localhost:1234".to_string();
+    config.runtime.stream = true;
+    let provider_ctx =
+        anvil::provider::ProviderRuntimeContext::bootstrap(&config).expect("provider bootstrap");
+    let mut app = anvil::app::App::new(
+        config,
+        provider_ctx,
+        std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+    )
+    .expect("app should initialize");
+    let tui = Tui::new();
+
+    let transport = MockHttpTransport {
+        seen_urls: Rc::new(RefCell::new(Vec::new())),
+        seen_bodies: Rc::new(RefCell::new(Vec::new())),
+        seen_headers: Rc::new(RefCell::new(Vec::new())),
+        response: HttpResponse {
+            status_code: 200,
+            body: concat!(
+                "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_stream_write_001\",\"type\":\"function\",\"function\":{\"name\":\"file_write\",\"arguments\":\"{\\\"path\\\":\\\"./sandbox/native/stream.html\\\",\"}}]},\"finish_reason\":null}]}\n",
+                "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"\\\"content\\\":\\\"<html><body>native stream</body></html>\\\"}\"}}]},\"finish_reason\":null}]}\n",
+                "data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"tool_calls\"}],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":5}}\n",
+                "data: [DONE]\n"
+            )
+            .as_bytes()
+            .to_vec(),
+        },
+        get_response: None,
+    };
+    let client = anvil::provider::openai::OpenAiCompatibleProviderClient::with_transport(
+        "http://localhost:1234",
+        transport,
+    );
+
+    let frames = app
+        .run_live_turn("build via streaming native tool_calls", &client, &tui)
+        .expect("streaming native tool_calls response should execute");
+
+    let written = fs::read_to_string(root.join("sandbox/native/stream.html"))
+        .expect("file should be written from streaming native tool_calls");
+    assert!(written.contains("native stream"));
+    assert!(
+        frames
+            .iter()
+            .any(|frame| frame.contains("file.write completed ./sandbox/native/stream.html"))
+    );
+}
+
+#[test]
+fn openai_compatible_provider_surfaces_invalid_native_tool_call_arguments() {
+    let request = ProviderTurnRequest::new(
+        "local-openai".to_string(),
+        vec![anvil::provider::ProviderMessage::new(
+            ProviderMessageRole::User,
+            "inspect src/provider",
+        )],
+        false,
+    );
+
+    let transport = MockHttpTransport {
+        seen_urls: Rc::new(RefCell::new(Vec::new())),
+        seen_bodies: Rc::new(RefCell::new(Vec::new())),
+        seen_headers: Rc::new(RefCell::new(Vec::new())),
+        response: HttpResponse {
+            status_code: 200,
+            body: br#"{"choices":[{"message":{"role":"assistant","content":"","tool_calls":[{"id":"call_invalid_args_001","type":"function","function":{"name":"file_write","arguments":"{not json}"}}]}}]}"#.to_vec(),
+        },
+        get_response: None,
+    };
+    let client = anvil::provider::openai::OpenAiCompatibleProviderClient::with_transport(
+        "http://localhost:1234",
+        transport,
+    );
+
+    let err = client
+        .stream_turn(&request, &mut |_| {})
+        .expect_err("invalid native tool call arguments should surface");
+    assert!(
+        err.to_string()
+            .contains("invalid openai tool_call arguments")
     );
 }
 


### PR DESCRIPTION
## Summary
developブランチの最新変更をmainにマージするリリースPRです。

### 含まれるIssue/変更

| Issue | タイトル | 種別 |
|-------|---------|------|
| #215 | LM Studio (OpenAI互換API) でレスポンスをパースできない | fix |
| #214 | --provider lmstudio エイリアス追加（準備） | feat (部分) |
| — | read_transition_guard (file.read→file.editワークフロー最適化) | feat |

### 主な変更内容

**バグ修正**
- OpenAI互換プロバイダーで `tool_calls` レスポンスをパース可能に（ストリーミング/非ストリーミング両対応）
- LM Studio の `/v1` ベースURL対応

**新機能**
- `read_transition_guard`: file.read後にfile.editへの遷移を最適化するガード機構
- OpenAI互換プロバイダーの `tool_calls` 応答サポート

### 品質チェック
- [x] cargo fmt --check: Pass
- [x] cargo clippy --all-targets: Pass
- [x] cargo test: Pass（全テスト通過）

### 変更規模
- 12ファイル、+712/-19行

🤖 Generated with [Claude Code](https://claude.com/claude-code)