### PR TITLE
feat(issue-275): post-mutation stagnation decomposition telemetry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,7 +117,7 @@ src/
 │   ├── read_repeat_tracker.rs # file.read繰り返し検出・ヒント注入（セッション横断型・閾値2/4）
 │   ├── write_fail_tracker.rs # file.write連続失敗トラッキング（ヒント提供・閾値2）
 │   ├── write_repeat_tracker.rs # file.write成功繰り返しトラッキング（同一ファイルへのwrite検出・Warn閾値3/StrongWarn閾値4）
-│   ├── stagnation_state.rs # 停滞検知・ワークセットステアリング・budget-aware閾値（Issue #263）
+│   ├── stagnation_state.rs # 停滞検知・ワークセットステアリング・budget-aware閾値（Issue #263）・PostMutationClassifier（Issue #275）
 │   ├── plan.rs          # プラン管理
 │   ├── policy.rs        # offlineポリシーチェック（共通ヘルパー）
 │   ├── render.rs        # コンソール描画

--- a/src/agent/subagent.rs
+++ b/src/agent/subagent.rs
@@ -234,11 +234,7 @@ impl SubAgentResult {
             status: ToolExecutionStatus::Completed,
             summary,
             payload: ToolExecutionPayload::Text(json),
-            artifacts: Vec::new(),
-            elapsed_ms: 0,
-            diff_summary: None,
-            edit_detail: None,
-            rolled_back: false,
+            ..Default::default()
         }
     }
 }
@@ -286,11 +282,7 @@ impl SubAgentError {
             status: ToolExecutionStatus::Failed,
             summary: output.clone(),
             payload: ToolExecutionPayload::Text(output),
-            artifacts: Vec::new(),
-            elapsed_ms: 0,
-            diff_summary: None,
-            edit_detail: None,
-            rolled_back: false,
+            ..Default::default()
         }
     }
 }
@@ -600,11 +592,7 @@ impl<'a, C: ProviderClient> SubAgentSession<'a, C> {
                     status: ToolExecutionStatus::Failed,
                     summary: err.to_string(),
                     payload: ToolExecutionPayload::Text(err.to_string()),
-                    artifacts: Vec::new(),
-                    elapsed_ms: 0,
-                    diff_summary: None,
-                    edit_detail: None,
-                    rolled_back: false,
+                    ..Default::default()
                 });
 
             // Record tool result in the sub-agent session

--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -27,6 +27,9 @@ use crate::tooling::{PermissionClass, effective_permission_class};
 use super::policy::{OFFLINE_BLOCK_PAYLOAD, check_offline_blocked};
 use super::read_repeat_tracker::ReadRepeatAction;
 use super::read_transition_guard::ReadTransitionAction;
+use super::stagnation_state::{
+    PostMutationToolObservation, PostMutationTurnObservation, classify_post_mutation_turn,
+};
 use super::write_repeat_tracker::WriteRepeatAction;
 use super::{App, AppError, CompactInfo, format_tool_counts};
 
@@ -204,11 +207,7 @@ fn execute_parallel_group_standalone(
                                 status: ToolExecutionStatus::Failed,
                                 summary,
                                 payload,
-                                artifacts: Vec::new(),
-                                elapsed_ms: 0,
-                                diff_summary: None,
-                                edit_detail: None,
-                                rolled_back: false,
+                                ..Default::default()
                             }
                         });
                         // Update progress entry
@@ -246,16 +245,9 @@ fn execute_parallel_group_standalone(
                         results.push((
                             usize::MAX,
                             ToolExecutionResult {
-                                tool_call_id: String::new(),
-                                tool_name: String::new(),
                                 status: ToolExecutionStatus::Failed,
                                 summary: "parallel tool execution failed unexpectedly".to_string(),
-                                payload: ToolExecutionPayload::None,
-                                artifacts: Vec::new(),
-                                elapsed_ms: 0,
-                                diff_summary: None,
-                                edit_detail: None,
-                                rolled_back: false,
+                                ..Default::default()
                             },
                         ));
                     }
@@ -315,11 +307,7 @@ impl App {
                     payload: ToolExecutionPayload::Text(
                         "too many subagent calls in a single turn".to_string(),
                     ),
-                    artifacts: Vec::new(),
-                    elapsed_ms: 0,
-                    diff_summary: None,
-                    edit_detail: None,
-                    rolled_back: false,
+                    ..Default::default()
                 });
                 continue;
             }
@@ -489,6 +477,16 @@ impl App {
                 self.stagnation_state.begin_turn(&workset);
             }
 
+            // Issue #275 Task 2.2: Snapshot touched_files and edit_fail state before tool execution.
+            let pre_turn_touched_snapshot: HashSet<String> = self
+                .session
+                .working_memory
+                .touched_files
+                .iter()
+                .cloned()
+                .collect();
+            let pre_turn_last_failed_path = self.edit_fail_tracker.last_failed_path.clone();
+
             // Step 1: Extract and run sub-agent calls (IR3-001)
             let (agent_results, normal_calls) =
                 self.extract_and_run_subagent_calls(&current.tool_calls, provider_client);
@@ -562,6 +560,91 @@ impl App {
                     }
                 }
             }
+
+            // Issue #275 Task 2.2: Build PostMutationToolObservation list and turn_local_failed_paths.
+            let (post_mutation_tool_actions, turn_local_failed_paths) = {
+                let cwd = &self.config.paths.cwd;
+                let mut actions = Vec::new();
+                let mut failed_paths = Vec::new();
+
+                // File tools with single-path semantics (first artifact).
+                // CB-003: file.search uses multi-path (all artifacts) since it can match many files.
+                const SINGLE_PATH_TOOLS: &[&str] =
+                    &["file.read", "file.write", "file.edit", "file.edit_anchor"];
+                // File tools with multi-path semantics (all artifacts).
+                const MULTI_PATH_TOOLS: &[&str] = &["file.list", "file.search"];
+                // Tools whose target_paths should be empty (no file path).
+                const NO_PATH_TOOLS: &[&str] = &["web.fetch", "web.search", "shell.exec"];
+
+                // Helper: normalize an absolute artifact path to cwd-relative.
+                // CB-005: discard paths that are not under cwd (sandbox boundary).
+                let normalize_path = |a: &str| -> Option<String> {
+                    let p = std::path::Path::new(a);
+                    p.strip_prefix(cwd)
+                        .ok()
+                        .map(|rel| rel.to_string_lossy().into_owned())
+                };
+
+                for r in &results {
+                    let target_paths: Vec<String> =
+                        if SINGLE_PATH_TOOLS.contains(&r.tool_name.as_str()) {
+                            // CB-001: For file.edit/file.edit_anchor failures where artifacts
+                            // may be empty, fall back to edit_fail_tracker.last_failed_path
+                            // (already updated by record_tool_result before this point).
+                            let from_artifacts: Vec<String> = r
+                                .artifacts
+                                .first()
+                                .and_then(|a| normalize_path(a))
+                                .into_iter()
+                                .collect();
+                            if from_artifacts.is_empty()
+                                && r.status == ToolExecutionStatus::Failed
+                                && matches!(r.tool_name.as_str(), "file.edit" | "file.edit_anchor")
+                            {
+                                // record_tool_result() was called inside execute_structured_tool_calls,
+                                // so last_failed_path reflects this turn's failure.
+                                self.edit_fail_tracker
+                                    .last_failed_path
+                                    .as_deref()
+                                    .map(|p| vec![p.to_string()])
+                                    .unwrap_or_default()
+                            } else {
+                                from_artifacts
+                            }
+                        } else if MULTI_PATH_TOOLS.contains(&r.tool_name.as_str()) {
+                            r.artifacts
+                                .iter()
+                                .filter_map(|a| normalize_path(a))
+                                .collect()
+                        } else if NO_PATH_TOOLS.contains(&r.tool_name.as_str()) {
+                            vec![]
+                        } else {
+                            // Unknown tools: best-effort single-path from first artifact.
+                            r.artifacts
+                                .first()
+                                .and_then(|a| normalize_path(a))
+                                .into_iter()
+                                .collect()
+                        };
+
+                    // Collect turn-local failed paths for file tools.
+                    if r.status == ToolExecutionStatus::Failed
+                        && (SINGLE_PATH_TOOLS.contains(&r.tool_name.as_str())
+                            || MULTI_PATH_TOOLS.contains(&r.tool_name.as_str()))
+                    {
+                        failed_paths.extend(target_paths.iter().cloned());
+                    }
+
+                    actions.push(PostMutationToolObservation {
+                        tool_name: r.tool_name.clone(),
+                        target_paths,
+                        cache_hit_count: r.cache_hit_count,
+                        status: r.status.clone(),
+                    });
+                }
+
+                (actions, failed_paths)
+            };
 
             let tool_log_views: Vec<ToolLogView> = results
                 .iter()
@@ -764,6 +847,45 @@ impl App {
                     "stagnation detected; forced_mode_active=true"
                 );
             }
+
+            // Issue #275 Task 2.2: Post-mutation turn classification (telemetry only).
+            {
+                let is_post_first_mutation =
+                    self.agent_telemetry.first_mutation_event_turn.is_some();
+                if is_post_first_mutation {
+                    let obs = PostMutationTurnObservation {
+                        pre_turn_touched_snapshot,
+                        pre_turn_last_failed_path,
+                        turn_local_failed_paths,
+                        tool_actions: post_mutation_tool_actions,
+                        has_anvil_final: anvil_final_seen,
+                        tool_call_count: results.len(),
+                    };
+                    let dominant_class = classify_post_mutation_turn(&obs);
+                    self.agent_telemetry
+                        .post_mutation
+                        .record_class(dominant_class);
+
+                    // Update post_mutation_touched_paths on the session record
+                    // (capped at 1000 entries to bound memory).
+                    let paths = &mut self.session.post_mutation_touched_paths;
+                    for action in &obs.tool_actions {
+                        for path in &action.target_paths {
+                            if paths.contains(path) {
+                                continue;
+                            }
+                            if paths.len() < 1000 {
+                                paths.insert(path.clone());
+                            } else {
+                                self.session.post_mutation_touched_paths_overflowed = true;
+                            }
+                        }
+                    }
+                    self.agent_telemetry.post_mutation.new_path_count =
+                        self.session.post_mutation_touched_paths.len() as u32;
+                }
+            }
+
             log_turn_summary(&TurnSummary {
                 turn: self.session_stats.total_turns,
                 max_turns: max_iterations as u32,
@@ -959,11 +1081,7 @@ impl App {
                         status: ToolExecutionStatus::Failed,
                         summary,
                         payload: ToolExecutionPayload::Text(OFFLINE_BLOCK_PAYLOAD.to_string()),
-                        artifacts: Vec::new(),
-                        elapsed_ms: 0,
-                        diff_summary: None,
-                        edit_detail: None,
-                        rolled_back: false,
+                        ..Default::default()
                     },
                 ));
                 continue;
@@ -1054,16 +1172,10 @@ impl App {
         let result = executor
             .execute(request)
             .unwrap_or_else(|err| ToolExecutionResult {
-                tool_call_id: String::new(),
-                tool_name: String::new(),
                 status: ToolExecutionStatus::Failed,
                 summary: err.to_string(),
                 payload: ToolExecutionPayload::Text(err.to_string()),
-                artifacts: Vec::new(),
-                elapsed_ms: 0,
-                diff_summary: None,
-                edit_detail: None,
-                rolled_back: false,
+                ..Default::default()
             });
 
         // Remove checkpoint if tool execution failed.
@@ -1094,12 +1206,7 @@ impl App {
                 tool_name,
                 status: ToolExecutionStatus::Failed,
                 summary: "MCP manager not available".to_string(),
-                payload: ToolExecutionPayload::None,
-                artifacts: Vec::new(),
-                elapsed_ms: 0,
-                diff_summary: None,
-                edit_detail: None,
-                rolled_back: false,
+                ..Default::default()
             };
         };
 
@@ -1123,11 +1230,8 @@ impl App {
             status,
             summary,
             payload,
-            artifacts: Vec::new(),
             elapsed_ms: started.elapsed().as_millis(),
-            diff_summary: None,
-            edit_detail: None,
-            rolled_back: false,
+            ..Default::default()
         }
     }
 
@@ -1183,12 +1287,7 @@ impl App {
                                     tool_name: request.spec.name.clone(),
                                     status: ToolExecutionStatus::Failed,
                                     summary: format!("blocked by hook: {reason}"),
-                                    payload: crate::tooling::ToolExecutionPayload::None,
-                                    artifacts: Vec::new(),
-                                    elapsed_ms: 0,
-                                    diff_summary: None,
-                                    edit_detail: None,
-                                    rolled_back: false,
+                                    ..Default::default()
                                 },
                             ));
                         }
@@ -1245,14 +1344,9 @@ impl App {
             | super::loop_detector::LoopAction::StrongWarn(msg) => Some(ToolExecutionResult {
                 tool_call_id: "loop_detector_warning".to_string(),
                 tool_name: "system.loop_detector".to_string(),
-                status: ToolExecutionStatus::Completed,
                 summary: msg.clone(),
                 payload: ToolExecutionPayload::Text(msg.clone()),
-                artifacts: vec![],
-                elapsed_ms: 0,
-                diff_summary: None,
-                edit_detail: None,
-                rolled_back: false,
+                ..Default::default()
             }),
             _ => None,
         };
@@ -1493,14 +1587,9 @@ impl App {
             let transition_result = ToolExecutionResult {
                 tool_call_id: "read_transition_guard".to_string(),
                 tool_name: "system.read_guard".to_string(),
-                status: ToolExecutionStatus::Completed,
                 summary: msg.clone(),
                 payload: ToolExecutionPayload::Text(msg.clone()),
-                artifacts: vec![],
-                elapsed_ms: 0,
-                diff_summary: None,
-                edit_detail: None,
-                rolled_back: false,
+                ..Default::default()
             };
             self.record_tool_result(&transition_result);
             results.push(transition_result);
@@ -1523,14 +1612,9 @@ impl App {
                 let transition_result = ToolExecutionResult {
                     tool_call_id: "phase_estimator_transition".to_string(),
                     tool_name: "system.phase_estimator".to_string(),
-                    status: ToolExecutionStatus::Completed,
                     summary: msg.clone(),
                     payload: ToolExecutionPayload::Text(msg),
-                    artifacts: vec![],
-                    elapsed_ms: 0,
-                    diff_summary: None,
-                    edit_detail: None,
-                    rolled_back: false,
+                    ..Default::default()
                 };
                 self.record_tool_result(&transition_result);
                 results.push(transition_result);
@@ -2277,12 +2361,7 @@ fn build_failed_result(
         tool_name: call.tool_name.clone(),
         status: crate::tooling::ToolExecutionStatus::Failed,
         summary,
-        payload: crate::tooling::ToolExecutionPayload::None,
-        artifacts: Vec::new(),
-        elapsed_ms: 0,
-        diff_summary: None,
-        edit_detail: None,
-        rolled_back: false,
+        ..Default::default()
     }
 }
 
@@ -2532,14 +2611,10 @@ mod trust_tests {
         let result = ToolExecutionResult {
             tool_call_id: "call_001".to_string(),
             tool_name: "file.read".to_string(),
-            status: ToolExecutionStatus::Completed,
             summary: "read ok".to_string(),
             payload: ToolExecutionPayload::Text("A".repeat(3_000)),
             artifacts: vec!["./src/main.rs".to_string()],
-            elapsed_ms: 0,
-            diff_summary: None,
-            edit_detail: None,
-            rolled_back: false,
+            ..Default::default()
         };
 
         let formatted = format_tool_result_message(&result, 8_000);

--- a/src/app/edit_fail_tracker.rs
+++ b/src/app/edit_fail_tracker.rs
@@ -68,6 +68,9 @@ pub(crate) struct EditFailTracker {
     consecutive_failures: HashMap<String, u32>,
     reread_threshold: u32,
     write_fallback_threshold: u32,
+    /// Last failed edit path, used by post-mutation classifier (Issue #275).
+    /// Cleared when the same path succeeds (stale marker prevention).
+    pub(crate) last_failed_path: Option<String>,
 }
 
 impl EditFailTracker {
@@ -76,12 +79,14 @@ impl EditFailTracker {
             consecutive_failures: HashMap::new(),
             reread_threshold,
             write_fallback_threshold,
+            last_failed_path: None,
         }
     }
 
     /// Record a file.edit failure for the given path.
     /// Returns the recommended fallback action based on the cumulative failure count.
     pub(crate) fn record_failure(&mut self, path: &str) -> EditFallbackAction {
+        self.last_failed_path = Some(path.to_string());
         let count = self
             .consecutive_failures
             .entry(path.to_string())
@@ -93,6 +98,10 @@ impl EditFailTracker {
     /// Record a successful file.edit, resetting the failure count for that path.
     pub(crate) fn record_success(&mut self, path: &str) {
         self.consecutive_failures.remove(path);
+        // Clear repair marker if the same path succeeded (stale marker prevention, Issue #275).
+        if self.last_failed_path.as_deref() == Some(path) {
+            self.last_failed_path = None;
+        }
     }
 
     /// Get the current failure count for a path.
@@ -271,5 +280,33 @@ mod tests {
             EditFallbackAction::WriteFallback
         );
         assert_eq!(tracker.failure_count("a.rs"), 7);
+    }
+
+    // --- Issue #275: last_failed_path tests ---
+
+    #[test]
+    fn test_last_failed_path_set_on_record_failure() {
+        let mut tracker = EditFailTracker::new(3, 5);
+        assert_eq!(tracker.last_failed_path, None);
+        tracker.record_failure("src/a.rs");
+        assert_eq!(tracker.last_failed_path.as_deref(), Some("src/a.rs"));
+    }
+
+    #[test]
+    fn test_last_failed_path_cleared_on_same_path_success() {
+        let mut tracker = EditFailTracker::new(3, 5);
+        tracker.record_failure("src/a.rs");
+        assert_eq!(tracker.last_failed_path.as_deref(), Some("src/a.rs"));
+        tracker.record_success("src/a.rs");
+        assert_eq!(tracker.last_failed_path, None);
+    }
+
+    #[test]
+    fn test_last_failed_path_preserved_on_other_path_success() {
+        let mut tracker = EditFailTracker::new(3, 5);
+        tracker.record_failure("src/b.rs");
+        assert_eq!(tracker.last_failed_path.as_deref(), Some("src/b.rs"));
+        tracker.record_success("src/c.rs");
+        assert_eq!(tracker.last_failed_path.as_deref(), Some("src/b.rs"));
     }
 }

--- a/src/app/stagnation_state.rs
+++ b/src/app/stagnation_state.rs
@@ -4,9 +4,10 @@
 //! Policy decisions (scoring, plan repair, workset steering) are
 //! implemented as module-level pure functions to maintain SRP.
 
-use std::collections::VecDeque;
+use std::collections::{HashSet, VecDeque};
 
-use crate::contracts::{ExecutionPlan, PlanItem};
+use crate::contracts::{ExecutionPlan, PlanItem, PostMutationDominantClass};
+use crate::tooling::ToolExecutionStatus;
 
 /// Maximum number of recent read-only turn flags to keep.
 const RECENT_TURNS_CAP: usize = 5;
@@ -409,4 +410,112 @@ pub fn build_plan_repair_message(starved_target_files: &[String]) -> String {
          - Do NOT re-add completed items\n\
          - Add only concrete mutation actions (file.edit / file.write)"
     )
+}
+
+// ---------------------------------------------------------------------------
+// Post-mutation stall classifier (Issue #275)
+// ---------------------------------------------------------------------------
+
+/// Minimal tool-level observation for post-mutation classification.
+///
+/// App-local type: not serialized, not stored in contracts.
+pub struct PostMutationToolObservation {
+    /// Tool name (e.g. "file.read", "file.edit").
+    pub tool_name: String,
+    /// cwd-relative target paths (sandbox-validated). May be empty for web tools.
+    pub target_paths: Vec<String>,
+    /// FileReadCache hit count. `Some(n)` where n >= 2 = true cache hit.
+    pub cache_hit_count: Option<usize>,
+    /// Tool execution status.
+    pub status: ToolExecutionStatus,
+}
+
+/// Turn-level observation for post-mutation classification.
+///
+/// App-local type: not serialized, not stored in contracts.
+pub struct PostMutationTurnObservation {
+    /// Touched files snapshot taken at the start of this turn.
+    pub pre_turn_touched_snapshot: HashSet<String>,
+    /// Last failed edit path from EditFailTracker (pre-turn).
+    pub pre_turn_last_failed_path: Option<String>,
+    /// Failed edit paths that occurred during this turn.
+    pub turn_local_failed_paths: Vec<String>,
+    /// Tool observations for this turn.
+    pub tool_actions: Vec<PostMutationToolObservation>,
+    /// Whether ANVIL_FINAL was present in the response.
+    pub has_anvil_final: bool,
+    /// Number of tool calls in this turn.
+    pub tool_call_count: usize,
+}
+
+/// Classify a post-mutation turn into its dominant class.
+///
+/// **Precondition**: caller has verified `is_post_first_mutation == true`.
+/// This function does not perform pre-mutation guards (SRP).
+///
+/// Priority: SameFileRepair > TouchedPathRepair > CacheHitReread > UntouchedExploration > PlanOnlyNoTool
+pub fn classify_post_mutation_turn(obs: &PostMutationTurnObservation) -> PostMutationDominantClass {
+    let failed_paths: HashSet<&str> = obs
+        .pre_turn_last_failed_path
+        .iter()
+        .map(String::as_str)
+        .chain(obs.turn_local_failed_paths.iter().map(String::as_str))
+        .collect();
+
+    // 1. SameFileRepair (highest priority)
+    for action in &obs.tool_actions {
+        if matches!(
+            action.tool_name.as_str(),
+            "file.read" | "file.edit" | "file.edit_anchor"
+        ) && action
+            .target_paths
+            .iter()
+            .any(|path| failed_paths.contains(path.as_str()))
+        {
+            return PostMutationDominantClass::SameFileRepair;
+        }
+    }
+
+    // 2. TouchedPathRepair
+    for action in &obs.tool_actions {
+        if action
+            .target_paths
+            .iter()
+            .any(|path| obs.pre_turn_touched_snapshot.contains(path))
+        {
+            return PostMutationDominantClass::TouchedPathRepair;
+        }
+    }
+
+    // 3. CacheHitReread (n >= 2 = true cache hit)
+    if obs
+        .tool_actions
+        .iter()
+        .any(|a| a.cache_hit_count.is_some_and(|n| n >= 2))
+    {
+        return PostMutationDominantClass::CacheHitReread;
+    }
+
+    // 4. UntouchedExploration
+    let exploration_tools = [
+        "file.read",
+        "file.search",
+        "file.list",
+        "web.fetch",
+        "web.search",
+    ];
+    for action in &obs.tool_actions {
+        if exploration_tools.contains(&action.tool_name.as_str())
+            && (action.target_paths.is_empty()
+                || action
+                    .target_paths
+                    .iter()
+                    .any(|path| !obs.pre_turn_touched_snapshot.contains(path)))
+        {
+            return PostMutationDominantClass::UntouchedExploration;
+        }
+    }
+
+    // 5. PlanOnlyNoTool (default)
+    PostMutationDominantClass::PlanOnlyNoTool
 }

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -171,6 +171,70 @@ impl CompletionKind {
 }
 
 // ---------------------------------------------------------------------------
+// Post-mutation stall classification (Issue #275)
+// ---------------------------------------------------------------------------
+
+/// Dominant class of a post-mutation stall turn.
+///
+/// Priority order (highest first):
+/// 1. SameFileRepair
+/// 2. TouchedPathRepair
+/// 3. CacheHitReread
+/// 4. UntouchedExploration
+/// 5. PlanOnlyNoTool
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum PostMutationDominantClass {
+    SameFileRepair,
+    TouchedPathRepair,
+    CacheHitReread,
+    UntouchedExploration,
+    #[default]
+    PlanOnlyNoTool,
+}
+
+/// Post-mutation stall classification / measurement telemetry (Issue #275).
+///
+/// Sub-struct of `AgentTelemetry` to avoid field proliferation.
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct PostMutationTelemetry {
+    #[serde(default)]
+    pub stall_segment_count: u32,
+    #[serde(default)]
+    pub same_file_repair_turn_count: u32,
+    #[serde(default)]
+    pub touched_path_repair_turn_count: u32,
+    #[serde(default)]
+    pub untouched_exploration_turn_count: u32,
+    #[serde(default)]
+    pub plan_only_turn_count: u32,
+    #[serde(default)]
+    pub cache_hit_reread_count: u32,
+    #[serde(default)]
+    pub new_path_count: u32,
+    #[serde(default)]
+    pub dominant_class: Option<PostMutationDominantClass>,
+}
+
+impl PostMutationTelemetry {
+    /// Increment the counter for the given dominant class and update the latest class.
+    pub fn record_class(&mut self, class: PostMutationDominantClass) {
+        match class {
+            PostMutationDominantClass::SameFileRepair => self.same_file_repair_turn_count += 1,
+            PostMutationDominantClass::TouchedPathRepair => {
+                self.touched_path_repair_turn_count += 1;
+            }
+            PostMutationDominantClass::CacheHitReread => self.cache_hit_reread_count += 1,
+            PostMutationDominantClass::UntouchedExploration => {
+                self.untouched_exploration_turn_count += 1;
+            }
+            PostMutationDominantClass::PlanOnlyNoTool => self.plan_only_turn_count += 1,
+        }
+        self.dominant_class = Some(class);
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Agent telemetry (Issue #255: Stage 0 observability)
 // ---------------------------------------------------------------------------
 
@@ -249,6 +313,10 @@ pub struct AgentTelemetry {
     /// None if no mutation occurred during the session.
     #[serde(default)]
     pub first_mutation_event_tool: Option<String>,
+
+    /// Post-mutation stall classification telemetry (Issue #275).
+    #[serde(default)]
+    pub post_mutation: PostMutationTelemetry,
 }
 
 impl AgentTelemetry {
@@ -444,6 +512,7 @@ impl AgentTelemetry {
             "first_mutation_event_elapsed_s": self.first_mutation_event_elapsed_s,
             "first_mutation_event_tool": self.first_mutation_event_tool,
             "first_mutation_event_semantic_basis": "runtime_lower_bound",
+            "post_mutation": self.post_mutation,
         });
 
         let json_bytes = serde_json::to_vec_pretty(&payload)?;

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -330,6 +330,14 @@ pub struct SessionRecord {
     /// Added in Issue #130.
     #[serde(default)]
     pub working_memory: WorkingMemory,
+    /// Post-mutation touched paths (hidden state, not injected into prompt).
+    /// Used by post-mutation classifier to track new vs. previously-touched paths (Issue #275).
+    /// Capped at 1000 entries; `post_mutation_touched_paths_overflowed` signals cap reached.
+    #[serde(default)]
+    pub post_mutation_touched_paths: HashSet<String>,
+    /// Whether `post_mutation_touched_paths` reached its capacity limit (Issue #275).
+    #[serde(default)]
+    pub post_mutation_touched_paths_overflowed: bool,
     /// Tracks whether in-memory state has diverged from disk.
     /// Not serialized — always starts as `false` after deserialization.
     #[serde(skip)]
@@ -378,6 +386,8 @@ impl SessionRecord {
             provider_errors: Vec::new(),
             used_tools: HashSet::new(),
             working_memory: WorkingMemory::default(),
+            post_mutation_touched_paths: HashSet::new(),
+            post_mutation_touched_paths_overflowed: false,
             dirty: false,
             cached_token_count: std::cell::Cell::new(None),
             auto_compact_threshold: 64,

--- a/src/tooling/mod.rs
+++ b/src/tooling/mod.rs
@@ -608,15 +608,17 @@ pub struct ToolExecutionRequest {
     pub input: ToolInput,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub enum ToolExecutionStatus {
+    #[default]
     Completed,
     Failed,
     Interrupted,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub enum ToolExecutionPayload {
+    #[default]
     None,
     Text(String),
     Paths(Vec<String>),
@@ -643,7 +645,7 @@ pub struct EditResultDetail {
     pub fallback_stage: EditFallbackStage,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct ToolExecutionResult {
     pub tool_call_id: String,
     pub tool_name: String,
@@ -659,6 +661,9 @@ pub struct ToolExecutionResult {
     pub edit_detail: Option<EditResultDetail>,
     /// Whether this result was rolled back by atomic transaction failure (Issue #259).
     pub rolled_back: bool,
+    /// Cache hit count from FileReadCache (Issue #275).
+    /// `None` for non-file.read tools or initial read. `Some(n)` where n >= 2 = true cache hit.
+    pub cache_hit_count: Option<usize>,
 }
 
 impl ToolExecutionResult {
@@ -1347,13 +1352,15 @@ impl LocalToolExecutor {
                 hit.content.len()
             );
             let payload = format!("{}{}", header, hit.content);
-            return Ok(build_completed_result(
+            let mut result = build_completed_result(
                 request,
                 path.to_string(),
                 ToolExecutionPayload::Text(payload),
                 vec![resolved.display().to_string()],
                 started,
-            ));
+            );
+            result.cache_hit_count = Some(hit.hit_count);
+            return Ok(result);
         }
         // Mutex poison → fall through to normal read (best-effort)
 
@@ -1949,9 +1956,7 @@ impl LocalToolExecutor {
                     payload: ToolExecutionPayload::Text(combined),
                     artifacts: Vec::new(),
                     elapsed_ms: started.elapsed().as_millis(),
-                    diff_summary: None,
-                    edit_detail: None,
-                    rolled_back: false,
+                    ..Default::default()
                 });
             }
             match child.try_wait() {
@@ -1987,9 +1992,7 @@ impl LocalToolExecutor {
             payload: ToolExecutionPayload::Text(combined),
             artifacts: Vec::new(),
             elapsed_ms: started.elapsed().as_millis(),
-            diff_summary: None,
-            edit_detail: None,
-            rolled_back: false,
+            ..Default::default()
         })
     }
 
@@ -2178,9 +2181,7 @@ impl LocalToolExecutor {
                 payload: ToolExecutionPayload::Text(error_msg),
                 artifacts: Vec::new(),
                 elapsed_ms: started.elapsed().as_millis(),
-                diff_summary: None,
-                edit_detail: None,
-                rolled_back: false,
+                ..Default::default()
             });
         }
 
@@ -2537,8 +2538,7 @@ fn build_completed_result_with_diff(
         artifacts,
         elapsed_ms: started.elapsed().as_millis(),
         diff_summary,
-        edit_detail: None,
-        rolled_back: false,
+        ..Default::default()
     }
 }
 

--- a/tests/agent_phase.rs
+++ b/tests/agent_phase.rs
@@ -438,11 +438,9 @@ fn make_mutation_result(
         status,
         summary: summary.to_string(),
         payload: anvil::tooling::ToolExecutionPayload::Text("ok".to_string()),
-        artifacts: vec![],
         elapsed_ms: 10,
-        diff_summary: None,
-        edit_detail: None,
         rolled_back,
+        ..Default::default()
     }
 }
 

--- a/tests/stagnation_control.rs
+++ b/tests/stagnation_control.rs
@@ -4,9 +4,15 @@
 //! workset steering, forced mode, plan repair, and budget-aware thresholds.
 
 use anvil::app::stagnation_state::{
-    StagnationState, compute_next_workset, compute_stagnation_score, should_request_plan_repair,
+    PostMutationToolObservation, PostMutationTurnObservation, StagnationState,
+    classify_post_mutation_turn, compute_next_workset, compute_stagnation_score,
+    should_request_plan_repair,
 };
-use anvil::contracts::{AgentTelemetry, ExecutionPlan, PlanItem, PlanItemStatus};
+use anvil::contracts::{
+    AgentTelemetry, ExecutionPlan, PlanItem, PlanItemStatus, PostMutationDominantClass,
+};
+use anvil::tooling::ToolExecutionStatus;
+use std::collections::HashSet;
 
 // ---------------------------------------------------------------------------
 // Phase 0: StagnationState struct + policy pure functions
@@ -520,4 +526,256 @@ fn telemetry_serde_backward_compatibility() {
     assert_eq!(telemetry.first_mutation_event_turn, None);
     assert_eq!(telemetry.first_mutation_event_elapsed_s, None);
     assert_eq!(telemetry.first_mutation_event_tool, None);
+}
+
+// ---------------------------------------------------------------------------
+// Issue #275: Post-mutation classifier tests
+// ---------------------------------------------------------------------------
+
+/// Helper: build a minimal PostMutationTurnObservation with defaults.
+fn make_obs(
+    tool_actions: Vec<PostMutationToolObservation>,
+    pre_turn_touched: HashSet<String>,
+    pre_turn_last_failed_path: Option<String>,
+    turn_local_failed_paths: Vec<String>,
+) -> PostMutationTurnObservation {
+    let tool_call_count = tool_actions.len();
+    PostMutationTurnObservation {
+        pre_turn_touched_snapshot: pre_turn_touched,
+        pre_turn_last_failed_path,
+        turn_local_failed_paths,
+        tool_actions,
+        has_anvil_final: false,
+        tool_call_count,
+    }
+}
+
+fn make_tool_obs(
+    tool_name: &str,
+    target_paths: Vec<&str>,
+    cache_hit_count: Option<usize>,
+    status: ToolExecutionStatus,
+) -> PostMutationToolObservation {
+    PostMutationToolObservation {
+        tool_name: tool_name.to_string(),
+        target_paths: target_paths.into_iter().map(String::from).collect(),
+        cache_hit_count,
+        status,
+    }
+}
+
+#[test]
+fn test_classify_same_file_repair_dominant() {
+    // file.read on last_failed_path → SameFileRepair
+    let obs = make_obs(
+        vec![make_tool_obs(
+            "file.read",
+            vec!["src/a.rs"],
+            None,
+            ToolExecutionStatus::Completed,
+        )],
+        HashSet::new(),
+        Some("src/a.rs".to_string()),
+        vec![],
+    );
+    assert_eq!(
+        classify_post_mutation_turn(&obs),
+        PostMutationDominantClass::SameFileRepair
+    );
+}
+
+#[test]
+fn test_classify_touched_path_repair_dominant() {
+    // file.read on a touched path (not failed) → TouchedPathRepair
+    let mut touched = HashSet::new();
+    touched.insert("src/b.rs".to_string());
+    let obs = make_obs(
+        vec![make_tool_obs(
+            "file.read",
+            vec!["src/b.rs"],
+            None,
+            ToolExecutionStatus::Completed,
+        )],
+        touched,
+        None,
+        vec![],
+    );
+    assert_eq!(
+        classify_post_mutation_turn(&obs),
+        PostMutationDominantClass::TouchedPathRepair
+    );
+}
+
+#[test]
+fn test_classify_untouched_exploration_dominant() {
+    // file.read on an untouched path → UntouchedExploration
+    let obs = make_obs(
+        vec![make_tool_obs(
+            "file.read",
+            vec!["src/new.rs"],
+            None,
+            ToolExecutionStatus::Completed,
+        )],
+        HashSet::new(),
+        None,
+        vec![],
+    );
+    assert_eq!(
+        classify_post_mutation_turn(&obs),
+        PostMutationDominantClass::UntouchedExploration
+    );
+}
+
+#[test]
+fn test_classify_plan_only_no_tool() {
+    // No tools → PlanOnlyNoTool
+    let obs = PostMutationTurnObservation {
+        pre_turn_touched_snapshot: HashSet::new(),
+        pre_turn_last_failed_path: None,
+        turn_local_failed_paths: vec![],
+        tool_actions: vec![],
+        has_anvil_final: false,
+        tool_call_count: 0,
+    };
+    assert_eq!(
+        classify_post_mutation_turn(&obs),
+        PostMutationDominantClass::PlanOnlyNoTool
+    );
+}
+
+#[test]
+fn test_classify_cache_hit_reread() {
+    // file.read with cache_hit_count >= 2 on untouched path → CacheHitReread
+    // Note: cache hit check has lower priority than TouchedPathRepair,
+    // so use an untouched path that wouldn't trigger SameFileRepair or TouchedPathRepair
+    let obs = make_obs(
+        vec![make_tool_obs(
+            "file.read",
+            vec!["src/cached.rs"],
+            Some(3),
+            ToolExecutionStatus::Completed,
+        )],
+        HashSet::new(),
+        None,
+        vec![],
+    );
+    // untouched exploration triggers before cache_hit since we have target_paths
+    // that are not in touched_snapshot. But the design says CacheHitReread has
+    // priority 3 (lower than TouchedPathRepair but higher than UntouchedExploration).
+    // Wait - re-reading design: priority is SameFileRepair(1) > TouchedPathRepair(2) > CacheHitReread(3) > UntouchedExploration(4)
+    // So CacheHitReread wins over UntouchedExploration.
+    assert_eq!(
+        classify_post_mutation_turn(&obs),
+        PostMutationDominantClass::CacheHitReread
+    );
+}
+
+#[test]
+fn test_priority_same_file_over_touched() {
+    // Path is both failed and touched → SameFileRepair wins
+    let mut touched = HashSet::new();
+    touched.insert("src/a.rs".to_string());
+    let obs = make_obs(
+        vec![make_tool_obs(
+            "file.edit",
+            vec!["src/a.rs"],
+            None,
+            ToolExecutionStatus::Completed,
+        )],
+        touched,
+        Some("src/a.rs".to_string()),
+        vec![],
+    );
+    assert_eq!(
+        classify_post_mutation_turn(&obs),
+        PostMutationDominantClass::SameFileRepair
+    );
+}
+
+#[test]
+fn test_priority_touched_over_cache_hit() {
+    // Path is touched + has cache hit → TouchedPathRepair wins (priority 2 > 3)
+    let mut touched = HashSet::new();
+    touched.insert("src/b.rs".to_string());
+    let obs = make_obs(
+        vec![make_tool_obs(
+            "file.read",
+            vec!["src/b.rs"],
+            Some(5),
+            ToolExecutionStatus::Completed,
+        )],
+        touched,
+        None,
+        vec![],
+    );
+    assert_eq!(
+        classify_post_mutation_turn(&obs),
+        PostMutationDominantClass::TouchedPathRepair
+    );
+}
+
+#[test]
+fn test_same_turn_new_mutation_not_touched_path_repair() {
+    // Path NOT in pre_turn_touched_snapshot (even if mutated this turn)
+    // → should NOT be TouchedPathRepair (snapshot is pre-turn)
+    let obs = make_obs(
+        vec![make_tool_obs(
+            "file.read",
+            vec!["src/new_this_turn.rs"],
+            None,
+            ToolExecutionStatus::Completed,
+        )],
+        HashSet::new(), // empty pre-turn snapshot
+        None,
+        vec![],
+    );
+    assert_eq!(
+        classify_post_mutation_turn(&obs),
+        PostMutationDominantClass::UntouchedExploration
+    );
+}
+
+// test_stale_repair_marker_cleared_on_success is in src/app/edit_fail_tracker.rs inline tests
+// because EditFailTracker is pub(crate).
+
+#[test]
+fn test_same_turn_failure_then_success_is_same_file_repair() {
+    // Scenario: file.edit fails on src/a.rs in the same turn, then file.read on src/a.rs
+    // turn_local_failed_paths contains src/a.rs → SameFileRepair
+    let obs = make_obs(
+        vec![make_tool_obs(
+            "file.read",
+            vec!["src/a.rs"],
+            None,
+            ToolExecutionStatus::Completed,
+        )],
+        HashSet::new(),
+        None,
+        vec!["src/a.rs".to_string()], // turn-local failure
+    );
+    assert_eq!(
+        classify_post_mutation_turn(&obs),
+        PostMutationDominantClass::SameFileRepair
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Issue #275: Telemetry backward compatibility
+// ---------------------------------------------------------------------------
+
+#[test]
+fn telemetry_post_mutation_backward_compatible() {
+    // Old JSON without post_mutation should deserialize with defaults
+    let json = r#"{
+        "premature_final_count": 1,
+        "total_final_requests": 2,
+        "plan_registration_count": 1,
+        "plan_update_count": 0,
+        "sync_from_touched_files_count": 0,
+        "completion_kind": null
+    }"#;
+    let telemetry: AgentTelemetry = serde_json::from_str(json).unwrap();
+    assert_eq!(telemetry.post_mutation.stall_segment_count, 0);
+    assert_eq!(telemetry.post_mutation.same_file_repair_turn_count, 0);
+    assert_eq!(telemetry.post_mutation.dominant_class, None);
 }

--- a/tests/state_session.rs
+++ b/tests/state_session.rs
@@ -2019,3 +2019,54 @@ fn note_kind_display() {
     assert_eq!(NoteKind::ShellExec.to_string(), "shell_exec");
     assert_eq!(NoteKind::ErrorHit.to_string(), "error_hit");
 }
+
+// ---------------------------------------------------------------------------
+// Issue #275: post_mutation_touched_paths serde tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn post_mutation_touched_paths_backward_compat() {
+    // Old SessionRecord JSON without post_mutation_touched_paths should deserialize with defaults
+    let json = serde_json::json!({
+        "metadata": {
+            "session_id": "test-275",
+            "cwd": "/tmp",
+            "created_at_ms": 0u64,
+            "updated_at_ms": 0u64,
+        }
+    });
+    let record: SessionRecord = serde_json::from_value(json).unwrap();
+    assert!(record.post_mutation_touched_paths.is_empty());
+    assert!(!record.post_mutation_touched_paths_overflowed);
+}
+
+#[test]
+fn post_mutation_touched_paths_round_trip() {
+    use std::collections::HashSet;
+    let json = serde_json::json!({
+        "metadata": {
+            "session_id": "test-275-rt",
+            "cwd": "/tmp",
+            "created_at_ms": 0u64,
+            "updated_at_ms": 0u64,
+        },
+        "post_mutation_touched_paths": ["src/a.rs", "src/b.rs"],
+        "post_mutation_touched_paths_overflowed": false,
+    });
+    let record: SessionRecord = serde_json::from_value(json).unwrap();
+    assert_eq!(record.post_mutation_touched_paths.len(), 2);
+    assert!(record.post_mutation_touched_paths.contains("src/a.rs"));
+    assert!(record.post_mutation_touched_paths.contains("src/b.rs"));
+
+    // Round-trip
+    let serialized = serde_json::to_value(&record).unwrap();
+    let paths = serialized["post_mutation_touched_paths"]
+        .as_array()
+        .unwrap();
+    let path_set: HashSet<String> = paths
+        .iter()
+        .map(|v| v.as_str().unwrap().to_string())
+        .collect();
+    assert!(path_set.contains("src/a.rs"));
+    assert!(path_set.contains("src/b.rs"));
+}

--- a/tests/telemetry_artifact.rs
+++ b/tests/telemetry_artifact.rs
@@ -138,6 +138,7 @@ fn telemetry_artifact_all_fields_present() {
         "first_mutation_event_elapsed_s",
         "first_mutation_event_tool",
         "first_mutation_event_semantic_basis",
+        "post_mutation",
     ];
 
     for key in &expected_keys {

--- a/tests/tooling_system.rs
+++ b/tests/tooling_system.rs
@@ -202,9 +202,7 @@ fn validated_tool_call_builds_typed_execution_request_and_result() {
         payload: ToolExecutionPayload::Text("mod app".to_string()),
         artifacts: vec!["src/app/mod.rs".to_string()],
         elapsed_ms: 12,
-        diff_summary: None,
-        edit_detail: None,
-        rolled_back: false,
+        ..Default::default()
     };
 
     assert_eq!(execution.spec.kind, ToolKind::FileRead);
@@ -377,9 +375,7 @@ fn tool_execution_result_can_bridge_into_console_tool_log_view() {
         payload: ToolExecutionPayload::Text("mod app".to_string()),
         artifacts: vec!["src/app/mod.rs".to_string()],
         elapsed_ms: 12,
-        diff_summary: None,
-        edit_detail: None,
-        rolled_back: false,
+        ..Default::default()
     };
     let log = result.to_tool_log_view();
 
@@ -2294,9 +2290,7 @@ fn format_tool_result_message_image_payload() {
         },
         artifacts: Vec::new(),
         elapsed_ms: 10,
-        diff_summary: None,
-        edit_detail: None,
-        rolled_back: false,
+        ..Default::default()
     };
     let msg = format_tool_result_message(&result, 10000);
     assert!(msg.contains("file.read"));
@@ -2323,9 +2317,7 @@ fn format_tool_result_message_truncates_multibyte_safely() {
         payload: ToolExecutionPayload::Text(cjk_content),
         artifacts: Vec::new(),
         elapsed_ms: 5,
-        diff_summary: None,
-        edit_detail: None,
-        rolled_back: false,
+        ..Default::default()
     };
 
     // Must not panic — the old byte-slicing implementation would panic here.
@@ -2348,9 +2340,7 @@ fn format_tool_result_message_ascii_truncation_still_works() {
         payload: ToolExecutionPayload::Text(ascii_content),
         artifacts: Vec::new(),
         elapsed_ms: 5,
-        diff_summary: None,
-        edit_detail: None,
-        rolled_back: false,
+        ..Default::default()
     };
 
     let msg = format_tool_result_message(&result, 100);
@@ -2376,9 +2366,7 @@ fn format_tool_result_message_boundary_char_3byte() {
         payload: ToolExecutionPayload::Text(content),
         artifacts: Vec::new(),
         elapsed_ms: 5,
-        diff_summary: None,
-        edit_detail: None,
-        rolled_back: false,
+        ..Default::default()
     };
 
     let msg = format_tool_result_message(&result, 100);
@@ -2461,9 +2449,7 @@ fn format_tool_result_message_success_head_priority() {
         payload: ToolExecutionPayload::Text(content),
         artifacts: Vec::new(),
         elapsed_ms: 5,
-        diff_summary: None,
-        edit_detail: None,
-        rolled_back: false,
+        ..Default::default()
     };
 
     let msg = format_tool_result_message(&result, 100);
@@ -2489,9 +2475,7 @@ fn format_tool_result_message_failure_tail_priority() {
         payload: ToolExecutionPayload::Text(content),
         artifacts: Vec::new(),
         elapsed_ms: 5,
-        diff_summary: None,
-        edit_detail: None,
-        rolled_back: false,
+        ..Default::default()
     };
 
     let msg = format_tool_result_message(&result, 100);
@@ -2517,9 +2501,7 @@ fn format_tool_result_message_interrupted_tail_priority() {
         payload: ToolExecutionPayload::Text(content),
         artifacts: Vec::new(),
         elapsed_ms: 5,
-        diff_summary: None,
-        edit_detail: None,
-        rolled_back: false,
+        ..Default::default()
     };
 
     let msg = format_tool_result_message(&result, 100);
@@ -6201,9 +6183,7 @@ fn tool_execution_result_edit_detail_default_none() {
         payload: ToolExecutionPayload::Text("content".to_string()),
         artifacts: vec![],
         elapsed_ms: 0,
-        diff_summary: None,
-        edit_detail: None,
-        rolled_back: false,
+        ..Default::default()
     };
     assert!(result.edit_detail.is_none());
 }
@@ -6215,7 +6195,6 @@ fn tool_execution_result_edit_detail_with_stage() {
     let result = ToolExecutionResult {
         tool_call_id: "edit1".to_string(),
         tool_name: "file.edit".to_string(),
-        status: ToolExecutionStatus::Completed,
         summary: "edited ok".to_string(),
         payload: ToolExecutionPayload::Text("done".to_string()),
         artifacts: vec!["/tmp/test.rs".to_string()],
@@ -6224,7 +6203,7 @@ fn tool_execution_result_edit_detail_with_stage() {
         edit_detail: Some(EditResultDetail {
             fallback_stage: EditFallbackStage::Anchor,
         }),
-        rolled_back: false,
+        ..Default::default()
     };
     assert!(result.edit_detail.is_some());
     assert_eq!(
@@ -6257,14 +6236,10 @@ fn rolled_back_result_has_flag_set() {
     let mut result = ToolExecutionResult {
         tool_call_id: "call_rb".to_string(),
         tool_name: "file.edit".to_string(),
-        status: ToolExecutionStatus::Completed,
         summary: "edit ok".to_string(),
-        payload: ToolExecutionPayload::None,
         artifacts: vec!["/tmp/test.rs".to_string()],
-        elapsed_ms: 0,
         diff_summary: Some("+line\n-old".to_string()),
-        edit_detail: None,
-        rolled_back: false,
+        ..Default::default()
     };
     assert!(!result.rolled_back);
 


### PR DESCRIPTION
## Summary
- Issue #275: first mutation後のstagnationをsame-file repair / untouched expansionに分解計測
- StagnationStateにsame-file repair / untouched expansion分離ロジック追加
- AgentTelemetryに対応するカウンターフィールド追加

## Test plan
- [x] cargo fmt --check
- [x] cargo clippy --all-targets: 0警告
- [x] cargo test: 全パス

Closes #275

🤖 Generated with [Claude Code](https://claude.com/claude-code)