### PR TITLE
fix(issue-259): align files_modified with actual disk changes

### DIFF
--- a/src/agent/subagent.rs
+++ b/src/agent/subagent.rs
@@ -238,6 +238,7 @@ impl SubAgentResult {
             elapsed_ms: 0,
             diff_summary: None,
             edit_detail: None,
+            rolled_back: false,
         }
     }
 }
@@ -289,6 +290,7 @@ impl SubAgentError {
             elapsed_ms: 0,
             diff_summary: None,
             edit_detail: None,
+            rolled_back: false,
         }
     }
 }
@@ -602,6 +604,7 @@ impl<'a, C: ProviderClient> SubAgentSession<'a, C> {
                     elapsed_ms: 0,
                     diff_summary: None,
                     edit_detail: None,
+                    rolled_back: false,
                 });
 
             // Record tool result in the sub-agent session

--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -204,6 +204,7 @@ fn execute_parallel_group_standalone(
                                 elapsed_ms: 0,
                                 diff_summary: None,
                                 edit_detail: None,
+                                rolled_back: false,
                             }
                         });
                         // Update progress entry
@@ -250,6 +251,7 @@ fn execute_parallel_group_standalone(
                                 elapsed_ms: 0,
                                 diff_summary: None,
                                 edit_detail: None,
+                                rolled_back: false,
                             },
                         ));
                     }
@@ -313,6 +315,7 @@ impl App {
                     elapsed_ms: 0,
                     diff_summary: None,
                     edit_detail: None,
+                    rolled_back: false,
                 });
                 continue;
             }
@@ -623,7 +626,10 @@ impl App {
             // Collect tool names for this iteration's turn summary (before LLM call)
             let turn_tool_names: Vec<String> =
                 results.iter().map(|r| r.tool_name.clone()).collect();
-            let turn_files_modified = results.iter().filter(|r| r.diff_summary.is_some()).count();
+            let turn_files_modified = results
+                .iter()
+                .filter(|r| r.diff_summary.is_some() && !r.rolled_back)
+                .count();
             let turn_tool_count = results.len() + agent_results.len();
 
             let mut next_token_buffer = String::new();
@@ -899,6 +905,7 @@ impl App {
                         elapsed_ms: 0,
                         diff_summary: None,
                         edit_detail: None,
+                        rolled_back: false,
                     },
                 ));
                 continue;
@@ -998,6 +1005,7 @@ impl App {
                 elapsed_ms: 0,
                 diff_summary: None,
                 edit_detail: None,
+                rolled_back: false,
             });
 
         // Remove checkpoint if tool execution failed.
@@ -1033,6 +1041,7 @@ impl App {
                 elapsed_ms: 0,
                 diff_summary: None,
                 edit_detail: None,
+                rolled_back: false,
             };
         };
 
@@ -1060,6 +1069,7 @@ impl App {
             elapsed_ms: started.elapsed().as_millis(),
             diff_summary: None,
             edit_detail: None,
+            rolled_back: false,
         }
     }
 
@@ -1120,6 +1130,7 @@ impl App {
                                     elapsed_ms: 0,
                                     diff_summary: None,
                                     edit_detail: None,
+                                    rolled_back: false,
                                 },
                             ));
                         }
@@ -1183,6 +1194,7 @@ impl App {
                 elapsed_ms: 0,
                 diff_summary: None,
                 edit_detail: None,
+                rolled_back: false,
             }),
             _ => None,
         };
@@ -1307,10 +1319,11 @@ impl App {
                 .map(|(_, r)| r.tool_call_id.clone())
                 .collect();
 
-            // Annotate successful file-mutating results with rollback info
+            // Annotate successful file-mutating results with rollback info (Issue #259)
             for (_, r) in &mut indexed_results {
                 if r.status == ToolExecutionStatus::Completed && rb_ids.contains(&r.tool_call_id) {
                     r.summary = format!("{} [rolled back: atomic transaction failed]", r.summary);
+                    r.rolled_back = true;
                 }
             }
 
@@ -1418,6 +1431,7 @@ impl App {
                 elapsed_ms: 0,
                 diff_summary: None,
                 edit_detail: None,
+                rolled_back: false,
             };
             self.record_tool_result(&transition_result);
             results.push(transition_result);
@@ -1447,6 +1461,7 @@ impl App {
                     elapsed_ms: 0,
                     diff_summary: None,
                     edit_detail: None,
+                    rolled_back: false,
                 };
                 self.record_tool_result(&transition_result);
                 results.push(transition_result);
@@ -1462,11 +1477,16 @@ impl App {
         // Session stats: record tool call (Issue #206 C-3)
         self.session_stats.record_tool_call(&result.tool_name);
 
-        // Session stats: record file change line counts from diff_summary (Issue #206 C-3)
-        if let Some(ref diff) = result.diff_summary {
+        // Session stats: record file change line counts from diff_summary (Issue #206 C-3, #259)
+        // Skip rolled-back results to avoid counting reverted changes.
+        if !result.rolled_back
+            && let Some(ref diff) = result.diff_summary
+        {
             let (added, deleted) = super::count_diff_lines(diff);
             self.session_stats.record_file_change(added, deleted);
-            self.session_stats.files_modified += 1;
+            for artifact in &result.artifacts {
+                self.session_stats.files_modified.insert(artifact.clone());
+            }
         }
 
         // Track tool usage for dynamic system prompt generation (Issue #73)
@@ -2178,6 +2198,7 @@ fn build_failed_result(
         elapsed_ms: 0,
         diff_summary: None,
         edit_detail: None,
+        rolled_back: false,
     }
 }
 
@@ -2434,6 +2455,7 @@ mod trust_tests {
             elapsed_ms: 0,
             diff_summary: None,
             edit_detail: None,
+            rolled_back: false,
         };
 
         let formatted = format_tool_result_message(&result, 8_000);

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -144,7 +144,8 @@ pub struct SessionStats {
     pub total_turns: u32,
     pub session_start: Option<Instant>,
     pub tool_calls: HashMap<String, u32>,
-    pub files_modified: u32,
+    /// Unique file paths that were actually persisted to disk (Issue #259).
+    pub files_modified: std::collections::HashSet<String>,
     pub lines_added: u32,
     pub lines_deleted: u32,
     pub compact_count: u32,
@@ -853,7 +854,7 @@ impl App {
             total_turns = self.session_stats.total_turns,
             total_tool_calls = self.session_stats.total_tool_calls(),
             tools = %self.session_stats.tool_calls_summary(),
-            files_modified = self.session_stats.files_modified,
+            files_modified = self.session_stats.files_modified.len(),
             lines_added = self.session_stats.lines_added,
             lines_deleted = self.session_stats.lines_deleted,
             compact_count = self.session_stats.compact_count,

--- a/src/tooling/mod.rs
+++ b/src/tooling/mod.rs
@@ -657,6 +657,8 @@ pub struct ToolExecutionResult {
     pub diff_summary: Option<String>,
     /// file.edit fallback stage detail (Issue #206). `None` for non-edit tools.
     pub edit_detail: Option<EditResultDetail>,
+    /// Whether this result was rolled back by atomic transaction failure (Issue #259).
+    pub rolled_back: bool,
 }
 
 impl ToolExecutionResult {
@@ -1466,6 +1468,19 @@ impl LocalToolExecutor {
             }
         }
 
+        // Issue #259: skip write and diff_summary when content is identical to existing file.
+        if let Ok(existing) = fs::read_to_string(&resolved)
+            && existing == content
+        {
+            return Ok(build_completed_result(
+                request,
+                format!("{path} (no changes)"),
+                ToolExecutionPayload::None,
+                vec![],
+                started,
+            ));
+        }
+
         if let Some(parent) = resolved.parent() {
             fs::create_dir_all(parent).map_err(|err| {
                 ToolRuntimeError::Io(format!(
@@ -1942,6 +1957,7 @@ impl LocalToolExecutor {
                     elapsed_ms: started.elapsed().as_millis(),
                     diff_summary: None,
                     edit_detail: None,
+                    rolled_back: false,
                 });
             }
             match child.try_wait() {
@@ -1979,6 +1995,7 @@ impl LocalToolExecutor {
             elapsed_ms: started.elapsed().as_millis(),
             diff_summary: None,
             edit_detail: None,
+            rolled_back: false,
         })
     }
 
@@ -2169,6 +2186,7 @@ impl LocalToolExecutor {
                 elapsed_ms: started.elapsed().as_millis(),
                 diff_summary: None,
                 edit_detail: None,
+                rolled_back: false,
             });
         }
 
@@ -2518,6 +2536,7 @@ fn build_completed_result_with_diff(
         elapsed_ms: started.elapsed().as_millis(),
         diff_summary,
         edit_detail: None,
+        rolled_back: false,
     }
 }
 

--- a/tests/tooling_system.rs
+++ b/tests/tooling_system.rs
@@ -204,6 +204,7 @@ fn validated_tool_call_builds_typed_execution_request_and_result() {
         elapsed_ms: 12,
         diff_summary: None,
         edit_detail: None,
+        rolled_back: false,
     };
 
     assert_eq!(execution.spec.kind, ToolKind::FileRead);
@@ -378,6 +379,7 @@ fn tool_execution_result_can_bridge_into_console_tool_log_view() {
         elapsed_ms: 12,
         diff_summary: None,
         edit_detail: None,
+        rolled_back: false,
     };
     let log = result.to_tool_log_view();
 
@@ -2292,6 +2294,7 @@ fn format_tool_result_message_image_payload() {
         elapsed_ms: 10,
         diff_summary: None,
         edit_detail: None,
+        rolled_back: false,
     };
     let msg = format_tool_result_message(&result, 10000);
     assert!(msg.contains("file.read"));
@@ -2320,6 +2323,7 @@ fn format_tool_result_message_truncates_multibyte_safely() {
         elapsed_ms: 5,
         diff_summary: None,
         edit_detail: None,
+        rolled_back: false,
     };
 
     // Must not panic — the old byte-slicing implementation would panic here.
@@ -2344,6 +2348,7 @@ fn format_tool_result_message_ascii_truncation_still_works() {
         elapsed_ms: 5,
         diff_summary: None,
         edit_detail: None,
+        rolled_back: false,
     };
 
     let msg = format_tool_result_message(&result, 100);
@@ -2371,6 +2376,7 @@ fn format_tool_result_message_boundary_char_3byte() {
         elapsed_ms: 5,
         diff_summary: None,
         edit_detail: None,
+        rolled_back: false,
     };
 
     let msg = format_tool_result_message(&result, 100);
@@ -2455,6 +2461,7 @@ fn format_tool_result_message_success_head_priority() {
         elapsed_ms: 5,
         diff_summary: None,
         edit_detail: None,
+        rolled_back: false,
     };
 
     let msg = format_tool_result_message(&result, 100);
@@ -2482,6 +2489,7 @@ fn format_tool_result_message_failure_tail_priority() {
         elapsed_ms: 5,
         diff_summary: None,
         edit_detail: None,
+        rolled_back: false,
     };
 
     let msg = format_tool_result_message(&result, 100);
@@ -2509,6 +2517,7 @@ fn format_tool_result_message_interrupted_tail_priority() {
         elapsed_ms: 5,
         diff_summary: None,
         edit_detail: None,
+        rolled_back: false,
     };
 
     let msg = format_tool_result_message(&result, 100);
@@ -6191,6 +6200,7 @@ fn tool_execution_result_edit_detail_default_none() {
         elapsed_ms: 0,
         diff_summary: None,
         edit_detail: None,
+        rolled_back: false,
     };
     assert!(result.edit_detail.is_none());
 }
@@ -6211,10 +6221,122 @@ fn tool_execution_result_edit_detail_with_stage() {
         edit_detail: Some(EditResultDetail {
             fallback_stage: EditFallbackStage::Anchor,
         }),
+        rolled_back: false,
     };
     assert!(result.edit_detail.is_some());
     assert_eq!(
         result.edit_detail.unwrap().fallback_stage,
         EditFallbackStage::Anchor
+    );
+}
+
+// -----------------------------------------------------------------------
+// Issue #259: file.edit/write disk sync — files_modified accuracy
+// -----------------------------------------------------------------------
+
+#[test]
+fn session_stats_files_modified_tracks_unique_paths() {
+    use anvil::app::SessionStats;
+
+    let mut stats = SessionStats::new();
+    // Simulate two edits to the same file — should count as 1
+    stats.files_modified.insert("/tmp/a.rs".to_string());
+    stats.files_modified.insert("/tmp/a.rs".to_string());
+    assert_eq!(stats.files_modified.len(), 1);
+
+    // Different file adds to the count
+    stats.files_modified.insert("/tmp/b.rs".to_string());
+    assert_eq!(stats.files_modified.len(), 2);
+}
+
+#[test]
+fn rolled_back_result_has_flag_set() {
+    let mut result = ToolExecutionResult {
+        tool_call_id: "call_rb".to_string(),
+        tool_name: "file.edit".to_string(),
+        status: ToolExecutionStatus::Completed,
+        summary: "edit ok".to_string(),
+        payload: ToolExecutionPayload::None,
+        artifacts: vec!["/tmp/test.rs".to_string()],
+        elapsed_ms: 0,
+        diff_summary: Some("+line\n-old".to_string()),
+        edit_detail: None,
+        rolled_back: false,
+    };
+    assert!(!result.rolled_back);
+
+    // Simulate rollback annotation (as done in agentic.rs)
+    result.rolled_back = true;
+    result.summary = format!(
+        "{} [rolled back: atomic transaction failed]",
+        result.summary
+    );
+    assert!(result.rolled_back);
+    assert!(result.summary.contains("[rolled back"));
+}
+
+#[test]
+fn file_write_same_content_produces_no_diff() {
+    let root = std::env::temp_dir().join("anvil_issue259_write_same");
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(&root).expect("dir");
+    let file_path = root.join("existing.txt");
+    fs::write(&file_path, "unchanged content").expect("seed file");
+
+    let mut executor = LocalToolExecutor::new_without_rate_limit(root.clone());
+    let result = executor
+        .execute(ToolExecutionRequest {
+            tool_call_id: "call_same_001".to_string(),
+            spec: build_registry()
+                .get("file.write")
+                .expect("file.write spec")
+                .clone(),
+            input: ToolInput::FileWrite {
+                path: "./existing.txt".to_string(),
+                content: "unchanged content".to_string(),
+            },
+        })
+        .expect("write should succeed");
+
+    assert_eq!(result.status, ToolExecutionStatus::Completed);
+    assert!(
+        result.diff_summary.is_none(),
+        "same-content write should NOT produce diff_summary, got: {:?}",
+        result.diff_summary
+    );
+    assert!(
+        result.summary.contains("no changes"),
+        "summary should indicate no changes, got: {}",
+        result.summary
+    );
+}
+
+#[test]
+fn file_write_different_content_produces_diff() {
+    let root = std::env::temp_dir().join("anvil_issue259_write_diff");
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(&root).expect("dir");
+    let file_path = root.join("target.txt");
+    fs::write(&file_path, "old content").expect("seed file");
+
+    let mut executor = LocalToolExecutor::new_without_rate_limit(root.clone());
+    let result = executor
+        .execute(ToolExecutionRequest {
+            tool_call_id: "call_diff_001".to_string(),
+            spec: build_registry()
+                .get("file.write")
+                .expect("file.write spec")
+                .clone(),
+            input: ToolInput::FileWrite {
+                path: "./target.txt".to_string(),
+                content: "new content".to_string(),
+            },
+        })
+        .expect("write should succeed");
+
+    assert_eq!(result.status, ToolExecutionStatus::Completed);
+    assert!(
+        result.diff_summary.is_some(),
+        "different-content write should produce diff_summary"
     );
 }


### PR DESCRIPTION
## Summary
- file.editが成功報告するがディスクに反映されないケースでfiles_modifiedが不正にカウントされる問題を修正
- `SessionStats.files_modified` を `u32` から `HashSet<String>` に変更し、同一ファイルの重複カウントを防止
- file.edit/file.writeの結果にrollbackフラグを追加し、ロールバックされた変更をfiles_modifiedから除外
- 新規テスト追加

Closes #259

## Test plan
- [x] `cargo build` パス
- [x] `cargo clippy --all-targets` 警告0
- [x] `cargo test` 全パス
- [x] `cargo fmt --check` 差分なし