### PR TITLE
feat(issue-242): add phase estimation to turn summary logs

### DIFF
--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -41,6 +41,7 @@ pub struct TurnSummary<'a> {
     pub tool_names: &'a [String],
     pub files_modified: usize,
     pub compact_info: Option<&'a CompactInfo>,
+    pub phase: super::phase_estimator::Phase,
 }
 
 /// Log a turn summary using structured tracing.
@@ -69,6 +70,7 @@ pub fn log_turn_summary(summary: &TurnSummary<'_>) {
         tools = %tool_summary,
         files_modified = summary.files_modified,
         compact = %compact_str,
+        phase = %summary.phase,
         "turn completed"
     );
 }
@@ -659,6 +661,7 @@ impl App {
                 tool_names: &turn_tool_names,
                 files_modified: turn_files_modified,
                 compact_info: self.last_compact_info.as_ref(),
+                phase: self.phase_estimator.current_phase(),
             });
             // Reset last_compact_info after it's been consumed by the turn summary
             self.last_compact_info = None;
@@ -1820,6 +1823,7 @@ impl App {
                 tool_names: &[],
                 files_modified: 0,
                 compact_info: None,
+                phase: self.phase_estimator.current_phase(),
             });
             return Ok(None);
         }

--- a/src/app/phase_estimator.rs
+++ b/src/app/phase_estimator.rs
@@ -22,7 +22,6 @@ pub enum PhaseAction {
 
 /// Estimated agent phase (for logging/debugging).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[allow(dead_code)]
 pub enum Phase {
     /// Not enough data to determine phase.
     Unknown,
@@ -30,6 +29,16 @@ pub enum Phase {
     Exploring,
     /// Has performed write operations.
     Implementing,
+}
+
+impl std::fmt::Display for Phase {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Phase::Unknown => write!(f, "unknown"),
+            Phase::Exploring => write!(f, "exploring"),
+            Phase::Implementing => write!(f, "implementing"),
+        }
+    }
 }
 
 /// Tool category for phase estimation.
@@ -60,7 +69,6 @@ pub struct PhaseEstimator {
     /// Whether ANVIL_FINAL has been observed at least once in this session.
     anvil_final_observed: bool,
     /// Threshold N: consecutive reads to enter "exploring" phase.
-    #[allow(dead_code)]
     explore_threshold: usize,
     /// Threshold M: consecutive reads to trigger forced transition (M > N).
     force_transition_threshold: usize,
@@ -153,7 +161,6 @@ impl PhaseEstimator {
     }
 
     /// Return the estimated phase for logging/debugging.
-    #[allow(dead_code)]
     pub fn current_phase(&self) -> Phase {
         if self.has_written {
             Phase::Implementing
@@ -310,6 +317,13 @@ mod tests {
         est.record_tool_call("shell.exec", true);
         assert_eq!(est.consecutive_reads, 0);
         assert!(!est.has_written);
+    }
+
+    #[test]
+    fn phase_display() {
+        assert_eq!(Phase::Unknown.to_string(), "unknown");
+        assert_eq!(Phase::Exploring.to_string(), "exploring");
+        assert_eq!(Phase::Implementing.to_string(), "implementing");
     }
 
     #[test]

--- a/tests/phase_estimation.rs
+++ b/tests/phase_estimation.rs
@@ -3,6 +3,7 @@
 //! Tests cover the PhaseEstimator's interaction with Config settings
 //! and its overall behavior patterns.
 
+use anvil::app::agentic::{TurnSummary, log_turn_summary};
 use anvil::app::phase_estimator::{Phase, PhaseAction, PhaseEstimator};
 
 #[test]
@@ -129,4 +130,23 @@ fn phase_estimator_other_tools_ignored() {
     est.record_tool_call("shell.exec", true);
     est.record_tool_call("agent.plan", true);
     assert_eq!(est.current_phase(), Phase::Unknown);
+}
+
+#[test]
+fn turn_summary_includes_phase_field() {
+    let summary = TurnSummary {
+        turn: 1,
+        max_turns: 10,
+        elapsed: std::time::Duration::from_secs(1),
+        tokens_used: 100,
+        token_budget: 1000,
+        tool_calls: 2,
+        tool_names: &[],
+        files_modified: 0,
+        compact_info: None,
+        phase: Phase::Exploring,
+    };
+    // Verify phase field exists and log_turn_summary is callable
+    assert_eq!(format!("{}", summary.phase), "exploring");
+    log_turn_summary(&summary);
 }


### PR DESCRIPTION
## Summary
- ターンサマリーログに `phase=` フィールドを追加し、PhaseEstimator の推定結果を出力
- `TurnSummary` 構造体に `phase` フィールドを追加
- 既存の PhaseEstimator ロジックは変更なし

Closes #242

## Test plan
- [x] `cargo build` パス
- [x] `cargo clippy --all-targets` 警告0
- [x] `cargo test` 全パス
- [x] `cargo fmt --check` 差分なし