### PR TITLE
fix: separate failed tool call counts and improve write feedback

### DIFF
--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -638,11 +638,24 @@ impl App {
                 .collect();
             all_tool_log_views.extend(tool_log_views.clone());
 
-            let working = AppStateSnapshot::new(RuntimeState::Working)
-                .with_status(format!(
+            let failed_count = results
+                .iter()
+                .filter(|r| r.status == ToolExecutionStatus::Failed)
+                .count();
+            let status_msg = if failed_count > 0 {
+                format!(
+                    "Executed {} tool call(s) ({} failed). Sending results to model...",
+                    results.len(),
+                    failed_count
+                )
+            } else {
+                format!(
                     "Executed {} tool call(s). Sending results to model...",
                     results.len()
-                ))
+                )
+            };
+            let working = AppStateSnapshot::new(RuntimeState::Working)
+                .with_status(status_msg)
                 .with_tool_logs(tool_log_views)
                 .with_elapsed_ms(elapsed_ms);
             let _ = self.transition_with_context(working, StateTransition::StartWorking)?;
@@ -1523,8 +1536,13 @@ impl App {
 
     /// Push a tool execution result into the session as a tool message.
     fn record_tool_result(&mut self, result: &ToolExecutionResult) {
-        // Session stats: record tool call (Issue #206 C-3)
-        self.session_stats.record_tool_call(&result.tool_name);
+        // Session stats: record tool call, separating success/failure (Issue #206 C-3, Issue #233)
+        if result.status == ToolExecutionStatus::Failed {
+            self.session_stats
+                .record_tool_call_failed(&result.tool_name);
+        } else {
+            self.session_stats.record_tool_call(&result.tool_name);
+        }
 
         // Session stats: record file change line counts from diff_summary (Issue #206 C-3)
         if let Some(ref diff) = result.diff_summary {
@@ -1751,25 +1769,38 @@ impl App {
             return None;
         }
         if result.status == ToolExecutionStatus::Failed {
-            if let Some(path) = extract_write_path_from_summary(&result.summary)
-                .filter(|p| self.write_fail_tracker.record_failure(p))
-            {
+            // Always provide clear feedback that the file was NOT written (Issue #233).
+            // Additionally, track consecutive failures for escalated hints.
+            if let Some(path) = extract_write_path_from_summary(&result.summary) {
+                let threshold_hit = self.write_fail_tracker.record_failure(&path);
                 let count = self.write_fail_tracker.failure_count(&path);
-                tracing::warn!(
-                    tool = "file.write",
-                    path = %path,
-                    count = count,
-                    "repeated write failure"
-                );
                 let safe_path = crate::session::sanitize_for_prompt_entry(&path);
+                if threshold_hit {
+                    tracing::warn!(
+                        tool = "file.write",
+                        path = %path,
+                        count = count,
+                        "repeated write failure"
+                    );
+                    return Some(format!(
+                        "\n\n[Anvil warning] file.write was NOT written to disk for '{safe_path}' \
+                         ({count} consecutive failures). Please check the error message carefully. \
+                         Consider: (1) verifying the file path is correct, \
+                         (2) splitting the content into smaller files, \
+                         (3) using file.edit for partial modifications instead."
+                    ));
+                }
                 return Some(format!(
-                    "\n\n[Anvil hint] file.write has failed {count} consecutive \
-                     times for '{safe_path}'. Please check the error message carefully. \
-                     Consider: (1) verifying the file path is correct, \
-                     (2) splitting the content into smaller files, \
-                     (3) using file.edit for partial modifications instead."
+                    "\n\n[Anvil notice] file.write was NOT written to disk for '{safe_path}'. \
+                     The file on disk is unchanged. Check the error above and retry \
+                     or use file.edit for partial modifications."
                 ));
             }
+            // No path extracted — still provide generic notice
+            return Some(
+                "\n\n[Anvil notice] file.write failed — no changes were written to disk."
+                    .to_string(),
+            );
         } else if result.status == ToolExecutionStatus::Completed
             && let Some(artifact) = result.artifacts.first()
         {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -144,6 +144,8 @@ pub struct SessionStats {
     pub total_turns: u32,
     pub session_start: Option<Instant>,
     pub tool_calls: HashMap<String, u32>,
+    /// Failed tool call counts, tracked separately from successful ones (Issue #233).
+    pub failed_tool_calls: HashMap<String, u32>,
     pub files_modified: u32,
     pub lines_added: u32,
     pub lines_deleted: u32,
@@ -161,6 +163,14 @@ impl SessionStats {
 
     pub fn record_tool_call(&mut self, tool_name: &str) {
         *self.tool_calls.entry(tool_name.to_string()).or_insert(0) += 1;
+    }
+
+    /// Record a failed tool call separately from successful ones (Issue #233).
+    pub fn record_tool_call_failed(&mut self, tool_name: &str) {
+        *self
+            .failed_tool_calls
+            .entry(tool_name.to_string())
+            .or_insert(0) += 1;
     }
 
     pub fn record_file_change(&mut self, added: u32, deleted: u32) {
@@ -183,9 +193,19 @@ impl SessionStats {
         self.tool_calls.values().sum()
     }
 
+    /// Total number of failed tool calls (Issue #233).
+    pub fn total_failed_tool_calls(&self) -> u32 {
+        self.failed_tool_calls.values().sum()
+    }
+
     /// Format tool call counts summary (e.g. `"file.read x18, file.edit x12"`).
     pub fn tool_calls_summary(&self) -> String {
         format_tool_counts(self.tool_calls.iter().map(|(k, v)| (k.clone(), *v)))
+    }
+
+    /// Format failed tool call counts summary (Issue #233).
+    pub fn failed_tool_calls_summary(&self) -> String {
+        format_tool_counts(self.failed_tool_calls.iter().map(|(k, v)| (k.clone(), *v)))
     }
 }
 
@@ -846,10 +866,13 @@ impl App {
             .session_start
             .map(|s| s.elapsed())
             .unwrap_or_default();
+        let failed_total = self.session_stats.total_failed_tool_calls();
         tracing::info!(
             total_turns = self.session_stats.total_turns,
             total_tool_calls = self.session_stats.total_tool_calls(),
+            failed_tool_calls = failed_total,
             tools = %self.session_stats.tool_calls_summary(),
+            failed_tools = %self.session_stats.failed_tool_calls_summary(),
             files_modified = self.session_stats.files_modified,
             lines_added = self.session_stats.lines_added,
             lines_deleted = self.session_stats.lines_deleted,
@@ -2824,5 +2847,54 @@ mod tests {
             None => context_window as usize,
         };
         assert_eq!(effective, 262_144);
+    }
+
+    // --- Issue #233: failed tool calls must be tracked separately ---
+
+    #[test]
+    fn session_stats_failed_tool_calls_tracked_separately() {
+        let mut stats = SessionStats::new();
+        stats.record_tool_call("file.write");
+        stats.record_tool_call_failed("file.write");
+        // 1 success + 1 failure
+        assert_eq!(
+            stats.total_tool_calls(),
+            1,
+            "total should count only successes"
+        );
+        assert_eq!(
+            stats.total_failed_tool_calls(),
+            1,
+            "failed should be tracked separately"
+        );
+    }
+
+    #[test]
+    fn session_stats_summary_includes_failed_counts() {
+        let mut stats = SessionStats::new();
+        stats.record_tool_call("file.read");
+        stats.record_tool_call("file.read");
+        stats.record_tool_call_failed("file.write");
+        let summary = stats.tool_calls_summary();
+        assert!(
+            summary.contains("file.read x2"),
+            "summary should show successful calls"
+        );
+        // failed_tool_calls_summary should mention file.write
+        let failed_summary = stats.failed_tool_calls_summary();
+        assert!(
+            failed_summary.contains("file.write"),
+            "failed summary should include failed tool name"
+        );
+    }
+
+    #[test]
+    fn session_stats_file_write_fail_does_not_inflate_total() {
+        let mut stats = SessionStats::new();
+        stats.record_tool_call_failed("file.write");
+        // No successful tool calls
+        assert_eq!(stats.total_tool_calls(), 0);
+        assert_eq!(stats.files_modified, 0);
+        assert_eq!(stats.total_failed_tool_calls(), 1);
     }
 }


### PR DESCRIPTION
## Summary
- `SessionStats` に `failed_tool_calls` を分離追跡
- `record_tool_result` で成功/失敗を分けてカウント
- セッションサマリー・ターンサマリーに失敗件数を表示
- `file.write` 失敗時に初回から「NOT written to disk」をLLMにフィードバック

Closes #233

## Test plan
- [x] `cargo test` 全パス
- [x] `cargo clippy --all-targets` 警告ゼロ
- [x] `cargo fmt --check` 差分なし
- [x] 失敗カウント分離のテスト追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)