### PR TITLE
feat(issue-271): telemetry artifact infrastructure for comparison baseline repair

### DIFF
--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -741,6 +741,11 @@ impl App {
                 guidance_chars_this_turn as u32,
                 workset_size_this_turn as u32,
             );
+            // Issue #271: Track last mutation turn for late-mutation detection.
+            if turn_mutations > 0 {
+                self.agent_telemetry
+                    .record_mutation_turn(self.session_stats.total_turns);
+            }
 
             // Issue #269 Phase 3: stagnation end_turn hook + forced mode update.
             self.stagnation_state.end_turn(turn_mutations > 0);

--- a/src/app/execution_plan.rs
+++ b/src/app/execution_plan.rs
@@ -42,6 +42,7 @@ impl App {
                 // Mark first item as InProgress
                 self.execution_plan.mark_in_progress(0);
                 self.agent_telemetry.record_plan_registration();
+                self.agent_telemetry.record_anvil_plan_visible();
                 return true;
             }
         }
@@ -257,6 +258,9 @@ impl App {
             } => {
                 // Issue #255: Track premature final request (PFRR).
                 self.agent_telemetry.record_premature_final();
+                // Issue #271: Track ANVIL_FINAL suppression with remaining targets.
+                self.agent_telemetry
+                    .record_final_suppressed_with_remaining_targets();
                 tracing::info!(
                     remaining,
                     total,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -891,6 +891,14 @@ impl App {
                 "agent telemetry"
             );
         }
+
+        // Issue #271: Write telemetry artifact (opt-in via ANVIL_TELEMETRY_DIR).
+        if let Err(err) = self
+            .agent_telemetry
+            .write_artifact(&self.session.metadata.session_id)
+        {
+            tracing::warn!("telemetry artifact write failed: {err}");
+        }
     }
 
     /// Run PostSession hook (DR2-005, DR2-007 facade method).

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -222,6 +222,18 @@ pub struct AgentTelemetry {
     /// Number of ANVIL_PLAN_UPDATE requests triggered by stagnation control (Issue #263).
     #[serde(default)]
     pub plan_repair_request_count: u32,
+
+    /// Number of ANVIL_PLAN blocks observed (visible to external telemetry).
+    #[serde(default)]
+    pub anvil_plan_visible_count: u32,
+
+    /// Last turn on which a mutation (file change) occurred.
+    #[serde(default)]
+    pub last_mutation_turn: u32,
+
+    /// ANVIL_FINAL suppressed with remaining core targets > 0 (count).
+    #[serde(default)]
+    pub final_suppressed_with_remaining_targets_count: u32,
 }
 
 impl AgentTelemetry {
@@ -286,6 +298,139 @@ impl AgentTelemetry {
     /// Record a plan repair request (Issue #263).
     pub fn record_plan_repair_request(&mut self) {
         self.plan_repair_request_count += 1;
+    }
+
+    /// Record an ANVIL_PLAN block observed (visible to external telemetry).
+    pub fn record_anvil_plan_visible(&mut self) {
+        self.anvil_plan_visible_count += 1;
+    }
+
+    /// Record the turn on which a mutation occurred.
+    pub fn record_mutation_turn(&mut self, turn: u32) {
+        self.last_mutation_turn = turn;
+    }
+
+    /// Record an ANVIL_FINAL suppression with remaining core targets.
+    pub fn record_final_suppressed_with_remaining_targets(&mut self) {
+        self.final_suppressed_with_remaining_targets_count += 1;
+    }
+
+    /// Threshold: mutations after this turn are considered "late".
+    pub const LATE_MUTATION_THRESHOLD: u32 = 20;
+
+    /// Late mutation flag: last_mutation_turn exceeds the threshold.
+    pub fn is_late_mutation(&self) -> bool {
+        self.last_mutation_turn > Self::LATE_MUTATION_THRESHOLD
+    }
+
+    /// Accepted ANVIL_FINAL count: total minus premature (saturating).
+    pub fn accepted_final_count(&self) -> u32 {
+        self.total_final_requests
+            .saturating_sub(self.premature_final_count)
+    }
+
+    /// Write telemetry artifact to `$ANVIL_TELEMETRY_DIR/{session_id}_telemetry.json`.
+    ///
+    /// Returns `Ok(())` when `ANVIL_TELEMETRY_DIR` is unset (no-op) or when the
+    /// file was successfully written.  Returns `Err` on validation or I/O failure.
+    pub fn write_artifact(&self, session_id: &str) -> Result<(), Box<dyn std::error::Error>> {
+        let dir_raw = match std::env::var("ANVIL_TELEMETRY_DIR") {
+            Ok(v) if !v.is_empty() => v,
+            _ => return Ok(()), // no-op when unset
+        };
+
+        self.write_artifact_to_dir(&dir_raw, session_id)
+    }
+
+    /// Write telemetry artifact to the given directory path.
+    ///
+    /// Validates that the path is absolute, not a symlink, and is an existing
+    /// directory.  Creates `{session_id}_telemetry.json` using `create_new`
+    /// (refuses to overwrite).
+    pub fn write_artifact_to_dir(
+        &self,
+        dir_raw: &str,
+        session_id: &str,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let dir_path = std::path::Path::new(dir_raw);
+
+        // Reject relative paths.
+        if !dir_path.is_absolute() {
+            return Err("telemetry dir must be an absolute path".into());
+        }
+
+        // Reject symlinks on the directory itself.
+        let meta = std::fs::symlink_metadata(dir_path)
+            .map_err(|_| "telemetry dir does not exist or is inaccessible")?;
+        if meta.file_type().is_symlink() {
+            return Err("telemetry dir must not be a symlink".into());
+        }
+
+        // Canonicalize and verify it is a directory.
+        let canonical =
+            std::fs::canonicalize(dir_path).map_err(|_| "telemetry dir cannot be canonicalized")?;
+        if !canonical.is_dir() {
+            return Err("telemetry dir is not a directory".into());
+        }
+
+        // Sanitize session_id: reject any path separators or leading dots to prevent
+        // directory traversal (e.g. "../evil" or "/abs/path").
+        if session_id.contains('/') || session_id.contains('\\') || session_id.starts_with('.') {
+            return Err("session_id contains invalid characters for use in a filename".into());
+        }
+
+        let file_path = canonical.join(format!("{session_id}_telemetry.json"));
+
+        // Verify the resulting path is still inside the canonical directory.
+        if !file_path.starts_with(&canonical) {
+            return Err("telemetry file path escapes the target directory".into());
+        }
+
+        // Build the artifact payload with derived values.
+        let completion = self
+            .completion_kind
+            .map(|k| k.to_string())
+            .unwrap_or_else(|| "none".to_string());
+
+        let payload = serde_json::json!({
+            "schema_version": "1",
+            "session_id": session_id,
+            "completion_kind": completion,
+            "premature_final_count": self.premature_final_count,
+            "total_final_requests": self.total_final_requests,
+            "accepted_final_count": self.accepted_final_count(),
+            "plan_registration_count": self.plan_registration_count,
+            "plan_update_count": self.plan_update_count,
+            "anvil_plan_visible_count": self.anvil_plan_visible_count,
+            "last_mutation_turn": self.last_mutation_turn,
+            "late_mutation_flag": self.is_late_mutation(),
+            "final_suppressed_with_remaining_targets_count":
+                self.final_suppressed_with_remaining_targets_count,
+            "sync_from_touched_files_count": self.sync_from_touched_files_count,
+            "forced_workset_transition_count": self.forced_workset_transition_count,
+            "initial_plan_miss_count": self.initial_plan_miss_count,
+            "no_op_mutation_count": self.no_op_mutation_count,
+            "rolled_back_mutation_count": self.rolled_back_mutation_count,
+            "plan_repair_request_count": self.plan_repair_request_count,
+            "mutations_per_turn": self.mutations_per_turn,
+            "items_advanced_per_turn": self.items_advanced_per_turn,
+            "guidance_chars_per_turn": self.guidance_chars_per_turn,
+            "workset_size_per_turn": self.workset_size_per_turn,
+        });
+
+        let json_bytes = serde_json::to_vec_pretty(&payload)?;
+
+        // create_new: refuse to overwrite existing files.
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&file_path)
+            .map_err(|e| format!("failed to create telemetry file: {e}"))?;
+
+        use std::io::Write;
+        file.write_all(&json_bytes)?;
+
+        Ok(())
     }
 
     /// Premature Final Request Rate: ratio of suppressed finals to total finals.

--- a/tests/agent_phase.rs
+++ b/tests/agent_phase.rs
@@ -378,6 +378,10 @@ fn telemetry_serde_backward_compatible() {
     assert!(tel.items_advanced_per_turn.is_empty());
     assert!(tel.guidance_chars_per_turn.is_empty());
     assert!(tel.workset_size_per_turn.is_empty());
+    // Issue #271: new fields default to zero
+    assert_eq!(tel.anvil_plan_visible_count, 0);
+    assert_eq!(tel.last_mutation_turn, 0);
+    assert_eq!(tel.final_suppressed_with_remaining_targets_count, 0);
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/stagnation_control.rs
+++ b/tests/stagnation_control.rs
@@ -512,4 +512,8 @@ fn telemetry_serde_backward_compatibility() {
     let telemetry: AgentTelemetry = serde_json::from_str(json).unwrap();
     assert_eq!(telemetry.forced_workset_transition_count, 0);
     assert_eq!(telemetry.plan_repair_request_count, 0);
+    // Issue #271: new fields default to zero
+    assert_eq!(telemetry.anvil_plan_visible_count, 0);
+    assert_eq!(telemetry.last_mutation_turn, 0);
+    assert_eq!(telemetry.final_suppressed_with_remaining_targets_count, 0);
 }

--- a/tests/telemetry_artifact.rs
+++ b/tests/telemetry_artifact.rs
@@ -1,0 +1,142 @@
+//! Tests for AgentTelemetry::write_artifact / write_artifact_to_dir (Issue #271 Phase 4).
+
+use anvil::contracts::AgentTelemetry;
+use std::fs;
+
+/// Helper: create a telemetry instance with known values for testing.
+fn sample_telemetry() -> AgentTelemetry {
+    let mut tel = AgentTelemetry::new();
+    tel.premature_final_count = 2;
+    tel.total_final_requests = 5;
+    tel.plan_registration_count = 1;
+    tel.plan_update_count = 1;
+    tel.anvil_plan_visible_count = 3;
+    tel.last_mutation_turn = 25;
+    tel.final_suppressed_with_remaining_targets_count = 1;
+    tel.sync_from_touched_files_count = 2;
+    tel.initial_plan_miss_count = 1;
+    tel.no_op_mutation_count = 1;
+    tel.rolled_back_mutation_count = 1;
+    tel.record_turn_metrics(3, 2, 100, 1);
+    tel.record_turn_metrics(1, 0, 50, 2);
+    tel
+}
+
+/// Write the artifact and return the parsed JSON object.
+fn write_and_parse(tel: &AgentTelemetry, label: &str) -> serde_json::Value {
+    let dir = tempfile::tempdir().unwrap();
+    let session_id = format!("test_{label}_{}", std::process::id());
+    let dir_str = dir.path().to_str().unwrap();
+
+    tel.write_artifact_to_dir(dir_str, &session_id).unwrap();
+
+    let file_path = dir.path().join(format!("{session_id}_telemetry.json"));
+    let contents = fs::read_to_string(&file_path).unwrap();
+    serde_json::from_str(&contents).unwrap()
+}
+
+#[test]
+fn telemetry_artifact_written_when_dir_set() {
+    let dir = tempfile::tempdir().unwrap();
+    let session_id = format!("test_written_{}", std::process::id());
+    let dir_str = dir.path().to_str().unwrap();
+
+    let tel = sample_telemetry();
+    let result = tel.write_artifact_to_dir(dir_str, &session_id);
+
+    assert!(result.is_ok(), "write_artifact should succeed: {result:?}");
+
+    let file_path = dir.path().join(format!("{session_id}_telemetry.json"));
+    assert!(file_path.exists(), "telemetry file should exist");
+
+    let contents = fs::read_to_string(&file_path).unwrap();
+    assert!(!contents.is_empty());
+}
+
+#[test]
+fn telemetry_artifact_not_written_when_dir_unset() {
+    // write_artifact reads env; when ANVIL_TELEMETRY_DIR is unset it should be no-op.
+    let tel = AgentTelemetry::new();
+    let result = tel.write_artifact("test_unset_no_env");
+    // This relies on ANVIL_TELEMETRY_DIR not being set in the test environment.
+    assert!(result.is_ok(), "should be no-op when dir unset");
+}
+
+#[test]
+fn telemetry_artifact_schema_version() {
+    let json = write_and_parse(&AgentTelemetry::new(), "schema");
+    assert_eq!(json["schema_version"], "1");
+}
+
+#[test]
+fn telemetry_artifact_derived_values() {
+    let json = write_and_parse(&sample_telemetry(), "derived");
+
+    // accepted_final_count = total(5) - premature(2) = 3
+    assert_eq!(json["accepted_final_count"], 3);
+    // late_mutation_flag: last_mutation_turn(25) > LATE_MUTATION_THRESHOLD(20) = true
+    assert_eq!(json["late_mutation_flag"], true);
+}
+
+#[test]
+fn telemetry_artifact_no_overwrite() {
+    let dir = tempfile::tempdir().unwrap();
+    let session_id = format!("test_nooverwrite_{}", std::process::id());
+    let file_path = dir.path().join(format!("{session_id}_telemetry.json"));
+    let dir_str = dir.path().to_str().unwrap();
+
+    // Create existing file.
+    fs::write(&file_path, "existing").unwrap();
+
+    let tel = AgentTelemetry::new();
+    let result = tel.write_artifact_to_dir(dir_str, &session_id);
+
+    assert!(result.is_err(), "should fail when file already exists");
+
+    // Original content should be preserved.
+    let contents = fs::read_to_string(&file_path).unwrap();
+    assert_eq!(contents, "existing");
+}
+
+#[test]
+fn telemetry_artifact_relative_path_rejected() {
+    let tel = AgentTelemetry::new();
+    let result = tel.write_artifact_to_dir("relative/path", "test_relative");
+
+    assert!(result.is_err(), "relative path should be rejected");
+}
+
+#[test]
+fn telemetry_artifact_all_fields_present() {
+    let json = write_and_parse(&sample_telemetry(), "allfields");
+    let obj = json.as_object().expect("should be a JSON object");
+
+    let expected_keys = [
+        "schema_version",
+        "session_id",
+        "completion_kind",
+        "premature_final_count",
+        "total_final_requests",
+        "accepted_final_count",
+        "plan_registration_count",
+        "plan_update_count",
+        "anvil_plan_visible_count",
+        "last_mutation_turn",
+        "late_mutation_flag",
+        "final_suppressed_with_remaining_targets_count",
+        "sync_from_touched_files_count",
+        "forced_workset_transition_count",
+        "initial_plan_miss_count",
+        "no_op_mutation_count",
+        "rolled_back_mutation_count",
+        "plan_repair_request_count",
+        "mutations_per_turn",
+        "items_advanced_per_turn",
+        "guidance_chars_per_turn",
+        "workset_size_per_turn",
+    ];
+
+    for key in &expected_keys {
+        assert!(obj.contains_key(*key), "telemetry JSON missing key: {key}");
+    }
+}


### PR DESCRIPTION
## Summary
- Issue #271: Issue193 比較基盤修復のためのテレメトリ artifact インフラを追加
- ANVIL_PLAN可視回数、ANVIL_FINAL observed/accepted/suppressed分離、target coverage追跡、late mutation flagなどの構造化テレメトリフィールドを実装
- artifact書き込み関数と包括的テストを含む

## Changes
- `src/contracts/mod.rs`: テレメトリ構造体・フィールド追加
- `src/app/agentic.rs`: テレメトリ収集ロジック
- `src/app/execution_plan.rs`: プラン実行のテレメトリ連携
- `src/app/mod.rs`: アプリケーション層のテレメトリ統合
- `tests/telemetry_artifact.rs`: 新規テストファイル
- `tests/agent_phase.rs`, `tests/stagnation_control.rs`: 既存テスト調整

## Test plan
- [x] cargo fmt --check: 差分なし
- [x] cargo clippy --all-targets: 警告0件
- [x] cargo test: 全1,629テストパス

Closes #271

🤖 Generated with [Claude Code](https://claude.com/claude-code)