### PR TITLE
fix: file.edit no-op reports actual path and retry hint

### DIFF
--- a/src/tooling/mod.rs
+++ b/src/tooling/mod.rs
@@ -1520,9 +1520,12 @@ impl LocalToolExecutor {
         if old_string == new_string {
             return Ok(build_completed_result(
                 request,
-                format!("{path} (no changes)"),
+                format!(
+                    "{path} (no changes: old_string and new_string are identical. \
+                     Review the content and provide a different new_string to make the intended edit.)"
+                ),
                 ToolExecutionPayload::None,
-                vec![],
+                vec![path.to_string()],
                 started,
             ));
         }
@@ -1577,9 +1580,12 @@ impl LocalToolExecutor {
         if params.old_content == params.new_content {
             return Ok(build_completed_result(
                 request,
-                format!("{path} (no changes)"),
+                format!(
+                    "{path} (no changes: old_content and new_content are identical. \
+                     Review the content and provide a different new_content to make the intended edit.)"
+                ),
                 ToolExecutionPayload::None,
-                vec![],
+                vec![path.to_string()],
                 started,
             ));
         }

--- a/tests/tooling_system.rs
+++ b/tests/tooling_system.rs
@@ -1753,6 +1753,20 @@ fn file_edit_noop_when_strings_equal() {
 
     assert_eq!(result.status, ToolExecutionStatus::Completed);
     assert!(result.summary.contains("no changes"));
+    assert!(
+        result
+            .summary
+            .contains("old_string and new_string are identical"),
+        "summary should tell LLM that old_string == new_string: {}",
+        result.summary,
+    );
+    // artifacts must contain the file path (not be empty / "unknown")
+    assert_eq!(result.artifacts, vec!["./test.txt".to_string()]);
+    // edit_detail must be set by the fallback wrapper
+    assert!(
+        result.edit_detail.is_some(),
+        "edit_detail should be Some for no-op edit",
+    );
     let content = fs::read_to_string(&file_path).expect("read should succeed");
     assert_eq!(content, "hello world");
 }


### PR DESCRIPTION
## Summary
- `file.edit` / `file.edit_anchor` で `old_string==new_string` の場合、artifacts に実パスを含めるよう修正
- LLM へのリトライ誘導メッセージを追加（`path=unknown` → 実パス表示）
- テスト追加

Closes #234

## Test plan
- [x] `cargo test` 全パス
- [x] `cargo clippy --all-targets` 警告ゼロ
- [x] `cargo fmt --check` 差分なし
- [x] no-op path でパス表示・リトライヒントのテスト追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)