### PR TITLE
feat(issue-241): add session note extraction with logging

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,7 +140,7 @@ src/
 │   ├── openai.rs        # OpenAI互換クライアント
 │   └── transport.rs     # HTTPトランスポート
 ├── retrieval/mod.rs     # リポジトリ検索（オンデマンドコンテンツ読込・軽量キャッシュ）
-├── session/mod.rs       # セッション永続化（名前付きセッション・一覧・切替・削除・マイグレーション・構造化WorkingMemory・LLM要約コンパクション）
+├── session/mod.rs       # セッション永続化（名前付きセッション・一覧・切替・削除・マイグレーション・構造化WorkingMemory・LLM要約コンパクション・SessionNote抽出）
 ├── spinner.rs           # スピナーUI
 ├── state/mod.rs         # 状態マシン
 ├── tooling/

--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -430,6 +430,10 @@ impl App {
         // Reset read transition guard per-turn counters (Issue #216)
         self.read_transition_guard.reset();
 
+        // Session note extraction bookkeeping (Issue #241)
+        let msg_count_before = self.session.messages.len();
+        let tokens_before = self.session.estimated_token_count();
+
         for iteration in 0..max_iterations {
             let iteration_started = std::time::Instant::now();
 
@@ -761,6 +765,24 @@ impl App {
         let mut done_snapshot = self.transition_with_context(done, StateTransition::Finish)?;
         self.evaluate_context_warning(&mut done_snapshot);
         frames.push(self.render_console(tui)?);
+
+        // Session note extraction (Issue #241)
+        let tokens_after = self.session.estimated_token_count();
+        let context_window = self.effective_context_window() as usize;
+        let token_delta = tokens_after.saturating_sub(tokens_before);
+        if total_tool_count >= 5 || token_delta >= context_window / 10 {
+            let turn_messages = &self.session.messages[msg_count_before..];
+            let notes = crate::session::extract_session_notes(turn_messages);
+            for note in &notes {
+                tracing::info!(
+                    kind = %note.kind,
+                    files = ?note.files,
+                    "session_note: {}",
+                    note.summary
+                );
+            }
+        }
+
         Ok(frames)
     }
 

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -1329,6 +1329,164 @@ fn is_noise_token(token: &str) -> bool {
     false
 }
 
+// ── Session Notes (Issue #241) ───────────────────────────────────────
+
+/// Category of a session note — represents tool operation types only.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum NoteKind {
+    FileEdit,
+    FileRead,
+    ShellExec,
+    ErrorHit,
+}
+
+impl std::fmt::Display for NoteKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            NoteKind::FileEdit => write!(f, "file_edit"),
+            NoteKind::FileRead => write!(f, "file_read"),
+            NoteKind::ShellExec => write!(f, "shell_exec"),
+            NoteKind::ErrorHit => write!(f, "error_hit"),
+        }
+    }
+}
+
+/// A deterministic note extracted from a turn's messages.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SessionNote {
+    pub kind: NoteKind,
+    pub files: Vec<String>,
+    pub summary: String,
+}
+
+/// Truncate a string at the given byte limit, respecting UTF-8 char boundaries.
+/// Appends "..." when truncation occurs.
+fn truncate_at_boundary(s: &str, max_bytes: usize) -> String {
+    if s.len() <= max_bytes {
+        return s.to_string();
+    }
+    let mut end = max_bytes;
+    while !s.is_char_boundary(end) && end > 0 {
+        end -= 1;
+    }
+    format!("{}...", &s[..end])
+}
+
+/// Extract session notes from a slice of messages.
+///
+/// Scans Tool-role messages, classifies by author, aggregates by kind,
+/// and produces summary strings. Unknown authors are ignored.
+pub fn extract_session_notes(messages: &[SessionMessage]) -> Vec<SessionNote> {
+    use std::collections::HashMap;
+
+    struct Accumulator {
+        files: Vec<String>,
+        count: usize,
+    }
+
+    impl Accumulator {
+        fn new() -> Self {
+            Self {
+                files: Vec::new(),
+                count: 0,
+            }
+        }
+
+        /// Merge unique file paths and bump the operation count.
+        fn record(&mut self, paths: &[String]) {
+            for f in paths {
+                if !self.files.contains(f) {
+                    self.files.push(f.clone());
+                }
+            }
+            self.count += 1;
+        }
+    }
+
+    let mut accumulators: HashMap<NoteKind, Accumulator> = HashMap::new();
+
+    for msg in messages {
+        if msg.role != MessageRole::Tool {
+            continue;
+        }
+
+        let kind = match msg.author.as_str() {
+            "file.edit" | "file.write" => Some(NoteKind::FileEdit),
+            "file.read" => Some(NoteKind::FileRead),
+            "shell.exec" => Some(NoteKind::ShellExec),
+            _ => None,
+        };
+
+        // Extract file paths from this single message
+        let file_targets = extract_file_targets(std::slice::from_ref(msg));
+        // Sanitize: strip control chars, limit path length (128 chars), limit count (20 files)
+        let sanitized: Vec<String> = file_targets
+            .into_iter()
+            .take(20)
+            .map(|f| {
+                let clean: String = f.chars().filter(|c| !c.is_control()).collect();
+                truncate_at_boundary(&clean, 128)
+            })
+            .collect();
+
+        // If is_error, always create an ErrorHit entry (regardless of known/unknown author)
+        if msg.is_error {
+            accumulators
+                .entry(NoteKind::ErrorHit)
+                .or_insert_with(Accumulator::new)
+                .record(&sanitized);
+        }
+
+        // For known tools, also create the tool-type note
+        let Some(k) = kind else { continue };
+
+        accumulators
+            .entry(k)
+            .or_insert_with(Accumulator::new)
+            .record(&sanitized);
+    }
+
+    // Build notes in a stable order
+    let order = [
+        NoteKind::FileEdit,
+        NoteKind::FileRead,
+        NoteKind::ShellExec,
+        NoteKind::ErrorHit,
+    ];
+
+    let mut notes = Vec::new();
+    for kind in order {
+        if let Some(acc) = accumulators.remove(&kind) {
+            let verb = match kind {
+                NoteKind::FileEdit => "Edited",
+                NoteKind::FileRead => "Read",
+                NoteKind::ShellExec => "Executed shell command",
+                NoteKind::ErrorHit => "Error in",
+            };
+
+            let summary = if acc.files.is_empty() {
+                format!("{verb} {count} operation(s)", count = acc.count)
+            } else {
+                let file_list = acc.files.join(", ");
+                format!(
+                    "{verb} {count} file(s): {file_list}",
+                    count = acc.files.len()
+                )
+            };
+
+            let summary = truncate_at_boundary(&summary, 200);
+
+            notes.push(SessionNote {
+                kind,
+                files: acc.files,
+                summary,
+            });
+        }
+    }
+
+    notes
+}
+
 #[cfg(test)]
 mod working_memory_tests {
     use super::*;

--- a/tests/state_session.rs
+++ b/tests/state_session.rs
@@ -2,9 +2,9 @@ mod common;
 
 use anvil::contracts::{AppEvent, AppStateSnapshot, RuntimeState};
 use anvil::session::{
-    MessageRole, MessageStatus, SessionMessage, SessionRecord, SessionStore, WorkingMemory,
-    build_conversation_text_for_summary, extract_file_targets, new_assistant_message,
-    new_user_message, validate_session_name,
+    MessageRole, MessageStatus, NoteKind, SessionMessage, SessionNote, SessionRecord, SessionStore,
+    WorkingMemory, build_conversation_text_for_summary, extract_file_targets,
+    extract_session_notes, new_assistant_message, new_user_message, validate_session_name,
 };
 use anvil::state::{StateMachine, StateTransition};
 use std::path::PathBuf;
@@ -1931,4 +1931,91 @@ fn compact_history_public_signature_unchanged() {
     // Verify compact_history() still works with original signature (keep_recent: usize) -> bool
     let changed: bool = session.compact_history(5);
     assert!(changed);
+}
+
+// ── Session Note Tests (Issue #241) ──────────────────────────────────
+
+#[test]
+fn extract_session_notes_empty() {
+    let notes = extract_session_notes(&[]);
+    assert!(notes.is_empty());
+}
+
+#[test]
+fn extract_session_notes_file_edit() {
+    let msg = SessionMessage::new(MessageRole::Tool, "file.edit", "Updated src/main.rs");
+    let notes = extract_session_notes(&[msg]);
+    assert_eq!(notes.len(), 1);
+    assert_eq!(notes[0].kind, NoteKind::FileEdit);
+    assert!(!notes[0].summary.is_empty());
+}
+
+#[test]
+fn extract_session_notes_file_read() {
+    let msg = SessionMessage::new(MessageRole::Tool, "file.read", "Read src/lib.rs");
+    let notes = extract_session_notes(&[msg]);
+    assert_eq!(notes.len(), 1);
+    assert_eq!(notes[0].kind, NoteKind::FileRead);
+}
+
+#[test]
+fn extract_session_notes_shell_exec() {
+    let msg = SessionMessage::new(MessageRole::Tool, "shell.exec", "cargo test output");
+    let notes = extract_session_notes(&[msg]);
+    assert_eq!(notes.len(), 1);
+    assert_eq!(notes[0].kind, NoteKind::ShellExec);
+}
+
+#[test]
+fn extract_session_notes_error_hit() {
+    let mut msg = SessionMessage::new(
+        MessageRole::Tool,
+        "file.edit",
+        "Error: file not found src/missing.rs",
+    );
+    msg.is_error = true;
+    let notes = extract_session_notes(&[msg]);
+    // Should produce both ErrorHit and FileEdit notes
+    assert_eq!(notes.len(), 2);
+    let kinds: Vec<NoteKind> = notes.iter().map(|n| n.kind).collect();
+    assert!(kinds.contains(&NoteKind::ErrorHit));
+    assert!(kinds.contains(&NoteKind::FileEdit));
+}
+
+#[test]
+fn extract_session_notes_aggregation() {
+    let msg1 = SessionMessage::new(MessageRole::Tool, "file.edit", "Updated src/a.rs");
+    let msg2 = SessionMessage::new(MessageRole::Tool, "file.edit", "Updated src/b.rs");
+    let notes = extract_session_notes(&[msg1, msg2]);
+    // Should aggregate into a single FileEdit note
+    let edit_notes: Vec<&SessionNote> = notes
+        .iter()
+        .filter(|n| n.kind == NoteKind::FileEdit)
+        .collect();
+    assert_eq!(edit_notes.len(), 1);
+    assert!(edit_notes[0].summary.contains('2'));
+}
+
+#[test]
+fn extract_session_notes_unknown_author_ignored() {
+    let msg = SessionMessage::new(MessageRole::Tool, "unknown.tool", "some content");
+    let notes = extract_session_notes(&[msg]);
+    assert!(notes.is_empty());
+}
+
+#[test]
+fn extract_session_notes_unknown_author_error_still_captured() {
+    let mut msg = SessionMessage::new(MessageRole::Tool, "mcp.custom_tool", "Error: timeout");
+    msg.is_error = true;
+    let notes = extract_session_notes(&[msg]);
+    assert_eq!(notes.len(), 1);
+    assert_eq!(notes[0].kind, NoteKind::ErrorHit);
+}
+
+#[test]
+fn note_kind_display() {
+    assert_eq!(NoteKind::FileEdit.to_string(), "file_edit");
+    assert_eq!(NoteKind::FileRead.to_string(), "file_read");
+    assert_eq!(NoteKind::ShellExec.to_string(), "shell_exec");
+    assert_eq!(NoteKind::ErrorHit.to_string(), "error_hit");
 }


### PR DESCRIPTION
## Summary
- `SessionNote` 型と `extract_session_notes()` 関数を `src/session/mod.rs` に追加
- ターン完了時にdeterministic要点抽出を実行し、INFOレベルログに出力
- トリガー条件: ツール呼び出し5回以上、またはトークン増分が context_window の 10% 以上
- 既存の `WorkingMemory` / `SessionRecord` の構造は変更なし

Closes #241

## Test plan
- [x] `cargo build` パス
- [x] `cargo clippy --all-targets` 警告0
- [x] `cargo test` 全パス
- [x] `cargo fmt --check` 差分なし