### PR TITLE
fix(issue-253): permanent fix for plan-execute mode

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -792,6 +792,17 @@ const PROMPT_OPTIONAL_CATALOG_HEADER: &str =
     "\nAdditional tools (use ANVIL_TOOL block format shown above):\n";
 
 const PROMPT_TOOL_RULES: &str = concat!(
+    "## ANVIL_PLAN — Change plan\n",
+    "Before modifying files, output a change plan using an ANVIL_PLAN block:\n",
+    "```ANVIL_PLAN\n",
+    "- [ ] src/foo.rs: Description of change\n",
+    "- [ ] src/bar.rs: Description of change\n",
+    "```\n",
+    "Rules for ANVIL_PLAN:\n",
+    "- Output ANVIL_PLAN once per user request, before any file.write/file.edit.\n",
+    "- Each item is a checklist entry: `- [ ] <path>: <description>`.\n",
+    "- Do NOT output ANVIL_FINAL until ALL plan items are completed.\n",
+    "\n",
     "After ALL tool blocks, include exactly one final block with your summary:\n",
     "```ANVIL_FINAL\n",
     "User-facing summary and code review notes.\n",

--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -1889,6 +1889,22 @@ impl App {
             {
                 // ANVIL_FINAL detected → record observation (Issue #159)
                 self.phase_estimator.observe_anvil_final();
+                // Issue #253: Apply plan gate even on zero-tool-call Done path.
+                // Use require_plan variant so NoPlan also suppresses.
+                if self.check_plan_final_gate_require_plan() {
+                    self.record_assistant_output(
+                        self.next_message_id("assistant"),
+                        assistant_message,
+                    )?;
+                    return Ok(Some(self.run_guarded_retry_turn(
+                        status,
+                        saved_status,
+                        *elapsed_ms,
+                        inference_performance.clone(),
+                        tui,
+                        provider_client,
+                    )?));
+                }
                 self.inject_final_guard_retry();
                 // Record the assistant message that triggered the guard
                 self.record_assistant_output(self.next_message_id("assistant"), assistant_message)?;

--- a/src/app/execution_plan.rs
+++ b/src/app/execution_plan.rs
@@ -31,6 +31,10 @@ impl App {
     ///
     /// Returns `true` if a new plan was registered.
     pub(crate) fn try_register_plan(&mut self, content: &str) -> bool {
+        // Guard: ignore re-registration when a plan is already active.
+        if !self.execution_plan.is_empty() {
+            return false;
+        }
         if let Some(block) = extract_plan_block(content) {
             let items = parse_plan_items(&block);
             if !items.is_empty() {
@@ -118,17 +122,29 @@ impl App {
     ///
     /// Returns `true` if ANVIL_FINAL should be suppressed (plan incomplete).
     /// When suppressed, injects a guidance message into the session.
+    /// Check the plan-aware ANVIL_FINAL gate.
+    ///
+    /// Returns `true` if ANVIL_FINAL should be suppressed (plan incomplete).
+    /// When suppressed, injects a guidance message into the session.
+    ///
+    /// When `require_plan` is true, the NoPlan branch also suppresses
+    /// ANVIL_FINAL and requests plan creation (Issue #253).
     pub(crate) fn check_plan_final_gate(&mut self) -> bool {
-        if self.execution_plan.is_empty() {
-            return false; // No plan → fall through to existing guard
-        }
+        self.check_plan_final_gate_inner(false)
+    }
 
+    /// Like [`check_plan_final_gate`] but also suppresses ANVIL_FINAL when
+    /// no plan has been registered yet (Issue #253: Done path guard).
+    pub(crate) fn check_plan_final_gate_require_plan(&mut self) -> bool {
+        self.check_plan_final_gate_inner(true)
+    }
+
+    fn check_plan_final_gate_inner(&mut self, require_plan: bool) -> bool {
         // Issue #251: Sync plan completion from touched_files before gate check.
-        // This ensures file modifications executed outside the normal
-        // execute_structured_tool_calls path (e.g. tool calls placed after
-        // ANVIL_FINAL in the LLM response) are reflected in plan status.
-        self.execution_plan
-            .sync_from_touched_files(&self.session.working_memory.touched_files);
+        if !self.execution_plan.is_empty() {
+            self.execution_plan
+                .sync_from_touched_files(&self.session.working_memory.touched_files);
+        }
 
         match self.execution_plan.check_final_gate() {
             FinalGateDecision::Allow => {
@@ -136,6 +152,9 @@ impl App {
                 false
             }
             FinalGateDecision::NoPlan => {
+                if !require_plan {
+                    return false; // No plan → fall through to existing guard
+                }
                 tracing::info!("plan-aware final gate: no plan, requesting plan creation");
                 let msg = SessionMessage::new(
                     MessageRole::Tool,

--- a/tests/provider_integration.rs
+++ b/tests/provider_integration.rs
@@ -3930,13 +3930,14 @@ fn anvil_final_guard_handle_structured_done_fires_for_plan_only_response() {
         "expected 2 provider calls: initial + guard retry via handle_structured_done"
     );
 
-    // Verify the guard retry message was injected
+    // Issue #253: Plan gate fires before final guard, injecting plan-required message
     assert!(
         app.session()
             .messages
             .iter()
-            .any(|m| m.content.contains("No file modifications detected")),
-        "guard retry message should be in session"
+            .any(|m| m.content.contains("ANVIL_PLAN")
+                || m.content.contains("No file modifications detected")),
+        "plan-required or guard retry message should be in session"
     );
 }
 
@@ -4199,13 +4200,14 @@ fn guard_retry_post_final() {
         "post-FINAL tool call_002 (lib.rs) should NOT appear in session messages after guard retry"
     );
 
-    // Verify guard DID fire (guard retry message present)
+    // Issue #253: Plan gate fires before final guard, injecting plan-required message
     assert!(
         app.session()
             .messages
             .iter()
-            .any(|m| m.content.contains("No file modifications detected")),
-        "guard retry message should be in session"
+            .any(|m| m.content.contains("ANVIL_PLAN")
+                || m.content.contains("No file modifications detected")),
+        "plan-required or guard retry message should be in session"
     );
 }
 


### PR DESCRIPTION
## Summary
プラン実行モードの根本改修（4件同時修正）:

- **C1**: システムプロンプトにANVIL_PLANの説明を追加（LLMがタグを認識可能に）
- **B1**: `try_register_plan()`にプラン登録済みガード追加（再登録による進捗リセット防止）
- **A1**: `check_plan_final_gate()`の`is_empty()`ガード修正（NoPlan→PLAN_REQUIRED_MESSAGE注入を到達可能に）
- **C2**: `handle_structured_done()`でplan gateを適用（Doneパスでのバイパス防止）

Closes #253

## Test plan
- [x] `cargo build` パス
- [x] `cargo clippy --all-targets` 警告0
- [x] `cargo test` 全パス
- [x] `cargo fmt --check` 差分なし