### PR TITLE
feat(issue-261): plan-aware batch guidance and correctness fixes

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -144,6 +144,9 @@ pub struct StructuredAssistantResponse {
     pub final_response: String,
     /// Whether an ANVIL_FINAL block was detected in this response (Issue #173).
     pub anvil_final_detected: bool,
+    /// Provider の生レスポンス全文。ANVIL_PLAN 抽出専用。
+    /// ログ・永続化に使わないこと。
+    pub raw_content: String,
 }
 
 impl StructuredAssistantResponse {
@@ -151,6 +154,7 @@ impl StructuredAssistantResponse {
     pub fn empty(final_response: String) -> Self {
         Self {
             tool_calls: Vec::new(),
+            raw_content: final_response.clone(),
             final_response,
             anvil_final_detected: false,
         }
@@ -319,6 +323,7 @@ impl BasicAgentLoop {
             tool_calls,
             final_response,
             anvil_final_detected,
+            raw_content: content.to_string(),
         })
     }
 
@@ -1283,26 +1288,49 @@ pub fn parse_plan_items(block: &str) -> Vec<crate::contracts::PlanItem> {
             continue;
         }
 
-        // Extract target file path: text before the first ":"
-        let target_files = extract_target_file(&description).into_iter().collect();
+        // Extract target file path(s): text before the first ":"
+        let target_files = extract_target_files(&description);
 
         items.push(crate::contracts::PlanItem::new(description, target_files));
     }
     items
 }
 
-/// Extract a file path from a plan item description.
+/// Extract file path(s) from a plan item description.
 ///
-/// Looks for a path-like prefix before the first `:` (e.g. `src/foo.rs: do stuff`).
-fn extract_target_file(description: &str) -> Option<String> {
-    let colon_pos = description.find(':')?;
+/// Supports both single file (`src/foo.rs: do stuff`) and comma-separated
+/// multi-target (`src/a.rs, src/b.rs: update both`) formats.
+///
+/// Security: rejects paths containing `..` and absolute paths (starting with `/`).
+/// Empty elements and whitespace-only paths are also filtered out.
+fn extract_target_files(description: &str) -> Vec<String> {
+    let colon_pos = match description.find(':') {
+        Some(pos) => pos,
+        None => return Vec::new(),
+    };
     let candidate = description[..colon_pos].trim();
-    // Heuristic: must contain a `/` or `.` to look like a file path
-    if candidate.contains('/') || candidate.contains('.') {
-        Some(candidate.to_string())
-    } else {
-        None
+
+    // Split by comma for multi-target support
+    let mut files = Vec::new();
+    for part in candidate.split(',') {
+        let path = part.trim();
+        if path.is_empty() {
+            continue;
+        }
+        // Security: reject paths with ".." (traversal)
+        if path.contains("..") {
+            continue;
+        }
+        // Security: reject absolute paths
+        if path.starts_with('/') {
+            continue;
+        }
+        // Heuristic: must contain a `/` or `.` to look like a file path
+        if (path.contains('/') || path.contains('.')) && !files.contains(&path.to_string()) {
+            files.push(path.to_string());
+        }
     }
+    files
 }
 
 // --- MCP tool description generation ---
@@ -1576,5 +1604,53 @@ mod tests {
         assert_eq!(items.len(), 2);
         // All parsed items start as Pending regardless of [x] in the source
         assert_eq!(items[0].status, crate::contracts::PlanItemStatus::Pending);
+    }
+
+    #[test]
+    fn multi_target_parser_parses_comma_separated() {
+        let block = "- [ ] src/a.rs, src/b.rs: update both";
+        let items = parse_plan_items(block);
+        assert_eq!(items.len(), 1);
+        assert_eq!(
+            items[0].target_files,
+            vec!["src/a.rs".to_string(), "src/b.rs".to_string()]
+        );
+    }
+
+    #[test]
+    fn multi_target_parser_backward_compatible() {
+        // Single file format must still work
+        let block = "- [ ] src/main.rs: entry point change";
+        let items = parse_plan_items(block);
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].target_files, vec!["src/main.rs".to_string()]);
+    }
+
+    #[test]
+    fn multi_target_parser_rejects_dotdot() {
+        let block = "- [ ] src/../etc/passwd, src/a.rs: malicious path";
+        let items = parse_plan_items(block);
+        assert_eq!(items.len(), 1);
+        // The .. path should be excluded, only src/a.rs should remain
+        assert_eq!(items[0].target_files, vec!["src/a.rs".to_string()]);
+    }
+
+    #[test]
+    fn multi_target_parser_rejects_absolute_path() {
+        let block = "- [ ] /etc/passwd, src/a.rs: absolute path test";
+        let items = parse_plan_items(block);
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].target_files, vec!["src/a.rs".to_string()]);
+    }
+
+    #[test]
+    fn multi_target_parser_trims_whitespace() {
+        let block = "- [ ] src/a.rs , src/b.rs : update both";
+        let items = parse_plan_items(block);
+        assert_eq!(items.len(), 1);
+        assert_eq!(
+            items[0].target_files,
+            vec!["src/a.rs".to_string(), "src/b.rs".to_string()]
+        );
     }
 }

--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -43,6 +43,10 @@ pub struct TurnSummary<'a> {
     pub files_modified: usize,
     pub compact_info: Option<&'a CompactInfo>,
     pub phase: super::phase_estimator::Phase,
+    /// Mutations executed this turn.
+    pub mutations_this_turn: Option<u32>,
+    /// Items advanced this turn.
+    pub items_advanced_this_turn: Option<u32>,
 }
 
 /// Log a turn summary using structured tracing.
@@ -465,7 +469,7 @@ impl App {
         self.reset_execution_plan();
 
         // Issue #249: Detect ANVIL_PLAN from initial response
-        self.try_register_plan(&current.final_response);
+        self.try_register_plan(&current.raw_content);
 
         // Session note extraction bookkeeping (Issue #241)
         let msg_count_before = self.session.messages.len();
@@ -494,6 +498,7 @@ impl App {
                 tool_calls: normal_calls,
                 final_response: current.final_response.clone(),
                 anvil_final_detected: current.anvil_final_detected,
+                raw_content: current.raw_content.clone(),
             };
 
             // Show plan for this iteration
@@ -522,8 +527,8 @@ impl App {
             let (results, loop_action) = self.execute_structured_tool_calls(&current_normal)?;
             total_tool_count += results.len();
 
-            // Issue #249: Update plan item status from tool results
-            self.update_plan_from_results(&results);
+            // Update plan item status from tool results; capture telemetry.
+            let (turn_mutations, turn_items_advanced) = self.update_plan_from_results(&results);
 
             let tool_log_views: Vec<ToolLogView> = results
                 .iter()
@@ -565,6 +570,7 @@ impl App {
                     anvil_final_seen = false;
                 } else {
                     tracing::info!("ANVIL_FINAL detected; terminating after tool execution");
+                    self.phase_estimator.accept_anvil_final();
                     break;
                 }
             }
@@ -705,6 +711,8 @@ impl App {
 
             // Record turn stats AFTER the full iteration completes (Issue #206 CB-001)
             self.session_stats.record_turn();
+            self.agent_telemetry
+                .record_turn_metrics(turn_mutations, turn_items_advanced, 0, 0);
             log_turn_summary(&TurnSummary {
                 turn: self.session_stats.total_turns,
                 max_turns: max_iterations as u32,
@@ -716,6 +724,8 @@ impl App {
                 files_modified: turn_files_modified,
                 compact_info: self.last_compact_info.as_ref(),
                 phase: self.phase_estimator.current_phase(),
+                mutations_this_turn: Some(turn_mutations),
+                items_advanced_this_turn: Some(turn_items_advanced),
             });
             // Reset last_compact_info after it's been consumed by the turn summary
             self.last_compact_info = None;
@@ -738,9 +748,6 @@ impl App {
                         tracing::info!(
                             "Guidance follow-up ended without edits; escalating to final guard retry"
                         );
-                        if !next_structured.anvil_final_detected {
-                            self.phase_estimator.observe_anvil_final();
-                        }
                         self.inject_final_guard_retry();
                         final_guard_retries += 1;
                         current = next_structured;
@@ -755,10 +762,6 @@ impl App {
                 }
                 // ANVIL_FINAL guard: check if any file modifications were made
                 if self.should_activate_final_guard(final_guard_retries) {
-                    // ANVIL_FINAL was detected → record observation (Issue #159)
-                    if !next_structured.anvil_final_detected {
-                        self.phase_estimator.observe_anvil_final();
-                    }
                     self.inject_final_guard_retry();
                     final_guard_retries += 1;
                     current = next_structured;
@@ -788,6 +791,10 @@ impl App {
                 }
 
                 // No more tool calls — this is the final answer
+                // Issue #261 Task 0.4: Mark as accepted (not suppressed)
+                if anvil_final_seen {
+                    self.phase_estimator.accept_anvil_final();
+                }
                 self.record_assistant_output(
                     self.next_message_id("assistant"),
                     next_structured.final_response,
@@ -1969,6 +1976,8 @@ impl App {
                 files_modified: 0,
                 compact_info: None,
                 phase: self.phase_estimator.current_phase(),
+                mutations_this_turn: None,
+                items_advanced_this_turn: None,
             });
             return Ok(None);
         }

--- a/src/app/execution_plan.rs
+++ b/src/app/execution_plan.rs
@@ -19,6 +19,7 @@ const PLAN_REQUIRED_MESSAGE: &str = "[System] まず変更計画を作成して�
      ```";
 
 /// Message injected when ANVIL_FINAL is suppressed because items remain.
+/// Backward-compatible wrapper for sequential mode.
 fn incomplete_plan_message(next_desc: &str, remaining: usize, total: usize) -> String {
     format!(
         "[System] まだ {remaining}/{total} 項目が未完了です。次の項目を実行してください:\n  {next_desc}\n\
@@ -73,70 +74,134 @@ impl App {
 
     /// Update plan item status based on tool execution results.
     ///
-    /// Issue #255: Uses `record_mutation_success` to require ALL target_files
-    /// to be mutated before marking an item as Done. Each successful mutation
-    /// is tracked individually per file path.
+    /// Filters out rolled-back and no-op mutations. Each valid mutation is
+    /// matched against all unfinished items' target_files (multi-item attribution).
+    ///
+    /// Returns `(mutations, items_advanced)` for per-turn telemetry.
     pub(crate) fn update_plan_from_results(
         &mut self,
         results: &[crate::tooling::ToolExecutionResult],
-    ) {
+    ) -> (u32, u32) {
+        use crate::contracts::PlanItemStatus;
+
         if self.execution_plan.is_empty() {
-            return;
+            return (0, 0);
         }
 
-        let idx = match self.execution_plan.next_actionable_index() {
-            Some(i) => i,
-            None => return,
-        };
+        let mut mutations_count: u32 = 0;
+        let current_idx = self.execution_plan.next_actionable_index();
 
         let mutation_tools = ["file.write", "file.edit", "file.edit_anchor"];
 
-        let was_done_before = self.execution_plan.items[idx].is_finished();
+        // Snapshot finished state before processing
+        let was_finished: Vec<bool> = self
+            .execution_plan
+            .items
+            .iter()
+            .map(|i| i.is_finished())
+            .collect();
 
-        // Record each successful mutation individually (Issue #255)
         for r in results {
-            if mutation_tools.contains(&r.tool_name.as_str())
-                && r.status == crate::tooling::ToolExecutionStatus::Completed
+            if !mutation_tools.contains(&r.tool_name.as_str())
+                || r.status != crate::tooling::ToolExecutionStatus::Completed
             {
-                // summary contains the file path for mutation tools
-                if !r.summary.is_empty() {
+                continue;
+            }
+
+            // Skip rolled_back mutations
+            if r.rolled_back {
+                self.agent_telemetry.record_rolled_back_mutation();
+                continue;
+            }
+            // Skip no-op mutations
+            if r.summary.contains("(no changes)") {
+                self.agent_telemetry.record_no_op_mutation();
+                continue;
+            }
+
+            if r.summary.is_empty() {
+                continue;
+            }
+
+            mutations_count += 1;
+
+            // Find matching unfinished items by target_files
+            let mut matches: Vec<usize> = Vec::new();
+            for (i, item) in self.execution_plan.items.iter().enumerate() {
+                if item.is_finished() || item.target_files.is_empty() {
+                    continue;
+                }
+                let file_matches = item
+                    .target_files
+                    .iter()
+                    .any(|tf| r.summary.ends_with(tf) || tf.ends_with(&r.summary));
+                if file_matches {
+                    matches.push(i);
+                }
+            }
+
+            if !matches.is_empty() {
+                // Prioritize InProgress items over Pending
+                let inprogress: Vec<usize> = matches
+                    .iter()
+                    .copied()
+                    .filter(|&i| self.execution_plan.items[i].status == PlanItemStatus::InProgress)
+                    .collect();
+                let targets = if inprogress.is_empty() {
+                    matches
+                } else {
+                    inprogress
+                };
+                for idx in targets {
+                    self.execution_plan.record_mutation_success(idx, &r.summary);
+                }
+            } else {
+                // Fallback: attribute to current item only (empty target_files or no match)
+                if let Some(idx) = current_idx {
                     self.execution_plan.record_mutation_success(idx, &r.summary);
                 }
             }
         }
 
-        // Check if item just transitioned to Done
-        if !was_done_before && self.execution_plan.items[idx].is_finished() {
-            tracing::info!(
-                item = idx + 1,
-                description = %self.execution_plan.items[idx].description,
-                "plan item completed (all target_files mutated)"
-            );
-            // Auto-advance next item to InProgress
-            if let Some(next) = self.execution_plan.next_actionable_index() {
-                self.execution_plan.mark_in_progress(next);
+        // Check which items just transitioned to Done and log; count advances
+        let mut items_advanced: u32 = 0;
+        for (i, &was) in was_finished.iter().enumerate() {
+            if !was && self.execution_plan.items[i].is_finished() {
+                items_advanced += 1;
+                tracing::info!(
+                    item = i + 1,
+                    description = %self.execution_plan.items[i].description,
+                    "plan item completed (all target_files mutated)"
+                );
             }
         }
 
-        // Record failures
-        let has_failed_mutation = results.iter().any(|r| {
-            mutation_tools.contains(&r.tool_name.as_str())
-                && r.status == crate::tooling::ToolExecutionStatus::Failed
-        });
-        if has_failed_mutation && !self.execution_plan.items[idx].is_finished() {
-            self.execution_plan.record_failure(idx);
-            tracing::warn!(
-                item = idx + 1,
-                retry_count = self.execution_plan.items[idx].retry_count,
-                "plan item mutation failed"
-            );
+        // Auto-advance next pending item to InProgress
+        if let Some(next) = self.execution_plan.next_actionable_index()
+            && self.execution_plan.items[next].status == PlanItemStatus::Pending
+        {
+            self.execution_plan.mark_in_progress(next);
         }
+
+        // Record failures (attributed to current item)
+        if let Some(idx) = current_idx {
+            let has_failed_mutation = results.iter().any(|r| {
+                mutation_tools.contains(&r.tool_name.as_str())
+                    && r.status == crate::tooling::ToolExecutionStatus::Failed
+            });
+            if has_failed_mutation && !self.execution_plan.items[idx].is_finished() {
+                self.execution_plan.record_failure(idx);
+                tracing::warn!(
+                    item = idx + 1,
+                    retry_count = self.execution_plan.items[idx].retry_count,
+                    "plan item mutation failed"
+                );
+            }
+        }
+
+        (mutations_count, items_advanced)
     }
 
-    /// Check the plan-aware ANVIL_FINAL gate.
-    ///
-    /// Returns `true` if ANVIL_FINAL should be suppressed (plan incomplete).
-    /// When suppressed, injects a guidance message into the session.
     /// Check the plan-aware ANVIL_FINAL gate.
     ///
     /// Returns `true` if ANVIL_FINAL should be suppressed (plan incomplete).
@@ -204,12 +269,15 @@ impl App {
                     pfrr = %self.agent_telemetry.premature_final_request_rate(),
                     "plan-aware final gate: suppressing ANVIL_FINAL (premature)"
                 );
-                let msg = SessionMessage::new(
-                    MessageRole::Tool,
-                    "system",
-                    incomplete_plan_message(&next_description, remaining, total),
-                )
-                .with_id(self.next_message_id("tool"));
+                let mode = self.config.runtime.guidance_mode;
+                let guidance_text = match mode {
+                    crate::config::GuidanceMode::Batch => self
+                        .execution_plan
+                        .build_incomplete_plan_message_with_mode(mode),
+                    _ => incomplete_plan_message(&next_description, remaining, total),
+                };
+                let msg = SessionMessage::new(MessageRole::Tool, "system", guidance_text)
+                    .with_id(self.next_message_id("tool"));
                 self.session.push_message(msg);
                 true
             }
@@ -219,8 +287,10 @@ impl App {
     /// Inject turn guidance for the current plan item.
     ///
     /// Called at the beginning of each follow-up turn to guide the LLM.
+    /// Uses the configured `guidance_mode` from runtime config.
     pub(crate) fn inject_plan_turn_guidance(&mut self) {
-        if let Some(guidance) = self.execution_plan.build_turn_guidance() {
+        let mode = self.config.runtime.guidance_mode;
+        if let Some(guidance) = self.execution_plan.build_turn_guidance_with_mode(mode) {
             let msg = SessionMessage::new(MessageRole::Tool, "system", guidance)
                 .with_id(self.next_message_id("tool"));
             self.session.push_message(msg);

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -878,6 +878,9 @@ impl App {
                 plan_registration_count = tel.plan_registration_count,
                 plan_update_count = tel.plan_update_count,
                 sync_from_touched_files_count = tel.sync_from_touched_files_count,
+                no_op_mutation_count = tel.no_op_mutation_count,
+                rolled_back_mutation_count = tel.rolled_back_mutation_count,
+                initial_plan_miss_count = tel.initial_plan_miss_count,
                 "agent telemetry"
             );
         }

--- a/src/app/phase_estimator.rs
+++ b/src/app/phase_estimator.rs
@@ -68,6 +68,9 @@ pub struct PhaseEstimator {
     has_written: bool,
     /// Whether ANVIL_FINAL has been observed at least once in this session.
     anvil_final_observed: bool,
+    /// Whether ANVIL_FINAL has been accepted (not suppressed) at least once.
+    /// Only accepted finals disable fallback completion.
+    anvil_final_accepted: bool,
     /// Threshold N: consecutive reads to enter "exploring" phase.
     explore_threshold: usize,
     /// Threshold M: consecutive reads to trigger forced transition (M > N).
@@ -87,6 +90,7 @@ impl PhaseEstimator {
             consecutive_reads: 0,
             has_written: false,
             anvil_final_observed: false,
+            anvil_final_accepted: false,
             explore_threshold,
             force_transition_threshold,
             completion_read_threshold,
@@ -138,7 +142,7 @@ impl PhaseEstimator {
     ///
     /// Otherwise returns `Continue`.
     pub fn check_empty_response(&self) -> PhaseAction {
-        if self.anvil_final_observed {
+        if self.anvil_final_accepted {
             return PhaseAction::Continue;
         }
         if self.has_written && self.consecutive_reads >= self.completion_read_threshold {
@@ -147,17 +151,26 @@ impl PhaseEstimator {
         PhaseAction::Continue
     }
 
-    /// Record that ANVIL_FINAL was observed. Disables fallback completion
-    /// for the remainder of the session.
+    /// Record that ANVIL_FINAL was observed (including suppressed premature finals).
+    /// Does NOT disable fallback completion; use `accept_anvil_final()` for that.
     pub fn observe_anvil_final(&mut self) {
         self.anvil_final_observed = true;
     }
 
+    /// Record that ANVIL_FINAL was accepted (not suppressed).
+    /// Disables fallback completion for the remainder of the session.
+    pub fn accept_anvil_final(&mut self) {
+        self.anvil_final_accepted = true;
+        self.anvil_final_observed = true;
+    }
+
     /// Reset model-dependent state (called on `/model` switch).
-    /// Clears `anvil_final_observed` since a new model may not emit ANVIL_FINAL.
+    /// Clears `anvil_final_observed` and `anvil_final_accepted` since a new model
+    /// may not emit ANVIL_FINAL.
     #[allow(dead_code)]
     pub fn reset_model_state(&mut self) {
         self.anvil_final_observed = false;
+        self.anvil_final_accepted = false;
     }
 
     /// Return the estimated phase for logging/debugging.
@@ -264,21 +277,33 @@ mod tests {
     }
 
     #[test]
-    fn anvil_final_observed_disables_fallback() {
+    fn anvil_final_accepted_disables_fallback() {
+        let mut est = default_estimator();
+        est.record_tool_call("file.write", true);
+        for _ in 0..5 {
+            est.record_tool_call("file.read", true);
+        }
+        est.accept_anvil_final();
+        assert_eq!(est.check_empty_response(), PhaseAction::Continue);
+    }
+
+    #[test]
+    fn anvil_final_observed_only_does_not_disable_fallback() {
         let mut est = default_estimator();
         est.record_tool_call("file.write", true);
         for _ in 0..5 {
             est.record_tool_call("file.read", true);
         }
         est.observe_anvil_final();
-        assert_eq!(est.check_empty_response(), PhaseAction::Continue);
+        // observe without accept should NOT disable fallback
+        assert_eq!(est.check_empty_response(), PhaseAction::FallbackComplete);
     }
 
     #[test]
     fn reset_preserves_has_written_and_anvil_final() {
         let mut est = default_estimator();
         est.record_tool_call("file.write", true);
-        est.observe_anvil_final();
+        est.accept_anvil_final();
         est.record_tool_call("file.read", true);
 
         est.reset();
@@ -286,16 +311,19 @@ mod tests {
         assert_eq!(est.consecutive_reads, 0);
         assert!(est.has_written);
         assert!(est.anvil_final_observed);
+        assert!(est.anvil_final_accepted);
     }
 
     #[test]
     fn reset_model_state_clears_anvil_final() {
         let mut est = default_estimator();
-        est.observe_anvil_final();
+        est.accept_anvil_final();
         assert!(est.anvil_final_observed);
+        assert!(est.anvil_final_accepted);
 
         est.reset_model_state();
         assert!(!est.anvil_final_observed);
+        assert!(!est.anvil_final_accepted);
     }
 
     #[test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -85,6 +85,40 @@ pub enum WebSearchProvider {
     SerperApi,
 }
 
+/// Guidance mode for plan-aware execution (Issue #261).
+///
+/// Controls whether the agent guidance encourages sequential (one item at a time)
+/// or batch (multiple items at once) execution.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GuidanceMode {
+    /// Execute plan items one at a time (default, backward compatible).
+    #[default]
+    Sequential,
+    /// Execute multiple plan items in a single turn (batch mode).
+    Batch,
+}
+
+impl std::fmt::Display for GuidanceMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Sequential => write!(f, "sequential"),
+            Self::Batch => write!(f, "batch"),
+        }
+    }
+}
+
+impl std::str::FromStr for GuidanceMode {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "sequential" => Ok(GuidanceMode::Sequential),
+            "batch" => Ok(GuidanceMode::Batch),
+            _ => Ok(GuidanceMode::Sequential), // fail-closed: unknown values fall back to Sequential
+        }
+    }
+}
+
 #[derive(Clone)]
 /// Provider, model, and transport settings.
 pub struct RuntimeConfig {
@@ -161,6 +195,9 @@ pub struct RuntimeConfig {
     /// Maximum output tokens per LLM turn (Issue #204).
     /// Translated to provider-specific limits (Ollama `num_predict`, OpenAI `max_tokens`).
     pub max_output_tokens: Option<u32>,
+    /// Guidance mode for plan-aware execution (Issue #261).
+    /// Sequential = one item at a time (default), Batch = multiple items per turn.
+    pub guidance_mode: GuidanceMode,
 }
 
 #[derive(Debug, Clone)]
@@ -341,6 +378,7 @@ impl EffectiveConfig {
                 ui_language: None,
                 max_tool_calls: DEFAULT_MAX_TOOL_CALLS,
                 max_output_tokens: Some(DEFAULT_MAX_OUTPUT_TOKENS),
+                guidance_mode: GuidanceMode::default(),
             },
             mode: ModeConfig {
                 prompt_source: PromptSource::Interactive,
@@ -463,6 +501,7 @@ impl EffectiveConfig {
             "ANVIL_SAFE_WRITE_DELETION_RATIO",
             "ANVIL_UI_LANGUAGE",
             "ANVIL_MAX_TOOL_CALLS",
+            "ANVIL_GUIDANCE_MODE",
         ] {
             if let Ok(value) = std::env::var(key) {
                 map.insert(key.to_string(), value);
@@ -863,6 +902,12 @@ impl EffectiveConfig {
                         .parse()
                         .map_err(|_| ConfigError::InvalidNumericValue(value.clone()))?;
                     self.runtime.max_output_tokens = if v == 0 { None } else { Some(v) };
+                }
+                "guidance_mode" | "ANVIL_GUIDANCE_MODE" => {
+                    // fail-closed: unknown values fall back to Sequential
+                    self.runtime.guidance_mode = value
+                        .parse::<GuidanceMode>()
+                        .unwrap_or(GuidanceMode::Sequential);
                 }
                 _ => {}
             }

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -97,9 +97,9 @@ impl SubAgentPayload {
 /// How the agentic session ended, classified by plan state and verification.
 ///
 /// Priority order (highest first):
-/// 1. CompleteVerified
-/// 2. CompleteUnverified
-/// 3. Blocked
+/// 1. Blocked (has_blocked items -> always Blocked)
+/// 2. CompleteVerified
+/// 3. CompleteUnverified
 /// 4. Exhausted
 /// 5. Partial
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
@@ -147,17 +147,17 @@ impl CompletionKind {
             .iter()
             .any(|i| i.status == PlanItemStatus::Blocked);
 
-        // Priority 1-2: all items finished → complete_*
+        // Priority 1: blocked items exist → always Blocked
+        if has_blocked {
+            return CompletionKind::Blocked;
+        }
+
+        // Priority 2-3: all items finished → complete_*
         if all_finished {
             return match verify_pass {
                 Some(true) => CompletionKind::CompleteVerified,
                 _ => CompletionKind::CompleteUnverified,
             };
-        }
-
-        // Priority 3: blocked items exist
-        if has_blocked {
-            return CompletionKind::Blocked;
         }
 
         // Priority 4: budget exhausted
@@ -194,6 +194,28 @@ pub struct AgentTelemetry {
     pub sync_from_touched_files_count: u32,
     /// Final completion classification.
     pub completion_kind: Option<CompletionKind>,
+
+    /// Number of times initial ANVIL_PLAN detection missed (raw_content fallback used).
+    #[serde(default)]
+    pub initial_plan_miss_count: u32,
+    /// Number of no-op mutations filtered (summary contains "(no changes)").
+    #[serde(default)]
+    pub no_op_mutation_count: u32,
+    /// Number of rolled_back mutations filtered.
+    #[serde(default)]
+    pub rolled_back_mutation_count: u32,
+    /// Mutations per turn (Phase 0: actual values).
+    #[serde(default)]
+    pub mutations_per_turn: Vec<u32>,
+    /// Items advanced per turn (Phase 0: actual values).
+    #[serde(default)]
+    pub items_advanced_per_turn: Vec<u32>,
+    /// Guidance characters per turn (Phase 0: 0, Phase 1: actual values).
+    #[serde(default)]
+    pub guidance_chars_per_turn: Vec<u32>,
+    /// Workset size per turn (Phase 0: always 1, Phase 1: actual values).
+    #[serde(default)]
+    pub workset_size_per_turn: Vec<u32>,
 }
 
 impl AgentTelemetry {
@@ -219,6 +241,35 @@ impl AgentTelemetry {
 
     pub fn record_sync_from_touched_files(&mut self) {
         self.sync_from_touched_files_count += 1;
+    }
+
+    /// Record an initial plan miss (raw_content fallback used).
+    pub fn record_initial_plan_miss(&mut self) {
+        self.initial_plan_miss_count += 1;
+    }
+
+    /// Record a no-op mutation (filtered out).
+    pub fn record_no_op_mutation(&mut self) {
+        self.no_op_mutation_count += 1;
+    }
+
+    /// Record a rolled_back mutation (filtered out).
+    pub fn record_rolled_back_mutation(&mut self) {
+        self.rolled_back_mutation_count += 1;
+    }
+
+    /// Record per-turn metrics for batch experiment telemetry.
+    pub fn record_turn_metrics(
+        &mut self,
+        mutations: u32,
+        items_advanced: u32,
+        guidance_chars: u32,
+        workset_size: u32,
+    ) {
+        self.mutations_per_turn.push(mutations);
+        self.items_advanced_per_turn.push(items_advanced);
+        self.guidance_chars_per_turn.push(guidance_chars);
+        self.workset_size_per_turn.push(workset_size);
     }
 
     /// Premature Final Request Rate: ratio of suppressed finals to total finals.
@@ -397,11 +448,18 @@ impl ExecutionPlan {
         }
     }
 
+    /// Fuzzy path match: true when either path is a suffix of the other.
+    ///
+    /// Used consistently across `record_mutation_success`, `sync_from_touched_files`,
+    /// and `update_plan_from_results` to avoid divergent matching behaviour.
+    pub fn path_matches(a: &str, b: &str) -> bool {
+        a.ends_with(b) || b.ends_with(a)
+    }
+
     /// Record a successful mutation for a plan item (Issue #255).
     ///
     /// Tracks which files have been mutated. When all `target_files` are
     /// covered (or item has no target_files), marks the item as Done.
-    /// Uses fuzzy path matching (ends_with) for path normalization.
     pub fn record_mutation_success(&mut self, index: usize, file_path: &str) {
         let item = match self.items.get_mut(index) {
             Some(i) => i,
@@ -424,12 +482,32 @@ impl ExecutionPlan {
             let all_covered = item.target_files.iter().all(|tf| {
                 item.mutated_files
                     .iter()
-                    .any(|mf| mf.ends_with(tf) || tf.ends_with(mf))
+                    .any(|mf| Self::path_matches(mf, tf))
             });
             if all_covered {
                 item.status = PlanItemStatus::Done;
             }
         }
+    }
+
+    /// Return indices of the current workset: up to 5 actionable (Pending or InProgress) items.
+    ///
+    /// Used by batch guidance mode to identify items that can be executed together in a single turn.
+    /// Returns empty Vec when all items are finished.
+    pub fn current_workset(&self) -> Vec<usize> {
+        const MAX_WORKSET_SIZE: usize = 5;
+        self.items
+            .iter()
+            .enumerate()
+            .filter(|(_, item)| {
+                matches!(
+                    item.status,
+                    PlanItemStatus::Pending | PlanItemStatus::InProgress
+                )
+            })
+            .take(MAX_WORKSET_SIZE)
+            .map(|(i, _)| i)
+            .collect()
     }
 
     /// Append new items (used by ANVIL_PLAN_UPDATE).
@@ -463,7 +541,7 @@ impl ExecutionPlan {
             let all_matched = item.target_files.iter().all(|tf| {
                 touched_files
                     .iter()
-                    .any(|touched| touched.ends_with(tf) || tf.ends_with(touched))
+                    .any(|touched| ExecutionPlan::path_matches(touched, tf))
             });
             if all_matched {
                 tracing::info!(
@@ -496,19 +574,120 @@ impl ExecutionPlan {
     }
 
     /// Build the system message to inject at the start of each execution turn.
+    ///
+    /// Uses Sequential mode (backward compatible). For mode-aware guidance,
+    /// use [`build_turn_guidance_with_mode`].
     pub fn build_turn_guidance(&self) -> Option<String> {
+        self.build_turn_guidance_with_mode(crate::config::GuidanceMode::Sequential)
+    }
+
+    /// Build the system message with explicit guidance mode.
+    ///
+    /// - `Sequential`: guides LLM to execute one item at a time (current behavior).
+    /// - `Batch`: guides LLM to execute the current workset (up to 5 items) at once.
+    pub fn build_turn_guidance_with_mode(
+        &self,
+        mode: crate::config::GuidanceMode,
+    ) -> Option<String> {
         let idx = self.next_actionable_index()?;
-        let item = &self.items[idx];
         let finished = self.finished_count();
         let total = self.items.len();
-        Some(format!(
-            "[System] 計画の次の項目を実行してください:\n  {}. {}\n完了: {}/{} 項目\n\n現在の計画:\n{}\n\n1項目ずつ実行し、全項目完了時のみ ANVIL_FINAL を出力してください。",
-            idx + 1,
-            item.description,
-            finished,
-            total,
-            self.format_checklist()
-        ))
+
+        match mode {
+            crate::config::GuidanceMode::Sequential => {
+                let item = &self.items[idx];
+                Some(format!(
+                    "[System] 計画の次の項目を実行してください:\n  {}. {}\n完了: {}/{} 項目\n\n現在の計画:\n{}\n\n1項目ずつ実行し、全項目完了時のみ ANVIL_FINAL を出力してください。",
+                    idx + 1,
+                    item.description,
+                    finished,
+                    total,
+                    self.format_checklist()
+                ))
+            }
+            crate::config::GuidanceMode::Batch => {
+                let workset = self.current_workset();
+                let remaining = total - finished;
+                let mut workset_lines = Vec::new();
+                for &wi in &workset {
+                    workset_lines.push(format!("  {}. {}", wi + 1, self.items[wi].description));
+                }
+                Some(format!(
+                    "[System] 以下の項目をまとめて実行してください:\n{}\n完了: {}/{} 項目 (残り {})\n\n現在の計画:\n{}\n\nこれらの項目をまとめて進めてください。全項目完了時のみ ANVIL_FINAL を出力してください。",
+                    workset_lines.join("\n"),
+                    finished,
+                    total,
+                    remaining,
+                    self.format_checklist()
+                ))
+            }
+        }
+    }
+
+    /// Build the incomplete plan message for ANVIL_FINAL suppression.
+    ///
+    /// - `Sequential`: simple "next item" message (backward compatible).
+    /// - `Batch`: includes completed items, pending items (workset), and batch instruction.
+    pub fn build_incomplete_plan_message_with_mode(
+        &self,
+        mode: crate::config::GuidanceMode,
+    ) -> String {
+        let finished = self.finished_count();
+        let total = self.items.len();
+        let remaining = total - finished;
+
+        match mode {
+            crate::config::GuidanceMode::Sequential => {
+                let next_desc = self
+                    .next_actionable_index()
+                    .and_then(|i| self.items.get(i))
+                    .map(|i| i.description.as_str())
+                    .unwrap_or("");
+                format!(
+                    "[System] まだ {remaining}/{total} 項目が未完了です。次の項目を実行してください:\n  {next_desc}\n\
+                     全項目完了後に ANVIL_FINAL を出力してください。"
+                )
+            }
+            crate::config::GuidanceMode::Batch => {
+                // Completed items
+                let completed_lines: Vec<String> = self
+                    .items
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, item)| item.status == PlanItemStatus::Done)
+                    .map(|(i, item)| format!("  {}. {}", i + 1, item.description))
+                    .collect();
+
+                // Workset (pending/in-progress items)
+                let workset = self.current_workset();
+                let workset_lines: Vec<String> = workset
+                    .iter()
+                    .map(|&i| format!("  {}. {}", i + 1, self.items[i].description))
+                    .collect();
+
+                let mut msg = format!("[System] まだ {remaining}/{total} 項目が未完了です。\n\n");
+
+                if !completed_lines.is_empty() {
+                    msg.push_str(&format!(
+                        "完了済み ({}/{total}):\n{}\n\n",
+                        completed_lines.len(),
+                        completed_lines.join("\n")
+                    ));
+                }
+
+                if !workset_lines.is_empty() {
+                    msg.push_str(&format!(
+                        "未完了 (次のworkset):\n{}\n\n",
+                        workset_lines.join("\n")
+                    ));
+                }
+
+                msg.push_str(
+                    "これらの項目をまとめて実行してください。全項目完了後に ANVIL_FINAL を出力してください。",
+                );
+                msg
+            }
+        }
     }
 }
 

--- a/tests/agent_phase.rs
+++ b/tests/agent_phase.rs
@@ -127,19 +127,19 @@ fn classify_blocked_takes_priority_over_exhausted() {
 }
 
 #[test]
-fn classify_complete_takes_priority_over_blocked() {
+fn classify_blocked_takes_priority_over_complete() {
     let mut plan = ExecutionPlan::new(vec![
         PlanItem::new("task1".into(), vec!["src/a.rs".into()]),
         PlanItem::new("task2".into(), vec!["src/b.rs".into()]),
     ]);
     plan.mark_done(0);
-    // task2 blocked but all finished → complete wins
+    // task2 blocked but all finished → Blocked wins (Issue #261 Task 0.5)
     for _ in 0..PlanItem::MAX_RETRIES {
         plan.record_failure(1);
     }
     assert!(plan.all_finished());
     let kind = CompletionKind::classify(&plan, None, false);
-    assert_eq!(kind, CompletionKind::CompleteUnverified);
+    assert_eq!(kind, CompletionKind::Blocked);
 }
 
 // ---------------------------------------------------------------------------
@@ -324,4 +324,545 @@ fn final_gate_allows_when_all_done() {
     let mut plan = ExecutionPlan::new(vec![PlanItem::new("task1".into(), vec!["src/a.rs".into()])]);
     plan.mark_done(0);
     assert_eq!(plan.check_final_gate(), FinalGateDecision::Allow);
+}
+
+// ---------------------------------------------------------------------------
+// Task 0.6: telemetry extension
+// ---------------------------------------------------------------------------
+
+#[test]
+fn telemetry_tracks_no_op_mutation() {
+    let mut tel = AgentTelemetry::new();
+    assert_eq!(tel.no_op_mutation_count, 0);
+    tel.record_no_op_mutation();
+    tel.record_no_op_mutation();
+    assert_eq!(tel.no_op_mutation_count, 2);
+}
+
+#[test]
+fn telemetry_tracks_rolled_back_mutation() {
+    let mut tel = AgentTelemetry::new();
+    assert_eq!(tel.rolled_back_mutation_count, 0);
+    tel.record_rolled_back_mutation();
+    assert_eq!(tel.rolled_back_mutation_count, 1);
+}
+
+#[test]
+fn telemetry_tracks_turn_metrics() {
+    let mut tel = AgentTelemetry::new();
+    tel.record_turn_metrics(3, 2, 100, 1);
+    tel.record_turn_metrics(1, 1, 50, 2);
+    assert_eq!(tel.mutations_per_turn, vec![3, 1]);
+    assert_eq!(tel.items_advanced_per_turn, vec![2, 1]);
+    assert_eq!(tel.guidance_chars_per_turn, vec![100, 50]);
+    assert_eq!(tel.workset_size_per_turn, vec![1, 2]);
+}
+
+#[test]
+fn telemetry_serde_backward_compatible() {
+    // JSON without new fields should deserialize with defaults
+    let json = r#"{
+        "premature_final_count": 1,
+        "total_final_requests": 5,
+        "plan_registration_count": 1,
+        "plan_update_count": 0,
+        "sync_from_touched_files_count": 0,
+        "completion_kind": null
+    }"#;
+    let tel: AgentTelemetry = serde_json::from_str(json).expect("should deserialize");
+    assert_eq!(tel.premature_final_count, 1);
+    assert_eq!(tel.no_op_mutation_count, 0);
+    assert_eq!(tel.rolled_back_mutation_count, 0);
+    assert_eq!(tel.initial_plan_miss_count, 0);
+    assert!(tel.mutations_per_turn.is_empty());
+    assert!(tel.items_advanced_per_turn.is_empty());
+    assert!(tel.guidance_chars_per_turn.is_empty());
+    assert!(tel.workset_size_per_turn.is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// Task 0.5: completion semantics
+// ---------------------------------------------------------------------------
+
+#[test]
+fn blocked_items_do_not_classify_as_complete() {
+    let mut plan = ExecutionPlan::new(vec![
+        PlanItem::new("task1".into(), vec!["src/a.rs".into()]),
+        PlanItem::new("task2".into(), vec!["src/b.rs".into()]),
+    ]);
+    plan.mark_done(0);
+    // task2 blocked → all finished but has_blocked
+    for _ in 0..PlanItem::MAX_RETRIES {
+        plan.record_failure(1);
+    }
+    assert!(plan.all_finished());
+    let kind = CompletionKind::classify(&plan, None, false);
+    assert_eq!(kind, CompletionKind::Blocked);
+}
+
+#[test]
+fn final_gate_allows_when_all_done_or_blocked() {
+    let mut plan = ExecutionPlan::new(vec![
+        PlanItem::new("task1".into(), vec!["src/a.rs".into()]),
+        PlanItem::new("task2".into(), vec!["src/b.rs".into()]),
+    ]);
+    plan.mark_done(0);
+    for _ in 0..PlanItem::MAX_RETRIES {
+        plan.record_failure(1);
+    }
+    assert!(plan.all_finished());
+    assert_eq!(plan.check_final_gate(), FinalGateDecision::Allow);
+}
+
+// ---------------------------------------------------------------------------
+// Task 0.2: rolled_back / no-op mutation exclusion
+// ---------------------------------------------------------------------------
+
+fn make_mutation_result(
+    tool_name: &str,
+    summary: &str,
+    status: anvil::tooling::ToolExecutionStatus,
+    rolled_back: bool,
+) -> anvil::tooling::ToolExecutionResult {
+    anvil::tooling::ToolExecutionResult {
+        tool_call_id: "tc-1".to_string(),
+        tool_name: tool_name.to_string(),
+        status,
+        summary: summary.to_string(),
+        payload: anvil::tooling::ToolExecutionPayload::Text("ok".to_string()),
+        artifacts: vec![],
+        elapsed_ms: 10,
+        diff_summary: None,
+        edit_detail: None,
+        rolled_back,
+    }
+}
+
+#[test]
+fn rolled_back_mutation_does_not_advance_plan() {
+    // Build a plan with one item
+    let items = vec![PlanItem::new("update A".into(), vec!["src/a.rs".into()])];
+    let mut plan = ExecutionPlan::new(items);
+    plan.mark_in_progress(0);
+
+    // A rolled_back Completed result
+    let result = make_mutation_result(
+        "file.write",
+        "src/a.rs",
+        anvil::tooling::ToolExecutionStatus::Completed,
+        true, // rolled_back
+    );
+
+    // Simulate update_plan_from_results logic: rolled_back should be skipped
+    // We test the contracts layer directly since update_plan_from_results is on App
+    let mutation_tools = ["file.write", "file.edit", "file.edit_anchor"];
+    for r in &[result] {
+        if mutation_tools.contains(&r.tool_name.as_str())
+            && r.status == anvil::tooling::ToolExecutionStatus::Completed
+            && !r.rolled_back
+            && !r.summary.contains("(no changes)")
+            && !r.summary.is_empty()
+        {
+            plan.record_mutation_success(0, &r.summary);
+        }
+    }
+    // Item should NOT be done (rolled_back was filtered)
+    assert_eq!(plan.items[0].status, PlanItemStatus::InProgress);
+}
+
+#[test]
+fn noop_mutation_does_not_advance_plan() {
+    let items = vec![PlanItem::new("update A".into(), vec!["src/a.rs".into()])];
+    let mut plan = ExecutionPlan::new(items);
+    plan.mark_in_progress(0);
+
+    let result = make_mutation_result(
+        "file.edit",
+        "src/a.rs (no changes)",
+        anvil::tooling::ToolExecutionStatus::Completed,
+        false,
+    );
+
+    let mutation_tools = ["file.write", "file.edit", "file.edit_anchor"];
+    for r in &[result] {
+        if mutation_tools.contains(&r.tool_name.as_str())
+            && r.status == anvil::tooling::ToolExecutionStatus::Completed
+            && !r.rolled_back
+            && !r.summary.contains("(no changes)")
+            && !r.summary.is_empty()
+        {
+            plan.record_mutation_success(0, &r.summary);
+        }
+    }
+    assert_eq!(plan.items[0].status, PlanItemStatus::InProgress);
+}
+
+#[test]
+fn valid_mutation_still_advances_plan() {
+    let items = vec![PlanItem::new("update A".into(), vec!["src/a.rs".into()])];
+    let mut plan = ExecutionPlan::new(items);
+    plan.mark_in_progress(0);
+
+    let result = make_mutation_result(
+        "file.write",
+        "src/a.rs",
+        anvil::tooling::ToolExecutionStatus::Completed,
+        false,
+    );
+
+    let mutation_tools = ["file.write", "file.edit", "file.edit_anchor"];
+    for r in &[result] {
+        if mutation_tools.contains(&r.tool_name.as_str())
+            && r.status == anvil::tooling::ToolExecutionStatus::Completed
+            && !r.rolled_back
+            && !r.summary.contains("(no changes)")
+            && !r.summary.is_empty()
+        {
+            plan.record_mutation_success(0, &r.summary);
+        }
+    }
+    assert_eq!(plan.items[0].status, PlanItemStatus::Done);
+}
+
+// ---------------------------------------------------------------------------
+// Task 0.1: raw_content preserves full response for ANVIL_PLAN extraction
+// ---------------------------------------------------------------------------
+
+#[test]
+fn plan_registers_from_initial_raw_content() {
+    use anvil::agent::BasicAgentLoop;
+
+    // Response with ANVIL_PLAN outside ANVIL_FINAL (no tool blocks)
+    let response = "\
+```ANVIL_PLAN\n\
+- [ ] src/a.rs: add function\n\
+- [ ] src/b.rs: fix bug\n\
+```\n\
+```ANVIL_FINAL\n\
+Done.\n\
+```";
+
+    let parsed = BasicAgentLoop::parse_structured_response(response).expect("should parse");
+
+    // raw_content should contain the full response including ANVIL_PLAN
+    assert!(
+        parsed.raw_content.contains("ANVIL_PLAN"),
+        "raw_content should contain ANVIL_PLAN block"
+    );
+
+    // final_response (from ANVIL_FINAL) should NOT contain ANVIL_PLAN
+    assert!(
+        !parsed.final_response.contains("ANVIL_PLAN"),
+        "final_response should not contain ANVIL_PLAN"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Task 0.3: multi-item attribution
+// ---------------------------------------------------------------------------
+
+/// Helper: apply filtered mutation results to plan (simulates update_plan_from_results logic)
+fn apply_mutations_to_plan(
+    plan: &mut ExecutionPlan,
+    results: &[anvil::tooling::ToolExecutionResult],
+) {
+    let mutation_tools = ["file.write", "file.edit", "file.edit_anchor"];
+
+    for r in results {
+        if !mutation_tools.contains(&r.tool_name.as_str())
+            || r.status != anvil::tooling::ToolExecutionStatus::Completed
+            || r.rolled_back
+            || r.summary.contains("(no changes)")
+            || r.summary.is_empty()
+        {
+            continue;
+        }
+
+        // Find matching unfinished items by target_files
+        let mut matched = false;
+        // Prefer InProgress over Pending for same file
+        let mut matches: Vec<usize> = Vec::new();
+        for (i, item) in plan.items.iter().enumerate() {
+            if item.is_finished() {
+                continue;
+            }
+            if item.target_files.is_empty() {
+                continue;
+            }
+            let file_matches = item
+                .target_files
+                .iter()
+                .any(|tf| r.summary.ends_with(tf) || tf.ends_with(&r.summary));
+            if file_matches {
+                matches.push(i);
+            }
+        }
+
+        if !matches.is_empty() {
+            // Prioritize InProgress items
+            let inprogress: Vec<usize> = matches
+                .iter()
+                .copied()
+                .filter(|&i| plan.items[i].status == PlanItemStatus::InProgress)
+                .collect();
+            let targets = if inprogress.is_empty() {
+                matches
+            } else {
+                inprogress
+            };
+            for idx in targets {
+                plan.record_mutation_success(idx, &r.summary);
+            }
+            matched = true;
+        }
+
+        // Fallback: if no target_files match, attribute to current item only
+        if !matched && let Some(idx) = plan.next_actionable_index() {
+            plan.record_mutation_success(idx, &r.summary);
+        }
+    }
+
+    // Auto-advance next pending item to InProgress
+    if let Some(next) = plan.next_actionable_index()
+        && plan.items[next].status == PlanItemStatus::Pending
+    {
+        plan.mark_in_progress(next);
+    }
+}
+
+#[test]
+fn multi_item_mutation_advances_multiple_items() {
+    let mut plan = ExecutionPlan::new(vec![
+        PlanItem::new("update A".into(), vec!["src/a.rs".into()]),
+        PlanItem::new("update B".into(), vec!["src/b.rs".into()]),
+    ]);
+    plan.mark_in_progress(0);
+
+    let results = vec![
+        make_mutation_result(
+            "file.write",
+            "src/a.rs",
+            anvil::tooling::ToolExecutionStatus::Completed,
+            false,
+        ),
+        make_mutation_result(
+            "file.write",
+            "src/b.rs",
+            anvil::tooling::ToolExecutionStatus::Completed,
+            false,
+        ),
+    ];
+
+    apply_mutations_to_plan(&mut plan, &results);
+
+    assert_eq!(plan.items[0].status, PlanItemStatus::Done);
+    assert_eq!(plan.items[1].status, PlanItemStatus::Done);
+}
+
+#[test]
+fn empty_target_item_attributed_to_current_only() {
+    let mut plan = ExecutionPlan::new(vec![
+        PlanItem::new("generic task 1".into(), vec![]),
+        PlanItem::new("generic task 2".into(), vec![]),
+    ]);
+    plan.mark_in_progress(0);
+
+    let results = vec![make_mutation_result(
+        "file.write",
+        "src/a.rs",
+        anvil::tooling::ToolExecutionStatus::Completed,
+        false,
+    )];
+
+    apply_mutations_to_plan(&mut plan, &results);
+
+    // Only current item (0) should be done, not item 1
+    assert_eq!(plan.items[0].status, PlanItemStatus::Done);
+    assert_ne!(plan.items[1].status, PlanItemStatus::Done);
+}
+
+#[test]
+fn inprogress_item_prioritized_over_pending() {
+    let mut plan = ExecutionPlan::new(vec![
+        PlanItem::new("update A (first)".into(), vec!["src/a.rs".into()]),
+        PlanItem::new("update A (second)".into(), vec!["src/a.rs".into()]),
+    ]);
+    // Mark item 1 as InProgress (not item 0)
+    plan.mark_in_progress(1);
+
+    let results = vec![make_mutation_result(
+        "file.write",
+        "src/a.rs",
+        anvil::tooling::ToolExecutionStatus::Completed,
+        false,
+    )];
+
+    apply_mutations_to_plan(&mut plan, &results);
+
+    // InProgress item (1) should be prioritized and completed
+    assert_eq!(plan.items[1].status, PlanItemStatus::Done);
+    // Item 0 should NOT be Done (mutation was attributed to item 1)
+    assert_ne!(plan.items[0].status, PlanItemStatus::Done);
+}
+
+// ---------------------------------------------------------------------------
+// Issue #261 Task 1.2: current_workset()
+// ---------------------------------------------------------------------------
+
+#[test]
+fn workset_returns_multiple_actionable_items() {
+    let plan = ExecutionPlan::new(vec![
+        PlanItem::new("task1".into(), vec!["src/a.rs".into()]),
+        PlanItem::new("task2".into(), vec!["src/b.rs".into()]),
+        PlanItem::new("task3".into(), vec!["src/c.rs".into()]),
+        PlanItem::new("task4".into(), vec!["src/d.rs".into()]),
+        PlanItem::new("task5".into(), vec!["src/e.rs".into()]),
+        PlanItem::new("task6".into(), vec!["src/f.rs".into()]),
+    ]);
+    let workset = plan.current_workset();
+    // Should return up to 5 actionable items
+    assert_eq!(workset.len(), 5);
+    assert_eq!(workset, vec![0, 1, 2, 3, 4]);
+}
+
+#[test]
+fn workset_returns_empty_when_all_done() {
+    let mut plan = ExecutionPlan::new(vec![
+        PlanItem::new("task1".into(), vec!["src/a.rs".into()]),
+        PlanItem::new("task2".into(), vec!["src/b.rs".into()]),
+    ]);
+    plan.mark_done(0);
+    plan.mark_done(1);
+    let workset = plan.current_workset();
+    assert!(workset.is_empty());
+}
+
+#[test]
+fn workset_skips_done_and_blocked_items() {
+    let mut plan = ExecutionPlan::new(vec![
+        PlanItem::new("task1".into(), vec!["src/a.rs".into()]),
+        PlanItem::new("task2".into(), vec!["src/b.rs".into()]),
+        PlanItem::new("task3".into(), vec!["src/c.rs".into()]),
+        PlanItem::new("task4".into(), vec!["src/d.rs".into()]),
+    ]);
+    plan.mark_done(0);
+    plan.items[1].status = PlanItemStatus::Blocked;
+    let workset = plan.current_workset();
+    assert_eq!(workset, vec![2, 3]);
+}
+
+// ---------------------------------------------------------------------------
+// Issue #261 Task 1.3: batch guidance text
+// ---------------------------------------------------------------------------
+
+#[test]
+fn batch_guidance_does_not_contain_sequential_text() {
+    use anvil::config::GuidanceMode;
+    let plan = ExecutionPlan::new(vec![
+        PlanItem::new("src/a.rs: update module".into(), vec!["src/a.rs".into()]),
+        PlanItem::new("src/b.rs: add field".into(), vec!["src/b.rs".into()]),
+        PlanItem::new("src/c.rs: add test".into(), vec!["src/c.rs".into()]),
+    ]);
+    let guidance = plan.build_turn_guidance_with_mode(GuidanceMode::Batch);
+    assert!(guidance.is_some());
+    let text = guidance.unwrap();
+    // Must NOT contain the sequential "1項目ずつ" text
+    assert!(
+        !text.contains("1項目ずつ"),
+        "batch guidance must not contain sequential text, got: {text}"
+    );
+}
+
+#[test]
+fn sequential_guidance_maintains_current_text() {
+    use anvil::config::GuidanceMode;
+    let plan = ExecutionPlan::new(vec![
+        PlanItem::new("src/a.rs: update module".into(), vec!["src/a.rs".into()]),
+        PlanItem::new("src/b.rs: add field".into(), vec!["src/b.rs".into()]),
+    ]);
+    let guidance = plan.build_turn_guidance_with_mode(GuidanceMode::Sequential);
+    assert!(guidance.is_some());
+    let text = guidance.unwrap();
+    // Sequential mode must contain the traditional "1項目ずつ" text
+    assert!(
+        text.contains("1項目ずつ"),
+        "sequential guidance must contain sequential text, got: {text}"
+    );
+}
+
+#[test]
+fn batch_guidance_contains_workset_items() {
+    use anvil::config::GuidanceMode;
+    let plan = ExecutionPlan::new(vec![
+        PlanItem::new("src/a.rs: update module".into(), vec!["src/a.rs".into()]),
+        PlanItem::new("src/b.rs: add field".into(), vec!["src/b.rs".into()]),
+        PlanItem::new("src/c.rs: add test".into(), vec!["src/c.rs".into()]),
+    ]);
+    let guidance = plan.build_turn_guidance_with_mode(GuidanceMode::Batch);
+    assert!(guidance.is_some());
+    let text = guidance.unwrap();
+    // Batch guidance must list workset items
+    assert!(
+        text.contains("src/a.rs"),
+        "batch guidance must contain workset item src/a.rs"
+    );
+    assert!(
+        text.contains("src/b.rs"),
+        "batch guidance must contain workset item src/b.rs"
+    );
+    assert!(
+        text.contains("src/c.rs"),
+        "batch guidance must contain workset item src/c.rs"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Issue #261 Task 1.4: missing-set guidance
+// ---------------------------------------------------------------------------
+
+#[test]
+fn batch_missing_set_guidance_contains_completed_and_pending() {
+    use anvil::config::GuidanceMode;
+    let mut plan = ExecutionPlan::new(vec![
+        PlanItem::new("src/a.rs: update module".into(), vec!["src/a.rs".into()]),
+        PlanItem::new("src/b.rs: add field".into(), vec!["src/b.rs".into()]),
+        PlanItem::new("src/c.rs: add test".into(), vec!["src/c.rs".into()]),
+        PlanItem::new("src/d.rs: add docs".into(), vec!["src/d.rs".into()]),
+    ]);
+    plan.mark_done(0);
+    plan.mark_done(1);
+
+    let msg = plan.build_incomplete_plan_message_with_mode(GuidanceMode::Batch);
+    // Must contain completed items info
+    assert!(
+        msg.contains("完了済み"),
+        "batch missing-set guidance must contain completed info, got: {msg}"
+    );
+    // Must contain pending/workset items
+    assert!(
+        msg.contains("src/c.rs"),
+        "batch missing-set guidance must contain pending items, got: {msg}"
+    );
+    assert!(
+        msg.contains("src/d.rs"),
+        "batch missing-set guidance must contain pending items, got: {msg}"
+    );
+}
+
+#[test]
+fn sequential_missing_set_guidance_uses_next_item() {
+    use anvil::config::GuidanceMode;
+    let mut plan = ExecutionPlan::new(vec![
+        PlanItem::new("src/a.rs: update module".into(), vec!["src/a.rs".into()]),
+        PlanItem::new("src/b.rs: add field".into(), vec!["src/b.rs".into()]),
+    ]);
+    plan.mark_done(0);
+    plan.mark_in_progress(1);
+
+    let msg = plan.build_incomplete_plan_message_with_mode(GuidanceMode::Sequential);
+    // Sequential mode mentions the next item
+    assert!(
+        msg.contains("src/b.rs"),
+        "sequential missing-set guidance must contain next item, got: {msg}"
+    );
 }

--- a/tests/config_bootstrap.rs
+++ b/tests/config_bootstrap.rs
@@ -1350,3 +1350,50 @@ fn mode_config_default_log_format_is_text() {
     let config = EffectiveConfig::load().expect("config should load");
     assert_eq!(config.mode.log_format, LogFormat::Text);
 }
+
+// ---------------------------------------------------------------------------
+// Issue #261 Task 1.1: GuidanceMode config
+// ---------------------------------------------------------------------------
+
+#[test]
+fn guidance_mode_defaults_to_sequential() {
+    use anvil::config::GuidanceMode;
+    let config = EffectiveConfig::load().expect("config should load");
+    assert_eq!(config.runtime.guidance_mode, GuidanceMode::Sequential);
+}
+
+#[test]
+fn guidance_mode_batch_parses_correctly() {
+    use anvil::config::GuidanceMode;
+    let mut config = EffectiveConfig::load().expect("config should load");
+    let mut map = HashMap::new();
+    map.insert("guidance_mode".to_string(), "batch".to_string());
+    config
+        .apply_overrides_for_test(&map, &HashMap::new(), &HashMap::new())
+        .unwrap();
+    assert_eq!(config.runtime.guidance_mode, GuidanceMode::Batch);
+}
+
+#[test]
+fn guidance_mode_unknown_falls_back_to_sequential() {
+    use anvil::config::GuidanceMode;
+    let mut config = EffectiveConfig::load().expect("config should load");
+    let mut map = HashMap::new();
+    map.insert("guidance_mode".to_string(), "unknown_value".to_string());
+    config
+        .apply_overrides_for_test(&map, &HashMap::new(), &HashMap::new())
+        .unwrap();
+    assert_eq!(config.runtime.guidance_mode, GuidanceMode::Sequential);
+}
+
+#[test]
+fn guidance_mode_env_var_parses_batch() {
+    use anvil::config::GuidanceMode;
+    let mut config = EffectiveConfig::load().expect("config should load");
+    let mut env_map = HashMap::new();
+    env_map.insert("ANVIL_GUIDANCE_MODE".to_string(), "batch".to_string());
+    config
+        .apply_overrides_for_test(&HashMap::new(), &env_map, &HashMap::new())
+        .unwrap();
+    assert_eq!(config.runtime.guidance_mode, GuidanceMode::Batch);
+}

--- a/tests/phase_estimation.rs
+++ b/tests/phase_estimation.rs
@@ -50,8 +50,8 @@ fn phase_estimator_anvil_final_disables_fallback() {
     // Before ANVIL_FINAL: fallback should trigger
     assert_eq!(est.check_empty_response(), PhaseAction::FallbackComplete);
 
-    // After ANVIL_FINAL: fallback disabled
-    est.observe_anvil_final();
+    // After ANVIL_FINAL accepted: fallback disabled
+    est.accept_anvil_final();
     assert_eq!(est.check_empty_response(), PhaseAction::Continue);
 }
 
@@ -95,12 +95,12 @@ fn phase_estimator_reset_preserves_cross_turn_state() {
 fn phase_estimator_model_switch_resets_anvil_final() {
     let mut est = PhaseEstimator::new(5, 10, 5);
 
-    est.observe_anvil_final();
+    est.accept_anvil_final();
     est.record_tool_call("file.write", true);
     for _ in 0..5 {
         est.record_tool_call("file.read", true);
     }
-    // ANVIL_FINAL observed → no fallback
+    // ANVIL_FINAL accepted → no fallback
     assert_eq!(est.check_empty_response(), PhaseAction::Continue);
 
     // Model switch
@@ -145,8 +145,31 @@ fn turn_summary_includes_phase_field() {
         files_modified: 0,
         compact_info: None,
         phase: Phase::Exploring,
+        mutations_this_turn: None,
+        items_advanced_this_turn: None,
     };
     // Verify phase field exists and log_turn_summary is callable
     assert_eq!(format!("{}", summary.phase), "exploring");
     log_turn_summary(&summary);
+}
+
+// ---------------------------------------------------------------------------
+// Task 0.4: observed_final / accepted_final separation
+// ---------------------------------------------------------------------------
+
+#[test]
+fn suppressed_final_does_not_disable_fallback() {
+    let mut est = PhaseEstimator::new(5, 10, 5);
+
+    // Write + K reads → conditions for fallback
+    est.record_tool_call("file.write", true);
+    for _ in 0..5 {
+        est.record_tool_call("file.read", true);
+    }
+
+    // Observe (but do NOT accept) ANVIL_FINAL → suppressed premature final
+    est.observe_anvil_final();
+
+    // Fallback should still work because accept_anvil_final() was not called
+    assert_eq!(est.check_empty_response(), PhaseAction::FallbackComplete);
 }


### PR DESCRIPTION
## Summary
- Fix initial `ANVIL_PLAN` registration from raw response content (not just `final_response`)
- Exclude `rolled_back` and no-op `(no changes)` mutations from plan progress
- Separate `observe_anvil_final()` / `accept_anvil_final()` to prevent suppressed premature finals from disabling fallback completion
- Fix `CompletionKind::classify()` so `Blocked` items don't count as complete
- Add multi-item mutation attribution (1 turn can advance multiple plan items)
- Add `GuidanceMode::Sequential|Batch` config with `ANVIL_GUIDANCE_MODE` env var
- Add batch-aware workset guidance and missing-set messages
- Add multi-target file parsing for plan items (`src/a.rs, src/b.rs: ...`)
- Extend `AgentTelemetry` with `no_op_mutation_count`, `rolled_back_mutation_count`, `initial_plan_miss_count`, `premature_final_request_rate()`
- Extend `TurnSummary` with `mutations_this_turn`, `items_advanced_this_turn`

Closes #261

## Test plan
- [x] `cargo build` — no errors
- [x] `cargo clippy --all-targets` — no warnings
- [x] `cargo test` — all tests pass (including new tests for each correctness fix)
- [x] `cargo fmt --check` — no diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)