### PR TITLE
feat(issue-221): prompt suggestion UX

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,7 @@ src/
 │   ├── plan.rs          # プラン管理
 │   ├── policy.rs        # offlineポリシーチェック（共通ヘルパー）
 │   ├── render.rs        # コンソール描画
+│   ├── suggestion.rs    # prompt suggestion エンジン（ヒューリスティックベース・Done ステート候補提示）
 │   └── mock.rs          # テスト用モック
 ├── config/mod.rs        # 設定管理
 ├── contracts/

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -16,6 +16,7 @@ pub mod policy;
 pub(crate) mod read_repeat_tracker;
 pub(crate) mod read_transition_guard;
 pub mod render;
+pub mod suggestion;
 pub(crate) mod write_fail_tracker;
 pub(crate) mod write_repeat_tracker;
 
@@ -271,6 +272,8 @@ pub struct App {
     session_stats: SessionStats,
     /// Last compact operation info for turn summary reporting (Issue #206).
     last_compact_info: Option<CompactInfo>,
+    /// Last slash command executed (volatile, for suggestion heuristics Issue #221).
+    last_slash_command: Option<String>,
 }
 
 /// Whether the session loop should continue or exit.
@@ -600,6 +603,7 @@ impl App {
             file_read_cache,
             session_stats: SessionStats::new(),
             last_compact_info: None,
+            last_slash_command: None,
         })
     }
 
@@ -1069,6 +1073,7 @@ impl App {
         self.current_session_name = name.to_string();
         self.active_model = None;
         self.active_context_window = None;
+        self.clear_transient_state();
 
         // Clear file read cache on session switch (DR2-004)
         if let Ok(mut cache) = self.file_read_cache.lock() {
@@ -1783,12 +1788,17 @@ impl App {
         // Exclude all messages from frame rendering because they were
         // already shown during the live turn — streaming to stderr and
         // tool execution output (Issue #1).
-        self.session.console_render_context(
+        let mut ctx = self.session.console_render_context(
             self.state_machine.snapshot(),
             self.effective_model(),
             self.config.runtime.max_console_messages,
             true,
-        )
+        );
+        // Config guard: inject suggestion only when enabled and interactive (Issue #221).
+        if self.config.runtime.suggestion_enabled && self.config.mode.interactive {
+            ctx.suggestion = self.suggest_next_input(&ctx.snapshot);
+        }
+        ctx
     }
 
     fn build_startup_render_context(&self) -> ConsoleRenderContext {
@@ -1800,6 +1810,27 @@ impl App {
             self.config.runtime.max_console_messages,
             false,
         )
+    }
+
+    /// Generate a prompt suggestion based on current session state (Issue #221).
+    ///
+    /// Pure generation logic; config guards are applied by the caller.
+    fn suggest_next_input(&self, snapshot: &AppStateSnapshot) -> Option<String> {
+        let recent = self.session.last_n_messages(5);
+        let ctx = suggestion::SuggestionContext {
+            state: &snapshot.state,
+            tool_logs: &snapshot.tool_logs,
+            working_memory: &self.session.working_memory,
+            recent_messages: recent,
+            last_slash_command: self.last_slash_command.as_deref(),
+            message_count: self.session.messages.len(),
+        };
+        suggestion::suggest(&ctx)
+    }
+
+    /// Clear volatile transient state (called on /reset, session switch, non-slash turn completion).
+    fn clear_transient_state(&mut self) {
+        self.last_slash_command = None;
     }
 
     fn next_message_id(&self, prefix: &str) -> String {
@@ -1854,6 +1885,8 @@ impl App {
             return self.handle_slash_command(trimmed, provider_client, tui);
         }
 
+        // Clear transient state after non-slash live turn (Issue #221).
+        self.clear_transient_state();
         self.run_turn_to_output(trimmed, provider_client, tui)
     }
 
@@ -1898,6 +1931,9 @@ impl App {
         provider_client: &impl ProviderClient,
         tui: &Tui,
     ) -> Result<CliTurnOutput, AppError> {
+        // Track last slash command for suggestion heuristics (Issue #221).
+        self.last_slash_command = Some(command.to_string());
+
         let output = match self
             .extensions
             .find_slash_command(command)
@@ -2083,6 +2119,7 @@ impl App {
             }
             Some(SlashCommandAction::Reset) => {
                 let _ = self.reset_to_ready()?;
+                self.clear_transient_state();
                 CliTurnOutput {
                     frames: vec![self.render_console(tui)?],
                     control: SessionControl::Continue,

--- a/src/app/suggestion.rs
+++ b/src/app/suggestion.rs
@@ -1,0 +1,286 @@
+//! Prompt suggestion engine (Issue #221).
+//!
+//! Deterministic / heuristic-based suggestion generation.
+//! No LLM calls — fixed template strings only (security: no raw user input embedding).
+
+use crate::contracts::{RuntimeState, ToolLogView};
+use crate::session::{SessionMessage, WorkingMemory};
+
+/// Context required by the suggestion engine.
+pub struct SuggestionContext<'a> {
+    pub state: &'a RuntimeState,
+    pub tool_logs: &'a [ToolLogView],
+    pub working_memory: &'a WorkingMemory,
+    pub recent_messages: Vec<&'a SessionMessage>,
+    pub last_slash_command: Option<&'a str>,
+    pub message_count: usize,
+}
+
+/// Generate a prompt suggestion based on heuristic rules.
+///
+/// Returns `None` when no suggestion applies or the state is not `Done`.
+/// The caller is responsible for config guards (`suggestion_enabled`, `interactive`).
+pub fn suggest(ctx: &SuggestionContext) -> Option<String> {
+    // Only suggest in Done state
+    if *ctx.state != RuntimeState::Done {
+        return None;
+    }
+
+    // Rule 1: unresolved errors present
+    if !ctx.working_memory.unresolved_errors.is_empty() {
+        return Some("前回のエラーを修正してください".to_string());
+    }
+
+    // Rule 2: file.write / file.edit / file.edit_anchor completed in this turn
+    if has_recent_file_edit_completed(ctx.tool_logs) {
+        return Some("cargo test".to_string());
+    }
+
+    // Rule 3: after /plan add
+    if ctx
+        .last_slash_command
+        .is_some_and(|cmd| cmd.starts_with("/plan add"))
+    {
+        return Some("/plan add で次のステップを追加、または作業を開始".to_string());
+    }
+
+    // Rule 4: consecutive same-tool pattern detection (placeholder for future expansion)
+    // Currently no-op: raw message content is never echoed into suggestions.
+
+    // Rule 5: empty session
+    if ctx.message_count == 0 {
+        return Some("/help でコマンド一覧を確認".to_string());
+    }
+
+    None
+}
+
+/// Check whether any file mutation tool completed in the current turn's tool logs.
+fn has_recent_file_edit_completed(tool_logs: &[ToolLogView]) -> bool {
+    tool_logs.iter().any(|log| {
+        matches!(
+            log.tool_name.as_str(),
+            "file.write" | "file.edit" | "file.edit_anchor"
+        ) && log.is_completed()
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::contracts::ToolLogView;
+    use crate::session::{MessageRole, SessionMessage, WorkingMemory};
+
+    fn empty_working_memory() -> WorkingMemory {
+        WorkingMemory::default()
+    }
+
+    fn done_state() -> RuntimeState {
+        RuntimeState::Done
+    }
+
+    fn make_message(role: MessageRole, content: &str) -> SessionMessage {
+        SessionMessage::new(role, "test", content)
+    }
+
+    #[test]
+    fn test_suggest_non_done_state() {
+        let wm = empty_working_memory();
+        let ctx = SuggestionContext {
+            state: &RuntimeState::Thinking,
+            tool_logs: &[],
+            working_memory: &wm,
+            recent_messages: vec![],
+            last_slash_command: None,
+            message_count: 5,
+        };
+        assert_eq!(suggest(&ctx), None);
+    }
+
+    #[test]
+    fn test_suggest_done_with_unresolved_errors() {
+        let mut wm = empty_working_memory();
+        wm.add_error("compilation failed");
+        let state = done_state();
+        let ctx = SuggestionContext {
+            state: &state,
+            tool_logs: &[],
+            working_memory: &wm,
+            recent_messages: vec![],
+            last_slash_command: None,
+            message_count: 3,
+        };
+        let suggestion = suggest(&ctx);
+        assert_eq!(
+            suggestion,
+            Some("前回のエラーを修正してください".to_string())
+        );
+    }
+
+    #[test]
+    fn test_suggest_done_after_file_edit() {
+        let wm = empty_working_memory();
+        let state = done_state();
+        let logs = vec![ToolLogView {
+            tool_name: "file.edit".to_string(),
+            action: "completed".to_string(),
+            target: "src/main.rs".to_string(),
+            elapsed_ms: None,
+        }];
+        let ctx = SuggestionContext {
+            state: &state,
+            tool_logs: &logs,
+            working_memory: &wm,
+            recent_messages: vec![],
+            last_slash_command: None,
+            message_count: 3,
+        };
+        assert_eq!(suggest(&ctx), Some("cargo test".to_string()));
+    }
+
+    #[test]
+    fn test_suggest_done_after_file_write() {
+        let wm = empty_working_memory();
+        let state = done_state();
+        let logs = vec![ToolLogView {
+            tool_name: "file.write".to_string(),
+            action: "completed".to_string(),
+            target: "src/lib.rs".to_string(),
+            elapsed_ms: None,
+        }];
+        let ctx = SuggestionContext {
+            state: &state,
+            tool_logs: &logs,
+            working_memory: &wm,
+            recent_messages: vec![],
+            last_slash_command: None,
+            message_count: 3,
+        };
+        assert_eq!(suggest(&ctx), Some("cargo test".to_string()));
+    }
+
+    #[test]
+    fn test_suggest_done_after_file_edit_failed_no_suggestion() {
+        let wm = empty_working_memory();
+        let state = done_state();
+        let logs = vec![ToolLogView {
+            tool_name: "file.edit".to_string(),
+            action: "failed".to_string(),
+            target: "src/main.rs".to_string(),
+            elapsed_ms: None,
+        }];
+        let ctx = SuggestionContext {
+            state: &state,
+            tool_logs: &logs,
+            working_memory: &wm,
+            recent_messages: vec![],
+            last_slash_command: None,
+            message_count: 3,
+        };
+        // failed file.edit should not trigger "cargo test"
+        assert_eq!(suggest(&ctx), None);
+    }
+
+    #[test]
+    fn test_suggest_after_plan_add() {
+        let wm = empty_working_memory();
+        let state = done_state();
+        let ctx = SuggestionContext {
+            state: &state,
+            tool_logs: &[],
+            working_memory: &wm,
+            recent_messages: vec![],
+            last_slash_command: Some("/plan add implement feature"),
+            message_count: 3,
+        };
+        let suggestion = suggest(&ctx);
+        assert!(suggestion.is_some());
+        assert!(suggestion.unwrap().contains("/plan add"));
+    }
+
+    #[test]
+    fn test_suggest_empty_session() {
+        let wm = empty_working_memory();
+        let state = done_state();
+        let ctx = SuggestionContext {
+            state: &state,
+            tool_logs: &[],
+            working_memory: &wm,
+            recent_messages: vec![],
+            last_slash_command: None,
+            message_count: 0,
+        };
+        let suggestion = suggest(&ctx);
+        assert_eq!(suggestion, Some("/help でコマンド一覧を確認".to_string()));
+    }
+
+    #[test]
+    fn test_suggest_rule_priority_errors_over_file_edit() {
+        let mut wm = empty_working_memory();
+        wm.add_error("test failure");
+        let state = done_state();
+        let logs = vec![ToolLogView {
+            tool_name: "file.edit".to_string(),
+            action: "completed".to_string(),
+            target: "src/main.rs".to_string(),
+            elapsed_ms: None,
+        }];
+        let ctx = SuggestionContext {
+            state: &state,
+            tool_logs: &logs,
+            working_memory: &wm,
+            recent_messages: vec![],
+            last_slash_command: None,
+            message_count: 3,
+        };
+        // Rule 1 (errors) should take priority over Rule 2 (file edit)
+        assert_eq!(
+            suggest(&ctx),
+            Some("前回のエラーを修正してください".to_string())
+        );
+    }
+
+    #[test]
+    fn test_suggest_rule4_never_echoes_raw_message_content() {
+        let wm = empty_working_memory();
+        let state = done_state();
+        let secret_msg = make_message(MessageRole::User, "SECRET_CONTENT_12345");
+        let ctx = SuggestionContext {
+            state: &state,
+            tool_logs: &[],
+            working_memory: &wm,
+            recent_messages: vec![&secret_msg],
+            last_slash_command: None,
+            message_count: 5,
+        };
+        let suggestion = suggest(&ctx);
+        // Whether Some or None, the suggestion must not contain raw message content
+        if let Some(ref s) = suggestion {
+            assert!(
+                !s.contains("SECRET_CONTENT_12345"),
+                "suggestion must not echo raw message content"
+            );
+        }
+    }
+
+    #[test]
+    fn test_suggest_done_no_applicable_rule() {
+        let wm = empty_working_memory();
+        let state = done_state();
+        let logs = vec![ToolLogView {
+            tool_name: "file.read".to_string(),
+            action: "completed".to_string(),
+            target: "src/main.rs".to_string(),
+            elapsed_ms: None,
+        }];
+        let ctx = SuggestionContext {
+            state: &state,
+            tool_logs: &logs,
+            working_memory: &wm,
+            recent_messages: vec![],
+            last_slash_command: None,
+            message_count: 3,
+        };
+        assert_eq!(suggest(&ctx), None);
+    }
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -161,6 +161,8 @@ pub struct RuntimeConfig {
     /// Maximum output tokens per LLM turn (Issue #204).
     /// Translated to provider-specific limits (Ollama `num_predict`, OpenAI `max_tokens`).
     pub max_output_tokens: Option<u32>,
+    /// Enable prompt suggestion UX (Issue #221). Default: true.
+    pub suggestion_enabled: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -341,6 +343,7 @@ impl EffectiveConfig {
                 ui_language: None,
                 max_tool_calls: DEFAULT_MAX_TOOL_CALLS,
                 max_output_tokens: Some(DEFAULT_MAX_OUTPUT_TOKENS),
+                suggestion_enabled: true,
             },
             mode: ModeConfig {
                 prompt_source: PromptSource::Interactive,
@@ -463,6 +466,7 @@ impl EffectiveConfig {
             "ANVIL_SAFE_WRITE_DELETION_RATIO",
             "ANVIL_UI_LANGUAGE",
             "ANVIL_MAX_TOOL_CALLS",
+            "ANVIL_SUGGESTION_ENABLED",
         ] {
             if let Ok(value) = std::env::var(key) {
                 map.insert(key.to_string(), value);
@@ -863,6 +867,9 @@ impl EffectiveConfig {
                         .parse()
                         .map_err(|_| ConfigError::InvalidNumericValue(value.clone()))?;
                     self.runtime.max_output_tokens = if v == 0 { None } else { Some(v) };
+                }
+                "suggestion_enabled" | "ANVIL_SUGGESTION_ENABLED" => {
+                    self.runtime.suggestion_enabled = parse_bool(value);
                 }
                 _ => {}
             }
@@ -1456,6 +1463,7 @@ impl std::fmt::Debug for RuntimeConfig {
             )
             .field("safe_write_max_lines", &self.safe_write_max_lines)
             .field("safe_write_deletion_ratio", &self.safe_write_deletion_ratio)
+            .field("suggestion_enabled", &self.suggestion_enabled)
             .finish()
     }
 }

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -160,6 +160,15 @@ pub struct ToolLogView {
     pub elapsed_ms: Option<u64>,
 }
 
+impl ToolLogView {
+    /// Whether the tool execution completed (i.e. was not "failed" or "interrupted").
+    ///
+    /// DRY: used by both `summarize_tool_logs` and suggestion heuristics.
+    pub fn is_completed(&self) -> bool {
+        !matches!(self.action.as_str(), "failed" | "interrupted")
+    }
+}
+
 /// Context usage warning level based on threshold evaluation.
 ///
 /// Used as `Option<ContextWarningLevel>` where `None` means no warning.
@@ -247,6 +256,9 @@ pub struct ConsoleRenderContext {
     pub model_name: String,
     pub messages: Vec<ConsoleMessageView>,
     pub history_summary: Option<String>,
+    /// Prompt suggestion for the next likely user input. Display-only, not persisted.
+    #[serde(default)]
+    pub suggestion: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -434,6 +434,15 @@ impl SessionRecord {
         self.messages.len()
     }
 
+    /// Return the last `limit` messages in chronological order (oldest first).
+    ///
+    /// Used by suggestion heuristics to detect recent conversation patterns.
+    pub fn last_n_messages(&self, limit: usize) -> Vec<&SessionMessage> {
+        let len = self.messages.len();
+        let start = len.saturating_sub(limit);
+        self.messages[start..].iter().collect()
+    }
+
     pub fn recent_message_views(
         &self,
         limit: usize,
@@ -525,6 +534,7 @@ impl SessionRecord {
             model_name: model_name.to_string(),
             messages,
             history_summary,
+            suggestion: None,
         }
     }
 

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -3,6 +3,7 @@
 //! [`Tui`] is a stateless renderer that converts [`ConsoleRenderContext`]
 //! snapshots into plain-text frames for the terminal.
 
+use crate::app::render::sanitize_output_line;
 use crate::config::EffectiveConfig;
 use crate::contracts::{
     AppStateSnapshot, ConsoleMessageRole, ConsoleMessageView, ConsoleRenderContext,
@@ -194,6 +195,19 @@ impl Tui {
         lines.push(status_divider());
         lines.push(self.render_footer(snapshot, &view.model_name));
         lines.push(render_hint_line(snapshot));
+
+        // Suggestion line (Issue #221): shown unconditionally when Some.
+        // Done-state check is performed by suggest() — render just displays.
+        if let Some(ref suggestion) = view.suggestion {
+            // Reuse the existing sanitize helper (CB-002): strips ANSI escapes,
+            // collapses control chars, trims, and truncates with ellipsis.
+            const SUGGESTION_MAX_CHARS: usize = 120;
+            let sanitized = sanitize_output_line(suggestion, SUGGESTION_MAX_CHARS);
+            if !sanitized.is_empty() {
+                lines.push(format!("  [suggestion] {sanitized}"));
+            }
+        }
+
         lines.push(status_divider());
 
         // Done/Ready: do NOT emit "[U] you >" here — the interactive
@@ -311,10 +325,12 @@ fn summarize_tool_logs(logs: &[crate::contracts::ToolLogView]) -> (usize, usize,
     let mut interrupted = 0;
 
     for log in logs {
-        match log.action.as_str() {
-            "failed" => failed += 1,
-            "interrupted" => interrupted += 1,
-            _ => completed += 1,
+        if log.is_completed() {
+            completed += 1;
+        } else if log.action == "interrupted" {
+            interrupted += 1;
+        } else {
+            failed += 1;
         }
     }
 

--- a/tests/tui_console.rs
+++ b/tests/tui_console.rs
@@ -380,6 +380,7 @@ fn context_warning_bar_displayed_for_warning_level() {
         model_name: "test-model".to_string(),
         messages: vec![],
         history_summary: None,
+        suggestion: None,
     };
 
     let rendered = tui.render_console(&context);
@@ -407,6 +408,7 @@ fn context_warning_bar_displayed_for_critical_level() {
         model_name: "test-model".to_string(),
         messages: vec![],
         history_summary: None,
+        suggestion: None,
     };
 
     let rendered = tui.render_console(&context);
@@ -433,6 +435,7 @@ fn context_warning_bar_absent_when_no_warning() {
         model_name: "test-model".to_string(),
         messages: vec![],
         history_summary: None,
+        suggestion: None,
     };
 
     let rendered = tui.render_console(&context);
@@ -455,6 +458,7 @@ fn done_hint_line_includes_compact() {
         model_name: "test-model".to_string(),
         messages: vec![],
         history_summary: None,
+        suggestion: None,
     };
 
     let rendered = tui.render_console(&context);
@@ -612,6 +616,7 @@ fn tool_log_displays_elapsed_ms() {
         model_name: "test-model".to_string(),
         messages: vec![],
         history_summary: None,
+        suggestion: None,
     };
 
     let rendered = tui.render_console(&context);
@@ -638,6 +643,7 @@ fn tool_log_omits_elapsed_ms_when_none() {
         model_name: "test-model".to_string(),
         messages: vec![],
         history_summary: None,
+        suggestion: None,
     };
 
     let rendered = tui.render_console(&context);
@@ -667,6 +673,7 @@ fn footer_shows_perf_with_metrics() {
         model_name: "test-model".to_string(),
         messages: vec![],
         history_summary: None,
+        suggestion: None,
     };
 
     let rendered = tui.render_console(&context);
@@ -689,6 +696,7 @@ fn footer_shows_perf_dash_without_metrics() {
         model_name: "test-model".to_string(),
         messages: vec![],
         history_summary: None,
+        suggestion: None,
     };
 
     let rendered = tui.render_console(&context);


### PR DESCRIPTION
## Summary
- Add heuristic-based prompt suggestion that surfaces likely next commands from recent history and tool patterns
- New `src/app/suggestion.rs` module with configurable display and disable options
- Suggestion rendered in TUI footer with sanitization and truncation

## Quality Gate
- [x] `cargo build` — Pass
- [x] `cargo clippy --all-targets` — Pass (0 warnings)
- [x] `cargo test` — Pass (all tests)
- [x] `cargo fmt --check` — Pass

Closes #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)