### PR TITLE
fix(issue-303): prevent agent.plan and ANVIL_PLAN conflict allowing unplanned mutations

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -838,6 +838,8 @@ const PROMPT_TOOL_RULES: &str = concat!(
     "```\n",
     "\n",
     "Rules:\n",
+    "- Implementation plans MUST use the ANVIL_PLAN block format, NOT the agent.plan tool. \
+       agent.plan is for read-only exploration/investigation only.\n",
     "- All paths must be relative (start with ./ or a directory name).\n",
     "- Do not use any other tool syntax.\n",
     "- Always include ANVIL_FINAL after your tool blocks.\n",

--- a/src/agent/tag_spec.rs
+++ b/src/agent/tag_spec.rs
@@ -75,7 +75,7 @@ pub const TOOL_TAG_SPECS: &[ToolTagSpec] = &[
         name: "agent.plan",
         attributes: &["scope"],
         child_elements: &["prompt"],
-        example: r#"<tool name="agent.plan" scope="..."><prompt>...</prompt></tool>"#,
+        example: r#"<tool name="agent.plan" scope="..."><prompt>...</prompt></tool> (for exploration only, use ANVIL_PLAN for implementation plans)"#,
     },
 ];
 

--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -505,6 +505,8 @@ impl App {
         // Issue #285 A2: limit NoPlan suppression at the post-tool ANVIL_FINAL gate.
         // After one suppression, if the model still can't produce a plan, let it through.
         let mut noplan_suppression_count: u8 = 0;
+        // Issue #303: pre-mutation plan barrier.
+        let mut mutation_barrier = super::mutation_barrier::MutationBarrier::new();
 
         for iteration in 0..max_iterations {
             let iteration_started = std::time::Instant::now();
@@ -564,7 +566,7 @@ impl App {
 
             // Execute normal tool calls and record results WITH payload
             let (results, loop_action, recovery_read_count) =
-                self.execute_structured_tool_calls(&current_normal)?;
+                self.execute_structured_tool_calls(&current_normal, &mut mutation_barrier)?;
             total_tool_count += results.len();
 
             // Update plan item status from tool results; capture telemetry.
@@ -1285,6 +1287,7 @@ impl App {
     pub(crate) fn execute_structured_tool_calls(
         &mut self,
         structured: &StructuredAssistantResponse,
+        mutation_barrier: &mut super::mutation_barrier::MutationBarrier,
     ) -> Result<
         (
             Vec<ToolExecutionResult>,
@@ -1369,6 +1372,16 @@ impl App {
         } else {
             validated_requests
         };
+
+        // Phase 1.75: Pre-mutation plan barrier (Issue #303).
+        // Block mutation tools when no execution plan is registered.
+        let barrier_result =
+            mutation_barrier.check_and_filter(validated_requests, self.execution_plan.is_empty());
+        let validated_requests = barrier_result.passed_requests;
+        failed_results.extend(barrier_result.blocked_results);
+        if barrier_result.blocked_count > 0 {
+            self.agent_telemetry.record_mutation_barrier_block();
+        }
 
         // Loop detection: record each validated tool call and check for repetition (Issue #145, #172)
         // Issue #299: recovery reads skip LoopDetector but not AlternatingLoopDetector.
@@ -1685,7 +1698,9 @@ impl App {
             {
                 let status_str = match result.status {
                     ToolExecutionStatus::Completed => "completed",
-                    ToolExecutionStatus::Failed | ToolExecutionStatus::Interrupted => "failed",
+                    ToolExecutionStatus::Failed
+                    | ToolExecutionStatus::Interrupted
+                    | ToolExecutionStatus::Blocked => "failed",
                 };
                 let event = crate::hooks::PostToolUseEvent {
                     hook_point: "PostToolUse",
@@ -1819,8 +1834,12 @@ impl App {
         }
 
         // Edit fail tracker: track consecutive file.edit/file.edit_anchor failures (Issue #143, #158)
+        // Issue #303: exclude barrier-blocked results from edit_fail_tracker.
         let mut edit_hint: Option<String> = None;
-        if result.tool_name == "file.edit" || result.tool_name == "file.edit_anchor" {
+        let is_barrier_blocked = result.summary.starts_with("[plan_barrier]");
+        if !is_barrier_blocked
+            && (result.tool_name == "file.edit" || result.tool_name == "file.edit_anchor")
+        {
             if result.status == ToolExecutionStatus::Failed {
                 if let Some(raw_path) = extract_edit_path_from_summary(&result.summary) {
                     let path = resolve_edit_tracker_path(&raw_path);
@@ -2463,7 +2482,9 @@ pub fn format_tool_result_message(result: &ToolExecutionResult, max_chars: usize
         ToolExecutionPayload::Text(content) => {
             let head_pct = match &result.status {
                 ToolExecutionStatus::Completed => 80,
-                ToolExecutionStatus::Failed | ToolExecutionStatus::Interrupted => 20,
+                ToolExecutionStatus::Failed
+                | ToolExecutionStatus::Interrupted
+                | ToolExecutionStatus::Blocked => 20,
             };
             let truncated = truncate_with_head_tail(content, max_chars, head_pct);
             if result.tool_name == "file.read"

--- a/src/app/execution_plan.rs
+++ b/src/app/execution_plan.rs
@@ -88,6 +88,22 @@ impl App {
         false
     }
 
+    /// Internal helper: register a plan from pre-parsed items (Issue #303).
+    ///
+    /// Used by `try_update_plan()` when an `ANVIL_PLAN_UPDATE` arrives but no
+    /// plan has been registered yet.  Shares the same registration logic as
+    /// `try_register_plan()` but skips block extraction and parsing.
+    fn register_plan_from_items(&mut self, items: Vec<PlanItem>) {
+        tracing::info!(
+            items = items.len(),
+            "ANVIL_PLAN_UPDATE on empty plan; registering as new plan (Issue #303)"
+        );
+        self.execution_plan = ExecutionPlan::new(items);
+        self.execution_plan.mark_in_progress(0);
+        self.agent_telemetry.record_plan_registration();
+        self.agent_telemetry.record_anvil_plan_visible();
+    }
+
     /// Try to detect and apply an `ANVIL_PLAN_UPDATE` block.
     ///
     /// Issue #301: checked-first processing. Before the standard flow:
@@ -102,6 +118,12 @@ impl App {
             let all_items = parse_plan_items(&block);
             if all_items.is_empty() {
                 return false;
+            }
+
+            // Issue #303: if plan is empty, treat ANVIL_PLAN_UPDATE as new plan registration.
+            if self.execution_plan.is_empty() {
+                self.register_plan_from_items(all_items);
+                return true;
             }
 
             // --- Issue #301: checked-first retire ---

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -11,6 +11,7 @@ pub(crate) mod edit_fail_tracker;
 pub(crate) mod execution_plan;
 pub mod loop_detector;
 pub mod mock;
+pub mod mutation_barrier;
 pub mod phase_estimator;
 pub mod plan;
 pub mod policy;

--- a/src/app/mutation_barrier.rs
+++ b/src/app/mutation_barrier.rs
@@ -1,0 +1,109 @@
+//! Pre-mutation plan barrier (Issue #303).
+//!
+//! Blocks mutation tools (file.write, file.edit, file.edit_anchor) when no
+//! execution plan has been registered.  The barrier fires at most
+//! `MUTATION_BARRIER_MAX` times to avoid infinite loops with models that
+//! ignore the guidance.
+
+use crate::tooling::{
+    ToolExecutionPayload, ToolExecutionRequest, ToolExecutionResult, ToolExecutionStatus,
+};
+
+/// Maximum number of barrier blocks before auto-release.
+pub const MUTATION_BARRIER_MAX: u8 = 2;
+
+/// Message returned to the LLM when the barrier blocks a mutation tool.
+pub const MUTATION_BARRIER_MESSAGE: &str = "Before modifying files, you must output an ANVIL_PLAN block with your implementation plan. \
+     Use the ANVIL_PLAN format (markdown checklist), NOT the agent.plan tool. \
+     Example:\n\
+     ANVIL_PLAN\n\
+     - [ ] path/to/file.rs: description of change\n\
+     END_ANVIL_PLAN";
+
+/// Tracks how many times mutation tools have been blocked.
+#[derive(Default)]
+pub struct MutationBarrier {
+    block_count: u8,
+}
+
+/// Result of a barrier check-and-filter operation.
+pub struct MutationBarrierResult {
+    /// Requests that passed the barrier (non-mutation, or barrier inactive).
+    pub passed_requests: Vec<(usize, ToolExecutionRequest)>,
+    /// Results for blocked mutation tools.
+    pub blocked_results: Vec<(usize, ToolExecutionResult)>,
+    /// Number of mutations blocked in this batch.
+    pub blocked_count: usize,
+}
+
+impl MutationBarrier {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Check a batch of validated requests and filter out mutation tools
+    /// when no execution plan is registered.
+    ///
+    /// When `execution_plan_empty` is true and `block_count < MUTATION_BARRIER_MAX`,
+    /// mutation tools are moved to `blocked_results` with a `[plan_barrier]` prefix
+    /// and `ToolExecutionStatus::Blocked` status.  Non-mutation tools always pass.
+    pub fn check_and_filter(
+        &mut self,
+        validated_requests: Vec<(usize, ToolExecutionRequest)>,
+        execution_plan_empty: bool,
+    ) -> MutationBarrierResult {
+        // Fast path: barrier inactive (plan exists or max reached).
+        if !execution_plan_empty || self.block_count >= MUTATION_BARRIER_MAX {
+            return MutationBarrierResult {
+                passed_requests: validated_requests,
+                blocked_results: Vec::new(),
+                blocked_count: 0,
+            };
+        }
+
+        // Check if any request is a mutation tool.
+        let has_mutation = validated_requests
+            .iter()
+            .any(|(_, r)| super::MUTATION_TOOLS.contains(&r.spec.name.as_str()));
+
+        if !has_mutation {
+            return MutationBarrierResult {
+                passed_requests: validated_requests,
+                blocked_results: Vec::new(),
+                blocked_count: 0,
+            };
+        }
+
+        // Barrier fires: split mutation vs non-mutation.
+        self.block_count += 1;
+        let mut passed = Vec::new();
+        let mut blocked = Vec::new();
+
+        for (idx, request) in validated_requests {
+            if super::MUTATION_TOOLS.contains(&request.spec.name.as_str()) {
+                let result = ToolExecutionResult {
+                    tool_call_id: request.tool_call_id.clone(),
+                    tool_name: request.spec.name.clone(),
+                    status: ToolExecutionStatus::Blocked,
+                    summary: format!("[plan_barrier] {MUTATION_BARRIER_MESSAGE}"),
+                    payload: ToolExecutionPayload::None,
+                    artifacts: Vec::new(),
+                    elapsed_ms: 0,
+                    diff_summary: None,
+                    edit_detail: None,
+                    rolled_back: false,
+                };
+                blocked.push((idx, result));
+            } else {
+                passed.push((idx, request));
+            }
+        }
+
+        let blocked_count = blocked.len();
+        MutationBarrierResult {
+            passed_requests: passed,
+            blocked_results: blocked,
+            blocked_count,
+        }
+    }
+}

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -215,6 +215,7 @@ pub fn map_tool_status(action: &str) -> ToolExecutionStatus {
     match action {
         "failed" => ToolExecutionStatus::Failed,
         "interrupted" => ToolExecutionStatus::Interrupted,
+        "blocked" => ToolExecutionStatus::Blocked,
         _ => ToolExecutionStatus::Completed,
     }
 }

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -231,6 +231,10 @@ pub struct AgentTelemetry {
     #[serde(default)]
     pub final_suppressed_with_remaining_targets_count: u32,
 
+    /// Number of times pre-mutation barrier blocked mutation tools (Issue #303).
+    #[serde(default)]
+    pub mutation_barrier_block_count: u32,
+
     /// First mutation event turn (Issue #273 Phase 1.5).
     /// None if no mutation occurred during the session.
     #[serde(default)]
@@ -314,6 +318,11 @@ impl AgentTelemetry {
     /// Record an ANVIL_PLAN block observed (visible to external telemetry).
     pub fn record_anvil_plan_visible(&mut self) {
         self.anvil_plan_visible_count += 1;
+    }
+
+    /// Record a pre-mutation barrier block (Issue #303).
+    pub fn record_mutation_barrier_block(&mut self) {
+        self.mutation_barrier_block_count += 1;
     }
 
     /// Record a mutation turn: updates `last_mutation_turn` and, on the first call only,

--- a/src/tooling/mod.rs
+++ b/src/tooling/mod.rs
@@ -619,6 +619,8 @@ pub enum ToolExecutionStatus {
     Completed,
     Failed,
     Interrupted,
+    /// Policy-level block (e.g. mutation barrier when no plan is registered).
+    Blocked,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -673,6 +675,7 @@ impl ToolExecutionResult {
             ToolExecutionStatus::Completed => "completed",
             ToolExecutionStatus::Failed => "failed",
             ToolExecutionStatus::Interrupted => "interrupted",
+            ToolExecutionStatus::Blocked => "blocked",
         };
 
         ToolLogView {

--- a/tests/mutation_barrier.rs
+++ b/tests/mutation_barrier.rs
@@ -1,0 +1,306 @@
+//! Tests for Issue #303: pre-mutation plan barrier and plan conflict fix.
+//!
+//! Covers:
+//! - MutationBarrier blocks mutation tools when no plan is registered
+//! - MutationBarrier passes through when plan is registered
+//! - Non-mutation tools always pass through
+//! - Barrier max count (auto-release after 2 blocks)
+//! - Auto-release after plan registration
+//! - Telemetry recording
+//! - Barrier result `[plan_barrier]` prefix
+//! - ANVIL_PLAN_UPDATE on empty plan registers new plan
+//! - PROMPT_TOOL_RULES contains ANVIL_PLAN guidance
+
+mod common;
+
+use anvil::app::mutation_barrier::{
+    MUTATION_BARRIER_MAX, MUTATION_BARRIER_MESSAGE, MutationBarrier,
+};
+use anvil::contracts::{AgentTelemetry, ExecutionPlan};
+use anvil::tooling::{
+    ExecutionClass, ExecutionMode, PermissionClass, PlanModePolicy, RollbackPolicy,
+    ToolExecutionRequest, ToolExecutionStatus, ToolInput, ToolKind, ToolSpec,
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn make_request(name: &str, kind: ToolKind, input: ToolInput) -> (usize, ToolExecutionRequest) {
+    (
+        0,
+        ToolExecutionRequest {
+            tool_call_id: format!("call_{name}"),
+            spec: ToolSpec {
+                version: 1,
+                name: name.to_string(),
+                kind,
+                execution_class: ExecutionClass::Mutating,
+                permission_class: PermissionClass::Confirm,
+                execution_mode: ExecutionMode::SequentialOnly,
+                plan_mode: PlanModePolicy::AllowedWithScope,
+                rollback_policy: RollbackPolicy::None,
+            },
+            input,
+            extra_field_warnings: Vec::new(),
+        },
+    )
+}
+
+fn make_edit_request() -> (usize, ToolExecutionRequest) {
+    make_request(
+        "file.edit",
+        ToolKind::FileEdit,
+        ToolInput::FileEdit {
+            path: "src/foo.rs".into(),
+            old_string: "old".into(),
+            new_string: "new".into(),
+        },
+    )
+}
+
+fn make_write_request() -> (usize, ToolExecutionRequest) {
+    make_request(
+        "file.write",
+        ToolKind::FileWrite,
+        ToolInput::FileWrite {
+            path: "src/foo.rs".into(),
+            content: "content".into(),
+        },
+    )
+}
+
+fn make_read_request() -> (usize, ToolExecutionRequest) {
+    make_request(
+        "file.read",
+        ToolKind::FileRead,
+        ToolInput::FileRead {
+            path: "src/foo.rs".into(),
+        },
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: barrier blocks edit without plan
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_mutation_barrier_blocks_edit_without_plan() {
+    let mut barrier = MutationBarrier::new();
+    let requests = vec![make_edit_request()];
+
+    let result = barrier.check_and_filter(requests, true);
+
+    assert_eq!(result.blocked_count, 1);
+    assert!(result.passed_requests.is_empty());
+    assert_eq!(result.blocked_results.len(), 1);
+    let (_, blocked) = &result.blocked_results[0];
+    assert_eq!(blocked.status, ToolExecutionStatus::Blocked);
+    assert_eq!(blocked.tool_name, "file.edit");
+}
+
+// ---------------------------------------------------------------------------
+// Test 2: barrier allows edit with plan
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_mutation_barrier_allows_edit_with_plan() {
+    let mut barrier = MutationBarrier::new();
+    let requests = vec![make_edit_request()];
+
+    // execution_plan_empty = false (plan registered)
+    let result = barrier.check_and_filter(requests, false);
+
+    assert_eq!(result.blocked_count, 0);
+    assert_eq!(result.passed_requests.len(), 1);
+    assert!(result.blocked_results.is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// Test 3: barrier allows non-mutation tools
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_mutation_barrier_allows_non_mutation_tools() {
+    let mut barrier = MutationBarrier::new();
+    let requests = vec![make_read_request()];
+
+    // Even without a plan, non-mutation tools pass through
+    let result = barrier.check_and_filter(requests, true);
+
+    assert_eq!(result.blocked_count, 0);
+    assert_eq!(result.passed_requests.len(), 1);
+    assert!(result.blocked_results.is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// Test 4: barrier max count
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_mutation_barrier_max_count() {
+    let mut barrier = MutationBarrier::new();
+
+    // First block
+    let result1 = barrier.check_and_filter(vec![make_edit_request()], true);
+    assert_eq!(result1.blocked_count, 1);
+
+    // Second block
+    let result2 = barrier.check_and_filter(vec![make_edit_request()], true);
+    assert_eq!(result2.blocked_count, 1);
+
+    // Third call: should pass through (max reached)
+    let result3 = barrier.check_and_filter(vec![make_edit_request()], true);
+    assert_eq!(result3.blocked_count, 0);
+    assert_eq!(result3.passed_requests.len(), 1);
+
+    // Verify max is 2
+    assert_eq!(MUTATION_BARRIER_MAX, 2);
+}
+
+// ---------------------------------------------------------------------------
+// Test 5: barrier auto-release after plan registration
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_mutation_barrier_auto_release_after_plan() {
+    let mut barrier = MutationBarrier::new();
+
+    // Block once
+    let result1 = barrier.check_and_filter(vec![make_edit_request()], true);
+    assert_eq!(result1.blocked_count, 1);
+
+    // Plan is now registered (execution_plan_empty = false)
+    let result2 = barrier.check_and_filter(vec![make_edit_request()], false);
+    assert_eq!(result2.blocked_count, 0);
+    assert_eq!(result2.passed_requests.len(), 1);
+}
+
+// ---------------------------------------------------------------------------
+// Test 6: telemetry mutation barrier count
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_telemetry_mutation_barrier_count() {
+    let mut telemetry = AgentTelemetry::new();
+    assert_eq!(telemetry.mutation_barrier_block_count, 0);
+
+    telemetry.record_mutation_barrier_block();
+    assert_eq!(telemetry.mutation_barrier_block_count, 1);
+
+    telemetry.record_mutation_barrier_block();
+    assert_eq!(telemetry.mutation_barrier_block_count, 2);
+}
+
+// ---------------------------------------------------------------------------
+// Test 7: barrier result has [plan_barrier] prefix
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_barrier_result_plan_barrier_prefix() {
+    let mut barrier = MutationBarrier::new();
+    let requests = vec![make_edit_request()];
+
+    let result = barrier.check_and_filter(requests, true);
+    let (_, blocked) = &result.blocked_results[0];
+
+    assert!(
+        blocked.summary.starts_with("[plan_barrier]"),
+        "blocked result summary should start with [plan_barrier], got: {}",
+        blocked.summary
+    );
+    assert!(
+        blocked.summary.contains(MUTATION_BARRIER_MESSAGE),
+        "blocked result should contain the barrier message"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 8: ANVIL_PLAN_UPDATE on empty plan — verify parsing path
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_plan_update_on_empty_plan() {
+    // Test that ANVIL_PLAN_UPDATE content can be parsed and used to create
+    // a new ExecutionPlan. The actual integration (try_update_plan calling
+    // register_plan_from_items when plan is empty) is pub(crate) and tested
+    // indirectly via the agentic loop.
+    let content =
+        "```ANVIL_PLAN_UPDATE\n- [ ] src/foo.rs: add feature\n- [ ] src/bar.rs: update module\n```";
+    let block = anvil::agent::extract_plan_update_block(content);
+    assert!(block.is_some(), "should extract ANVIL_PLAN_UPDATE block");
+
+    let items = anvil::agent::parse_plan_items(&block.unwrap());
+    assert_eq!(items.len(), 2);
+
+    // Simulate what register_plan_from_items does
+    let plan = ExecutionPlan::new(items);
+    assert!(!plan.is_empty());
+    assert_eq!(plan.items.len(), 2);
+    assert_eq!(plan.items[0].description, "src/foo.rs: add feature");
+}
+
+// ---------------------------------------------------------------------------
+// Test 9: PROMPT_TOOL_RULES contains ANVIL_PLAN guidance
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_prompt_rules_anvil_plan_guidance() {
+    let prompt = anvil::agent::tool_protocol_system_prompt_all_tools(&[], None);
+    assert!(
+        prompt.contains("Implementation plans MUST use the ANVIL_PLAN block format"),
+        "system prompt should contain ANVIL_PLAN guidance"
+    );
+    assert!(
+        prompt.contains("agent.plan is for read-only exploration/investigation only"),
+        "system prompt should contain agent.plan exploration-only guidance"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 10: mixed batch — mutation blocked, non-mutation passes
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_mutation_barrier_mixed_batch() {
+    let mut barrier = MutationBarrier::new();
+    let requests = vec![
+        make_read_request(),
+        make_edit_request(),
+        make_write_request(),
+    ];
+
+    let result = barrier.check_and_filter(requests, true);
+
+    // read should pass, edit and write should be blocked
+    assert_eq!(result.passed_requests.len(), 1);
+    assert_eq!(result.passed_requests[0].1.spec.name, "file.read");
+    assert_eq!(result.blocked_count, 2);
+    assert_eq!(result.blocked_results.len(), 2);
+}
+
+// ---------------------------------------------------------------------------
+// Test 11: tag-based prompt contains exploration-only note for agent.plan
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_tag_spec_agent_plan_exploration_note() {
+    let spec = anvil::agent::tag_spec::find_spec("agent.plan").expect("agent.plan should exist");
+    assert!(
+        spec.example.contains("for exploration only"),
+        "agent.plan example should contain exploration-only note, got: {}",
+        spec.example
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 12: telemetry serde default for new field
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_telemetry_serde_default_mutation_barrier() {
+    // Deserializing old telemetry without the new field should default to 0
+    let json = r#"{"premature_final_count":0,"total_final_requests":0,"plan_registration_count":0,"plan_update_count":0,"sync_from_touched_files_count":0}"#;
+    let telemetry: AgentTelemetry = serde_json::from_str(json).unwrap();
+    assert_eq!(telemetry.mutation_barrier_block_count, 0);
+}

--- a/tests/provider_integration.rs
+++ b/tests/provider_integration.rs
@@ -195,6 +195,9 @@ fn live_turn_executes_structured_file_write_response_without_approval() {
         events: vec![ProviderEvent::Agent(AgentEvent::Done {
             status: "Done. session saved".to_string(),
             assistant_message: concat!(
+                "```ANVIL_PLAN\n",
+                "- [ ] sandbox/test1_001/index.html: create game shell\n",
+                "```\n",
                 "```ANVIL_TOOL\n",
                 "{\"id\":\"call_write_001\",\"tool\":\"file.write\",\"path\":\"./sandbox/test1_001/index.html\",\"content\":\"<html><body>invaders</body></html>\"}\n",
                 "```\n",
@@ -268,6 +271,9 @@ fn live_turn_executes_complete_structured_response_from_token_stream() {
         seen_requests: Rc::new(RefCell::new(Vec::new())),
         events: vec![ProviderEvent::TokenDelta(
             concat!(
+                "```ANVIL_PLAN\n",
+                "- [ ] sandbox/test1_001/index.html: create game shell\n",
+                "```\n",
                 "```ANVIL_TOOL\n",
                 "{\"id\":\"call_write_001\",\"tool\":\"file.write\",\"path\":\"./sandbox/test1_001/index.html\",\"content\":\"<html><body>streamed invaders</body></html>\"}\n",
                 "```\n",
@@ -342,6 +348,9 @@ fn live_turn_executes_malformed_structured_file_write_response() {
         events: vec![ProviderEvent::Agent(AgentEvent::Done {
             status: "Done. session saved".to_string(),
             assistant_message: concat!(
+                "```ANVIL_PLAN\n",
+                "- [ ] sandbox/test1_002/Invader.html: create game\n",
+                "```\n",
                 "```ANVIL_TOOL\n",
                 "{\"id\":\"call_write_001\",\"tool\":\"file.write\",\"path\":\"./sandbox/test1_002/Invader.html\",\"content\":\"<html>\n",
                 "<body>\n",
@@ -681,7 +690,7 @@ fn live_turn_executes_structured_response_from_openai_compatible_provider() {
         seen_headers: Rc::new(RefCell::new(Vec::new())),
         response: HttpResponse {
             status_code: 200,
-            body: br#"{"choices":[{"message":{"role":"assistant","content":"```ANVIL_TOOL\n{\"id\":\"call_write_001\",\"tool\":\"file.write\",\"path\":\"./sandbox/openai/index.html\",\"content\":\"<html><body>openai parity</body></html>\"}\n```\n```ANVIL_FINAL\nOpenAI-compatible backend created the file and reviewed the output.\n```"}}]}"#.to_vec(),
+            body: br#"{"choices":[{"message":{"role":"assistant","content":"```ANVIL_PLAN\n- [ ] sandbox/openai/index.html: create file\n```\n```ANVIL_TOOL\n{\"id\":\"call_write_001\",\"tool\":\"file.write\",\"path\":\"./sandbox/openai/index.html\",\"content\":\"<html><body>openai parity</body></html>\"}\n```\n```ANVIL_FINAL\nOpenAI-compatible backend created the file and reviewed the output.\n```"}}]}"#.to_vec(),
         },
         get_response: None,
     };
@@ -729,7 +738,7 @@ fn live_turn_executes_native_tool_calls_response_from_openai_compatible_provider
         seen_headers: Rc::new(RefCell::new(Vec::new())),
         response: HttpResponse {
             status_code: 200,
-            body: br#"{"choices":[{"message":{"role":"assistant","content":"","tool_calls":[{"id":"call_native_write_001","type":"function","function":{"name":"file_write","arguments":"{\"path\":\"./sandbox/native/nonstream.html\",\"content\":\"<html><body>native non-stream</body></html>\"}"}}]}}],"stats":{},"system_fingerprint":"qwen3.5"}"#.to_vec(),
+            body: br#"{"choices":[{"message":{"role":"assistant","content":"```ANVIL_PLAN\n- [ ] sandbox/native/nonstream.html: create file\n```","tool_calls":[{"id":"call_native_write_001","type":"function","function":{"name":"file_write","arguments":"{\"path\":\"./sandbox/native/nonstream.html\",\"content\":\"<html><body>native non-stream</body></html>\"}"}}]}}],"stats":{},"system_fingerprint":"qwen3.5"}"#.to_vec(),
         },
         get_response: None,
     };
@@ -778,6 +787,7 @@ fn live_turn_executes_streaming_native_tool_calls_response_from_openai_compatibl
         response: HttpResponse {
             status_code: 200,
             body: concat!(
+                "data: {\"choices\":[{\"delta\":{\"content\":\"```ANVIL_PLAN\\n- [ ] sandbox/native/stream.html: create file\\n```\\n\"},\"finish_reason\":null}]}\n",
                 "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_stream_write_001\",\"type\":\"function\",\"function\":{\"name\":\"file_write\",\"arguments\":\"{\\\"path\\\":\\\"./sandbox/native/stream.html\\\",\"}}]},\"finish_reason\":null}]}\n",
                 "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"\\\"content\\\":\\\"<html><body>native stream</body></html>\\\"}\"}}]},\"finish_reason\":null}]}\n",
                 "data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"tool_calls\"}],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":5}}\n",
@@ -3663,6 +3673,9 @@ fn anvil_final_guard_does_not_fire_when_file_write_was_executed() {
         events: vec![ProviderEvent::Agent(AgentEvent::Done {
             status: "Done. session saved".to_string(),
             assistant_message: concat!(
+                "```ANVIL_PLAN\n",
+                "- [ ] output.txt: create file\n",
+                "```\n",
                 "```ANVIL_TOOL\n",
                 "{\"id\":\"call_001\",\"tool\":\"file.write\",\"path\":\"./output.txt\",\"content\":\"hello world\"}\n",
                 "```\n",


### PR DESCRIPTION
## Summary
- Issue #303: agent.planとANVIL_PLANが競合しplan未登録のままmutationが実行されるバグを修正
- mutation barrierでagent.plan pending中のfile.write/edit/edit_anchorをブロック
- ANVIL_PLAN登録前のmutation実行を防止

## Changes
- `src/app/mutation_barrier.rs`: 新規 - mutation barrier logic
- `src/app/agentic.rs`: barrier check integration
- `src/app/execution_plan.rs`: plan pending state tracking
- `src/contracts/mod.rs`: barrier telemetry
- `src/tooling/mod.rs`: mutation tool barrier check
- `tests/mutation_barrier.rs`: 新規 - regression tests

## Test plan
- [x] cargo fmt --check: Pass
- [x] cargo clippy --all-targets: 0 warnings
- [x] cargo test: 全テスト 0 failed

Closes #303

🤖 Generated with [Claude Code](https://claude.com/claude-code)