### PR TITLE
fix(issue-287): add orphan mutation detection to prevent final gate hang on path-relocated implementations

### DIFF
--- a/src/app/stagnation_state.rs
+++ b/src/app/stagnation_state.rs
@@ -179,11 +179,13 @@ pub fn compute_stagnation_score(state: &StagnationState) -> usize {
 
 /// ANVIL_PLAN_UPDATE request conditions.
 ///
-/// Returns `true` when all four conditions are met:
-/// - stagnation score >= 2
-/// - starved target files >= 2
-/// - plan_repair_request_count < 2 (limit)
-/// - remaining_turns >= 5
+/// Fires on any of three paths:
+/// 1. **normal**: score >= 2, starved >= 2, count < 2, remaining >= 5
+/// 2. **severe** (Issue #287): score >= 3, mutation_drought >= 5, starved non-empty,
+///    count < 2, remaining >= 1
+/// 3. **orphan mutation** (Issue #287 follow-up): plan stalled >= 5 turns BUT mutations
+///    are recent (< 3 turns), workset stuck >= 3, starved non-empty — catches the case
+///    where LLM edits non-target files (e.g. relocated/renamed implementation path).
 pub fn should_request_plan_repair(
     state: &StagnationState,
     plan_repair_request_count: usize,
@@ -203,7 +205,18 @@ pub fn should_request_plan_repair(
         && plan_repair_request_count < 2
         && remaining_turns >= 1;
 
-    normal_condition || severe_condition
+    // Issue #287 follow-up: orphan mutation condition — mutations happen but plan items
+    // don't advance because LLM implemented to a different path than planned
+    // (e.g. plan targets "auto-yes-manager.ts" but edits go to "auto-yes-poller.ts").
+    // In this case turns_since_last_mutation stays low so severe_condition never fires.
+    let orphan_mutation_condition = state.turns_since_plan_item_completion >= 5
+        && state.turns_since_last_mutation < 3
+        && state.same_workset_turns >= 3
+        && !state.starved_target_files.is_empty()
+        && plan_repair_request_count < 2
+        && remaining_turns >= 1;
+
+    normal_condition || severe_condition || orphan_mutation_condition
 }
 
 // ---------------------------------------------------------------------------
@@ -425,23 +438,34 @@ pub fn build_plan_repair_message(starved_target_files: &[String]) -> String {
 /// Escape hatch: allow forced loop termination when stagnation is severe
 /// and recovery attempts have been exhausted (Issue #285).
 ///
-/// Returns `true` when ALL conditions are met:
-/// - stagnation score >= 3
-/// - at least one plan repair was already attempted
-/// - mutation drought is deep (turns_since_last_mutation >= 8)
-/// - remaining turns are low (<= 10)
+/// Fires on either of two paths:
+/// 1. **base + drought/stall**: score >= 3, repair attempted, remaining <= 10,
+///    AND (mutation_drought >= 8 OR plan_stall >= 10)
+/// 2. **orphan escape**: score >= 2, repair attempted, remaining <= 10,
+///    plan_item_completion stalled >= 8, but mutations ARE recent (< 3 turns)
+///    — catches the case where LLM edits non-target files indefinitely.
 pub fn should_allow_escape_hatch(
     state: &StagnationState,
     plan_repair_request_count: usize,
     remaining_turns: usize,
 ) -> bool {
-    let base = compute_stagnation_score(state) >= 3
-        && plan_repair_request_count >= 1
-        && remaining_turns <= 10;
+    let score = compute_stagnation_score(state);
+
+    let base = score >= 3 && plan_repair_request_count >= 1 && remaining_turns <= 10;
 
     let mutation_drought = state.turns_since_last_mutation >= 8;
     // Issue #287: plan stall as alternative escape condition
     let plan_stall = state.turns_since_plan_item_completion >= 10;
 
-    base && (mutation_drought || plan_stall)
+    // Issue #287 follow-up: orphan mutation escape — plan repair was attempted but
+    // mutations still go to non-target files. Lower score threshold since mutations
+    // prevent the score from reaching 3 (mutation drought +1 never triggers).
+    let orphan_escape = score >= 2
+        && plan_repair_request_count >= 1
+        && state.turns_since_plan_item_completion >= 8
+        && state.turns_since_last_mutation < 3
+        && !state.starved_target_files.is_empty()
+        && remaining_turns <= 10;
+
+    (base && (mutation_drought || plan_stall)) || orphan_escape
 }

--- a/tests/stagnation_control.rs
+++ b/tests/stagnation_control.rs
@@ -1147,3 +1147,117 @@ fn supersede_respects_one_to_one_matching() {
         "only one item should be superseded per corrected item (1:1 matching)"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Issue #287 follow-up: orphan mutation tests
+// ---------------------------------------------------------------------------
+
+/// Reproduce the Issue #287 follow-up scenario:
+/// LLM edits non-target files (e.g. renamed path) — mutations happen every turn
+/// but no plan item advances. The orphan_mutation_condition must fire.
+#[test]
+fn plan_repair_orphan_mutation_fires_when_mutations_happen_but_plan_stalls() {
+    let mut state = StagnationState::new();
+    state.starved_target_files = vec!["src/lib/polling/auto-yes-manager.ts".to_string()];
+
+    // 6 turns: mutation every turn (to a different file), same workset, no plan completion
+    for _ in 0..6 {
+        state.begin_turn(&[0]);
+        state.record_mutation("src/lib/auto-yes-poller.ts");
+        state.end_turn(true); // had_mutation = true
+    }
+
+    // Verify the orphan mutation pattern:
+    assert_eq!(
+        state.turns_since_last_mutation, 0,
+        "mutations are happening"
+    );
+    assert!(
+        state.turns_since_plan_item_completion >= 5,
+        "plan items not advancing: got {}",
+        state.turns_since_plan_item_completion
+    );
+    assert!(
+        state.same_workset_turns >= 3,
+        "same workset stuck: got {}",
+        state.same_workset_turns
+    );
+
+    // Stagnation score should be only 2 (workset staleness + plan no-progress),
+    // NOT 3, because mutations prevent mutation drought and read domination.
+    let score = compute_stagnation_score(&state);
+    assert!(
+        score < 3,
+        "score should be < 3 in orphan mutation case, got {}",
+        score
+    );
+
+    // normal_condition requires starved >= 2: fails (only 1 starved file)
+    // severe_condition requires turns_since_last_mutation >= 5: fails (it's 0)
+    // But orphan_mutation_condition should fire
+    assert!(should_request_plan_repair(&state, 0, 1));
+}
+
+#[test]
+fn plan_repair_orphan_mutation_not_fire_without_starved_files() {
+    let mut state = StagnationState::new();
+    // No starved files
+    for _ in 0..6 {
+        state.begin_turn(&[0]);
+        state.record_mutation("src/lib/auto-yes-poller.ts");
+        state.end_turn(true);
+    }
+    assert_eq!(state.turns_since_last_mutation, 0);
+    assert!(state.turns_since_plan_item_completion >= 5);
+    // orphan_mutation_condition requires !starved.is_empty()
+    assert!(!should_request_plan_repair(&state, 0, 1));
+}
+
+#[test]
+fn plan_repair_orphan_mutation_not_fire_at_max_repair_count() {
+    let mut state = StagnationState::new();
+    state.starved_target_files = vec!["src/a.ts".to_string()];
+    for _ in 0..6 {
+        state.begin_turn(&[0]);
+        state.record_mutation("src/b.ts");
+        state.end_turn(true);
+    }
+    // plan_repair_request_count = 2 (max) → orphan_mutation_condition should not fire
+    assert!(!should_request_plan_repair(&state, 2, 1));
+}
+
+#[test]
+fn escape_hatch_orphan_escape_fires_after_repair_attempt() {
+    let mut state = StagnationState::new();
+    state.starved_target_files = vec!["src/lib/polling/auto-yes-manager.ts".to_string()];
+
+    // 9 turns: mutation every turn, same workset, no plan completion
+    for _ in 0..9 {
+        state.begin_turn(&[0]);
+        state.record_mutation("src/lib/auto-yes-poller.ts");
+        state.end_turn(true);
+    }
+
+    assert_eq!(state.turns_since_last_mutation, 0);
+    assert!(state.turns_since_plan_item_completion >= 8);
+    let score = compute_stagnation_score(&state);
+    assert!(score >= 2, "expected score >= 2, got {}", score);
+
+    // Plan repair was attempted once, remaining <= 10
+    assert!(should_allow_escape_hatch(&state, 1, 10));
+}
+
+#[test]
+fn escape_hatch_orphan_escape_not_fire_without_repair_attempt() {
+    let mut state = StagnationState::new();
+    state.starved_target_files = vec!["src/a.ts".to_string()];
+
+    for _ in 0..9 {
+        state.begin_turn(&[0]);
+        state.record_mutation("src/b.ts");
+        state.end_turn(true);
+    }
+
+    // plan_repair_request_count = 0 → orphan_escape requires >= 1
+    assert!(!should_allow_escape_hatch(&state, 0, 10));
+}


### PR DESCRIPTION
## Summary

- `should_request_plan_repair()` に `orphan_mutation_condition` を追加: LLMが計画対象と異なるパスに実装した場合（例: `auto-yes-manager.ts` → `auto-yes-poller.ts`）、suffix matchでplan itemがretireできず final gate が hang するケースを検出
- `should_allow_escape_hatch()` に `orphan_escape` を追加: plan repair後もpath不一致が続く場合、ループを強制終了
- 回帰テスト5件追加

## 背景

Issue #287のPR #288マージ後、実機テストで再現した同族バグ。

**従来修正（PR #288）**: EditFallbackStage suffix（`" (trailing-ws fallback)"`等）の正規化
**今回修正**: semantic path relocation — LLMがファイルをリネーム・移動して実装した場合

### 問題の再現シナリオ
- Plan target: `src/lib/polling/auto-yes-manager.ts`
- Actual edits: `src/lib/auto-yes-poller.ts`
- `path_matches()` はsuffix比較のみ → 一致しない
- mutationは発生しているので `turns_since_last_mutation = 0`
- `severe_condition`（`>= 5` 要件）も `stagnation_score >= 3`（mutation drought +1が不発）も満たせない
- → `should_request_plan_repair()` / `should_allow_escape_hatch()` 両方がブロックされループが無限継続

## Test plan

- [ ] `cargo build` — Pass
- [ ] `cargo clippy --all-targets -- -D warnings` — Pass (0 warnings)
- [ ] `cargo test` — Pass (1691 tests)
- [ ] `cargo fmt --check` — Pass
- [ ] `plan_repair_orphan_mutation_fires_when_mutations_happen_but_plan_stalls` — 新規回帰テスト
- [ ] `escape_hatch_orphan_escape_fires_after_repair_attempt` — 新規回帰テスト

🤖 Generated with [Claude Code](https://claude.com/claude-code)