### PR TITLE
feat(issue-240): add parallel tool progress display

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,12 +141,13 @@ src/
 │   └── transport.rs     # HTTPトランスポート
 ├── retrieval/mod.rs     # リポジトリ検索（オンデマンドコンテンツ読込・軽量キャッシュ）
 ├── session/mod.rs       # セッション永続化（名前付きセッション・一覧・切替・削除・マイグレーション・構造化WorkingMemory・LLM要約コンパクション・SessionNote抽出）
-├── spinner.rs           # スピナーUI
+├── spinner.rs           # スピナーUI（並列詳細進捗表示・start_parallel_detailed・format_detailed_progress）
 ├── state/mod.rs         # 状態マシン
 ├── tooling/
 │   ├── mod.rs           # ツール実行・検証・CheckpointStack（undo用チェックポイント管理）・EditFallbackStage・file.edit詳細ログ
 │   ├── diff.rs          # 差分プレビュー生成（file.write/file.edit承認時）
 │   ├── file_cache.rs    # ファイル読み取りキャッシュ（FileReadCache: LRUエビクション・sandbox境界検証）
+│   ├── progress.rs      # 並列実行進捗型（ToolProgressStatus・ToolProgressEntry）
 │   └── shell_policy.rs  # ShellPolicy分類（ReadOnly/BuildTest/General）・offline用ネットワークコマンド検出
 ├── tui/mod.rs           # TUI描画
 └── walk.rs              # 共通ディレクトリウォーカー（.gitignore対応・統一スキップ/バイナリ除外）

--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -11,6 +11,7 @@ use crate::provider::{ProviderClient, ProviderEvent};
 use crate::session::{MessageRole, SessionMessage};
 use crate::spinner::Spinner;
 use crate::state::StateTransition;
+use crate::tooling::progress::{ToolProgressEntry, ToolProgressStatus};
 use crate::tooling::{
     ExecutionMode, LocalToolExecutor, ToolCallRequest, ToolExecutionPayload, ToolExecutionPolicy,
     ToolExecutionRequest, ToolExecutionResult, ToolExecutionStatus, ToolInput, ToolKind,
@@ -137,23 +138,35 @@ fn execute_parallel_group_standalone(
     shutdown_flag: std::sync::Arc<std::sync::atomic::AtomicBool>,
     requests: Vec<(usize, ToolExecutionRequest)>,
     completed: Arc<AtomicUsize>,
+    entries: Arc<std::sync::Mutex<Vec<ToolProgressEntry>>>,
     file_cache: Option<std::sync::Arc<std::sync::Mutex<crate::tooling::file_cache::FileReadCache>>>,
 ) -> Vec<(usize, ToolExecutionResult)> {
     let cwd = config.paths.cwd.clone();
     let runtime = &config.runtime;
     let mut all_results = Vec::new();
 
+    let mut chunk_offset = 0usize;
     for chunk in requests.chunks(MAX_PARALLEL_THREADS) {
+        let current_offset = chunk_offset;
         all_results.extend(std::thread::scope(|s| {
             let handles: Vec<_> = chunk
                 .iter()
-                .map(|(idx, request)| {
+                .enumerate()
+                .map(|(pos_in_chunk, (idx, request))| {
                     let cwd = cwd.clone();
                     let shutdown = shutdown_flag.clone();
                     let idx = *idx;
                     let completed = completed.clone();
+                    let entries = entries.clone();
+                    let entry_index = current_offset + pos_in_chunk;
                     let file_cache = file_cache.clone();
                     s.spawn(move || {
+                        // Update started_at to actual execution start time
+                        if let Ok(mut guard) = entries.lock()
+                            && let Some(entry) = guard.get_mut(entry_index)
+                        {
+                            entry.started_at = std::time::Instant::now();
+                        }
                         let mut executor = LocalToolExecutor::new(cwd, runtime, file_cache)
                             .with_shutdown_flag(shutdown);
                         let tool_call_id = request.tool_call_id.clone();
@@ -193,6 +206,21 @@ fn execute_parallel_group_standalone(
                                 edit_detail: None,
                             }
                         });
+                        // Update progress entry
+                        if let Ok(mut guard) = entries.lock()
+                            && let Some(entry) = guard.get_mut(entry_index)
+                        {
+                            let elapsed =
+                                entry.started_at.elapsed().as_millis().min(u64::MAX as u128)
+                                    as u64;
+                            entry.elapsed_ms = Some(elapsed);
+                            entry.status =
+                                if result.status == ToolExecutionStatus::Completed {
+                                    ToolProgressStatus::Completed
+                                } else {
+                                    ToolProgressStatus::Failed
+                                };
+                        }
                         completed.fetch_add(1, Ordering::Relaxed);
                         (idx, result)
                     })
@@ -229,6 +257,7 @@ fn execute_parallel_group_standalone(
             }
             results
         }));
+        chunk_offset += chunk.len();
     }
 
     all_results
@@ -1135,13 +1164,27 @@ impl App {
             match group {
                 ExecutionGroup::Parallel(requests) if requests.len() >= 2 => {
                     let completed = Arc::new(AtomicUsize::new(0));
-                    let spinner =
-                        Spinner::start_parallel(requests.len(), completed.clone(), interactive);
+                    let progress_entries: Vec<ToolProgressEntry> = requests
+                        .iter()
+                        .map(|(_, req)| ToolProgressEntry {
+                            tool_name: req.spec.name.clone(),
+                            status: ToolProgressStatus::Running,
+                            started_at: std::time::Instant::now(),
+                            elapsed_ms: None,
+                        })
+                        .collect();
+                    let entries = Arc::new(std::sync::Mutex::new(progress_entries));
+                    let spinner = Spinner::start_parallel_detailed(
+                        entries.clone(),
+                        completed.clone(),
+                        interactive,
+                    );
                     let parallel_results = execute_parallel_group_standalone(
                         &self.config,
                         self.shutdown_flag(),
                         requests,
                         completed,
+                        entries,
                         Some(self.file_read_cache.clone()),
                     );
                     spinner.stop();

--- a/src/spinner.rs
+++ b/src/spinner.rs
@@ -7,9 +7,13 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use crate::app::render::sanitize_display_string;
+use crate::tooling::progress::{ToolProgressEntry, ToolProgressStatus};
 
 const FRAMES: &[char] = &['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
 const FRAME_MS: u64 = 80;
+
+/// Default maximum display width for detailed progress output.
+const DEFAULT_MAX_DISPLAY_WIDTH: usize = 120;
 
 /// The display mode for a spinner.
 #[derive(Clone)]
@@ -38,6 +42,10 @@ pub struct Spinner {
     paused: Arc<AtomicBool>,
     handle: Option<thread::JoinHandle<()>>,
     mode: SpinnerMode,
+    /// Detailed per-tool progress entries for parallel execution.
+    /// `Some` when started via `start_parallel_detailed()`, `None` otherwise.
+    #[allow(dead_code)]
+    detailed_entries: Option<Arc<Mutex<Vec<ToolProgressEntry>>>>,
 }
 
 impl Spinner {
@@ -48,6 +56,7 @@ impl Spinner {
             paused: Arc::new(AtomicBool::new(false)),
             handle: None,
             mode: SpinnerMode::Simple,
+            detailed_entries: None,
         }
     }
 
@@ -94,6 +103,7 @@ impl Spinner {
             paused,
             handle: Some(handle),
             mode: SpinnerMode::Simple,
+            detailed_entries: None,
         }
     }
 
@@ -155,6 +165,7 @@ impl Spinner {
             paused,
             handle: Some(handle),
             mode,
+            detailed_entries: None,
         }
     }
 
@@ -207,6 +218,72 @@ impl Spinner {
             paused,
             handle: Some(handle),
             mode,
+            detailed_entries: None,
+        }
+    }
+
+    /// Start a detailed parallel-progress spinner.
+    ///
+    /// Displays per-tool status: `⠋ [2/4] ✓file.read(0.3s) ⟳git.status(1.2s)`
+    ///
+    /// Falls back to `[done/total completed]` when `try_lock()` fails.
+    /// When `enabled` is false, returns a no-op spinner.
+    pub fn start_parallel_detailed(
+        entries: Arc<Mutex<Vec<ToolProgressEntry>>>,
+        completed: Arc<AtomicUsize>,
+        enabled: bool,
+    ) -> Self {
+        if !enabled {
+            return Self::noop();
+        }
+        let total = entries.lock().unwrap().len();
+        let running = Arc::new(AtomicBool::new(true));
+        let paused = Arc::new(AtomicBool::new(false));
+
+        let flag = running.clone();
+        let pause_flag = paused.clone();
+        let comp = completed.clone();
+        let entries_ref = entries.clone();
+
+        let mode = SpinnerMode::Parallel {
+            total,
+            completed: completed.clone(),
+        };
+
+        let handle = thread::spawn(move || {
+            let mut stderr = std::io::stderr();
+            let mut i = 0usize;
+            let mut prev_len = 0usize;
+            while flag.load(Ordering::Relaxed) {
+                if pause_flag.load(Ordering::Relaxed) {
+                    thread::sleep(Duration::from_millis(FRAME_MS));
+                    continue;
+                }
+                let frame = FRAMES[i % FRAMES.len()];
+                let line = if let Ok(guard) = entries_ref.try_lock() {
+                    let detail = format_detailed_progress(&guard, DEFAULT_MAX_DISPLAY_WIDTH);
+                    format!("{frame} {detail}")
+                } else {
+                    let done = comp.load(Ordering::Relaxed);
+                    format!("{frame} [{}/{} completed]", done, total)
+                };
+                let clear_width = prev_len.max(line.len());
+                let _ = write!(stderr, "\r{:width$}\r{line}", "", width = clear_width);
+                let _ = stderr.flush();
+                prev_len = line.len();
+                thread::sleep(Duration::from_millis(FRAME_MS));
+                i += 1;
+            }
+            let _ = write!(stderr, "\r{:width$}\r", "", width = prev_len + 2);
+            let _ = stderr.flush();
+        });
+
+        Self {
+            running,
+            paused,
+            handle: Some(handle),
+            mode,
+            detailed_entries: Some(entries),
         }
     }
 
@@ -268,6 +345,71 @@ pub(crate) fn format_elapsed_ms(ms: u64) -> String {
     let secs = ms / 1000;
     let tenths = (ms % 1000) / 100;
     format!("{secs}.{tenths}s")
+}
+
+/// Format detailed progress entries into a display string.
+///
+/// Example: `[2/4] ✓file.read(0.3s) ⟳git.status(1.2s)`
+///
+/// Truncates with `...` when exceeding `max_width`.
+fn format_detailed_progress(entries: &[ToolProgressEntry], max_width: usize) -> String {
+    if entries.is_empty() {
+        return String::new();
+    }
+
+    let completed_count = entries
+        .iter()
+        .filter(|e| {
+            matches!(
+                e.status,
+                ToolProgressStatus::Completed | ToolProgressStatus::Failed
+            )
+        })
+        .count();
+    let total = entries.len();
+    let prefix = format!("[{}/{}]", completed_count, total);
+
+    let mut parts: Vec<String> = Vec::with_capacity(entries.len());
+    for entry in entries {
+        let symbol = match entry.status {
+            ToolProgressStatus::Running => '⟳',
+            ToolProgressStatus::Completed => '✓',
+            ToolProgressStatus::Failed => '✗',
+        };
+        let name = sanitize_display_string(&entry.tool_name, 30);
+        let time_str = match entry.status {
+            ToolProgressStatus::Running => {
+                let elapsed = entry.started_at.elapsed().as_millis().min(u64::MAX as u128) as u64;
+                format_elapsed_ms(elapsed)
+            }
+            ToolProgressStatus::Completed | ToolProgressStatus::Failed => {
+                format_elapsed_ms(entry.elapsed_ms.unwrap_or(0))
+            }
+        };
+        parts.push(format!("{symbol}{name}({time_str})"));
+    }
+
+    let full = format!("{} {}", prefix, parts.join(" "));
+    if full.len() <= max_width {
+        full
+    } else {
+        // Truncate: build incrementally
+        let suffix = "...";
+        let mut result = prefix.clone();
+        for part in &parts {
+            let candidate = format!("{} {}", result, part);
+            if candidate.len() + suffix.len() > max_width {
+                result.push_str(suffix);
+                break;
+            }
+            result = candidate;
+        }
+        // If even the prefix + suffix exceeds, just truncate
+        if result.len() > max_width {
+            result.truncate(max_width);
+        }
+        result
+    }
 }
 
 #[cfg(test)]
@@ -357,6 +499,7 @@ mod tests {
                 current_index: current_index.clone(),
                 tool_name: tool_name.clone(),
             },
+            detailed_entries: None,
         };
         spinner.set_tool_progress(2, "file.write");
         assert_eq!(current_index.load(Ordering::Relaxed), 2);
@@ -368,5 +511,111 @@ mod tests {
         let spinner = Spinner::start("test", false);
         // Should not panic for Simple mode
         spinner.set_tool_progress(1, "anything");
+    }
+
+    // --- format_detailed_progress tests ---
+
+    use crate::tooling::progress::{ToolProgressEntry, ToolProgressStatus};
+    use std::time::Instant;
+
+    fn make_entry(
+        name: &str,
+        status: ToolProgressStatus,
+        elapsed_ms: Option<u64>,
+    ) -> ToolProgressEntry {
+        ToolProgressEntry {
+            tool_name: name.to_string(),
+            status,
+            started_at: Instant::now(),
+            elapsed_ms,
+        }
+    }
+
+    #[test]
+    fn format_detailed_progress_empty() {
+        let result = format_detailed_progress(&[], 120);
+        assert_eq!(result, "");
+    }
+
+    #[test]
+    fn format_detailed_progress_all_completed() {
+        let entries = vec![
+            make_entry("file.read", ToolProgressStatus::Completed, Some(300)),
+            make_entry("file.search", ToolProgressStatus::Completed, Some(500)),
+        ];
+        let result = format_detailed_progress(&entries, 120);
+        assert!(result.starts_with("[2/2]"));
+        assert!(result.contains("✓file.read(0.3s)"));
+        assert!(result.contains("✓file.search(0.5s)"));
+    }
+
+    #[test]
+    fn format_detailed_progress_mixed_status() {
+        let entries = vec![
+            make_entry("file.read", ToolProgressStatus::Completed, Some(300)),
+            make_entry("git.status", ToolProgressStatus::Running, None),
+            make_entry("shell.exec", ToolProgressStatus::Failed, Some(1500)),
+        ];
+        let result = format_detailed_progress(&entries, 120);
+        // 2 of 3 are done (completed + failed)
+        assert!(result.starts_with("[2/3]"));
+        assert!(result.contains("✓file.read(0.3s)"));
+        assert!(result.contains("⟳git.status("));
+        assert!(result.contains("✗shell.exec(1.5s)"));
+    }
+
+    #[test]
+    fn format_detailed_progress_all_running() {
+        let entries = vec![
+            make_entry("file.read", ToolProgressStatus::Running, None),
+            make_entry("git.status", ToolProgressStatus::Running, None),
+        ];
+        let result = format_detailed_progress(&entries, 120);
+        assert!(result.starts_with("[0/2]"));
+        assert!(result.contains("⟳file.read("));
+        assert!(result.contains("⟳git.status("));
+    }
+
+    #[test]
+    fn format_detailed_progress_truncation() {
+        let entries: Vec<_> = (0..20)
+            .map(|i| make_entry(&format!("tool_{i}"), ToolProgressStatus::Running, None))
+            .collect();
+        let result = format_detailed_progress(&entries, 60);
+        assert!(result.len() <= 60, "result length {} > 60", result.len());
+        assert!(result.contains("..."));
+    }
+
+    #[test]
+    fn format_detailed_progress_within_width() {
+        let entries = vec![make_entry("a", ToolProgressStatus::Completed, Some(100))];
+        let result = format_detailed_progress(&entries, 120);
+        assert!(!result.contains("..."));
+        assert!(result.len() <= 120);
+    }
+
+    // --- start_parallel_detailed tests ---
+
+    #[test]
+    fn start_parallel_detailed_disabled_returns_noop() {
+        let entries = Arc::new(Mutex::new(vec![make_entry(
+            "file.read",
+            ToolProgressStatus::Running,
+            None,
+        )]));
+        let completed = Arc::new(AtomicUsize::new(0));
+        let spinner = Spinner::start_parallel_detailed(entries, completed, false);
+        assert!(!spinner.running.load(Ordering::Relaxed));
+        assert!(spinner.handle.is_none());
+        assert!(spinner.detailed_entries.is_none()); // noop has no entries
+    }
+
+    #[test]
+    fn start_parallel_keeps_backward_compat() {
+        // Existing start_parallel still works
+        let completed = Arc::new(AtomicUsize::new(0));
+        let spinner = Spinner::start_parallel(4, completed, false);
+        assert!(!spinner.running.load(Ordering::Relaxed));
+        assert!(spinner.detailed_entries.is_none());
     }
 }

--- a/src/tooling/mod.rs
+++ b/src/tooling/mod.rs
@@ -6,6 +6,7 @@
 
 pub mod diff;
 pub mod file_cache;
+pub mod progress;
 pub mod shell_policy;
 
 pub use shell_policy::{ShellPolicy, classify_shell_policy, is_network_command};

--- a/src/tooling/progress.rs
+++ b/src/tooling/progress.rs
@@ -1,0 +1,103 @@
+//! Progress tracking types for parallel tool execution display.
+//!
+//! These types are display-only and do not affect tool execution logic.
+
+/// Status of an individual tool during parallel execution (display only).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ToolProgressStatus {
+    /// Tool is currently running.
+    Running,
+    /// Tool completed successfully.
+    Completed,
+    /// Tool execution failed.
+    Failed,
+}
+
+/// Progress entry for an individual tool during parallel execution (display only).
+#[derive(Debug, Clone)]
+pub struct ToolProgressEntry {
+    /// Tool name (e.g. "file.read").
+    pub tool_name: String,
+    /// Current status.
+    pub status: ToolProgressStatus,
+    /// When execution started.
+    pub started_at: std::time::Instant,
+    /// Elapsed time in milliseconds. `None` while `Running`;
+    /// set on `Completed` or `Failed`.
+    ///
+    /// Uses `u64` (sufficient for display; u64::MAX ms ≈ 584 million years).
+    pub elapsed_ms: Option<u64>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Instant;
+
+    #[test]
+    fn status_equality() {
+        assert_eq!(ToolProgressStatus::Running, ToolProgressStatus::Running);
+        assert_eq!(ToolProgressStatus::Completed, ToolProgressStatus::Completed);
+        assert_eq!(ToolProgressStatus::Failed, ToolProgressStatus::Failed);
+        assert_ne!(ToolProgressStatus::Running, ToolProgressStatus::Completed);
+        assert_ne!(ToolProgressStatus::Running, ToolProgressStatus::Failed);
+        assert_ne!(ToolProgressStatus::Completed, ToolProgressStatus::Failed);
+    }
+
+    #[test]
+    fn status_is_copy() {
+        let s = ToolProgressStatus::Running;
+        let s2 = s; // Copy
+        assert_eq!(s, s2);
+    }
+
+    #[test]
+    fn entry_creation_running() {
+        let entry = ToolProgressEntry {
+            tool_name: "file.read".to_string(),
+            status: ToolProgressStatus::Running,
+            started_at: Instant::now(),
+            elapsed_ms: None,
+        };
+        assert_eq!(entry.tool_name, "file.read");
+        assert_eq!(entry.status, ToolProgressStatus::Running);
+        assert!(entry.elapsed_ms.is_none());
+    }
+
+    #[test]
+    fn entry_creation_completed() {
+        let entry = ToolProgressEntry {
+            tool_name: "git.status".to_string(),
+            status: ToolProgressStatus::Completed,
+            started_at: Instant::now(),
+            elapsed_ms: Some(1234),
+        };
+        assert_eq!(entry.status, ToolProgressStatus::Completed);
+        assert_eq!(entry.elapsed_ms, Some(1234));
+    }
+
+    #[test]
+    fn entry_creation_failed() {
+        let entry = ToolProgressEntry {
+            tool_name: "shell.exec".to_string(),
+            status: ToolProgressStatus::Failed,
+            started_at: Instant::now(),
+            elapsed_ms: Some(500),
+        };
+        assert_eq!(entry.status, ToolProgressStatus::Failed);
+        assert_eq!(entry.elapsed_ms, Some(500));
+    }
+
+    #[test]
+    fn entry_clone() {
+        let entry = ToolProgressEntry {
+            tool_name: "file.write".to_string(),
+            status: ToolProgressStatus::Running,
+            started_at: Instant::now(),
+            elapsed_ms: None,
+        };
+        let cloned = entry.clone();
+        assert_eq!(cloned.tool_name, entry.tool_name);
+        assert_eq!(cloned.status, entry.status);
+    }
+}


### PR DESCRIPTION
## Summary
- `ToolProgressStatus` / `ToolProgressEntry` 型を `src/tooling/progress.rs` に新規追加
- 並列実行ループ内で各ツールの状態・経過時間を `ToolProgressEntry` で追跡
- Spinner に `start_parallel_detailed()` メソッドを追加し、個別ツール状態を表示
- 既存の `ToolExecutionStatus` / `ToolLogView` / `AppStateSnapshot` は変更なし

Closes #240

## Test plan
- [x] `cargo build` パス
- [x] `cargo clippy --all-targets` 警告0
- [x] `cargo test` 全パス
- [x] `cargo fmt --check` 差分なし