### PR TITLE
fix: accept query as prompt alias in agent.explore/plan

### DIFF
--- a/src/agent/tag_parser.rs
+++ b/src/agent/tag_parser.rs
@@ -278,11 +278,13 @@ fn build_tool_input(
         },
         "agent.explore" => ToolInput::AgentExplore {
             prompt: get_child("prompt")
+                .or_else(|| get_child("query"))
                 .ok_or_else(|| "missing prompt element for agent.explore".to_string())?,
             scope: get_attr("scope"),
         },
         "agent.plan" => ToolInput::AgentPlan {
             prompt: get_child("prompt")
+                .or_else(|| get_child("query"))
                 .ok_or_else(|| "missing prompt element for agent.plan".to_string())?,
             scope: get_attr("scope"),
         },

--- a/src/tooling/mod.rs
+++ b/src/tooling/mod.rs
@@ -312,6 +312,7 @@ impl ToolInput {
             "agent.explore" => Ok(ToolInput::AgentExplore {
                 prompt: value
                     .get("prompt")
+                    .or_else(|| value.get("query"))
                     .and_then(serde_json::Value::as_str)
                     .ok_or_else(|| "missing prompt in agent.explore tool block".to_string())?
                     .to_string(),
@@ -323,6 +324,7 @@ impl ToolInput {
             "agent.plan" => Ok(ToolInput::AgentPlan {
                 prompt: value
                     .get("prompt")
+                    .or_else(|| value.get("query"))
                     .and_then(serde_json::Value::as_str)
                     .ok_or_else(|| "missing prompt in agent.plan tool block".to_string())?
                     .to_string(),
@@ -445,11 +447,13 @@ impl ToolInput {
                 query: extract_simple(block, "query")?,
             }),
             "agent.explore" => Some(ToolInput::AgentExplore {
-                prompt: extract_simple(block, "prompt")?,
+                prompt: extract_simple(block, "prompt")
+                    .or_else(|| extract_simple(block, "query"))?,
                 scope: extract_simple(block, "scope"),
             }),
             "agent.plan" => Some(ToolInput::AgentPlan {
-                prompt: extract_simple(block, "prompt")?,
+                prompt: extract_simple(block, "prompt")
+                    .or_else(|| extract_simple(block, "query"))?,
                 scope: extract_simple(block, "scope"),
             }),
             "git.status" => Some(ToolInput::GitStatus {}),

--- a/tests/tooling_system.rs
+++ b/tests/tooling_system.rs
@@ -2597,6 +2597,149 @@ fn from_json_parses_agent_plan_without_scope() {
     );
 }
 
+// --- Issue #232: query alias for prompt in agent.explore / agent.plan ---
+
+#[test]
+fn from_json_agent_explore_accepts_query_as_prompt_alias() {
+    let json: serde_json::Value = serde_json::json!({
+        "query": "investigate logging patterns"
+    });
+    let input =
+        ToolInput::from_json("agent.explore", &json).expect("should accept query as prompt alias");
+    assert_eq!(
+        input,
+        ToolInput::AgentExplore {
+            prompt: "investigate logging patterns".to_string(),
+            scope: None,
+        }
+    );
+}
+
+#[test]
+fn from_json_agent_explore_query_with_scope() {
+    let json: serde_json::Value = serde_json::json!({
+        "query": "investigate logging patterns",
+        "scope": "src/tooling"
+    });
+    let input =
+        ToolInput::from_json("agent.explore", &json).expect("should accept query with scope");
+    assert_eq!(
+        input,
+        ToolInput::AgentExplore {
+            prompt: "investigate logging patterns".to_string(),
+            scope: Some("src/tooling".to_string()),
+        }
+    );
+}
+
+#[test]
+fn from_json_agent_explore_prompt_takes_precedence_over_query() {
+    let json: serde_json::Value = serde_json::json!({
+        "prompt": "from prompt field",
+        "query": "from query field"
+    });
+    let input = ToolInput::from_json("agent.explore", &json).expect("should prefer prompt");
+    assert_eq!(
+        input,
+        ToolInput::AgentExplore {
+            prompt: "from prompt field".to_string(),
+            scope: None,
+        }
+    );
+}
+
+#[test]
+fn from_json_agent_plan_accepts_query_as_prompt_alias() {
+    let json: serde_json::Value = serde_json::json!({
+        "query": "plan the refactoring"
+    });
+    let input =
+        ToolInput::from_json("agent.plan", &json).expect("should accept query as prompt alias");
+    assert_eq!(
+        input,
+        ToolInput::AgentPlan {
+            prompt: "plan the refactoring".to_string(),
+            scope: None,
+        }
+    );
+}
+
+#[test]
+fn from_json_agent_plan_query_with_scope() {
+    let json: serde_json::Value = serde_json::json!({
+        "query": "plan the refactoring",
+        "scope": "src/app"
+    });
+    let input = ToolInput::from_json("agent.plan", &json).expect("should accept query with scope");
+    assert_eq!(
+        input,
+        ToolInput::AgentPlan {
+            prompt: "plan the refactoring".to_string(),
+            scope: Some("src/app".to_string()),
+        }
+    );
+}
+
+#[test]
+fn repair_from_block_agent_explore_accepts_query_as_prompt_alias() {
+    fn extract_simple(block: &str, key: &str) -> Option<String> {
+        let pattern = format!("\"{}\":", key);
+        let start = block.find(&pattern)? + pattern.len();
+        let rest = &block[start..];
+        let rest = rest.trim_start();
+        if let Some(inner) = rest.strip_prefix('"') {
+            let end = inner.find('"')?;
+            Some(inner[..end].to_string())
+        } else {
+            None
+        }
+    }
+    fn extract_trailing(block: &str, key: &str) -> Option<String> {
+        extract_simple(block, key)
+    }
+
+    let block = r#"{"query": "investigate logging", "scope": "src/tooling"}"#;
+    let result =
+        ToolInput::repair_from_block("agent.explore", block, extract_simple, extract_trailing);
+    assert_eq!(
+        result,
+        Some(ToolInput::AgentExplore {
+            prompt: "investigate logging".to_string(),
+            scope: Some("src/tooling".to_string()),
+        })
+    );
+}
+
+#[test]
+fn repair_from_block_agent_plan_accepts_query_as_prompt_alias() {
+    fn extract_simple(block: &str, key: &str) -> Option<String> {
+        let pattern = format!("\"{}\":", key);
+        let start = block.find(&pattern)? + pattern.len();
+        let rest = &block[start..];
+        let rest = rest.trim_start();
+        if let Some(inner) = rest.strip_prefix('"') {
+            let end = inner.find('"')?;
+            Some(inner[..end].to_string())
+        } else {
+            None
+        }
+    }
+    fn extract_trailing(block: &str, key: &str) -> Option<String> {
+        extract_simple(block, key)
+    }
+
+    let block = r#"{"query": "plan the implementation"}"#;
+    let result =
+        ToolInput::repair_from_block("agent.plan", block, extract_simple, extract_trailing);
+    assert_eq!(
+        result,
+        Some(ToolInput::AgentPlan {
+            prompt: "plan the implementation".to_string(),
+            scope: None,
+        })
+    );
+}
+
 #[test]
 fn from_json_agent_explore_missing_prompt_fails() {
     let json: serde_json::Value = serde_json::json!({


### PR DESCRIPTION
## Summary
- `agent.explore` と `agent.plan` で `query` パラメータを `prompt` のエイリアスとして受理するよう修正
- JSON パース・tag パース・repair パースの全経路で対応
- 互換テスト追加（143行）

Closes #232

## Test plan
- [x] `cargo test` 全パス
- [x] `cargo clippy --all-targets` 警告ゼロ
- [x] `cargo fmt --check` 差分なし
- [x] agent.explore(query) / agent.plan(query) の互換テスト追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)