### PR TITLE
chore: release v0.0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+## [0.0.9] - 2026-03-31
+
+### Added
+- OpenAI native `tool_calls` support and LM Studio compatibility (#215)
+- Read transition guard to detect read-phase stalling
+
+### Fixed
+- Support `/v1` base URLs for OpenAI-compatible providers
+- OpenAI native tool calls parsing and response handling
+
 ## [0.0.8] - 2026-03-31
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,7 +72,7 @@ dependencies = [
 
 [[package]]
 name = "anvil"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anvil"
-version = "0.0.8"
+version = "0.0.9"
 edition = "2024"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ```bash
 # macOS (Apple Silicon)
-curl -L https://github.com/Kewton/Anvil/releases/download/v0.0.8/anvil-darwin-arm64.gz -o anvil.gz
+curl -L https://github.com/Kewton/Anvil/releases/download/v0.0.9/anvil-darwin-arm64.gz -o anvil.gz
 gunzip anvil.gz
 chmod +x anvil
 sudo mv anvil /usr/local/bin/


### PR DESCRIPTION
## Summary
- Bump version from 0.0.8 to 0.0.9
- Update CHANGELOG.md with all changes since v0.0.8
- Update README.md download link to v0.0.9

### Highlights
- OpenAI native `tool_calls` support and LM Studio compatibility (#215)
- Read transition guard to detect read-phase stalling
- `/v1` base URL support for OpenAI-compatible providers

🤖 Generated with [Claude Code](https://claude.com/claude-code)