### PR TITLE
fix(issue-313): add token-based fallback to extract_edit_context for mid-file recovery

### DIFF
--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -1935,6 +1935,14 @@ impl App {
                             "recovery budget granted"
                         );
                     }
+                    // Issue #313: detect whether the error payload already
+                    // contains mid-file context (from extract_edit_context).
+                    // If so, guide the model to use it instead of a generic
+                    // full-file read that truncates mid-file content.
+                    let has_inline_context = matches!(
+                        &result.payload,
+                        ToolExecutionPayload::Text(t) if t.contains("--- File context")
+                    );
                     match action {
                         crate::app::edit_fail_tracker::EditFallbackAction::Continue => {}
                         crate::app::edit_fail_tracker::EditFallbackAction::ReRead => {
@@ -1944,11 +1952,22 @@ impl App {
                                 count = count,
                                 "repeated tool failure"
                             );
-                            edit_hint = Some(format!(
-                                "\n\n[Anvil hint] file.edit has failed {count} consecutive \
-                                 times for '{path}'. Use file.read to get the current file \
-                                 content, then retry file.edit with the correct old_string."
-                            ));
+                            edit_hint = if has_inline_context {
+                                Some(format!(
+                                    "\n\n[Anvil hint] file.edit has failed {count} consecutive \
+                                     times for '{path}'. The file context above shows the actual \
+                                     content with line numbers — use it to correct your old_string. \
+                                     If you need more surrounding lines, use file.read with the \
+                                     offset shown in the context (e.g. file.read path offset=N \
+                                     limit=50)."
+                                ))
+                            } else {
+                                Some(format!(
+                                    "\n\n[Anvil hint] file.edit has failed {count} consecutive \
+                                     times for '{path}'. Use file.read to get the current file \
+                                     content, then retry file.edit with the correct old_string."
+                                ))
+                            };
                         }
                         crate::app::edit_fail_tracker::EditFallbackAction::WriteFallback => {
                             tracing::warn!(
@@ -1970,13 +1989,20 @@ impl App {
                             let line_count_check_failed = max_lines > 0 && line_count.is_none();
 
                             if is_large || line_count_check_failed {
-                                edit_hint = Some(format!(
-                                    "\n\n[Anvil hint] file.edit has failed {count} consecutive \
-                                     times for '{path}'. file.write is not available or could not be \
-                                     safely validated for this path. Instead: \
+                                let ctx_guidance = if has_inline_context {
+                                    "Check the file context above for actual line numbers. \
+                                     Use file.read with offset to get the target section, then \
+                                     retry file.edit with a smaller, precise old_string."
+                                } else {
+                                    "Instead: \
                                      (1) Use file.read to get the current content. \
                                      (2) Identify the exact section to change. \
                                      (3) Retry file.edit with a smaller, precise old_string."
+                                };
+                                edit_hint = Some(format!(
+                                    "\n\n[Anvil hint] file.edit has failed {count} consecutive \
+                                     times for '{path}'. file.write is not available or could not be \
+                                     safely validated for this path. {ctx_guidance}"
                                 ));
                             } else {
                                 edit_hint = Some(format!(

--- a/src/tooling/mod.rs
+++ b/src/tooling/mod.rs
@@ -1147,6 +1147,12 @@ pub fn is_sensitive_file(path: &str) -> bool {
 /// Extract context lines around the best matching location for `old_string`
 /// in `content`. Searches for the first line of `old_string` (trimmed) and
 /// returns surrounding lines with line numbers.
+///
+/// When the exact first-line match fails, falls back to token-based scoring:
+/// extracts identifier-like tokens from `old_string` and finds the content
+/// line with the highest overlap. This handles "hypothesis drift" where the
+/// model's `old_string` diverges from reality but shares key identifiers
+/// (Issue #313).
 pub fn extract_edit_context(
     content: &str,
     old_string: &str,
@@ -1158,11 +1164,19 @@ pub fn extract_edit_context(
     }
 
     let lines: Vec<&str> = content.lines().collect();
+
+    // Primary: exact first-line substring match
     let match_idx = lines
         .iter()
         .enumerate()
-        .find(|(_, line)| line.trim().contains(first_line))?
-        .0;
+        .find(|(_, line)| line.trim().contains(first_line))
+        .map(|(idx, _)| idx);
+
+    // Fallback: token-based scoring (Issue #313)
+    let match_idx = match match_idx {
+        Some(idx) => idx,
+        None => token_fallback_match(&lines, old_string)?,
+    };
 
     let start = match_idx.saturating_sub(context_lines);
     let end = (match_idx + context_lines + 1).min(lines.len());
@@ -1175,6 +1189,54 @@ pub fn extract_edit_context(
         .join("\n");
 
     Some(context)
+}
+
+/// Minimum token length for fallback matching. Short tokens like "a", "fn",
+/// "if" are too common to be useful anchors.
+const TOKEN_MIN_LEN: usize = 4;
+
+/// Minimum token score to accept a fallback match.
+/// Set to 1 because even a single specific identifier (e.g. a function name)
+/// is a strong anchor when exact first-line matching has already failed.
+const TOKEN_MIN_SCORE: usize = 1;
+
+/// Token-based fallback: extract identifier-like tokens from `old_string`,
+/// score each content line by token overlap, and return the best match index.
+fn token_fallback_match(lines: &[&str], old_string: &str) -> Option<usize> {
+    let tokens = extract_tokens(old_string);
+    if tokens.is_empty() {
+        return None;
+    }
+
+    let mut best_idx = 0usize;
+    let mut best_score = 0usize;
+
+    for (i, line) in lines.iter().enumerate() {
+        let lower = line.to_lowercase();
+        let score = tokens.iter().filter(|t| lower.contains(t.as_str())).count();
+        if score > best_score {
+            best_score = score;
+            best_idx = i;
+        }
+    }
+
+    if best_score >= TOKEN_MIN_SCORE {
+        Some(best_idx)
+    } else {
+        None
+    }
+}
+
+/// Extract identifier-like tokens from a string.
+/// Splits on non-alphanumeric/underscore boundaries, lowercases, deduplicates,
+/// and filters out tokens shorter than `TOKEN_MIN_LEN`.
+fn extract_tokens(s: &str) -> Vec<String> {
+    let mut seen = std::collections::HashSet::new();
+    s.split(|c: char| !c.is_alphanumeric() && c != '_')
+        .filter(|t| t.len() >= TOKEN_MIN_LEN)
+        .map(|t| t.to_lowercase())
+        .filter(|t| seen.insert(t.clone()))
+        .collect()
 }
 
 impl LocalToolExecutor {
@@ -1811,12 +1873,24 @@ impl LocalToolExecutor {
             return ToolRuntimeError::edit_not_found(message);
         }
 
-        // Try to read file content for context extraction
+        // Try to read file content for context extraction.
+        // Scale context_lines based on file size (Issue #313):
+        // large files need more surrounding context for mid-file targets.
         let context_snippet = self
             .resolve_path(path)
             .ok()
             .and_then(|resolved| fs::read_to_string(resolved).ok())
-            .and_then(|content| extract_edit_context(&content, old_string, 5));
+            .and_then(|content| {
+                let line_count = content.lines().count();
+                let ctx_lines = if line_count > 500 {
+                    12
+                } else if line_count > 100 {
+                    8
+                } else {
+                    5
+                };
+                extract_edit_context(&content, old_string, ctx_lines)
+            });
 
         match context_snippet {
             Some(ctx) => ToolRuntimeError::edit_not_found_with_context(message, ctx),

--- a/tests/edit_recovery_mid_context.rs
+++ b/tests/edit_recovery_mid_context.rs
@@ -1,0 +1,253 @@
+//! Integration tests for Issue #313: file.edit recovery mid-context acquisition.
+//!
+//! Tests that extract_edit_context returns useful context even when the
+//! first-line exact match fails, using token-based fallback matching.
+//! Also tests dynamic context sizing for large files.
+
+// ============================================================
+// Test 1: token-based fallback when first-line exact match fails
+// ============================================================
+
+#[test]
+fn test_extract_edit_context_token_fallback_on_first_line_drift() {
+    // Simulates the A2 failure shape: model hypothesis drifts from reality.
+    // Hypothesis: detectPrompt(cleanedOutput, detectedCliTool || 'claude')
+    // Reality:    detectPrompt(cleanOutput, { ...promptOptions, ... })
+    // The function name "detectPrompt" is a shared token that should anchor.
+    let content = r#"import { something } from 'module';
+
+const foo = 1;
+const bar = 2;
+
+function setupPoller() {
+    const config = getConfig();
+    return config;
+}
+
+// Many lines of code...
+const x = 10;
+const y = 20;
+const z = 30;
+
+function helperA() { return 1; }
+function helperB() { return 2; }
+
+const promptOptions = buildDetectPromptOptions(cliToolId);
+const promptDetection = detectPrompt(cleanOutput, {
+    ...promptOptions,
+    ...(precomputedLines && { precomputedLines }),
+});
+
+if (promptDetection.detected) {
+    handleDetection(promptDetection);
+}
+
+function cleanup() {
+    clearInterval(pollInterval);
+}
+
+export { setupPoller, cleanup };
+"#;
+
+    // Model's wrong hypothesis — first line doesn't match exactly
+    let old_string = "detectPrompt(cleanedOutput, detectedCliTool || 'claude')";
+
+    let result = anvil::tooling::extract_edit_context(content, old_string, 5);
+    assert!(
+        result.is_some(),
+        "should find context via token fallback even when first-line exact match fails"
+    );
+    let ctx = result.unwrap();
+    assert!(
+        ctx.contains("detectPrompt"),
+        "context should contain the actual detectPrompt call"
+    );
+    assert!(
+        ctx.contains("promptOptions"),
+        "context should show nearby lines with promptOptions"
+    );
+}
+
+// ============================================================
+// Test 2: token fallback with multiple candidate tokens
+// ============================================================
+
+#[test]
+fn test_extract_edit_context_token_fallback_best_scoring_line() {
+    let content = r#"line 1
+line 2
+fn process_data(input: &str) -> Result<Data, Error> {
+    let parsed = parse_input(input);
+    validate(parsed)
+}
+line 7
+line 8
+fn transform(data: Data) -> Output {
+    data.convert()
+}
+"#;
+
+    // Hypothesis has "process_data" and "input" — should match line 3
+    let old_string = "fn process_data(raw_input: String) -> Data {";
+
+    let result = anvil::tooling::extract_edit_context(content, old_string, 2);
+    assert!(result.is_some(), "token fallback should find process_data");
+    let ctx = result.unwrap();
+    assert!(
+        ctx.contains("process_data"),
+        "should anchor on process_data token"
+    );
+}
+
+// ============================================================
+// Test 3: large file gets more context lines
+// ============================================================
+
+#[test]
+fn test_extract_edit_context_large_file_expanded_context() {
+    // Build a 600-line file with target at line 326
+    let mut lines: Vec<String> = Vec::new();
+    for i in 1..=325 {
+        lines.push(format!("const padding_{i} = {i};"));
+    }
+    lines.push("const target = detectPrompt(cleanOutput, options);".to_string());
+    for i in 327..=600 {
+        lines.push(format!("const padding_{i} = {i};"));
+    }
+    let content = lines.join("\n");
+
+    let old_string = "detectPrompt(cleanOutput, options)";
+
+    // With context_lines=5 (old behavior), we'd get 11 lines
+    let result_small = anvil::tooling::extract_edit_context(&content, old_string, 5);
+    assert!(result_small.is_some());
+    let ctx_small = result_small.unwrap();
+    let small_line_count = ctx_small.lines().count();
+
+    // With context_lines=12 (large file), we'd get 25 lines
+    let result_large = anvil::tooling::extract_edit_context(&content, old_string, 12);
+    assert!(result_large.is_some());
+    let ctx_large = result_large.unwrap();
+    let large_line_count = ctx_large.lines().count();
+
+    assert!(
+        large_line_count > small_line_count,
+        "large file context ({large_line_count}) should have more lines than small ({small_line_count})"
+    );
+    assert!(
+        ctx_large.contains("326"),
+        "context should show line 326 where the target is"
+    );
+}
+
+// ============================================================
+// Test 4: exact match still takes priority over token fallback
+// ============================================================
+
+#[test]
+fn test_extract_edit_context_exact_match_priority() {
+    let content = "line 1\nline 2\nfn hello() {\n    println!(\"hi\");\n}\nline 6";
+    let old_string = "fn hello() {\n    println!(\"world\");\n}";
+
+    let result = anvil::tooling::extract_edit_context(content, old_string, 2);
+    assert!(result.is_some());
+    let ctx = result.unwrap();
+    // Exact first-line match should work as before
+    assert!(ctx.contains("fn hello()"));
+}
+
+// ============================================================
+// Test 5: token fallback returns None when no tokens match
+// ============================================================
+
+#[test]
+fn test_extract_edit_context_token_fallback_no_match() {
+    let content = "alpha\nbeta\ngamma\ndelta";
+    let old_string = "completely_unrelated_function(x, y, z)";
+
+    let result = anvil::tooling::extract_edit_context(content, old_string, 5);
+    assert!(
+        result.is_none(),
+        "should return None when no tokens match at all"
+    );
+}
+
+// ============================================================
+// Test 6: mid-file context for 500+ line file with drifted hypothesis
+// ============================================================
+
+#[test]
+fn test_mid_file_context_large_file_drifted_hypothesis() {
+    // Reproduction of Issue #313 A2 failure shape:
+    // - 599-line file
+    // - Target at line ~326
+    // - Model hypothesis first line completely wrong
+    let mut lines: Vec<String> = Vec::new();
+    for i in 1..=320 {
+        lines.push(format!("// filler line {i}"));
+    }
+    // Real code around line 321-330
+    lines.push("const promptOptions = buildDetectPromptOptions(cliToolId);".to_string());
+    lines.push("const promptDetection = detectPrompt(cleanOutput, {".to_string());
+    lines.push("    ...promptOptions,".to_string());
+    lines.push("    ...(precomputedLines && { precomputedLines }),".to_string());
+    lines.push("});".to_string());
+    lines.push("".to_string());
+    for i in 327..=599 {
+        lines.push(format!("// filler line {i}"));
+    }
+    let content = lines.join("\n");
+
+    // Model's completely wrong hypothesis
+    let old_string = "detectPrompt(cleanedOutput, detectedCliTool || 'claude')";
+
+    let result = anvil::tooling::extract_edit_context(&content, old_string, 8);
+    assert!(
+        result.is_some(),
+        "token fallback should find detectPrompt in mid-file despite drifted hypothesis"
+    );
+    let ctx = result.unwrap();
+    assert!(
+        ctx.contains("detectPrompt"),
+        "context must contain the real detectPrompt call"
+    );
+    assert!(
+        ctx.contains("promptOptions"),
+        "context should show nearby promptOptions"
+    );
+}
+
+// ============================================================
+// Test 7: build_edit_not_found_with_context uses scaled context_lines
+// ============================================================
+// (This is tested indirectly via extract_edit_context parameter scaling;
+//  the build function is private, but the public extract_edit_context
+//  receives the scaled value.)
+
+// ============================================================
+// Test 8: token extraction handles various identifier patterns
+// ============================================================
+
+#[test]
+fn test_extract_edit_context_token_fallback_various_identifiers() {
+    let content = r#"use std::collections::HashMap;
+
+fn main() {
+    let my_special_variable = compute_result(42);
+    println!("{}", my_special_variable);
+}
+
+fn compute_result(n: i32) -> i32 {
+    n * 2
+}
+"#;
+
+    // Hypothesis with wrong structure but shared identifiers
+    let old_string = "let my_special_variable = compute_result(input_value);";
+
+    let result = anvil::tooling::extract_edit_context(content, old_string, 3);
+    assert!(result.is_some(), "should match via shared identifiers");
+    let ctx = result.unwrap();
+    assert!(ctx.contains("my_special_variable"));
+    assert!(ctx.contains("compute_result"));
+}


### PR DESCRIPTION
## Summary

- When `file.edit` fails with a drifted hypothesis, the exact first-line `contains()` match returns no context, leaving the model blind to mid-file content in large files and forcing shell.exec drift
- Added token-based fallback matching in `extract_edit_context()`: extracts identifier tokens from `old_string`, scores content lines by overlap, and returns the best-matching mid-file context
- Dynamic `context_lines` scaling (5/8/12 for small/medium/large files) and updated recovery hints to reference inline context

## Changes

| File | Description |
|------|-------------|
| `src/tooling/mod.rs` | Token-based fallback in `extract_edit_context()`, `extract_tokens()`, `find_best_token_match()` |
| `src/app/agentic.rs` | Recovery hints reference inline context, `file.read` with offset guidance |
| `tests/edit_recovery_mid_context.rs` | 7 integration tests |

## Test plan

- [x] `cargo fmt --check` — no diff
- [x] `cargo clippy --all-targets` — 0 warnings
- [x] `cargo test` — all tests pass
- [ ] Re-run Issue193 short smoke v2 to verify A2 recovery

Fixes #313

🤖 Generated with [Claude Code](https://claude.com/claude-code)