### PR TITLE
fix: detect file-reading shell.exec in read_guard

### DIFF
--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -1367,9 +1367,20 @@ impl App {
             if !matches!(pa, super::phase_estimator::PhaseAction::Continue) {
                 phase_action = pa;
             }
-            let transition_action = self
-                .read_transition_guard
-                .record_tool_call(&result.tool_name, success);
+            // Issue #265: pass shell command to read_transition_guard so
+            // grep/sed/cat are counted as exploration calls.
+            let shell_cmd: Option<String> = if result.tool_name == "shell.exec" {
+                tool_input_map
+                    .get(&result.tool_call_id)
+                    .and_then(|(_, v)| v.get("command").and_then(|c| c.as_str()).map(String::from))
+            } else {
+                None
+            };
+            let transition_action = self.read_transition_guard.record_tool_call_ex(
+                &result.tool_name,
+                success,
+                shell_cmd.as_deref(),
+            );
             if let ReadTransitionAction::Inject(msg) = transition_action {
                 read_transition_message = Some(msg);
             }
@@ -1694,6 +1705,19 @@ impl App {
         // Append read repeat hint if repeated reads detected (Issue #185)
         if let Some(hint) = read_hint {
             formatted.push_str(&hint);
+        }
+        // Issue #265: Inject hint when shell.exec is used for file reading
+        // (grep/sed/cat), which bypasses the read transition guard.
+        if result.tool_name == "shell.exec"
+            && result.status == ToolExecutionStatus::Completed
+            && let Some(cmd) = result.summary.strip_prefix("shell.exec completed: ")
+            && crate::tooling::shell_policy::is_file_read_shell_command(cmd)
+        {
+            formatted.push_str(
+                "\n\n[Anvil hint] Using grep/sed/cat to read file contents counts as \
+                 exploration. You already have enough context — proceed to implement \
+                 changes using file.edit or file.write instead of reading more.",
+            );
         }
         let mut msg = SessionMessage::new(MessageRole::Tool, &result.tool_name, formatted)
             .with_id(self.next_message_id("tool"));

--- a/src/app/read_transition_guard.rs
+++ b/src/app/read_transition_guard.rs
@@ -45,7 +45,31 @@ impl ReadTransitionGuard {
         self.last_injected_at = None;
     }
 
+    /// Record a tool call, optionally with the shell command string for
+    /// `shell.exec` file-reading detection (Issue #265).
+    ///
+    /// When `shell_command` is `Some`, and the command is a file-reading
+    /// operation (grep/sed/cat/…), it counts as an exploration call instead
+    /// of resetting the guard.
+    pub fn record_tool_call_ex(
+        &mut self,
+        tool_name: &str,
+        success: bool,
+        shell_command: Option<&str>,
+    ) -> ReadTransitionAction {
+        self.record_inner(tool_name, success, shell_command)
+    }
+
     pub fn record_tool_call(&mut self, tool_name: &str, success: bool) -> ReadTransitionAction {
+        self.record_inner(tool_name, success, None)
+    }
+
+    fn record_inner(
+        &mut self,
+        tool_name: &str,
+        success: bool,
+        shell_command: Option<&str>,
+    ) -> ReadTransitionAction {
         if !success {
             return ReadTransitionAction::Continue;
         }
@@ -61,6 +85,13 @@ impl ReadTransitionGuard {
             "file.edit" | "file.edit_anchor" | "file.write" => {
                 self.reset();
                 return ReadTransitionAction::Continue;
+            }
+            "shell.exec"
+                if shell_command
+                    .is_some_and(crate::tooling::shell_policy::is_file_read_shell_command) =>
+            {
+                // Issue #265: grep/sed/cat etc. count as exploration, not a reset
+                self.consecutive_exploration_calls += 1;
             }
             _ => {
                 self.consecutive_exploration_calls = 0;
@@ -89,8 +120,8 @@ impl ReadTransitionGuard {
             "[System] You have already spent {} consecutive tool calls exploring \
              (including {} file.read calls). You have enough context. \
              Start implementing now using file.edit, file.edit_anchor, or file.write. \
-             Do NOT call file.read again unless a previous edit failed and you need one \
-             targeted verification read.",
+             Do NOT call file.read or use shell.exec with grep/sed/cat to read files. \
+             Proceed to implementation immediately.",
             self.consecutive_exploration_calls, self.consecutive_file_reads
         ))
     }
@@ -148,8 +179,9 @@ mod tests {
         let mut guard = ReadTransitionGuard::new(3, 2);
         guard.record_tool_call("file.read", true);
         guard.record_tool_call("file.search", true);
+        // Non-file-reading shell.exec resets the streak
         assert_eq!(
-            guard.record_tool_call("shell.exec", true),
+            guard.record_tool_call_ex("shell.exec", true, Some("cargo test")),
             ReadTransitionAction::Continue
         );
         assert_eq!(
@@ -169,5 +201,77 @@ mod tests {
             guard.record_tool_call("file.read", true),
             ReadTransitionAction::Continue
         );
+    }
+
+    // --- Issue #265: shell.exec file-reading detection ---
+
+    #[test]
+    fn shell_exec_grep_counts_as_exploration() {
+        let mut guard = ReadTransitionGuard::new(3, 2);
+        guard.record_tool_call("file.read", true);
+        guard.record_tool_call("file.read", true);
+        // grep should count as exploration, not reset
+        let action =
+            guard.record_tool_call_ex("shell.exec", true, Some("grep -n pattern src/main.rs"));
+        assert!(matches!(action, ReadTransitionAction::Inject(_)));
+    }
+
+    #[test]
+    fn shell_exec_sed_counts_as_exploration() {
+        let mut guard = ReadTransitionGuard::new(3, 2);
+        guard.record_tool_call("file.read", true);
+        guard.record_tool_call("file.read", true);
+        let action =
+            guard.record_tool_call_ex("shell.exec", true, Some("sed -n '10,20p' src/main.rs"));
+        assert!(matches!(action, ReadTransitionAction::Inject(_)));
+    }
+
+    #[test]
+    fn shell_exec_cat_counts_as_exploration() {
+        let mut guard = ReadTransitionGuard::new(3, 2);
+        guard.record_tool_call("file.read", true);
+        guard.record_tool_call("file.read", true);
+        let action = guard.record_tool_call_ex("shell.exec", true, Some("cat src/main.rs"));
+        assert!(matches!(action, ReadTransitionAction::Inject(_)));
+    }
+
+    #[test]
+    fn shell_exec_non_read_resets_streak() {
+        let mut guard = ReadTransitionGuard::new(3, 2);
+        guard.record_tool_call("file.read", true);
+        guard.record_tool_call("file.read", true);
+        // cargo build is not a file-reading command → resets
+        assert_eq!(
+            guard.record_tool_call_ex("shell.exec", true, Some("cargo build")),
+            ReadTransitionAction::Continue
+        );
+        // After reset, need 3 more to trigger
+        assert_eq!(
+            guard.record_tool_call("file.read", true),
+            ReadTransitionAction::Continue
+        );
+    }
+
+    #[test]
+    fn shell_exec_without_command_resets_streak() {
+        let mut guard = ReadTransitionGuard::new(3, 2);
+        guard.record_tool_call("file.read", true);
+        guard.record_tool_call("file.read", true);
+        // No command provided → falls through to default reset
+        assert_eq!(
+            guard.record_tool_call_ex("shell.exec", true, None),
+            ReadTransitionAction::Continue
+        );
+    }
+
+    #[test]
+    fn mixed_file_read_and_shell_grep_triggers_guard() {
+        let mut guard = ReadTransitionGuard::new(4, 2);
+        guard.record_tool_call("file.read", true);
+        guard.record_tool_call_ex("shell.exec", true, Some("grep -rn TODO src/"));
+        guard.record_tool_call("file.read", true);
+        let action =
+            guard.record_tool_call_ex("shell.exec", true, Some("sed -n '1,50p' src/lib.rs"));
+        assert!(matches!(action, ReadTransitionAction::Inject(_)));
     }
 }

--- a/src/tooling/shell_policy.rs
+++ b/src/tooling/shell_policy.rs
@@ -105,6 +105,30 @@ const NETWORK_COMMAND_PREFIXES: &[&str] = &[
     "ftp",
 ];
 
+/// File-reading command prefixes detected for read_guard integration (Issue #265).
+///
+/// When an LLM's `file.read` calls are restricted by the read transition guard,
+/// it may fall back to `shell.exec` with these commands to read file contents.
+/// Detecting them allows the guard to count these as exploration calls.
+const FILE_READ_COMMAND_PREFIXES: &[&str] =
+    &["grep", "sed", "cat", "head", "tail", "awk", "less", "more"];
+
+/// Returns `true` if the shell command is primarily a file-reading operation
+/// (e.g. `grep`, `sed -n`, `cat`) that could bypass the read transition guard.
+///
+/// Handles `sudo`/`env` prefixes and absolute paths via [`extract_first_command`].
+/// Pipe/chain commands are excluded (they fall to `General` via injection-vector
+/// detection anyway).
+pub fn is_file_read_shell_command(command: &str) -> bool {
+    let trimmed = command.trim();
+    if contains_injection_vectors(trimmed) {
+        return false;
+    }
+    let lower = trimmed.to_ascii_lowercase();
+    let first_cmd = extract_first_command(&lower);
+    FILE_READ_COMMAND_PREFIXES.contains(&first_cmd)
+}
+
 /// Classify a shell command into a [`ShellPolicy`] category.
 ///
 /// DR4-002: Prefix matching is case-insensitive (uses `to_ascii_lowercase()`).
@@ -601,5 +625,72 @@ mod tests {
     #[test]
     fn network_absolute_path_curl() {
         assert!(is_network_command("/usr/bin/curl https://example.com"));
+    }
+
+    // --- is_file_read_shell_command tests (Issue #265) ---
+
+    #[test]
+    fn file_read_grep() {
+        assert!(is_file_read_shell_command(
+            "grep -n \"pattern\" src/main.rs"
+        ));
+    }
+
+    #[test]
+    fn file_read_sed() {
+        assert!(is_file_read_shell_command("sed -n '37,60p' src/main.rs"));
+    }
+
+    #[test]
+    fn file_read_cat() {
+        assert!(is_file_read_shell_command("cat src/main.rs"));
+    }
+
+    #[test]
+    fn file_read_head() {
+        assert!(is_file_read_shell_command("head -50 src/main.rs"));
+    }
+
+    #[test]
+    fn file_read_tail() {
+        assert!(is_file_read_shell_command("tail -20 src/main.rs"));
+    }
+
+    #[test]
+    fn file_read_awk() {
+        assert!(is_file_read_shell_command(
+            "awk '/pattern/ {print}' src/main.rs"
+        ));
+    }
+
+    #[test]
+    fn file_read_case_insensitive() {
+        assert!(is_file_read_shell_command("GREP -rn pattern src/"));
+    }
+
+    #[test]
+    fn not_file_read_cargo_test() {
+        assert!(!is_file_read_shell_command("cargo test"));
+    }
+
+    #[test]
+    fn not_file_read_git_log() {
+        assert!(!is_file_read_shell_command("git log --oneline"));
+    }
+
+    #[test]
+    fn not_file_read_pipe() {
+        // Pipe commands are excluded (injection vector)
+        assert!(!is_file_read_shell_command("grep pattern file | head -5"));
+    }
+
+    #[test]
+    fn file_read_sudo_grep() {
+        assert!(is_file_read_shell_command("sudo grep -rn pattern src/"));
+    }
+
+    #[test]
+    fn file_read_absolute_path_cat() {
+        assert!(is_file_read_shell_command("/usr/bin/cat src/main.rs"));
     }
 }


### PR DESCRIPTION
## Summary
- shell.exec経由のファイル読み取りコマンド（grep/sed/cat/head/tail）をread_transition_guardの探索カウントに含める
- read_transition_guardにrecord_tool_call_ex()を追加し、shell.execのコマンド内容を解析
- shell_policy.rsにis_file_read_shell_command()を追加し、ファイル読み取り相当のコマンドを検出
- exploringフェーズでのshell.exec使用時にガイダンスヒントを注入

Closes #265

## Test plan
- [x] grep/sed/catコマンドがread_guardにカウントされることを確認
- [x] 通常のshell.execコマンド（npm test等）が影響を受けないことを確認
- [x] cargo clippy --all-targets: 警告0件
- [x] cargo test: 全テストパス
- [x] cargo fmt --check: 差分なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)