### PR TITLE
fix(issue-311): unify superseded-only terminal plan exit semantics

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -874,10 +874,11 @@ impl App {
     /// Check whether the last turn had any tool execution failures.
     /// Used by non-interactive mode to determine exit code.
     pub fn has_tool_execution_failure(&self) -> bool {
-        // Plan完了ベース (Issue #296): plan が正常完了していれば
-        // 途中の tool failure は回復済みとみなし exit 0 へ.
-        // plan なし実行では従来の is_error チェックをフォールスルー.
-        if self.execution_plan.is_successfully_completed() {
+        // Issue #311: Use is_cleanly_finished (same predicate as check_final_gate
+        // / CompletionKind) to prevent success/failure divergence on
+        // superseded-only plans.  Supersedes the Issue #296 is_successfully_completed
+        // check which excluded superseded-only plans from recovery.
+        if self.execution_plan.is_cleanly_finished() {
             return false;
         }
         self.session
@@ -913,13 +914,14 @@ impl App {
             .map(|s| s.elapsed())
             .unwrap_or_default();
 
-        // Issue #296: Count recovered vs unrecovered tool failures
+        // Issue #311: Use is_cleanly_finished to align recovery predicate with
+        // check_final_gate / CompletionKind (supersedes #296 is_successfully_completed).
         let total_tool_errors = self
             .session
             .last_turn_tool_results()
             .filter(|r| r.is_error)
             .count();
-        let plan_recovered = self.execution_plan.is_successfully_completed();
+        let plan_recovered = self.execution_plan.is_cleanly_finished();
         let (recovered, unrecovered) = if plan_recovered {
             (total_tool_errors, 0usize)
         } else {

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -688,6 +688,17 @@ impl ExecutionPlan {
             })
     }
 
+    /// Whether the plan reached a clean terminal state: all items finished with
+    /// no blocked items (Issue #311).
+    ///
+    /// Unlike `is_successfully_completed()` which requires positive evidence
+    /// (Done/AlreadySatisfied), this method also accepts superseded-only plans.
+    /// Used by exit/recovery logic to ensure consistency with
+    /// `check_final_gate` / `CompletionKind::classify`.
+    pub fn is_cleanly_finished(&self) -> bool {
+        self.all_finished() && !self.has_blocked_items()
+    }
+
     /// Decide whether ANVIL_FINAL should be accepted.
     pub fn check_final_gate(&self) -> FinalGateDecision {
         if self.items.is_empty() {
@@ -812,6 +823,12 @@ impl ExecutionPlan {
     ///
     /// Excludes new items whose `target_files` match an existing item
     /// (using `path_matches` for fuzzy comparison).
+    ///
+    /// Issue #311: `Superseded` items are excluded from dedup matching so that
+    /// corrected replacements survive and remain actionable in the plan.
+    /// Without this, a supersede→dedup pipeline can produce a superseded-only
+    /// terminal plan that diverges `check_final_gate` / `CompletionKind` from
+    /// `is_successfully_completed` / exit semantics.
     pub fn deduplicate_new_items(&self, new_items: Vec<PlanItem>) -> Vec<PlanItem> {
         new_items
             .into_iter()
@@ -820,6 +837,11 @@ impl ExecutionPlan {
                 new_targets.sort();
 
                 !self.items.iter().any(|existing| {
+                    // Issue #311: Skip Superseded items — corrected replacements
+                    // must not be deduped against the items they replaced.
+                    if existing.status == PlanItemStatus::Superseded {
+                        return false;
+                    }
                     let mut existing_targets = existing.target_files.clone();
                     existing_targets.sort();
                     if new_targets.len() != existing_targets.len() {

--- a/tests/followup_replan.rs
+++ b/tests/followup_replan.rs
@@ -101,7 +101,7 @@ fn replan_supersede_stale() {
     )]);
     plan.mark_in_progress(0);
 
-    // New item with same target → supersede old
+    // New item with same target → supersede old, corrected item appended
     let new_items = vec![PlanItem::new(
         "src/a.rs: new approach".into(),
         vec!["src/a.rs".into()],
@@ -110,15 +110,10 @@ fn replan_supersede_stale() {
 
     assert!(changed);
     assert_eq!(plan.items[0].status, PlanItemStatus::Superseded);
-    // New item appended (not deduped because old was superseded and dedup still finds target match)
-    // Actually, deduplicate_new_items checks ALL items including Superseded ones for target match.
-    // Since the superseded item still has same target, the new item IS deduped.
-    // But had_supersede=true, so changed=true.
-    assert!(
-        plan.items
-            .iter()
-            .any(|i| i.status == PlanItemStatus::Superseded)
-    );
+    // Issue #311: corrected item survives dedup (Superseded items excluded)
+    // and is appended as actionable Pending work.
+    assert_eq!(plan.items.len(), 2);
+    assert_eq!(plan.items[1].status, PlanItemStatus::Pending);
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/stagnation_control.rs
+++ b/tests/stagnation_control.rs
@@ -1046,10 +1046,9 @@ fn format_checklist_superseded_marker() {
     );
 }
 
-// CB-001: After supersede, the stale item becomes Superseded (finished).
-// The corrected item should then be deduped against it and not appended
-// (it's effectively the same work). But the overall update returns true
-// because a supersede occurred.
+// CB-001 / Issue #311: After supersede, the stale item becomes Superseded.
+// The corrected item must NOT be deduped against the Superseded item so it
+// remains actionable in the plan (prevents superseded-only terminal state).
 #[test]
 fn supersede_then_dedup_flow() {
     // Existing plan has a stale item (Pending, no mutations).
@@ -1065,15 +1064,19 @@ fn supersede_then_dedup_flow() {
     // Step 1: supersede — stale item becomes Superseded
     plan.supersede_stale_items(&new_items);
     assert_eq!(plan.items[0].status, PlanItemStatus::Superseded);
-    // Step 2: dedup — corrected item is deduped against now-finished Superseded item
+    // Step 2: dedup — corrected item survives (Superseded items excluded from dedup)
     let deduped = plan.deduplicate_new_items(new_items);
     assert_eq!(
         deduped.len(),
-        0,
-        "corrected item should be deduped after stale item is superseded (same work)"
+        1,
+        "corrected item must survive dedup after stale item is superseded (Issue #311)"
     );
-    // Plan still has the superseded item, which is finished.
-    assert!(plan.all_finished());
+    // After appending corrected item, plan has actionable work.
+    plan.append_items(deduped);
+    assert!(!plan.all_finished(), "plan has Pending corrected item");
+    assert_eq!(plan.items.len(), 2);
+    assert_eq!(plan.items[0].status, PlanItemStatus::Superseded);
+    assert_eq!(plan.items[1].status, PlanItemStatus::Pending);
 }
 
 // CB-001 variant: corrected item with DIFFERENT target (not matching stale)

--- a/tests/superseded_plan_exit.rs
+++ b/tests/superseded_plan_exit.rs
@@ -1,0 +1,309 @@
+//! Tests for Issue #311: superseded-only terminal plan exit semantics.
+//!
+//! Covers:
+//! - AC6-1: contract-level supersede→dedup consistency (check_final_gate, CompletionKind, is_successfully_completed)
+//! - AC6-2: is_cleanly_finished for superseded-only plans
+//! - AC6-3: CompletionKind + is_cleanly_finished consistency (no complete_* + failure divergence)
+//! - AC6-4: corrected replan with touched_files retains Done evidence
+//! - AC6-5: genuinely unrecovered tool failure preserves failure semantics
+
+use anvil::contracts::{
+    CompletionKind, ExecutionPlan, FinalGateDecision, PlanItem, PlanItemStatus,
+};
+
+// ---------------------------------------------------------------------------
+// AC6-1: contract-level supersede→dedup consistency
+// After supersede→dedup, the plan must not produce a state where
+// check_final_gate==Allow + CompletionKind==complete_* but
+// is_successfully_completed==false.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn ac6_1_supersede_dedup_retains_corrected_item() {
+    // Simulate the B2 scenario: replan with corrected items targeting same files.
+    let mut plan = ExecutionPlan::new(vec![
+        PlanItem::new(
+            "prompt-detector.ts: fix parsing".into(),
+            vec!["src/prompt-detector.ts".into()],
+        ),
+        PlanItem::new(
+            "response-poller.ts: update polling".into(),
+            vec!["src/response-poller.ts".into()],
+        ),
+    ]);
+
+    // Corrected items with same targets
+    let new_items = vec![
+        PlanItem::new(
+            "prompt-detector.ts: corrected fix".into(),
+            vec!["src/prompt-detector.ts".into()],
+        ),
+        PlanItem::new(
+            "response-poller.ts: corrected update".into(),
+            vec!["src/response-poller.ts".into()],
+        ),
+    ];
+
+    // Pipeline: supersede → dedup → append
+    plan.supersede_stale_items(&new_items);
+    assert_eq!(plan.items[0].status, PlanItemStatus::Superseded);
+    assert_eq!(plan.items[1].status, PlanItemStatus::Superseded);
+
+    let deduped = plan.deduplicate_new_items(new_items);
+    // Issue #311: corrected items survive dedup
+    assert_eq!(deduped.len(), 2, "corrected items must survive dedup");
+    plan.append_items(deduped);
+
+    // Plan has 4 items: 2 Superseded + 2 Pending
+    assert_eq!(plan.items.len(), 4);
+    assert!(!plan.all_finished(), "Pending corrected items remain");
+
+    // Simulate agent completing work on corrected items
+    plan.items[2].status = PlanItemStatus::Done;
+    plan.items[3].status = PlanItemStatus::Done;
+
+    // Now all predicates agree:
+    assert!(plan.all_finished());
+    assert!(plan.is_successfully_completed());
+    assert!(plan.is_cleanly_finished());
+    assert_eq!(plan.check_final_gate(), FinalGateDecision::Allow);
+    assert_eq!(
+        CompletionKind::classify(&plan, None, false),
+        CompletionKind::CompleteUnverified
+    );
+}
+
+// ---------------------------------------------------------------------------
+// AC6-2: is_cleanly_finished for superseded-only plans (safety net)
+// Even if a superseded-only plan somehow occurs, is_cleanly_finished
+// aligns with check_final_gate / CompletionKind.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn ac6_2_superseded_only_cleanly_finished() {
+    let mut plan = ExecutionPlan::new(vec![
+        PlanItem::new("task1".into(), vec!["src/a.ts".into()]),
+        PlanItem::new("task2".into(), vec!["src/b.ts".into()]),
+    ]);
+    plan.items[0].status = PlanItemStatus::Superseded;
+    plan.items[1].status = PlanItemStatus::Superseded;
+
+    // is_successfully_completed requires Done/AlreadySatisfied → false
+    assert!(!plan.is_successfully_completed());
+    // is_cleanly_finished only requires all_finished + no blocked → true
+    assert!(plan.is_cleanly_finished());
+    // check_final_gate uses all_finished → Allow
+    assert_eq!(plan.check_final_gate(), FinalGateDecision::Allow);
+    // CompletionKind uses all_finished → CompleteUnverified
+    assert_eq!(
+        CompletionKind::classify(&plan, None, false),
+        CompletionKind::CompleteUnverified
+    );
+
+    // Exit logic (has_tool_execution_failure) now uses is_cleanly_finished,
+    // so there is no divergence: all four agree on "clean terminal state".
+}
+
+// ---------------------------------------------------------------------------
+// AC6-3: CompletionKind + is_cleanly_finished consistency
+// Verify that for all terminal plan states, CompletionKind::complete_* implies
+// is_cleanly_finished==true (no divergence possible).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn ac6_3_complete_kind_implies_cleanly_finished() {
+    // Case 1: All Done
+    let mut plan = ExecutionPlan::new(vec![
+        PlanItem::new("t1".into(), vec![]),
+        PlanItem::new("t2".into(), vec![]),
+    ]);
+    plan.items[0].status = PlanItemStatus::Done;
+    plan.items[1].status = PlanItemStatus::Done;
+    let kind = CompletionKind::classify(&plan, None, false);
+    assert_eq!(kind, CompletionKind::CompleteUnverified);
+    assert!(plan.is_cleanly_finished());
+
+    // Case 2: Done + Superseded
+    let mut plan = ExecutionPlan::new(vec![
+        PlanItem::new("t1".into(), vec![]),
+        PlanItem::new("t2".into(), vec![]),
+    ]);
+    plan.items[0].status = PlanItemStatus::Done;
+    plan.items[1].status = PlanItemStatus::Superseded;
+    let kind = CompletionKind::classify(&plan, None, false);
+    assert_eq!(kind, CompletionKind::CompleteUnverified);
+    assert!(plan.is_cleanly_finished());
+
+    // Case 3: Done + AlreadySatisfied
+    let mut plan = ExecutionPlan::new(vec![
+        PlanItem::new("t1".into(), vec![]),
+        PlanItem::new("t2".into(), vec![]),
+    ]);
+    plan.items[0].status = PlanItemStatus::Done;
+    plan.items[1].status = PlanItemStatus::AlreadySatisfied;
+    let kind = CompletionKind::classify(&plan, None, false);
+    assert_eq!(kind, CompletionKind::CompleteUnverified);
+    assert!(plan.is_cleanly_finished());
+
+    // Case 4: Superseded-only (safety net)
+    let mut plan = ExecutionPlan::new(vec![PlanItem::new("t1".into(), vec![])]);
+    plan.items[0].status = PlanItemStatus::Superseded;
+    let kind = CompletionKind::classify(&plan, None, false);
+    assert_eq!(kind, CompletionKind::CompleteUnverified);
+    assert!(plan.is_cleanly_finished());
+
+    // Case 5: Blocked → CompletionKind::Blocked, not cleanly_finished
+    let mut plan = ExecutionPlan::new(vec![PlanItem::new("t1".into(), vec![])]);
+    plan.items[0].status = PlanItemStatus::Blocked;
+    let kind = CompletionKind::classify(&plan, None, false);
+    assert_eq!(kind, CompletionKind::Blocked);
+    assert!(!plan.is_cleanly_finished());
+}
+
+// ---------------------------------------------------------------------------
+// AC6-4: corrected replan with touched_files retains Done evidence
+// When corrected items are appended and then completed, the plan
+// has positive Done evidence in its terminal state.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn ac6_4_corrected_replan_with_mutations_reaches_done() {
+    let mut plan = ExecutionPlan::new(vec![
+        PlanItem::new(
+            "src/prompt-detector.ts: fix".into(),
+            vec!["src/prompt-detector.ts".into()],
+        ),
+        PlanItem::new("src/route.ts: update".into(), vec!["src/route.ts".into()]),
+    ]);
+
+    // Simulate replan: supersede → dedup → append
+    let corrected = vec![
+        PlanItem::new(
+            "src/prompt-detector.ts: corrected fix".into(),
+            vec!["src/prompt-detector.ts".into()],
+        ),
+        PlanItem::new(
+            "src/route.ts: corrected update".into(),
+            vec!["src/route.ts".into()],
+        ),
+    ];
+    plan.supersede_stale_items(&corrected);
+    let deduped = plan.deduplicate_new_items(corrected);
+    plan.append_items(deduped);
+
+    // Simulate agent editing files (records mutation + marks Done)
+    plan.mark_in_progress(2);
+    plan.record_mutation_success(2, "src/prompt-detector.ts");
+    plan.mark_done(2);
+    plan.mark_in_progress(3);
+    plan.record_mutation_success(3, "src/route.ts");
+    plan.mark_done(3);
+
+    // Terminal state has Done evidence
+    assert!(plan.is_successfully_completed());
+    assert!(plan.is_cleanly_finished());
+    assert_eq!(plan.check_final_gate(), FinalGateDecision::Allow);
+
+    // Mutations are preserved in corrected items
+    assert!(!plan.items[2].mutated_files.is_empty());
+    assert!(!plan.items[3].mutated_files.is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// AC6-5: genuinely unrecovered tool failure preserves failure semantics
+// When the plan has unfinished/blocked items, is_cleanly_finished is false
+// and exit should still report failure.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn ac6_5_genuinely_unrecovered_blocked_plan() {
+    let mut plan = ExecutionPlan::new(vec![
+        PlanItem::new("t1".into(), vec!["src/a.ts".into()]),
+        PlanItem::new("t2".into(), vec!["src/b.ts".into()]),
+    ]);
+    plan.items[0].status = PlanItemStatus::Done;
+    plan.items[1].status = PlanItemStatus::Blocked;
+
+    assert!(!plan.is_successfully_completed());
+    assert!(!plan.is_cleanly_finished());
+    assert_eq!(
+        CompletionKind::classify(&plan, None, false),
+        CompletionKind::Blocked
+    );
+}
+
+#[test]
+fn ac6_5_genuinely_unrecovered_partial_plan() {
+    let mut plan = ExecutionPlan::new(vec![
+        PlanItem::new("t1".into(), vec!["src/a.ts".into()]),
+        PlanItem::new("t2".into(), vec!["src/b.ts".into()]),
+    ]);
+    plan.items[0].status = PlanItemStatus::Done;
+    // t2 still Pending
+    assert!(!plan.is_cleanly_finished());
+    assert!(!plan.is_successfully_completed());
+    assert_eq!(
+        CompletionKind::classify(&plan, None, false),
+        CompletionKind::Partial
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Dedup still works against non-Superseded finished items
+// ---------------------------------------------------------------------------
+
+#[test]
+fn dedup_works_against_done_items() {
+    let mut plan = ExecutionPlan::new(vec![PlanItem::new(
+        "src/foo.ts: task".into(),
+        vec!["src/foo.ts".into()],
+    )]);
+    plan.items[0].status = PlanItemStatus::Done;
+    let duplicate = vec![PlanItem::new(
+        "src/foo.ts: same task".into(),
+        vec!["src/foo.ts".into()],
+    )];
+    let deduped = plan.deduplicate_new_items(duplicate);
+    assert_eq!(
+        deduped.len(),
+        0,
+        "new item matching a Done item should still be deduplicated"
+    );
+}
+
+#[test]
+fn dedup_works_against_already_satisfied_items() {
+    let mut plan = ExecutionPlan::new(vec![PlanItem::new(
+        "src/bar.ts: task".into(),
+        vec!["src/bar.ts".into()],
+    )]);
+    plan.items[0].status = PlanItemStatus::AlreadySatisfied;
+    let duplicate = vec![PlanItem::new(
+        "src/bar.ts: same task".into(),
+        vec!["src/bar.ts".into()],
+    )];
+    let deduped = plan.deduplicate_new_items(duplicate);
+    assert_eq!(
+        deduped.len(),
+        0,
+        "new item matching an AlreadySatisfied item should still be deduplicated"
+    );
+}
+
+#[test]
+fn dedup_works_against_pending_items() {
+    let plan = ExecutionPlan::new(vec![PlanItem::new(
+        "src/baz.ts: task".into(),
+        vec!["src/baz.ts".into()],
+    )]);
+    let duplicate = vec![PlanItem::new(
+        "src/baz.ts: same task".into(),
+        vec!["src/baz.ts".into()],
+    )];
+    let deduped = plan.deduplicate_new_items(duplicate);
+    assert_eq!(
+        deduped.len(),
+        0,
+        "new item matching a Pending item should still be deduplicated"
+    );
+}


### PR DESCRIPTION
## Summary

- Fixed contract divergence where `check_final_gate`/`CompletionKind` treated superseded-only plans as complete while `has_tool_execution_failure`/`log_session_summary` treated them as failure
- Root cause: `deduplicate_new_items()` deduped corrected items against the Superseded items they replaced, producing terminal plans with no positive completion evidence
- Added `is_cleanly_finished()` as the unified terminal-complete predicate, aligned exit/recovery logic with final gate semantics

## Changes

| File | Description |
|------|-------------|
| `src/contracts/mod.rs` | `deduplicate_new_items()`: skip Superseded items; add `is_cleanly_finished()` |
| `src/app/mod.rs` | `has_tool_execution_failure`/`log_session_summary`: use `is_cleanly_finished` |
| `tests/superseded_plan_exit.rs` | 9 regression tests (AC6-1..AC6-5) |
| `tests/followup_replan.rs` | Updated for corrected dedup behavior |
| `tests/stagnation_control.rs` | Updated for corrected dedup behavior |

## Test plan

- [x] `cargo fmt --check` — no diff
- [x] `cargo clippy --all-targets` — 0 warnings
- [x] `cargo test` — all tests pass (including 9 new superseded_plan_exit tests)
- [ ] Re-run Issue193 short smoke to verify B2 no longer reproduces

Fixes #311

🤖 Generated with [Claude Code](https://claude.com/claude-code)