### PR TITLE
feat(issue-249): introduce plan-execute mode with ANVIL_PLAN

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,6 +110,7 @@ src/
 │   ├── cli.rs           # CLI入力ループ
 │   ├── context.rs       # コンテキスト注入（@file展開・サンドボックス検証）
 │   ├── edit_fail_tracker.rs # 連続file.edit失敗の検出・回復ヒント注入
+│   ├── execution_plan.rs    # プラン→実行モード（ANVIL_PLAN検出・チェックリスト管理・ANVIL_FINAL抑制）
 │   ├── alternating_loop_detector.rs # AlternatingLoopDetector（交互/循環パターン検出）
 │   ├── loop_detector.rs # ループ検出（リングバッファ・段階的対応）
 │   ├── phase_estimator.rs # フェーズ推定（ツール呼び出しパターンベース・フォールバック完了検出）

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -1222,6 +1222,78 @@ fn extract_final_block_lenient(content: &str, label: &str) -> Option<String> {
     Some(tail.to_string())
 }
 
+// ---------------------------------------------------------------------------
+// ANVIL_PLAN / ANVIL_PLAN_UPDATE parsing (Issue #249)
+// ---------------------------------------------------------------------------
+
+/// Extract an ANVIL_PLAN or ANVIL_PLAN_UPDATE block from LLM output.
+///
+/// Returns the raw content of the first matching block, or `None`.
+pub fn extract_plan_block(content: &str) -> Option<String> {
+    extract_final_block(content, "ANVIL_PLAN")
+        .or_else(|| extract_final_block_lenient(content, "ANVIL_PLAN"))
+}
+
+/// Extract an ANVIL_PLAN_UPDATE block from LLM output.
+pub fn extract_plan_update_block(content: &str) -> Option<String> {
+    extract_final_block(content, "ANVIL_PLAN_UPDATE")
+        .or_else(|| extract_final_block_lenient(content, "ANVIL_PLAN_UPDATE"))
+}
+
+/// Parse a plan block into a list of `PlanItem`s.
+///
+/// Accepts markdown checkbox format:
+/// ```text
+/// - [ ] src/foo.rs: description of change
+/// - [ ] src/bar.rs: another change
+/// ```
+///
+/// Each line starting with `- [ ]` or `- [x]` is treated as a plan item.
+/// The optional file path before `:` is extracted as a target file.
+pub fn parse_plan_items(block: &str) -> Vec<crate::contracts::PlanItem> {
+    let mut items = Vec::new();
+    for line in block.lines() {
+        let trimmed = line.trim();
+        // Accept both "- [ ]" and "- [x]" prefixes; strip the checkbox
+        let description = if let Some(rest) = trimmed
+            .strip_prefix("- [ ] ")
+            .or_else(|| trimmed.strip_prefix("- [x] "))
+            .or_else(|| trimmed.strip_prefix("- [X] "))
+        {
+            rest.to_string()
+        } else if trimmed.starts_with("- ") && !trimmed.is_empty() {
+            // Also accept plain "- item" lines
+            trimmed[2..].to_string()
+        } else {
+            continue;
+        };
+
+        if description.is_empty() {
+            continue;
+        }
+
+        // Extract target file path: text before the first ":"
+        let target_files = extract_target_file(&description).into_iter().collect();
+
+        items.push(crate::contracts::PlanItem::new(description, target_files));
+    }
+    items
+}
+
+/// Extract a file path from a plan item description.
+///
+/// Looks for a path-like prefix before the first `:` (e.g. `src/foo.rs: do stuff`).
+fn extract_target_file(description: &str) -> Option<String> {
+    let colon_pos = description.find(':')?;
+    let candidate = description[..colon_pos].trim();
+    // Heuristic: must contain a `/` or `.` to look like a file path
+    if candidate.contains('/') || candidate.contains('.') {
+        Some(candidate.to_string())
+    } else {
+        None
+    }
+}
+
 // --- MCP tool description generation ---
 
 use crate::mcp::McpToolInfo;
@@ -1413,5 +1485,85 @@ mod tests {
         // context_window=512: quarter=128, half=256, clamp(256,256) => 256
         let budget = derive_context_budget(512, None);
         assert_eq!(budget, 256);
+    }
+
+    // ============================================================
+    // ANVIL_PLAN parser tests (Issue #249)
+    // ============================================================
+
+    #[test]
+    fn extract_plan_block_basic() {
+        let content = "Some text\n```ANVIL_PLAN\n- [ ] src/foo.rs: add function\n- [ ] src/bar.rs: fix bug\n```\nMore text";
+        let block = extract_plan_block(content).expect("should extract");
+        assert!(block.contains("src/foo.rs"));
+        assert!(block.contains("src/bar.rs"));
+    }
+
+    #[test]
+    fn extract_plan_block_lenient() {
+        let content = "```ANVIL_PLAN\n- [ ] src/foo.rs: add function\n";
+        let block = extract_plan_block(content).expect("should extract lenient");
+        assert!(block.contains("src/foo.rs"));
+    }
+
+    #[test]
+    fn extract_plan_block_none_when_absent() {
+        let content = "Just regular text without any plan blocks.";
+        assert!(extract_plan_block(content).is_none());
+    }
+
+    #[test]
+    fn extract_plan_update_block_basic() {
+        let content = "```ANVIL_PLAN_UPDATE\n- [ ] tests/new_test.rs: add test\n```";
+        let block = extract_plan_update_block(content).expect("should extract");
+        assert!(block.contains("tests/new_test.rs"));
+    }
+
+    #[test]
+    fn parse_plan_items_checkbox_format() {
+        let block = "- [ ] src/lib.rs: add module declaration\n- [ ] src/app/mod.rs: add field\n- [ ] tests/test.rs: add integration test";
+        let items = parse_plan_items(block);
+        assert_eq!(items.len(), 3);
+        assert_eq!(items[0].description, "src/lib.rs: add module declaration");
+        assert_eq!(items[0].target_files, vec!["src/lib.rs"]);
+        assert_eq!(items[1].target_files, vec!["src/app/mod.rs"]);
+    }
+
+    #[test]
+    fn parse_plan_items_plain_dash_format() {
+        let block = "- src/main.rs: entry point change\n- src/config.rs: add setting";
+        let items = parse_plan_items(block);
+        assert_eq!(items.len(), 2);
+    }
+
+    #[test]
+    fn parse_plan_items_no_file_path() {
+        let block = "- [ ] Add integration tests\n- [ ] Update documentation";
+        let items = parse_plan_items(block);
+        assert_eq!(items.len(), 2);
+        assert!(items[0].target_files.is_empty());
+    }
+
+    #[test]
+    fn parse_plan_items_ignores_non_items() {
+        let block =
+            "Plan:\n\n- [ ] src/foo.rs: change\n\nSome explanation\n\n- [ ] src/bar.rs: update";
+        let items = parse_plan_items(block);
+        assert_eq!(items.len(), 2);
+    }
+
+    #[test]
+    fn parse_plan_items_empty_block() {
+        let items = parse_plan_items("");
+        assert!(items.is_empty());
+    }
+
+    #[test]
+    fn parse_plan_items_with_checked_items() {
+        let block = "- [x] src/done.rs: already done\n- [ ] src/todo.rs: still todo";
+        let items = parse_plan_items(block);
+        assert_eq!(items.len(), 2);
+        // All parsed items start as Pending regardless of [x] in the source
+        assert_eq!(items[0].status, crate::contracts::PlanItemStatus::Pending);
     }
 }

--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -458,6 +458,11 @@ impl App {
         self.phase_estimator.reset();
         // Reset read transition guard per-turn counters (Issue #216)
         self.read_transition_guard.reset();
+        // Reset execution plan per user-turn (Issue #249)
+        self.reset_execution_plan();
+
+        // Issue #249: Detect ANVIL_PLAN from initial response
+        self.try_register_plan(&current.final_response);
 
         // Session note extraction bookkeeping (Issue #241)
         let msg_count_before = self.session.messages.len();
@@ -514,6 +519,9 @@ impl App {
             let (results, loop_action) = self.execute_structured_tool_calls(&current_normal)?;
             total_tool_count += results.len();
 
+            // Issue #249: Update plan item status from tool results
+            self.update_plan_from_results(&results);
+
             let tool_log_views: Vec<ToolLogView> = results
                 .iter()
                 .map(ToolExecutionResult::to_tool_log_view)
@@ -541,7 +549,11 @@ impl App {
             // Issue #173: If ANVIL_FINAL was already seen, terminate after
             // executing the current tool batch (no further LLM round-trips).
             if anvil_final_seen {
-                if self.should_activate_guidance_retry(guidance_retry_used, &results) {
+                // Issue #249: Plan-aware ANVIL_FINAL gate — suppress if plan is incomplete
+                if self.check_plan_final_gate() {
+                    tracing::info!("ANVIL_FINAL suppressed by plan gate; continuing execution");
+                    anvil_final_seen = false;
+                } else if self.should_activate_guidance_retry(guidance_retry_used, &results) {
                     tracing::info!(
                         "ANVIL_FINAL delayed: synthetic guidance injected, sending one follow-up turn"
                     );
@@ -568,6 +580,9 @@ impl App {
             if self.is_shutdown_requested() {
                 break;
             }
+
+            // Issue #249: Inject plan turn guidance before follow-up LLM call
+            self.inject_plan_turn_guidance();
 
             // Send tool results back to LLM for the next turn
             let spinner = Spinner::start(
@@ -699,6 +714,11 @@ impl App {
             // Reset last_compact_info after it's been consumed by the turn summary
             self.last_compact_info = None;
 
+            // Issue #249: Detect ANVIL_PLAN / ANVIL_PLAN_UPDATE from follow-up responses.
+            // Scan the raw token buffer since ANVIL_PLAN may be outside the ANVIL_FINAL block.
+            self.try_register_plan(&next_token_buffer);
+            self.try_update_plan(&next_token_buffer);
+
             // Issue #173: Update ANVIL_FINAL tracking from the new response
             if next_structured.anvil_final_detected {
                 anvil_final_seen = true;
@@ -752,6 +772,13 @@ impl App {
                     )?;
                     fallback_completed = true;
                     break;
+                }
+
+                // Issue #249: Plan gate — suppress termination if plan is incomplete
+                if self.check_plan_final_gate() {
+                    tracing::info!("Plan gate: suppressing termination with empty tool calls");
+                    current = next_structured;
+                    continue;
                 }
 
                 // No more tool calls — this is the final answer

--- a/src/app/execution_plan.rs
+++ b/src/app/execution_plan.rs
@@ -1,0 +1,180 @@
+//! Execution plan management for Plan → Execute mode (Issue #249).
+//!
+//! Provides helper methods on [`App`] for managing the execution plan lifecycle:
+//! detecting `ANVIL_PLAN` / `ANVIL_PLAN_UPDATE` blocks, updating plan item
+//! status based on tool execution results, and injecting turn guidance.
+
+use crate::agent::{extract_plan_block, extract_plan_update_block, parse_plan_items};
+use crate::contracts::{ExecutionPlan, FinalGateDecision};
+use crate::session::{MessageRole, SessionMessage};
+
+use super::App;
+
+/// Message injected when ANVIL_FINAL is suppressed because no plan exists yet.
+const PLAN_REQUIRED_MESSAGE: &str = "[System] まず変更計画を作成してください。```ANVIL_PLAN ブロックで変更対象ファイルと作業内容を出力してください。\n\
+     例:\n\
+     ```ANVIL_PLAN\n\
+     - [ ] src/foo.rs: 変更内容の説明\n\
+     - [ ] src/bar.rs: 変更内容の説明\n\
+     ```";
+
+/// Message injected when ANVIL_FINAL is suppressed because items remain.
+fn incomplete_plan_message(next_desc: &str, remaining: usize, total: usize) -> String {
+    format!(
+        "[System] まだ {remaining}/{total} 項目が未完了です。次の項目を実行してください:\n  {next_desc}\n\
+         全項目完了後に ANVIL_FINAL を出力してください。"
+    )
+}
+
+impl App {
+    /// Try to detect and register an `ANVIL_PLAN` block from the LLM response.
+    ///
+    /// Returns `true` if a new plan was registered.
+    pub(crate) fn try_register_plan(&mut self, content: &str) -> bool {
+        if let Some(block) = extract_plan_block(content) {
+            let items = parse_plan_items(&block);
+            if !items.is_empty() {
+                tracing::info!(
+                    items = items.len(),
+                    "ANVIL_PLAN detected; registering execution plan"
+                );
+                self.execution_plan = ExecutionPlan::new(items);
+                // Mark first item as InProgress
+                self.execution_plan.mark_in_progress(0);
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Try to detect and apply an `ANVIL_PLAN_UPDATE` block.
+    ///
+    /// Returns `true` if the plan was updated.
+    pub(crate) fn try_update_plan(&mut self, content: &str) -> bool {
+        if let Some(block) = extract_plan_update_block(content) {
+            let new_items = parse_plan_items(&block);
+            if !new_items.is_empty() {
+                tracing::info!(
+                    new_items = new_items.len(),
+                    "ANVIL_PLAN_UPDATE detected; appending items"
+                );
+                self.execution_plan.append_items(new_items);
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Update plan item status based on tool execution results.
+    ///
+    /// When a file.write or file.edit succeeds for a target file in the current
+    /// plan item, advance the item to Done and move to the next.
+    pub(crate) fn update_plan_from_results(
+        &mut self,
+        results: &[crate::tooling::ToolExecutionResult],
+    ) {
+        if self.execution_plan.is_empty() {
+            return;
+        }
+
+        let idx = match self.execution_plan.next_actionable_index() {
+            Some(i) => i,
+            None => return,
+        };
+
+        let mutation_tools = ["file.write", "file.edit", "file.edit_anchor"];
+        let has_successful_mutation = results.iter().any(|r| {
+            mutation_tools.contains(&r.tool_name.as_str())
+                && r.status == crate::tooling::ToolExecutionStatus::Completed
+        });
+
+        let has_failed_mutation = results.iter().any(|r| {
+            mutation_tools.contains(&r.tool_name.as_str())
+                && r.status == crate::tooling::ToolExecutionStatus::Failed
+        });
+
+        if has_successful_mutation {
+            tracing::info!(
+                item = idx + 1,
+                description = %self.execution_plan.items[idx].description,
+                "plan item completed"
+            );
+            self.execution_plan.mark_done(idx);
+            // Auto-advance next item to InProgress
+            if let Some(next) = self.execution_plan.next_actionable_index() {
+                self.execution_plan.mark_in_progress(next);
+            }
+        } else if has_failed_mutation {
+            self.execution_plan.record_failure(idx);
+            tracing::warn!(
+                item = idx + 1,
+                retry_count = self.execution_plan.items[idx].retry_count,
+                "plan item mutation failed"
+            );
+        }
+    }
+
+    /// Check the plan-aware ANVIL_FINAL gate.
+    ///
+    /// Returns `true` if ANVIL_FINAL should be suppressed (plan incomplete).
+    /// When suppressed, injects a guidance message into the session.
+    pub(crate) fn check_plan_final_gate(&mut self) -> bool {
+        if self.execution_plan.is_empty() {
+            return false; // No plan → fall through to existing guard
+        }
+
+        match self.execution_plan.check_final_gate() {
+            FinalGateDecision::Allow => {
+                tracing::info!("plan-aware final gate: all items finished, allowing ANVIL_FINAL");
+                false
+            }
+            FinalGateDecision::NoPlan => {
+                tracing::info!("plan-aware final gate: no plan, requesting plan creation");
+                let msg = SessionMessage::new(
+                    MessageRole::Tool,
+                    "system",
+                    PLAN_REQUIRED_MESSAGE.to_string(),
+                )
+                .with_id(self.next_message_id("tool"));
+                self.session.push_message(msg);
+                true
+            }
+            FinalGateDecision::Incomplete {
+                next_description,
+                remaining,
+                total,
+            } => {
+                tracing::info!(
+                    remaining,
+                    total,
+                    next = %next_description,
+                    "plan-aware final gate: suppressing ANVIL_FINAL"
+                );
+                let msg = SessionMessage::new(
+                    MessageRole::Tool,
+                    "system",
+                    incomplete_plan_message(&next_description, remaining, total),
+                )
+                .with_id(self.next_message_id("tool"));
+                self.session.push_message(msg);
+                true
+            }
+        }
+    }
+
+    /// Inject turn guidance for the current plan item.
+    ///
+    /// Called at the beginning of each follow-up turn to guide the LLM.
+    pub(crate) fn inject_plan_turn_guidance(&mut self) {
+        if let Some(guidance) = self.execution_plan.build_turn_guidance() {
+            let msg = SessionMessage::new(MessageRole::Tool, "system", guidance)
+                .with_id(self.next_message_id("tool"));
+            self.session.push_message(msg);
+        }
+    }
+
+    /// Reset the execution plan (e.g. at the start of a new user turn).
+    pub(crate) fn reset_execution_plan(&mut self) {
+        self.execution_plan = ExecutionPlan::default();
+    }
+}

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -8,6 +8,7 @@ pub mod alternating_loop_detector;
 pub mod cli;
 mod context;
 pub(crate) mod edit_fail_tracker;
+pub(crate) mod execution_plan;
 pub mod loop_detector;
 pub mod mock;
 pub mod phase_estimator;
@@ -271,6 +272,8 @@ pub struct App {
     session_stats: SessionStats,
     /// Last compact operation info for turn summary reporting (Issue #206).
     last_compact_info: Option<CompactInfo>,
+    /// Execution plan for Plan → Execute mode (Issue #249).
+    execution_plan: crate::contracts::ExecutionPlan,
 }
 
 /// Whether the session loop should continue or exit.
@@ -600,6 +603,7 @@ impl App {
             file_read_cache,
             session_stats: SessionStats::new(),
             last_compact_info: None,
+            execution_plan: crate::contracts::ExecutionPlan::default(),
         })
     }
 

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -91,6 +91,205 @@ impl SubAgentPayload {
 }
 
 // ---------------------------------------------------------------------------
+// Execution Plan types (Issue #249: Plan → Execute mode)
+// ---------------------------------------------------------------------------
+
+/// Status of an individual plan item.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PlanItemStatus {
+    /// Not yet started.
+    Pending,
+    /// Currently being executed.
+    InProgress,
+    /// Successfully completed.
+    Done,
+    /// Blocked due to repeated failures.
+    Blocked,
+}
+
+impl std::fmt::Display for PlanItemStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Pending => write!(f, "pending"),
+            Self::InProgress => write!(f, "in_progress"),
+            Self::Done => write!(f, "done"),
+            Self::Blocked => write!(f, "blocked"),
+        }
+    }
+}
+
+/// A single item in the execution plan.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PlanItem {
+    /// Human-readable description of the work item.
+    pub description: String,
+    /// Target file paths (extracted from the description, if any).
+    pub target_files: Vec<String>,
+    /// Current status.
+    pub status: PlanItemStatus,
+    /// Number of consecutive execution failures for this item.
+    #[serde(default)]
+    pub retry_count: u8,
+}
+
+impl PlanItem {
+    /// Maximum consecutive failures before marking as Blocked.
+    pub const MAX_RETRIES: u8 = 3;
+
+    pub fn new(description: String, target_files: Vec<String>) -> Self {
+        Self {
+            description,
+            target_files,
+            status: PlanItemStatus::Pending,
+            retry_count: 0,
+        }
+    }
+
+    /// Whether this item is considered finished (Done or Blocked).
+    pub fn is_finished(&self) -> bool {
+        matches!(self.status, PlanItemStatus::Done | PlanItemStatus::Blocked)
+    }
+}
+
+/// The execution plan maintained by Anvil (Issue #249).
+///
+/// Parsed from `ANVIL_PLAN` / `ANVIL_PLAN_UPDATE` blocks emitted by the LLM.
+/// Controls ANVIL_FINAL acceptance: the loop cannot terminate until all items
+/// are finished (Done or Blocked).
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct ExecutionPlan {
+    pub items: Vec<PlanItem>,
+}
+
+/// Result of checking whether ANVIL_FINAL should be accepted.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FinalGateDecision {
+    /// All items finished → allow ANVIL_FINAL.
+    Allow,
+    /// Plan not yet created → suppress and request plan creation.
+    NoPlan,
+    /// Unfinished items remain → suppress and guide to next item.
+    Incomplete {
+        next_description: String,
+        remaining: usize,
+        total: usize,
+    },
+}
+
+impl ExecutionPlan {
+    pub fn new(items: Vec<PlanItem>) -> Self {
+        Self { items }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.items.is_empty()
+    }
+
+    /// Number of finished (Done or Blocked) items.
+    pub fn finished_count(&self) -> usize {
+        self.items.iter().filter(|i| i.is_finished()).count()
+    }
+
+    /// Whether all items are finished.
+    pub fn all_finished(&self) -> bool {
+        !self.items.is_empty() && self.items.iter().all(PlanItem::is_finished)
+    }
+
+    /// Get the index of the next pending or in-progress item.
+    pub fn next_actionable_index(&self) -> Option<usize> {
+        self.items.iter().position(|i| {
+            matches!(
+                i.status,
+                PlanItemStatus::Pending | PlanItemStatus::InProgress
+            )
+        })
+    }
+
+    /// Mark an item as Done by index.
+    pub fn mark_done(&mut self, index: usize) {
+        if let Some(item) = self.items.get_mut(index) {
+            item.status = PlanItemStatus::Done;
+        }
+    }
+
+    /// Mark an item as InProgress by index.
+    pub fn mark_in_progress(&mut self, index: usize) {
+        if let Some(item) = self.items.get_mut(index) {
+            item.status = PlanItemStatus::InProgress;
+        }
+    }
+
+    /// Record a failure for the current in-progress item.
+    /// Automatically transitions to Blocked after MAX_RETRIES.
+    pub fn record_failure(&mut self, index: usize) {
+        if let Some(item) = self.items.get_mut(index) {
+            item.retry_count += 1;
+            if item.retry_count >= PlanItem::MAX_RETRIES {
+                item.status = PlanItemStatus::Blocked;
+            }
+        }
+    }
+
+    /// Decide whether ANVIL_FINAL should be accepted.
+    pub fn check_final_gate(&self) -> FinalGateDecision {
+        if self.items.is_empty() {
+            return FinalGateDecision::NoPlan;
+        }
+        if self.all_finished() {
+            return FinalGateDecision::Allow;
+        }
+        let remaining = self.items.iter().filter(|i| !i.is_finished()).count();
+        let next_desc = self
+            .next_actionable_index()
+            .and_then(|i| self.items.get(i))
+            .map(|i| i.description.clone())
+            .unwrap_or_default();
+        FinalGateDecision::Incomplete {
+            next_description: next_desc,
+            remaining,
+            total: self.items.len(),
+        }
+    }
+
+    /// Append new items (used by ANVIL_PLAN_UPDATE).
+    pub fn append_items(&mut self, new_items: Vec<PlanItem>) {
+        self.items.extend(new_items);
+    }
+
+    /// Format the plan as a checklist string for display / system prompt injection.
+    pub fn format_checklist(&self) -> String {
+        let mut lines = Vec::new();
+        for (i, item) in self.items.iter().enumerate() {
+            let marker = match item.status {
+                PlanItemStatus::Done => "[x]",
+                PlanItemStatus::Blocked => "[!]",
+                PlanItemStatus::InProgress => "[>]",
+                PlanItemStatus::Pending => "[ ]",
+            };
+            lines.push(format!("  {}. {} {}", i + 1, marker, item.description));
+        }
+        lines.join("\n")
+    }
+
+    /// Build the system message to inject at the start of each execution turn.
+    pub fn build_turn_guidance(&self) -> Option<String> {
+        let idx = self.next_actionable_index()?;
+        let item = &self.items[idx];
+        let finished = self.finished_count();
+        let total = self.items.len();
+        Some(format!(
+            "[System] 計画の次の項目を実行してください:\n  {}. {}\n完了: {}/{} 項目\n\n現在の計画:\n{}\n\n1項目ずつ実行し、全項目完了時のみ ANVIL_FINAL を出力してください。",
+            idx + 1,
+            item.description,
+            finished,
+            total,
+            self.format_checklist()
+        ))
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Application lifecycle types
 // ---------------------------------------------------------------------------
 
@@ -866,5 +1065,173 @@ mod tests {
         let back: SubAgentPayload = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(back.error, Some("timed out during exploration".to_string()));
         assert_eq!(back.termination_reason, TerminationReason::Timeout);
+    }
+
+    // ============================================================
+    // ExecutionPlan tests (Issue #249)
+    // ============================================================
+
+    #[test]
+    fn plan_item_new_defaults_to_pending() {
+        let item = PlanItem::new("do stuff".into(), vec!["src/main.rs".into()]);
+        assert_eq!(item.status, PlanItemStatus::Pending);
+        assert_eq!(item.retry_count, 0);
+        assert!(!item.is_finished());
+    }
+
+    #[test]
+    fn plan_item_is_finished() {
+        let mut item = PlanItem::new("x".into(), vec![]);
+        assert!(!item.is_finished());
+        item.status = PlanItemStatus::Done;
+        assert!(item.is_finished());
+        item.status = PlanItemStatus::Blocked;
+        assert!(item.is_finished());
+        item.status = PlanItemStatus::InProgress;
+        assert!(!item.is_finished());
+    }
+
+    #[test]
+    fn execution_plan_empty_default() {
+        let plan = ExecutionPlan::default();
+        assert!(plan.is_empty());
+        assert!(!plan.all_finished());
+        assert_eq!(plan.finished_count(), 0);
+        assert_eq!(plan.next_actionable_index(), None);
+    }
+
+    #[test]
+    fn execution_plan_mark_done_advances() {
+        let mut plan = ExecutionPlan::new(vec![
+            PlanItem::new("a".into(), vec![]),
+            PlanItem::new("b".into(), vec![]),
+            PlanItem::new("c".into(), vec![]),
+        ]);
+        plan.mark_in_progress(0);
+        assert_eq!(plan.next_actionable_index(), Some(0));
+
+        plan.mark_done(0);
+        assert_eq!(plan.finished_count(), 1);
+        assert!(!plan.all_finished());
+        assert_eq!(plan.next_actionable_index(), Some(1));
+
+        plan.mark_done(1);
+        plan.mark_done(2);
+        assert!(plan.all_finished());
+        assert_eq!(plan.next_actionable_index(), None);
+    }
+
+    #[test]
+    fn execution_plan_record_failure_blocks_after_max() {
+        let mut plan = ExecutionPlan::new(vec![PlanItem::new("x".into(), vec![])]);
+        plan.mark_in_progress(0);
+
+        for _ in 0..PlanItem::MAX_RETRIES - 1 {
+            plan.record_failure(0);
+            assert_eq!(plan.items[0].status, PlanItemStatus::InProgress);
+        }
+        plan.record_failure(0);
+        assert_eq!(plan.items[0].status, PlanItemStatus::Blocked);
+        assert!(plan.all_finished());
+    }
+
+    #[test]
+    fn execution_plan_check_final_gate_no_plan() {
+        let plan = ExecutionPlan::default();
+        assert_eq!(plan.check_final_gate(), FinalGateDecision::NoPlan);
+    }
+
+    #[test]
+    fn execution_plan_check_final_gate_incomplete() {
+        let mut plan = ExecutionPlan::new(vec![
+            PlanItem::new("first".into(), vec![]),
+            PlanItem::new("second".into(), vec![]),
+        ]);
+        plan.mark_in_progress(0);
+        match plan.check_final_gate() {
+            FinalGateDecision::Incomplete {
+                remaining, total, ..
+            } => {
+                assert_eq!(remaining, 2);
+                assert_eq!(total, 2);
+            }
+            other => panic!("expected Incomplete, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn execution_plan_check_final_gate_allow() {
+        let mut plan = ExecutionPlan::new(vec![PlanItem::new("only".into(), vec![])]);
+        plan.mark_done(0);
+        assert_eq!(plan.check_final_gate(), FinalGateDecision::Allow);
+    }
+
+    #[test]
+    fn execution_plan_append_items() {
+        let mut plan = ExecutionPlan::new(vec![PlanItem::new("a".into(), vec![])]);
+        plan.append_items(vec![PlanItem::new("b".into(), vec![])]);
+        assert_eq!(plan.items.len(), 2);
+    }
+
+    #[test]
+    fn execution_plan_format_checklist() {
+        let mut plan = ExecutionPlan::new(vec![
+            PlanItem::new("done item".into(), vec![]),
+            PlanItem::new("in progress".into(), vec![]),
+            PlanItem::new("pending item".into(), vec![]),
+        ]);
+        plan.mark_done(0);
+        plan.mark_in_progress(1);
+        let checklist = plan.format_checklist();
+        assert!(checklist.contains("[x]"));
+        assert!(checklist.contains("[>]"));
+        assert!(checklist.contains("[ ]"));
+    }
+
+    #[test]
+    fn execution_plan_build_turn_guidance() {
+        let mut plan = ExecutionPlan::new(vec![
+            PlanItem::new("first task".into(), vec![]),
+            PlanItem::new("second task".into(), vec![]),
+        ]);
+        plan.mark_done(0);
+        plan.mark_in_progress(1);
+        let guidance = plan.build_turn_guidance().expect("should have guidance");
+        assert!(guidance.contains("second task"));
+        assert!(guidance.contains("1/2"));
+    }
+
+    #[test]
+    fn execution_plan_build_turn_guidance_none_when_all_done() {
+        let mut plan = ExecutionPlan::new(vec![PlanItem::new("x".into(), vec![])]);
+        plan.mark_done(0);
+        assert!(plan.build_turn_guidance().is_none());
+    }
+
+    #[test]
+    fn plan_item_status_display() {
+        assert_eq!(PlanItemStatus::Pending.to_string(), "pending");
+        assert_eq!(PlanItemStatus::InProgress.to_string(), "in_progress");
+        assert_eq!(PlanItemStatus::Done.to_string(), "done");
+        assert_eq!(PlanItemStatus::Blocked.to_string(), "blocked");
+    }
+
+    #[test]
+    fn plan_item_serde_roundtrip() {
+        let item = PlanItem::new("desc".into(), vec!["src/lib.rs".into()]);
+        let json = serde_json::to_string(&item).expect("serialize");
+        let back: PlanItem = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(item, back);
+    }
+
+    #[test]
+    fn execution_plan_serde_roundtrip() {
+        let plan = ExecutionPlan::new(vec![
+            PlanItem::new("a".into(), vec!["f1.rs".into()]),
+            PlanItem::new("b".into(), vec![]),
+        ]);
+        let json = serde_json::to_string(&plan).expect("serialize");
+        let back: ExecutionPlan = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(plan, back);
     }
 }

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -182,7 +182,13 @@ impl WorkingMemory {
 /// injection), and truncates extremely long strings using char count for UTF-8
 /// safety.
 pub(crate) fn sanitize_for_prompt_entry(input: &str) -> String {
-    const REMOVALS: &[&str] = &["ANVIL_TOOL", "ANVIL_FINAL", "```"];
+    const REMOVALS: &[&str] = &[
+        "ANVIL_TOOL",
+        "ANVIL_FINAL",
+        "ANVIL_PLAN_UPDATE",
+        "ANVIL_PLAN",
+        "```",
+    ];
     let mut s = input.to_string();
     for pattern in REMOVALS {
         s = s.replace(pattern, "");


### PR DESCRIPTION
## Summary
- ANVIL_PLANタグによるプランモードを導入し、LLMが変更計画をチェックリスト形式で出力可能に
- ExecutionPlan構造体でチェックリスト進捗を管理し、全項目完了までANVIL_FINALを抑制
- FinalGateDecision enumでANVIL_FINAL出力の判断を構造化（Allow/SuppressWithHint）
- 既存のANVIL_FINAL動作は維持（プラン未設定時は従来通り）

Closes #249

## Test plan
- [x] `cargo build` パス
- [x] `cargo clippy --all-targets` 警告0
- [x] `cargo test` 全パス
- [x] `cargo fmt --check` 差分なし