### PR TITLE
feat(issue-277): file-role telemetry and mutation order measurement

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,6 +125,7 @@ src/
 ├── config/mod.rs        # 設定管理
 ├── contracts/
 │   ├── mod.rs           # 共通型定義（TerminationReason, Finding, SubAgentPayload含む）
+│   ├── file_role.rs     # ファイルロール分類（classify_file_role・make_cwd_relative、Issue #277）
 │   └── tokens.rs        # トークン推定（CJK対応ヒューリスティック・モデル実測値ベースEMA補正）
 ├── extensions/
 │   ├── mod.rs           # スラッシュコマンド・拡張

--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -559,6 +559,23 @@ impl App {
                             elapsed_s,
                             &r.tool_name, // already validated by MUTATION_TOOLS.contains()
                         );
+
+                        // Issue #277: file-role telemetry
+                        {
+                            use crate::contracts::file_role::make_cwd_relative;
+                            let canonical_path = r
+                                .artifacts
+                                .first()
+                                .map(|abs_path| {
+                                    make_cwd_relative(
+                                        abs_path,
+                                        std::path::Path::new(&self.config.paths.cwd),
+                                    )
+                                })
+                                .unwrap_or_else(|| r.summary.clone());
+                            self.agent_telemetry
+                                .record_file_role_mutation(&canonical_path);
+                        }
                     }
                 }
             }

--- a/src/app/execution_plan.rs
+++ b/src/app/execution_plan.rs
@@ -315,3 +315,57 @@ impl App {
         self.execution_plan = ExecutionPlan::default();
     }
 }
+
+/// Calculates the number of plan item order inversions (Issue #277).
+///
+/// An inversion occurs when plan item N+M is first mutated before plan item N (M >= 1).
+/// Returns 0 if the plan is empty or mutation_path_attribution is empty.
+pub(crate) fn calculate_plan_divergence(
+    plan: &crate::contracts::ExecutionPlan,
+    mutation_path_attribution: &[(String, Option<usize>)],
+) -> u32 {
+    if plan.is_empty() || mutation_path_attribution.is_empty() {
+        return 0;
+    }
+
+    // For each mutation path, find the first matching plan item index.
+    // Use ends_with matching (same as update_plan_from_results).
+    // Only record the first occurrence of each plan item index.
+    let mut seen_indices: Vec<usize> = Vec::new();
+    let mut seen_set = std::collections::HashSet::new();
+
+    for (path, _) in mutation_path_attribution {
+        // Find the smallest matching plan item index without allocating a Vec.
+        let idx = plan
+            .items
+            .iter()
+            .enumerate()
+            .filter(|(_, item)| {
+                !item.target_files.is_empty()
+                    && item
+                        .target_files
+                        .iter()
+                        .any(|tf| path.ends_with(tf.as_str()) || tf.ends_with(path.as_str()))
+            })
+            .map(|(i, _)| i)
+            .min();
+
+        let Some(idx) = idx else { continue };
+
+        if seen_set.insert(idx) {
+            seen_indices.push(idx);
+        }
+    }
+
+    // Count inversions in the sequence of plan indices.
+    let mut inversions: u32 = 0;
+    for i in 0..seen_indices.len() {
+        for j in (i + 1)..seen_indices.len() {
+            if seen_indices[i] > seen_indices[j] {
+                inversions += 1;
+            }
+        }
+    }
+
+    inversions
+}

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -897,11 +897,18 @@ impl App {
             );
         }
 
+        // Issue #277: Calculate plan divergence before writing artifact.
+        let mut tel = self.agent_telemetry.clone();
+        if !self.execution_plan.is_empty() {
+            let divergence = crate::app::execution_plan::calculate_plan_divergence(
+                &self.execution_plan,
+                tel.mutation_path_attribution(),
+            );
+            tel.plan_order_vs_actual_mutation_divergence = Some(divergence);
+        }
+
         // Issue #271: Write telemetry artifact (opt-in via ANVIL_TELEMETRY_DIR).
-        if let Err(err) = self
-            .agent_telemetry
-            .write_artifact(&self.session.metadata.session_id)
-        {
+        if let Err(err) = tel.write_artifact(&self.session.metadata.session_id) {
             tracing::warn!("telemetry artifact write failed: {err}");
         }
     }

--- a/src/contracts/file_role.rs
+++ b/src/contracts/file_role.rs
@@ -1,0 +1,269 @@
+//! File role classification for mutation telemetry (Issue #277).
+//!
+//! Classifies file paths into semantic roles to measure mutation order
+//! and detect anti-patterns like peripheral-before-core editing.
+
+/// Classifies a normalized cwd-relative path into a file role.
+/// Absolute paths (starting with '/') are classified as "unknown" for safety.
+pub(crate) fn classify_file_role(path: &str) -> &'static str {
+    // Rule 0: Absolute path guard
+    if path.starts_with('/') {
+        return "unknown";
+    }
+
+    // Normalize: strip leading "./"
+    let normalized = path.strip_prefix("./").unwrap_or(path);
+
+    // Rule 1: test files
+    if normalized.starts_with("tests/")
+        || normalized.contains(".test.")
+        || normalized.contains(".spec.")
+    {
+        return "test";
+    }
+
+    // Rule 2: docs or prompts
+    if normalized.starts_with("docs/")
+        || normalized.starts_with("prompts/")
+        || normalized.ends_with(".md")
+    {
+        return "docs_or_prompt";
+    }
+
+    // Rule 3: config or schema
+    if normalized.starts_with("config/")
+        || normalized.ends_with(".json")
+        || normalized.ends_with(".yaml")
+        || normalized.ends_with(".yml")
+        || normalized.ends_with(".toml")
+        || path_contains_segment(normalized, "schema")
+    {
+        return "config_or_schema";
+    }
+
+    // Extract file stem (filename without extension) for rules 4-5
+    let file_stem = std::path::Path::new(normalized)
+        .file_stem()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_default();
+
+    // Rule 4: route/handler/controller
+    if contains_word_in_stem(&file_stem, &["route", "handler", "controller"]) {
+        return "route_or_handler";
+    }
+
+    // Rule 5: adapter/wrapper/client
+    if contains_word_in_stem(&file_stem, &["adapter", "wrapper", "client"]) {
+        return "adapter_or_wrapper";
+    }
+
+    // Rule 6: core implementation source files
+    let core_extensions = [
+        ".rs", ".ts", ".js", ".py", ".go", ".java", ".c", ".cpp", ".rb",
+    ];
+    if core_extensions.iter().any(|ext| normalized.ends_with(ext)) {
+        return "core_impl";
+    }
+
+    // Rule 7: fallback
+    "unknown"
+}
+
+/// Converts an absolute path to a cwd-relative path.
+/// - Strips the cwd prefix to produce a relative path
+/// - Normalizes "./" prefix
+/// - Returns abs_path as-is if outside cwd (will be classified as "unknown" by classify_file_role)
+pub(crate) fn make_cwd_relative(abs_path: &str, cwd: &std::path::Path) -> String {
+    let abs = std::path::Path::new(abs_path);
+    if let Ok(rel) = abs.strip_prefix(cwd) {
+        let rel_str = rel.to_string_lossy().to_string();
+        if rel_str.is_empty() {
+            return ".".to_string();
+        }
+        rel_str
+    } else {
+        abs_path.to_string()
+    }
+}
+
+/// Check if a path contains a specific segment (between '/' separators).
+fn path_contains_segment(path: &str, segment: &str) -> bool {
+    path.split('/').any(|s| s == segment)
+}
+
+/// Check if the file stem contains any of the given words.
+fn contains_word_in_stem(stem: &str, words: &[&str]) -> bool {
+    let lower = stem.to_lowercase();
+    words.iter().any(|w| lower.contains(w))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- Rule 0: Absolute path guard ---
+    #[test]
+    fn absolute_path_returns_unknown() {
+        assert_eq!(classify_file_role("/usr/local/bin/foo.rs"), "unknown");
+        assert_eq!(
+            classify_file_role("/home/user/project/src/main.rs"),
+            "unknown"
+        );
+    }
+
+    // --- Rule 1: test files ---
+    #[test]
+    fn tests_dir_classified_as_test() {
+        assert_eq!(classify_file_role("tests/foo.rs"), "test");
+        assert_eq!(classify_file_role("tests/integration/bar.rs"), "test");
+    }
+
+    #[test]
+    fn dot_test_classified_as_test() {
+        assert_eq!(classify_file_role("src/foo.test.ts"), "test");
+    }
+
+    #[test]
+    fn dot_spec_classified_as_test() {
+        assert_eq!(classify_file_role("src/bar.spec.js"), "test");
+    }
+
+    // --- Rule 2: docs or prompts ---
+    #[test]
+    fn docs_dir_classified_as_docs() {
+        assert_eq!(classify_file_role("docs/guide.md"), "docs_or_prompt");
+    }
+
+    #[test]
+    fn prompts_dir_classified_as_docs() {
+        assert_eq!(classify_file_role("prompts/system.txt"), "docs_or_prompt");
+    }
+
+    #[test]
+    fn md_extension_classified_as_docs() {
+        assert_eq!(classify_file_role("README.md"), "docs_or_prompt");
+        assert_eq!(classify_file_role("CHANGELOG.md"), "docs_or_prompt");
+    }
+
+    // --- Rule 3: config or schema ---
+    #[test]
+    fn config_dir_classified_as_config() {
+        assert_eq!(classify_file_role("config/settings.rs"), "config_or_schema");
+    }
+
+    #[test]
+    fn json_extension_classified_as_config() {
+        assert_eq!(classify_file_role("package.json"), "config_or_schema");
+    }
+
+    #[test]
+    fn yaml_extension_classified_as_config() {
+        assert_eq!(
+            classify_file_role("docker-compose.yaml"),
+            "config_or_schema"
+        );
+        assert_eq!(classify_file_role("config.yml"), "config_or_schema");
+    }
+
+    #[test]
+    fn toml_extension_classified_as_config() {
+        assert_eq!(classify_file_role("Cargo.toml"), "config_or_schema");
+    }
+
+    #[test]
+    fn schema_segment_classified_as_config() {
+        assert_eq!(classify_file_role("src/schema/user.rs"), "config_or_schema");
+    }
+
+    // --- Rule 4: route/handler/controller ---
+    #[test]
+    fn route_handler_controller_classified() {
+        assert_eq!(classify_file_role("src/api/route.rs"), "route_or_handler");
+        assert_eq!(classify_file_role("src/handler.py"), "route_or_handler");
+        assert_eq!(
+            classify_file_role("src/user_controller.rb"),
+            "route_or_handler"
+        );
+    }
+
+    // --- Rule 5: adapter/wrapper/client ---
+    #[test]
+    fn adapter_wrapper_client_classified() {
+        assert_eq!(
+            classify_file_role("src/http_adapter.rs"),
+            "adapter_or_wrapper"
+        );
+        assert_eq!(
+            classify_file_role("src/api_wrapper.ts"),
+            "adapter_or_wrapper"
+        );
+        assert_eq!(
+            classify_file_role("src/redis_client.py"),
+            "adapter_or_wrapper"
+        );
+    }
+
+    // --- Rule 6: core implementation ---
+    #[test]
+    fn core_impl_extensions() {
+        assert_eq!(classify_file_role("src/main.rs"), "core_impl");
+        assert_eq!(classify_file_role("src/app.ts"), "core_impl");
+        assert_eq!(classify_file_role("src/utils.js"), "core_impl");
+        assert_eq!(classify_file_role("src/lib.py"), "core_impl");
+        assert_eq!(classify_file_role("src/main.go"), "core_impl");
+        assert_eq!(classify_file_role("src/App.java"), "core_impl");
+        assert_eq!(classify_file_role("src/helper.c"), "core_impl");
+        assert_eq!(classify_file_role("src/engine.cpp"), "core_impl");
+        assert_eq!(classify_file_role("src/util.rb"), "core_impl");
+    }
+
+    // --- Rule 7: unknown ---
+    #[test]
+    fn unknown_fallback() {
+        assert_eq!(classify_file_role("Makefile"), "unknown");
+        assert_eq!(classify_file_role("LICENSE"), "unknown");
+        assert_eq!(classify_file_role("data/output.bin"), "unknown");
+    }
+
+    // --- Anvil real file paths (smoke tests) ---
+    #[test]
+    fn anvil_real_paths() {
+        assert_eq!(classify_file_role("src/provider/ollama.rs"), "core_impl");
+        assert_eq!(classify_file_role("tests/telemetry_artifact.rs"), "test");
+        assert_eq!(classify_file_role("src/contracts/mod.rs"), "core_impl");
+        assert_eq!(classify_file_role("src/app/agentic.rs"), "core_impl");
+        assert_eq!(classify_file_role("src/config/mod.rs"), "core_impl");
+    }
+
+    // --- "./" normalization ---
+    #[test]
+    fn dot_slash_normalization() {
+        assert_eq!(classify_file_role("./src/x.rs"), "core_impl");
+        assert_eq!(classify_file_role("./tests/foo.rs"), "test");
+    }
+
+    // --- make_cwd_relative ---
+    #[test]
+    fn make_cwd_relative_strips_prefix() {
+        let cwd = std::path::Path::new("/home/user/project");
+        assert_eq!(
+            make_cwd_relative("/home/user/project/src/main.rs", cwd),
+            "src/main.rs"
+        );
+    }
+
+    #[test]
+    fn make_cwd_relative_outside_cwd() {
+        let cwd = std::path::Path::new("/home/user/project");
+        assert_eq!(
+            make_cwd_relative("/other/path/foo.rs", cwd),
+            "/other/path/foo.rs"
+        );
+    }
+
+    #[test]
+    fn make_cwd_relative_exact_cwd() {
+        let cwd = std::path::Path::new("/home/user/project");
+        assert_eq!(make_cwd_relative("/home/user/project", cwd), ".");
+    }
+}

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -4,9 +4,11 @@
 //! persistent session state.  They are intentionally plain data with
 //! `Serialize`/`Deserialize` support.
 
+pub(crate) mod file_role;
 pub mod tokens;
 
 use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
 
 // ---------------------------------------------------------------------------
 // Sub-agent payload types (Issue #129)
@@ -249,6 +251,41 @@ pub struct AgentTelemetry {
     /// None if no mutation occurred during the session.
     #[serde(default)]
     pub first_mutation_event_tool: Option<String>,
+
+    // -----------------------------------------------------------------------
+    // Issue #277: file-role telemetry fields
+    // -----------------------------------------------------------------------
+    /// File role of the first successful mutation (any role).
+    #[serde(default)]
+    pub first_successful_mutation_file_role: Option<String>,
+    /// File role of the first non-test mutation.
+    #[serde(default)]
+    pub first_non_test_mutation_file_role: Option<String>,
+    /// Sequence of file roles for each mutation (capped at 200).
+    #[serde(default)]
+    pub mutation_role_sequence: Vec<String>,
+    /// Number of peripheral (non-core_impl) mutations before the first core_impl mutation.
+    #[serde(default)]
+    pub peripheral_mutation_before_core_count: u32,
+    /// Number of role transitions where the new role was already seen (rework indicator).
+    #[serde(default)]
+    pub role_transition_rework_count: u32,
+    /// Number of unique files touched before the first core_impl mutation.
+    #[serde(default)]
+    pub files_touched_before_first_core_mutation: u32,
+    /// Plan order vs actual mutation divergence (inversion count).
+    #[serde(default)]
+    pub plan_order_vs_actual_mutation_divergence: Option<u32>,
+
+    // Internal tracking (not serialized)
+    #[serde(skip)]
+    core_mutation_seen: bool,
+    #[serde(skip)]
+    pre_core_touched_files: HashSet<String>,
+    #[serde(skip)]
+    seen_roles: HashSet<&'static str>,
+    #[serde(skip)]
+    mutation_path_attribution: Vec<(String, Option<usize>)>,
 }
 
 impl AgentTelemetry {
@@ -334,6 +371,63 @@ impl AgentTelemetry {
         }
     }
 
+    /// Record a file-role mutation for telemetry (Issue #277).
+    ///
+    /// Classifies the given cwd-relative path into a role and updates all
+    /// file-role telemetry fields (first mutation role, sequence, rework, etc.).
+    pub fn record_file_role_mutation(&mut self, path: &str) {
+        use crate::contracts::file_role::classify_file_role;
+        let role = classify_file_role(path);
+
+        // Convert role to String once; clone only for conditional first-* fields.
+        let role_string = role.to_string();
+        if self.first_successful_mutation_file_role.is_none() {
+            self.first_successful_mutation_file_role = Some(role_string.clone());
+        }
+        if role != "test" && self.first_non_test_mutation_file_role.is_none() {
+            self.first_non_test_mutation_file_role = Some(role_string.clone());
+        }
+
+        // Sequence push with 200-cap (consumes role_string)
+        self.mutation_role_sequence.push(role_string);
+        if self.mutation_role_sequence.len() > 200 {
+            self.mutation_role_sequence.remove(0);
+        }
+
+        // Rework count: prev != current AND current has been seen before
+        let prev_role = self
+            .mutation_role_sequence
+            .iter()
+            .rev()
+            .nth(1)
+            .map(|s| s.as_str());
+        if prev_role != Some(role) && self.seen_roles.contains(role) {
+            self.role_transition_rework_count += 1;
+        }
+        // seen_roles uses &'static str (classify_file_role always returns &'static str)
+        self.seen_roles.insert(role);
+
+        // Peripheral / unique files before first core mutation
+        if !self.core_mutation_seen {
+            if role == "core_impl" {
+                self.core_mutation_seen = true;
+            } else {
+                self.peripheral_mutation_before_core_count += 1;
+                self.pre_core_touched_files.insert(path.to_string());
+                self.files_touched_before_first_core_mutation =
+                    self.pre_core_touched_files.len() as u32;
+            }
+        }
+
+        self.mutation_path_attribution
+            .push((path.to_string(), None));
+    }
+
+    /// Access the internal mutation path attribution list (for plan divergence calculation).
+    pub(crate) fn mutation_path_attribution(&self) -> &[(String, Option<usize>)] {
+        &self.mutation_path_attribution
+    }
+
     /// Record an ANVIL_FINAL suppression with remaining core targets.
     pub fn record_final_suppressed_with_remaining_targets(&mut self) {
         self.final_suppressed_with_remaining_targets_count += 1;
@@ -417,7 +511,7 @@ impl AgentTelemetry {
             .unwrap_or_else(|| "none".to_string());
 
         let payload = serde_json::json!({
-            "schema_version": "2",
+            "schema_version": "3",
             "session_id": session_id,
             "completion_kind": completion,
             "premature_final_count": self.premature_final_count,
@@ -444,6 +538,13 @@ impl AgentTelemetry {
             "first_mutation_event_elapsed_s": self.first_mutation_event_elapsed_s,
             "first_mutation_event_tool": self.first_mutation_event_tool,
             "first_mutation_event_semantic_basis": "runtime_lower_bound",
+            "first_successful_mutation_file_role": self.first_successful_mutation_file_role,
+            "first_non_test_mutation_file_role": self.first_non_test_mutation_file_role,
+            "mutation_role_sequence": self.mutation_role_sequence,
+            "peripheral_mutation_before_core_count": self.peripheral_mutation_before_core_count,
+            "role_transition_rework_count": self.role_transition_rework_count,
+            "files_touched_before_first_core_mutation": self.files_touched_before_first_core_mutation,
+            "plan_order_vs_actual_mutation_divergence": self.plan_order_vs_actual_mutation_divergence,
         });
 
         let json_bytes = serde_json::to_vec_pretty(&payload)?;

--- a/tests/telemetry_artifact.rs
+++ b/tests/telemetry_artifact.rs
@@ -65,7 +65,7 @@ fn telemetry_artifact_not_written_when_dir_unset() {
 #[test]
 fn telemetry_artifact_schema_version() {
     let json = write_and_parse(&AgentTelemetry::new(), "schema");
-    assert_eq!(json["schema_version"], "2");
+    assert_eq!(json["schema_version"], "3");
 }
 
 #[test]
@@ -138,6 +138,13 @@ fn telemetry_artifact_all_fields_present() {
         "first_mutation_event_elapsed_s",
         "first_mutation_event_tool",
         "first_mutation_event_semantic_basis",
+        "first_successful_mutation_file_role",
+        "first_non_test_mutation_file_role",
+        "mutation_role_sequence",
+        "peripheral_mutation_before_core_count",
+        "role_transition_rework_count",
+        "files_touched_before_first_core_mutation",
+        "plan_order_vs_actual_mutation_divergence",
     ];
 
     for key in &expected_keys {
@@ -186,6 +193,39 @@ fn first_mutation_event_in_artifact_payload() {
         json["first_mutation_event_semantic_basis"],
         "runtime_lower_bound"
     );
+}
+
+// ---------------------------------------------------------------------------
+// Issue #277: backward compatibility test
+// ---------------------------------------------------------------------------
+
+/// Deserializing schema_version 2 JSON (without Issue #277 fields) should
+/// produce default values for all new fields.
+#[test]
+fn backward_compat_schema_v2_deserializes_with_defaults() {
+    let v2_json = r#"{
+        "premature_final_count": 1,
+        "total_final_requests": 3,
+        "plan_registration_count": 1,
+        "plan_update_count": 0,
+        "sync_from_touched_files_count": 0,
+        "last_mutation_turn": 5,
+        "anvil_plan_visible_count": 1,
+        "final_suppressed_with_remaining_targets_count": 0,
+        "initial_plan_miss_count": 0,
+        "no_op_mutation_count": 0,
+        "rolled_back_mutation_count": 0
+    }"#;
+    let tel: AgentTelemetry = serde_json::from_str(v2_json).unwrap();
+
+    // All Issue #277 fields should have their default values
+    assert!(tel.first_successful_mutation_file_role.is_none());
+    assert!(tel.first_non_test_mutation_file_role.is_none());
+    assert!(tel.mutation_role_sequence.is_empty());
+    assert_eq!(tel.peripheral_mutation_before_core_count, 0);
+    assert_eq!(tel.role_transition_rework_count, 0);
+    assert_eq!(tel.files_touched_before_first_core_mutation, 0);
+    assert!(tel.plan_order_vs_actual_mutation_divergence.is_none());
 }
 
 /// (f) Artifact payload has null first_mutation_event_* when no mutations occurred.


### PR DESCRIPTION
## Summary
- Issue #277: file-role telemetry追加・mutation order測定
- FileRole分類（core/supporting/test/config/unknown）とper-mutation file-role tracking
- mutation_orderでcore filesが最初にmutateされるかを分析可能に
- Schema version 3に更新

## Test plan
- [x] cargo fmt --check
- [x] cargo clippy --all-targets: 0警告
- [x] cargo test: 全パス

Closes #277

🤖 Generated with [Claude Code](https://claude.com/claude-code)