### PR TITLE
release: Phase0 runtime convergence fixes (#309, #311, #313, #315)

### DIFF
--- a/.claude/commands/multi-stage-design-review.md
+++ b/.claude/commands/multi-stage-design-review.md
@@ -173,8 +173,10 @@ IMPORTANT: Only update design policy documents. Do NOT modify source code.
 
 Stage 3（影響分析）とStage 4（セキュリティ）は**Codex**（`--agent codex`）に委譲し、異なるモデルによるクロスレビューで品質を向上させます。
 
-> **⚠ 禁止事項**: このステージをClaudeサブエージェント（Agent tool）で代替実行しないこと。
-> 必ず `commandmatedev send --agent codex` でCodexに送信すること。
+> **⚠ 禁止事項（厳守）**:
+> 1. このステージをClaudeサブエージェント（Agent tool）で代替実行しないこと。必ず `commandmatedev send --agent codex` でCodexに送信すること。
+> 2. Codexが生成した結果ファイルを Claude 側で再実行・上書きしないこと。Codex が findings 0件を返した場合も「問題なし」という正当な結果であり、件数が少ないことを理由に opus で再レビューすることを禁止する。
+> 3. 結果ファイルの `reviewer` フィールドが `"codex"` でない場合は、不正な上書きが発生しているため即座にユーザーに報告すること。
 
 #### 3-0. commandmatedev 利用可能性確認
 
@@ -234,7 +236,11 @@ commandmatedev wait "$WORKTREE_ID" --timeout 3600 --on-prompt agent
 #### 3-2. Stage 3完了確認
 
 - `stage3-review-result.json` が生成されている
-- 影響範囲が適切に分析されている
+- `reviewer` フィールドが `"codex"` であることを確認する
+
+> **⚠ 上書き禁止**: Codexの結果ファイルが既に存在する場合、Claude側で再実行・上書きしてはならない。
+> Codexが findings 0件を返した場合も、それは「問題なし」という正当なレビュー結果である。
+> findings の件数が少ないことを理由に Agent tool (opus) で再実行することを禁止する。
 
 ---
 
@@ -270,9 +276,12 @@ commandmatedev wait "$WORKTREE_ID" --timeout 3600 --on-prompt agent
 #### 4-1. Stage 4完了確認
 
 - `stage4-review-result.json` が生成されている
+- `reviewer` フィールドが `"codex"` であることを確認する
 - セキュリティ上の問題がすべて解消
 - unsafe使用の正当性確認
 - サンドボックス・コマンドインジェクション対策確認
+
+> **⚠ 上書き禁止**: Stage 3-2 と同様、Codexの結果を Claude 側で再実行・上書きしてはならない。
 
 ---
 

--- a/.claude/commands/multi-stage-issue-review.md
+++ b/.claude/commands/multi-stage-issue-review.md
@@ -42,9 +42,11 @@ Issueの記載内容を多角的にレビューし、ブラッシュアップす
 | Stage 5-8（2回目） | **Codex**（commandmatedev `--agent codex` 経由） | 異なるモデルによるクロスレビュー |
 | 指摘反映（全ステージ） | sonnet（継承） | JSON→Issue更新のみ |
 
-> **⚠ 重要**: Stage 5-8 は必ず `commandmatedev send ... --agent codex` でCodexに委譲すること。
-> Claude サブエージェント（Agent tool）で代替実行してはならない。
-> commandmatedev が利用不可の場合はユーザーに報告して中断すること。
+> **⚠ 禁止事項（厳守）**:
+> 1. Stage 5-8 は必ず `commandmatedev send ... --agent codex` でCodexに委譲すること。Claude サブエージェント（Agent tool）で代替実行してはならない。
+> 2. Codexが生成した結果ファイルを Claude 側で再実行・上書きしないこと。Codex が findings 0件を返した場合も「問題なし」という正当な結果であり、件数が少ないことを理由に opus で再レビューすることを禁止する。
+> 3. 結果ファイルの `reviewer` フィールドが `"codex"` でない場合は、不正な上書きが発生しているため即座にユーザーに報告すること。
+> 4. commandmatedev が利用不可の場合はユーザーに報告して中断すること。
 
 ---
 
@@ -299,7 +301,12 @@ commandmatedev wait "$WORKTREE_ID" --timeout 3600 --on-prompt agent
 Stage 5-8完了後、以下を確認:
 - `stage5-review-result.json` が生成されている
 - `stage7-review-result.json` が生成されている
+- 両ファイルの `reviewer` フィールドが `"codex"` であることを確認する
 - GitHubのIssueが更新されている（Must Fix指摘があった場合）
+
+> **⚠ 上書き禁止**: Codexの結果ファイルが既に存在する場合、Claude側で再実行・上書きしてはならない。
+> Codexが findings 0件を返した場合も、それは「問題なし」という正当なレビュー結果である。
+> `reviewer` が `"codex"` でないファイルが見つかった場合、不正な上書きが発生しているためユーザーに報告すること。
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,7 +111,7 @@ src/
 │   ├── context.rs       # コンテキスト注入（@file展開・サンドボックス検証）
 │   ├── edit_fail_tracker.rs # 連続file.edit失敗の検出・回復ヒント注入
 │   ├── tool_recovery_budget.rs # ToolRecoveryBudget（file.edit失敗後のrecovery read budget管理・detector抑制）
-│   ├── execution_plan.rs    # プラン→実行モード（ANVIL_PLAN検出・チェックリスト管理・ANVIL_FINAL抑制）
+│   ├── execution_plan.rs    # プラン→実行モード（ANVIL_PLAN検出・チェックリスト管理・ANVIL_FINAL抑制・checked-first retire）
 │   ├── alternating_loop_detector.rs # AlternatingLoopDetector（交互/循環パターン検出）
 │   ├── loop_detector.rs # ループ検出（リングバッファ・段階的対応）
 │   ├── phase_estimator.rs # フェーズ推定（ツール呼び出しパターンベース・フォールバック完了検出）
@@ -171,6 +171,7 @@ tests/
 ├── context_inject.rs    # コンテキスト注入テスト
 ├── stagnation_control.rs # 停滞制御テスト（Issue #263）
 ├── edit_recovery_loop.rs # file.edit recovery loop fix テスト（Issue #299）
+├── plan_item_retire.rs  # stale plan item retire テスト（Issue #301）
 └── walk_system.rs       # ディレクトリウォーカーテスト
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,6 +173,7 @@ tests/
 ├── edit_recovery_loop.rs # file.edit recovery loop fix テスト（Issue #299）
 ├── plan_item_retire.rs  # stale plan item retire テスト（Issue #301）
 ├── followup_replan.rs   # follow-up ANVIL_PLAN replan テスト（Issue #305）
+├── prose_retire_fallback.rs # prose-only確認のplan retire変換テスト（Issue #307）
 └── walk_system.rs       # ディレクトリウォーカーテスト
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,6 +174,7 @@ tests/
 ├── plan_item_retire.rs  # stale plan item retire テスト（Issue #301）
 ├── followup_replan.rs   # follow-up ANVIL_PLAN replan テスト（Issue #305）
 ├── prose_retire_fallback.rs # prose-only確認のplan retire変換テスト（Issue #307）
+├── shell_inspection_drift.rs # shell.exec inspection drift テスト（Issue #309）
 └── walk_system.rs       # ディレクトリウォーカーテスト
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,6 +110,7 @@ src/
 │   ├── cli.rs           # CLI入力ループ
 │   ├── context.rs       # コンテキスト注入（@file展開・サンドボックス検証）
 │   ├── edit_fail_tracker.rs # 連続file.edit失敗の検出・回復ヒント注入
+│   ├── tool_recovery_budget.rs # ToolRecoveryBudget（file.edit失敗後のrecovery read budget管理・detector抑制）
 │   ├── execution_plan.rs    # プラン→実行モード（ANVIL_PLAN検出・チェックリスト管理・ANVIL_FINAL抑制）
 │   ├── alternating_loop_detector.rs # AlternatingLoopDetector（交互/循環パターン検出）
 │   ├── loop_detector.rs # ループ検出（リングバッファ・段階的対応）
@@ -169,6 +170,7 @@ tests/
 ├── phase_estimation.rs  # フェーズ推定テスト
 ├── context_inject.rs    # コンテキスト注入テスト
 ├── stagnation_control.rs # 停滞制御テスト（Issue #263）
+├── edit_recovery_loop.rs # file.edit recovery loop fix テスト（Issue #299）
 └── walk_system.rs       # ディレクトリウォーカーテスト
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,7 +111,7 @@ src/
 │   ├── context.rs       # コンテキスト注入（@file展開・サンドボックス検証）
 │   ├── edit_fail_tracker.rs # 連続file.edit失敗の検出・回復ヒント注入
 │   ├── tool_recovery_budget.rs # ToolRecoveryBudget（file.edit失敗後のrecovery read budget管理・detector抑制）
-│   ├── execution_plan.rs    # プラン→実行モード（ANVIL_PLAN検出・チェックリスト管理・ANVIL_FINAL抑制・checked-first retire）
+│   ├── execution_plan.rs    # プラン→実行モード（ANVIL_PLAN検出・チェックリスト管理・ANVIL_FINAL抑制・checked-first retire・follow-up replan）
 │   ├── alternating_loop_detector.rs # AlternatingLoopDetector（交互/循環パターン検出）
 │   ├── loop_detector.rs # ループ検出（リングバッファ・段階的対応）
 │   ├── phase_estimator.rs # フェーズ推定（ツール呼び出しパターンベース・フォールバック完了検出）
@@ -172,6 +172,7 @@ tests/
 ├── stagnation_control.rs # 停滞制御テスト（Issue #263）
 ├── edit_recovery_loop.rs # file.edit recovery loop fix テスト（Issue #299）
 ├── plan_item_retire.rs  # stale plan item retire テスト（Issue #301）
+├── followup_replan.rs   # follow-up ANVIL_PLAN replan テスト（Issue #305）
 └── walk_system.rs       # ディレクトリウォーカーテスト
 ```
 

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -442,11 +442,40 @@ fn parse_tool_call_value(
         }
     };
 
-    Ok(ToolCallRequest::new(
-        tool_call_id.to_string(),
-        resolved_name,
-        input,
-    ))
+    let mut request = ToolCallRequest::new(tool_call_id.to_string(), resolved_name, input);
+
+    // Issue #299: detect unsupported extra fields for file.read.
+    if tool_name == "file.read"
+        && let Some(obj) = value.as_object()
+    {
+        let known = ["tool", "id", "path"];
+        let max_warnings = 3;
+        let mut count = 0usize;
+        let mut extra_total = 0usize;
+        for key in obj.keys() {
+            if !known.contains(&key.as_str()) {
+                extra_total += 1;
+                if count < max_warnings {
+                    // Sanitize: truncate long names, remove control chars.
+                    let sanitized: String =
+                        key.chars().filter(|c| !c.is_control()).take(64).collect();
+                    request.extra_field_warnings.push(format!(
+                        "Note: '{}' field is not supported by file.read and was ignored",
+                        sanitized
+                    ));
+                    count += 1;
+                }
+            }
+        }
+        if extra_total > max_warnings {
+            request.extra_field_warnings.push(format!(
+                "and {} more unsupported field(s)",
+                extra_total - max_warnings
+            ));
+        }
+    }
+
+    Ok(request)
 }
 
 fn repair_tool_call_block(block: &str) -> Option<ToolCallRequest> {

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -838,6 +838,8 @@ const PROMPT_TOOL_RULES: &str = concat!(
     "```\n",
     "\n",
     "Rules:\n",
+    "- Implementation plans MUST use the ANVIL_PLAN block format, NOT the agent.plan tool. \
+       agent.plan is for read-only exploration/investigation only.\n",
     "- All paths must be relative (start with ./ or a directory name).\n",
     "- Do not use any other tool syntax.\n",
     "- Always include ANVIL_FINAL after your tool blocks.\n",

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -1312,6 +1312,23 @@ fn extract_target_files(description: &str) -> Vec<String> {
         if path.is_empty() {
             continue;
         }
+        // Issue #289: Strip parenthesized annotation suffix, e.g.,
+        // "src/foo.ts (bar.ts)" → "src/foo.ts".
+        // Only strip when there is a space before the opening paren to preserve
+        // legitimate paths like "foo(1).ts".
+        let path = if let Some(pos) = path.find(" (") {
+            if path.ends_with(')') {
+                let stripped = path[..pos].trim_end();
+                if stripped.is_empty() {
+                    continue;
+                }
+                stripped
+            } else {
+                path
+            }
+        } else {
+            path
+        };
         // Security: reject paths with ".." (traversal)
         if path.contains("..") {
             continue;
@@ -1647,5 +1664,24 @@ mod tests {
             items[0].target_files,
             vec!["src/a.rs".to_string(), "src/b.rs".to_string()]
         );
+    }
+
+    // ── Issue #289: parenthesized annotation stripping ──────────────
+
+    #[test]
+    fn extract_target_files_strips_parenthesized() {
+        let desc = "src/lib/polling/auto-yes-manager.ts (auto-yes-poller.ts): change desc";
+        let files = extract_target_files(desc);
+        assert_eq!(
+            files,
+            vec!["src/lib/polling/auto-yes-manager.ts".to_string()]
+        );
+    }
+
+    #[test]
+    fn extract_target_files_preserves_non_spaced_parens() {
+        let desc = "src/foo(1).ts: change";
+        let files = extract_target_files(desc);
+        assert_eq!(files, vec!["src/foo(1).ts".to_string()]);
     }
 }

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -831,6 +831,7 @@ const PROMPT_TOOL_RULES: &str = concat!(
     "```ANVIL_PLAN\n- [ ] src/foo.rs: description\n- [ ] src/bar.rs: description\n```\n",
     "Each item: `- [ ] <relative-path>: <description>`. Do NOT output ANVIL_FINAL until ALL items are done.\n",
     "To add items mid-task, output an ANVIL_PLAN_UPDATE block with the same format.\n",
+    "To mark items as already done (no changes needed), use [x] in ANVIL_PLAN_UPDATE: `- [x] path: reason`.\n",
     "\n",
     "After ALL tool blocks, include exactly one final block with your summary:\n",
     "```ANVIL_FINAL\n",

--- a/src/agent/tag_spec.rs
+++ b/src/agent/tag_spec.rs
@@ -75,7 +75,7 @@ pub const TOOL_TAG_SPECS: &[ToolTagSpec] = &[
         name: "agent.plan",
         attributes: &["scope"],
         child_elements: &["prompt"],
-        example: r#"<tool name="agent.plan" scope="..."><prompt>...</prompt></tool>"#,
+        example: r#"<tool name="agent.plan" scope="..."><prompt>...</prompt></tool> (for exploration only, use ANVIL_PLAN for implementation plans)"#,
     },
 ];
 

--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -485,15 +485,39 @@ impl App {
 
         // Issue #249: Detect ANVIL_PLAN from initial response
         // Issue #287: re-initialize stagnation_state on plan registration
-        if self.try_register_plan(&current.raw_content) {
-            let target_files: Vec<String> = self
-                .execution_plan
-                .items
-                .iter()
-                .flat_map(|i| i.target_files.iter().cloned())
-                .collect();
-            self.stagnation_state =
-                crate::app::stagnation_state::StagnationState::init_from_plan(&target_files);
+        // Issue #305: match on PlanRegistrationResult
+        match self.try_register_plan(&current.raw_content) {
+            crate::app::execution_plan::PlanRegistrationResult::Registered => {
+                let target_files: Vec<String> = self
+                    .execution_plan
+                    .items
+                    .iter()
+                    .flat_map(|i| i.target_files.iter().cloned())
+                    .collect();
+                self.stagnation_state =
+                    crate::app::stagnation_state::StagnationState::init_from_plan(&target_files);
+            }
+            crate::app::execution_plan::PlanRegistrationResult::Replan => {
+                // Replan after reset_execution_plan() should not happen here,
+                // but handle for completeness: merge new targets.
+                let existing = &self.stagnation_state.starved_target_files;
+                let new_targets: Vec<String> = self
+                    .execution_plan
+                    .items
+                    .iter()
+                    .filter(|i| !i.is_finished())
+                    .flat_map(|i| i.target_files.iter().cloned())
+                    .filter(|tf| {
+                        !existing
+                            .iter()
+                            .any(|sf| crate::contracts::ExecutionPlan::path_matches(sf, tf))
+                    })
+                    .collect();
+                self.stagnation_state
+                    .starved_target_files
+                    .extend(new_targets);
+            }
+            crate::app::execution_plan::PlanRegistrationResult::NoBlock => {}
         }
 
         // Session note extraction bookkeeping (Issue #241)
@@ -891,35 +915,63 @@ impl App {
             // Issue #249: Detect ANVIL_PLAN / ANVIL_PLAN_UPDATE from follow-up responses.
             // Scan the raw token buffer since ANVIL_PLAN may be outside the ANVIL_FINAL block.
             // Issue #287: re-initialize stagnation_state on plan registration
-            if self.try_register_plan(&next_token_buffer) {
-                let target_files: Vec<String> = self
-                    .execution_plan
-                    .items
-                    .iter()
-                    .flat_map(|i| i.target_files.iter().cloned())
-                    .collect();
-                self.stagnation_state =
-                    crate::app::stagnation_state::StagnationState::init_from_plan(&target_files);
-            }
-            // Issue #287: merge new target_files into starved_target_files on plan update
-            if self.try_update_plan(&next_token_buffer) {
-                let existing = &self.stagnation_state.starved_target_files;
-                // CB-003: only include unfinished items to avoid re-adding completed files
-                let new_targets: Vec<String> = self
-                    .execution_plan
-                    .items
-                    .iter()
-                    .filter(|i| !i.is_finished())
-                    .flat_map(|i| i.target_files.iter().cloned())
-                    .filter(|tf| {
-                        !existing
+            // Issue #305: match on PlanRegistrationResult for replan support
+            match self.try_register_plan(&next_token_buffer) {
+                crate::app::execution_plan::PlanRegistrationResult::Registered => {
+                    let target_files: Vec<String> = self
+                        .execution_plan
+                        .items
+                        .iter()
+                        .flat_map(|i| i.target_files.iter().cloned())
+                        .collect();
+                    self.stagnation_state =
+                        crate::app::stagnation_state::StagnationState::init_from_plan(
+                            &target_files,
+                        );
+                }
+                crate::app::execution_plan::PlanRegistrationResult::Replan => {
+                    // Replan: stagnation_state を差分マージ (Issue #305)
+                    let existing = &self.stagnation_state.starved_target_files;
+                    let new_targets: Vec<String> = self
+                        .execution_plan
+                        .items
+                        .iter()
+                        .filter(|i| !i.is_finished())
+                        .flat_map(|i| i.target_files.iter().cloned())
+                        .filter(|tf| {
+                            !existing
+                                .iter()
+                                .any(|sf| crate::contracts::ExecutionPlan::path_matches(sf, tf))
+                        })
+                        .collect();
+                    self.stagnation_state
+                        .starved_target_files
+                        .extend(new_targets);
+                }
+                crate::app::execution_plan::PlanRegistrationResult::NoBlock => {
+                    // ANVIL_PLAN なし → ANVIL_PLAN_UPDATE を通常処理
+                    // DR2-005: Replan 時はスキップして二重処理を防ぐ
+                    // Issue #287: merge new target_files into starved_target_files on plan update
+                    if self.try_update_plan(&next_token_buffer) {
+                        let existing = &self.stagnation_state.starved_target_files;
+                        // CB-003: only include unfinished items to avoid re-adding completed files
+                        let new_targets: Vec<String> = self
+                            .execution_plan
+                            .items
                             .iter()
-                            .any(|sf| crate::contracts::ExecutionPlan::path_matches(sf, tf))
-                    })
-                    .collect();
-                self.stagnation_state
-                    .starved_target_files
-                    .extend(new_targets);
+                            .filter(|i| !i.is_finished())
+                            .flat_map(|i| i.target_files.iter().cloned())
+                            .filter(|tf| {
+                                !existing
+                                    .iter()
+                                    .any(|sf| crate::contracts::ExecutionPlan::path_matches(sf, tf))
+                            })
+                            .collect();
+                        self.stagnation_state
+                            .starved_target_files
+                            .extend(new_targets);
+                    }
+                }
             }
 
             // Issue #173: Update ANVIL_FINAL tracking from the new response

--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -1935,6 +1935,14 @@ impl App {
                             "recovery budget granted"
                         );
                     }
+                    // Issue #313: detect whether the error payload already
+                    // contains mid-file context (from extract_edit_context).
+                    // If so, guide the model to use it instead of a generic
+                    // full-file read that truncates mid-file content.
+                    let has_inline_context = matches!(
+                        &result.payload,
+                        ToolExecutionPayload::Text(t) if t.contains("--- File context")
+                    );
                     match action {
                         crate::app::edit_fail_tracker::EditFallbackAction::Continue => {}
                         crate::app::edit_fail_tracker::EditFallbackAction::ReRead => {
@@ -1944,11 +1952,22 @@ impl App {
                                 count = count,
                                 "repeated tool failure"
                             );
-                            edit_hint = Some(format!(
-                                "\n\n[Anvil hint] file.edit has failed {count} consecutive \
-                                 times for '{path}'. Use file.read to get the current file \
-                                 content, then retry file.edit with the correct old_string."
-                            ));
+                            edit_hint = if has_inline_context {
+                                Some(format!(
+                                    "\n\n[Anvil hint] file.edit has failed {count} consecutive \
+                                     times for '{path}'. The file context above shows the actual \
+                                     content with line numbers — use it to correct your old_string. \
+                                     If you need more surrounding lines, use file.read with the \
+                                     offset shown in the context (e.g. file.read path offset=N \
+                                     limit=50)."
+                                ))
+                            } else {
+                                Some(format!(
+                                    "\n\n[Anvil hint] file.edit has failed {count} consecutive \
+                                     times for '{path}'. Use file.read to get the current file \
+                                     content, then retry file.edit with the correct old_string."
+                                ))
+                            };
                         }
                         crate::app::edit_fail_tracker::EditFallbackAction::WriteFallback => {
                             tracing::warn!(
@@ -1970,13 +1989,20 @@ impl App {
                             let line_count_check_failed = max_lines > 0 && line_count.is_none();
 
                             if is_large || line_count_check_failed {
-                                edit_hint = Some(format!(
-                                    "\n\n[Anvil hint] file.edit has failed {count} consecutive \
-                                     times for '{path}'. file.write is not available or could not be \
-                                     safely validated for this path. Instead: \
+                                let ctx_guidance = if has_inline_context {
+                                    "Check the file context above for actual line numbers. \
+                                     Use file.read with offset to get the target section, then \
+                                     retry file.edit with a smaller, precise old_string."
+                                } else {
+                                    "Instead: \
                                      (1) Use file.read to get the current content. \
                                      (2) Identify the exact section to change. \
                                      (3) Retry file.edit with a smaller, precise old_string."
+                                };
+                                edit_hint = Some(format!(
+                                    "\n\n[Anvil hint] file.edit has failed {count} consecutive \
+                                     times for '{path}'. file.write is not available or could not be \
+                                     safely validated for this path. {ctx_guidance}"
                                 ));
                             } else {
                                 edit_hint = Some(format!(

--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -528,7 +528,7 @@ impl App {
 
             // Record sub-agent results first (IR3-002)
             for result in &agent_results {
-                self.record_tool_result(result);
+                self.record_tool_result(result, false);
             }
             total_tool_count += agent_results.len();
 
@@ -563,11 +563,21 @@ impl App {
             // live streaming output on stderr (Issue #1).
 
             // Execute normal tool calls and record results WITH payload
-            let (results, loop_action) = self.execute_structured_tool_calls(&current_normal)?;
+            let (results, loop_action, recovery_read_count) =
+                self.execute_structured_tool_calls(&current_normal)?;
             total_tool_count += results.len();
 
             // Update plan item status from tool results; capture telemetry.
-            let (turn_mutations, turn_items_advanced) = self.update_plan_from_results(&results);
+            let (mut turn_mutations, turn_items_advanced) = self.update_plan_from_results(&results);
+            // Issue #299: count recovery reads as mutations so stagnation
+            // scoring does not inflate during recovery.
+            if recovery_read_count > 0 {
+                turn_mutations += recovery_read_count as u32;
+                tracing::debug!(
+                    recovery_read_count,
+                    "recovery reads counted as mutations for stagnation"
+                );
+            }
 
             // Issue #269 Phase 3: record each successful mutation for stagnation tracking.
             // Issue #273: Also record first mutation event telemetry here so plan-free runs
@@ -1267,10 +1277,22 @@ impl App {
         }
     }
 
+    /// Execute validated and approved tool calls from a structured response.
+    ///
+    /// Returns `(results, loop_action, recovery_read_count)` where
+    /// `recovery_read_count` is the number of recovery reads consumed
+    /// (Issue #299) for stagnation adjustment.
     pub(crate) fn execute_structured_tool_calls(
         &mut self,
         structured: &StructuredAssistantResponse,
-    ) -> Result<(Vec<ToolExecutionResult>, super::loop_detector::LoopAction), AppError> {
+    ) -> Result<
+        (
+            Vec<ToolExecutionResult>,
+            super::loop_detector::LoopAction,
+            usize,
+        ),
+        AppError,
+    > {
         // Phase 1: Validation + Approval
         let (validated_requests, mut failed_results) =
             self.validate_and_approve_all(&structured.tool_calls);
@@ -1349,13 +1371,36 @@ impl App {
         };
 
         // Loop detection: record each validated tool call and check for repetition (Issue #145, #172)
+        // Issue #299: recovery reads skip LoopDetector but not AlternatingLoopDetector.
         let mut worst_loop_action = super::loop_detector::LoopAction::Continue;
         for (_, req) in &validated_requests {
             if let Some((tool_name, tool_input)) = tool_input_map.get(&req.tool_call_id) {
-                // LoopDetector: same-call repetition
-                let action = self.loop_detector.record_and_check(tool_name, tool_input);
-                worst_loop_action = worst_loop_action.merge(action);
+                // Issue #299: Check if this is a recovery read (file.read with budget).
+                let recovery_path = if tool_name == "file.read" {
+                    tool_input
+                        .get("path")
+                        .and_then(|v| v.as_str())
+                        .map(String::from)
+                } else {
+                    None
+                };
+                let is_pre_recovery = recovery_path
+                    .as_deref()
+                    .is_some_and(|p| self.tool_recovery_budget.has_budget(p));
+
+                if is_pre_recovery {
+                    tracing::debug!(
+                        tool = %tool_name,
+                        path = ?recovery_path,
+                        "loop_detector skipped during recovery"
+                    );
+                } else {
+                    // LoopDetector: same-call repetition
+                    let action = self.loop_detector.record_and_check(tool_name, tool_input);
+                    worst_loop_action = worst_loop_action.merge(action);
+                }
                 // AlternatingLoopDetector: cyclic pattern detection (Issue #172)
+                // Always runs, even during recovery (design decision).
                 let alt_action = self
                     .alternating_loop_detector
                     .record_and_check(tool_name, tool_input);
@@ -1372,7 +1417,7 @@ impl App {
             failed_results.sort_by_key(|(idx, _)| *idx);
             let results: Vec<ToolExecutionResult> =
                 failed_results.into_iter().map(|(_, r)| r).collect();
-            return Ok((results, worst_loop_action));
+            return Ok((results, worst_loop_action, 0));
         }
 
         // For Warn/StrongWarn: create synthetic tool result to include in results
@@ -1544,32 +1589,73 @@ impl App {
         let mut results: Vec<ToolExecutionResult> = Vec::with_capacity(indexed_results.len());
         let mut phase_action = super::phase_estimator::PhaseAction::Continue;
         let mut read_transition_message: Option<String> = None;
+        let mut recovery_read_count: usize = 0;
         for (_, result) in indexed_results {
-            self.record_tool_result(&result);
-            // Phase estimator: record tool call pattern (Issue #159)
-            let success = result.status == ToolExecutionStatus::Completed;
-            let pa = self
-                .phase_estimator
-                .record_tool_call(&result.tool_name, success);
-            if !matches!(pa, super::phase_estimator::PhaseAction::Continue) {
-                phase_action = pa;
-            }
-            // Issue #265: pass shell command to read_transition_guard so
-            // grep/sed/cat are counted as exploration calls.
-            let shell_cmd: Option<String> = if result.tool_name == "shell.exec" {
+            // Issue #299: Check if this is a recovery read and consume budget.
+            // Use the raw input path (not the resolved artifact path) so that
+            // the key matches the grant-time path (which is also relative).
+            let recovery_path_for_result = if result.tool_name == "file.read" {
                 tool_input_map
                     .get(&result.tool_call_id)
-                    .and_then(|(_, v)| v.get("command").and_then(|c| c.as_str()).map(String::from))
+                    .and_then(|(_, v)| v.get("path").and_then(|p| p.as_str()))
             } else {
                 None
             };
-            let transition_action = self.read_transition_guard.record_tool_call_ex(
-                &result.tool_name,
-                success,
-                shell_cmd.as_deref(),
-            );
-            if let ReadTransitionAction::Inject(msg) = transition_action {
-                read_transition_message = Some(msg);
+            let is_recovery = recovery_path_for_result.is_some_and(|p| {
+                self.tool_recovery_budget
+                    .should_suppress_detectors(&result.tool_name, p)
+            });
+            if is_recovery {
+                recovery_read_count += 1;
+                let remaining_info = if let Some(p) = recovery_path_for_result {
+                    if self.tool_recovery_budget.has_budget(p) {
+                        "has_remaining"
+                    } else {
+                        "exhausted"
+                    }
+                } else {
+                    "unknown"
+                };
+                tracing::debug!(
+                    tool = %result.tool_name,
+                    path = ?recovery_path_for_result,
+                    budget_status = remaining_info,
+                    "recovery read consumed"
+                );
+            }
+
+            self.record_tool_result(&result, is_recovery);
+
+            // Phase estimator: record tool call pattern (Issue #159)
+            // Issue #299: skip during recovery reads.
+            let success = result.status == ToolExecutionStatus::Completed;
+            if !is_recovery {
+                let pa = self
+                    .phase_estimator
+                    .record_tool_call(&result.tool_name, success);
+                if !matches!(pa, super::phase_estimator::PhaseAction::Continue) {
+                    phase_action = pa;
+                }
+            }
+            // Issue #265: pass shell command to read_transition_guard so
+            // grep/sed/cat are counted as exploration calls.
+            // Issue #299: skip during recovery reads.
+            if !is_recovery {
+                let shell_cmd: Option<String> = if result.tool_name == "shell.exec" {
+                    tool_input_map.get(&result.tool_call_id).and_then(|(_, v)| {
+                        v.get("command").and_then(|c| c.as_str()).map(String::from)
+                    })
+                } else {
+                    None
+                };
+                let transition_action = self.read_transition_guard.record_tool_call_ex(
+                    &result.tool_name,
+                    success,
+                    shell_cmd.as_deref(),
+                );
+                if let ReadTransitionAction::Inject(msg) = transition_action {
+                    read_transition_message = Some(msg);
+                }
             }
 
             // Emit folded tool result to stderr for interactive sessions
@@ -1621,7 +1707,7 @@ impl App {
 
         // Append synthetic loop detection warning if present
         if let Some(warning_result) = synthetic_warning {
-            self.record_tool_result(&warning_result);
+            self.record_tool_result(&warning_result, false);
             results.push(warning_result);
         }
 
@@ -1638,7 +1724,7 @@ impl App {
                 edit_detail: None,
                 rolled_back: false,
             };
-            self.record_tool_result(&transition_result);
+            self.record_tool_result(&transition_result, false);
             results.push(transition_result);
         }
 
@@ -1668,17 +1754,17 @@ impl App {
                     edit_detail: None,
                     rolled_back: false,
                 };
-                self.record_tool_result(&transition_result);
+                self.record_tool_result(&transition_result, false);
                 results.push(transition_result);
             }
         }
 
         self.persist_session(crate::contracts::AppEvent::SessionSaved)?;
-        Ok((results, worst_loop_action))
+        Ok((results, worst_loop_action, recovery_read_count))
     }
 
     /// Push a tool execution result into the session as a tool message.
-    fn record_tool_result(&mut self, result: &ToolExecutionResult) {
+    fn record_tool_result(&mut self, result: &ToolExecutionResult, is_recovery: bool) {
         // Session stats: record tool call (Issue #206 C-3)
         self.session_stats.record_tool_call(&result.tool_name);
 
@@ -1740,6 +1826,18 @@ impl App {
                     let path = resolve_edit_tracker_path(&raw_path);
                     let action = self.edit_fail_tracker.record_failure(&path);
                     let count = self.edit_fail_tracker.failure_count(&path);
+                    // Issue #299: grant recovery budget only for exact-match
+                    // mismatch failures (old_string not found).  IO errors,
+                    // permission failures, etc. are not recoverable by re-reading.
+                    let is_exact_match_failure = result.summary.contains("not found");
+                    if is_exact_match_failure {
+                        self.tool_recovery_budget.grant(&path);
+                        tracing::info!(
+                            path = %path,
+                            budget = self.config.runtime.edit_recovery_read_budget,
+                            "recovery budget granted"
+                        );
+                    }
                     match action {
                         crate::app::edit_fail_tracker::EditFallbackAction::Continue => {}
                         crate::app::edit_fail_tracker::EditFallbackAction::ReRead => {
@@ -1800,6 +1898,12 @@ impl App {
                     let path_str = resolve_edit_tracker_path(artifact);
                     self.edit_fail_tracker.record_success(&path_str);
                     self.write_repeat_tracker.reset_for_path(&path_str);
+                    // Issue #299: clear recovery budget on edit success.
+                    self.tool_recovery_budget.clear(&path_str);
+                    tracing::info!(
+                        path = %path_str,
+                        "recovery budget cleared on success"
+                    );
                 }
             }
         }
@@ -1817,8 +1921,10 @@ impl App {
         let write_hint = self.update_write_trackers(result);
 
         // Read repeat tracker: track repeated file.read calls (Issue #185)
+        // Issue #299: skip during recovery reads to avoid false warnings.
         let mut read_hint: Option<String> = None;
-        if result.tool_name == "file.read"
+        if !is_recovery
+            && result.tool_name == "file.read"
             && result.status == ToolExecutionStatus::Completed
             && let Some(path) = result.artifacts.first()
         {

--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -505,6 +505,8 @@ impl App {
         // Issue #285 A2: limit NoPlan suppression at the post-tool ANVIL_FINAL gate.
         // After one suppression, if the model still can't produce a plan, let it through.
         let mut noplan_suppression_count: u8 = 0;
+        // Issue #303: pre-mutation plan barrier.
+        let mut mutation_barrier = super::mutation_barrier::MutationBarrier::new();
 
         for iteration in 0..max_iterations {
             let iteration_started = std::time::Instant::now();
@@ -564,7 +566,7 @@ impl App {
 
             // Execute normal tool calls and record results WITH payload
             let (results, loop_action, recovery_read_count) =
-                self.execute_structured_tool_calls(&current_normal)?;
+                self.execute_structured_tool_calls(&current_normal, &mut mutation_barrier)?;
             total_tool_count += results.len();
 
             // Update plan item status from tool results; capture telemetry.
@@ -1285,6 +1287,7 @@ impl App {
     pub(crate) fn execute_structured_tool_calls(
         &mut self,
         structured: &StructuredAssistantResponse,
+        mutation_barrier: &mut super::mutation_barrier::MutationBarrier,
     ) -> Result<
         (
             Vec<ToolExecutionResult>,
@@ -1369,6 +1372,16 @@ impl App {
         } else {
             validated_requests
         };
+
+        // Phase 1.75: Pre-mutation plan barrier (Issue #303).
+        // Block mutation tools when no execution plan is registered.
+        let barrier_result =
+            mutation_barrier.check_and_filter(validated_requests, self.execution_plan.is_empty());
+        let validated_requests = barrier_result.passed_requests;
+        failed_results.extend(barrier_result.blocked_results);
+        if barrier_result.blocked_count > 0 {
+            self.agent_telemetry.record_mutation_barrier_block();
+        }
 
         // Loop detection: record each validated tool call and check for repetition (Issue #145, #172)
         // Issue #299: recovery reads skip LoopDetector but not AlternatingLoopDetector.
@@ -1685,7 +1698,9 @@ impl App {
             {
                 let status_str = match result.status {
                     ToolExecutionStatus::Completed => "completed",
-                    ToolExecutionStatus::Failed | ToolExecutionStatus::Interrupted => "failed",
+                    ToolExecutionStatus::Failed
+                    | ToolExecutionStatus::Interrupted
+                    | ToolExecutionStatus::Blocked => "failed",
                 };
                 let event = crate::hooks::PostToolUseEvent {
                     hook_point: "PostToolUse",
@@ -1819,8 +1834,12 @@ impl App {
         }
 
         // Edit fail tracker: track consecutive file.edit/file.edit_anchor failures (Issue #143, #158)
+        // Issue #303: exclude barrier-blocked results from edit_fail_tracker.
         let mut edit_hint: Option<String> = None;
-        if result.tool_name == "file.edit" || result.tool_name == "file.edit_anchor" {
+        let is_barrier_blocked = result.summary.starts_with("[plan_barrier]");
+        if !is_barrier_blocked
+            && (result.tool_name == "file.edit" || result.tool_name == "file.edit_anchor")
+        {
             if result.status == ToolExecutionStatus::Failed {
                 if let Some(raw_path) = extract_edit_path_from_summary(&result.summary) {
                     let path = resolve_edit_tracker_path(&raw_path);
@@ -2463,7 +2482,9 @@ pub fn format_tool_result_message(result: &ToolExecutionResult, max_chars: usize
         ToolExecutionPayload::Text(content) => {
             let head_pct = match &result.status {
                 ToolExecutionStatus::Completed => 80,
-                ToolExecutionStatus::Failed | ToolExecutionStatus::Interrupted => 20,
+                ToolExecutionStatus::Failed
+                | ToolExecutionStatus::Interrupted
+                | ToolExecutionStatus::Blocked => 20,
             };
             let truncated = truncate_with_head_tail(content, max_chars, head_pct);
             if result.tool_name == "file.read"

--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -884,6 +884,17 @@ impl App {
                     plan_repair_count_before_this_turn,
                     remaining_turns,
                 ) {
+                    // Issue #309: inject structured repair turn before termination.
+                    // Give the agent one last chance to close remaining items.
+                    if !self.execution_plan.is_empty()
+                        && !self.execution_plan.is_successfully_completed()
+                    {
+                        let repair_msg = self.build_pre_exit_repair_message();
+                        let msg = SessionMessage::new(MessageRole::Tool, "system", repair_msg)
+                            .with_id(self.next_message_id("tool"));
+                        self.session.push_message(msg);
+                        tracing::info!("pre-exit repair turn injected before escape hatch");
+                    }
                     tracing::warn!(
                         score = stagnation_score,
                         "stagnation escape hatch: terminating loop"
@@ -1701,13 +1712,25 @@ impl App {
 
             self.record_tool_result(&result, is_recovery);
 
-            // Phase estimator: record tool call pattern (Issue #159)
+            // Issue #265/#309: extract shell command once for both guards.
             // Issue #299: skip during recovery reads.
             let success = result.status == ToolExecutionStatus::Completed;
+            let shell_cmd: Option<String> = if result.tool_name == "shell.exec" {
+                tool_input_map
+                    .get(&result.tool_call_id)
+                    .and_then(|(_, v)| v.get("command").and_then(|c| c.as_str()).map(String::from))
+            } else {
+                None
+            };
+            // Phase estimator: record tool call pattern (Issue #159)
+            // Issue #309: pass shell command so inspection counts as Read.
+            // Issue #299: skip during recovery reads.
             if !is_recovery {
-                let pa = self
-                    .phase_estimator
-                    .record_tool_call(&result.tool_name, success);
+                let pa = self.phase_estimator.record_tool_call_ex(
+                    &result.tool_name,
+                    success,
+                    shell_cmd.as_deref(),
+                );
                 if !matches!(pa, super::phase_estimator::PhaseAction::Continue) {
                     phase_action = pa;
                 }
@@ -1716,13 +1739,6 @@ impl App {
             // grep/sed/cat are counted as exploration calls.
             // Issue #299: skip during recovery reads.
             if !is_recovery {
-                let shell_cmd: Option<String> = if result.tool_name == "shell.exec" {
-                    tool_input_map.get(&result.tool_call_id).and_then(|(_, v)| {
-                        v.get("command").and_then(|c| c.as_str()).map(String::from)
-                    })
-                } else {
-                    None
-                };
                 let transition_action = self.read_transition_guard.record_tool_call_ex(
                     &result.tool_name,
                     success,

--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -1013,13 +1013,23 @@ impl App {
                 if let super::phase_estimator::PhaseAction::FallbackComplete =
                     self.phase_estimator.check_empty_response()
                 {
-                    tracing::info!("Phase estimator: fallback completion detected");
-                    self.record_assistant_output(
-                        self.next_message_id("assistant"),
-                        next_structured.final_response,
-                    )?;
-                    fallback_completed = true;
-                    break;
+                    // Issue #307: plan に未完了 item がある場合は break せず
+                    // Plan Gate に fallthrough して既存のガイダンス注入・ループ防止を再利用
+                    if !self.execution_plan.is_empty() && !self.execution_plan.all_finished() {
+                        tracing::info!(
+                            "Phase estimator: fallback completion suppressed \
+                             (plan incomplete, falling through to plan gate; Issue #307)"
+                        );
+                        // break しない → 後続の Plan Gate に到達する
+                    } else {
+                        tracing::info!("Phase estimator: fallback completion detected");
+                        self.record_assistant_output(
+                            self.next_message_id("assistant"),
+                            next_structured.final_response,
+                        )?;
+                        fallback_completed = true;
+                        break;
+                    }
                 }
 
                 // Issue #249/#285: Plan gate — suppress termination if plan is incomplete.

--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -484,7 +484,17 @@ impl App {
         self.reset_execution_plan();
 
         // Issue #249: Detect ANVIL_PLAN from initial response
-        self.try_register_plan(&current.raw_content);
+        // Issue #287: re-initialize stagnation_state on plan registration
+        if self.try_register_plan(&current.raw_content) {
+            let target_files: Vec<String> = self
+                .execution_plan
+                .items
+                .iter()
+                .flat_map(|i| i.target_files.iter().cloned())
+                .collect();
+            self.stagnation_state =
+                crate::app::stagnation_state::StagnationState::init_from_plan(&target_files);
+        }
 
         // Session note extraction bookkeeping (Issue #241)
         let msg_count_before = self.session.messages.len();
@@ -791,6 +801,11 @@ impl App {
                 guidance_chars_this_turn as u32,
                 workset_size_this_turn as u32,
             );
+            // Issue #287: record plan item completion before end_turn (for correct
+            // turns_since_plan_item_completion reset).
+            if turn_items_advanced > 0 {
+                self.stagnation_state.record_plan_item_completion();
+            }
             // Issue #269 Phase 3: stagnation end_turn hook + forced mode update.
             self.stagnation_state.end_turn(turn_mutations > 0);
             let stagnation_score =
@@ -863,8 +878,37 @@ impl App {
 
             // Issue #249: Detect ANVIL_PLAN / ANVIL_PLAN_UPDATE from follow-up responses.
             // Scan the raw token buffer since ANVIL_PLAN may be outside the ANVIL_FINAL block.
-            self.try_register_plan(&next_token_buffer);
-            self.try_update_plan(&next_token_buffer);
+            // Issue #287: re-initialize stagnation_state on plan registration
+            if self.try_register_plan(&next_token_buffer) {
+                let target_files: Vec<String> = self
+                    .execution_plan
+                    .items
+                    .iter()
+                    .flat_map(|i| i.target_files.iter().cloned())
+                    .collect();
+                self.stagnation_state =
+                    crate::app::stagnation_state::StagnationState::init_from_plan(&target_files);
+            }
+            // Issue #287: merge new target_files into starved_target_files on plan update
+            if self.try_update_plan(&next_token_buffer) {
+                let existing = &self.stagnation_state.starved_target_files;
+                // CB-003: only include unfinished items to avoid re-adding completed files
+                let new_targets: Vec<String> = self
+                    .execution_plan
+                    .items
+                    .iter()
+                    .filter(|i| !i.is_finished())
+                    .flat_map(|i| i.target_files.iter().cloned())
+                    .filter(|tf| {
+                        !existing
+                            .iter()
+                            .any(|sf| crate::contracts::ExecutionPlan::path_matches(sf, tf))
+                    })
+                    .collect();
+                self.stagnation_state
+                    .starved_target_files
+                    .extend(new_targets);
+            }
 
             // Issue #173: Update ANVIL_FINAL tracking from the new response
             if next_structured.anvil_final_detected {

--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -89,6 +89,21 @@ pub fn summarize_tool_names(names: &[String]) -> String {
     format_tool_counts(counts.into_iter())
 }
 
+/// Mutation tool names used for the successful-mutation check (Issue #285).
+const MUTATION_TOOL_NAMES: &[&str] = &["file.write", "file.edit", "file.edit_anchor"];
+
+/// Check whether the tool results contain at least one successful mutation
+/// (file.write / file.edit / file.edit_anchor with Completed status,
+/// not rolled back, and with an actual diff). Issue #285 A2 fix.
+pub fn results_contain_successful_mutation(results: &[ToolExecutionResult]) -> bool {
+    results.iter().any(|r| {
+        MUTATION_TOOL_NAMES.contains(&r.tool_name.as_str())
+            && r.status == ToolExecutionStatus::Completed
+            && !r.rolled_back
+            && r.diff_summary.is_some()
+    })
+}
+
 /// Maximum number of parallel threads for tool execution.
 const MAX_PARALLEL_THREADS: usize = 8;
 
@@ -475,8 +490,16 @@ impl App {
         let msg_count_before = self.session.messages.len();
         let tokens_before = self.session.estimated_token_count();
 
+        // Issue #285: track forced_mode_active transitions for telemetry.
+        let mut prev_forced_mode_active = false;
+        // Issue #285 A2: limit NoPlan suppression at the post-tool ANVIL_FINAL gate.
+        // After one suppression, if the model still can't produce a plan, let it through.
+        let mut noplan_suppression_count: u8 = 0;
+
         for iteration in 0..max_iterations {
             let iteration_started = std::time::Instant::now();
+
+            // (prev_forced_mode_active is snapshotted from the previous iteration)
 
             // Check shutdown flag before tool execution
             if self.is_shutdown_requested() {
@@ -590,8 +613,23 @@ impl App {
             // Issue #173: If ANVIL_FINAL was already seen, terminate after
             // executing the current tool batch (no further LLM round-trips).
             if anvil_final_seen {
-                // Issue #249: Plan-aware ANVIL_FINAL gate — suppress if plan is incomplete
-                if self.check_plan_final_gate() {
+                // Issue #249/#285: Plan-aware ANVIL_FINAL gate — suppress if plan is incomplete.
+                // A2 fix: only require plan when session has no file changes AND
+                // the current batch contains no successful mutation.
+                // A2 fix: only suppress NoPlan when the batch contains mutation
+                // tool attempts (successful or not) but no actual persisted changes.
+                // Read-only batches (file.read only) should pass through NoPlan.
+                let batch_has_mutation_attempts = results
+                    .iter()
+                    .any(|r| MUTATION_TOOL_NAMES.contains(&r.tool_name.as_str()));
+                let is_effectively_mutation_task = batch_has_mutation_attempts
+                    && self.session_stats.files_modified.is_empty()
+                    && !results_contain_successful_mutation(&results)
+                    && noplan_suppression_count == 0;
+                if self.check_plan_final_gate_with_require(is_effectively_mutation_task) {
+                    if is_effectively_mutation_task {
+                        noplan_suppression_count += 1;
+                    }
                     tracing::info!("ANVIL_FINAL suppressed by plan gate; continuing execution");
                     anvil_final_seen = false;
                 } else if self.should_activate_guidance_retry(guidance_retry_used, &results) {
@@ -764,6 +802,48 @@ impl App {
                     "stagnation detected; forced_mode_active=true"
                 );
             }
+
+            // Issue #285: staged stagnation recovery.
+            let remaining_turns = max_iterations.saturating_sub(iteration + 1);
+            let plan_repair_count_before_this_turn =
+                self.agent_telemetry.plan_repair_request_count as usize;
+
+            // Workset transition telemetry: record only on first activation.
+            if self.forced_mode_active && !prev_forced_mode_active {
+                self.agent_telemetry.record_forced_workset_transition();
+            }
+
+            // Plan repair request.
+            if crate::app::stagnation_state::should_request_plan_repair(
+                &self.stagnation_state,
+                plan_repair_count_before_this_turn,
+                remaining_turns,
+            ) {
+                let msg_text = crate::app::stagnation_state::build_plan_repair_message(
+                    &self.stagnation_state.starved_target_files,
+                );
+                let msg = SessionMessage::new(MessageRole::Tool, "system", msg_text)
+                    .with_id(self.next_message_id("tool"));
+                self.session.push_message(msg);
+                self.agent_telemetry.record_plan_repair_request();
+            } else {
+                // Escape hatch: plan repair was already attempted but stagnation persists.
+                if crate::app::stagnation_state::should_allow_escape_hatch(
+                    &self.stagnation_state,
+                    plan_repair_count_before_this_turn,
+                    remaining_turns,
+                ) {
+                    tracing::warn!(
+                        score = stagnation_score,
+                        "stagnation escape hatch: terminating loop"
+                    );
+                    break;
+                }
+            }
+
+            // Update prev_forced_mode_active at turn end.
+            prev_forced_mode_active = self.forced_mode_active;
+
             log_turn_summary(&TurnSummary {
                 turn: self.session_stats.total_turns,
                 max_turns: max_iterations as u32,
@@ -834,8 +914,20 @@ impl App {
                     break;
                 }
 
-                // Issue #249: Plan gate — suppress termination if plan is incomplete
-                if self.check_plan_final_gate() {
+                // Issue #249/#285: Plan gate — suppress termination if plan is incomplete.
+                // B1 fix: require plan only when mutation tools were attempted
+                // but no files were actually modified, and we haven't already
+                // suppressed once (to avoid infinite loops for read-only tasks).
+                let session_has_mutation_attempts = MUTATION_TOOL_NAMES
+                    .iter()
+                    .any(|t| self.session_stats.tool_calls.contains_key(*t));
+                let require_plan_here = session_has_mutation_attempts
+                    && self.session_stats.files_modified.is_empty()
+                    && noplan_suppression_count == 0;
+                if self.check_plan_final_gate_with_require(require_plan_here) {
+                    if require_plan_here {
+                        noplan_suppression_count += 1;
+                    }
                     tracing::info!("Plan gate: suppressing termination with empty tool calls");
                     current = next_structured;
                     continue;

--- a/src/app/cli.rs
+++ b/src/app/cli.rs
@@ -235,22 +235,28 @@ fn run_non_interactive<C: ProviderClient>(
                 print!("{}", response);
             }
 
-            // Log session summary (Issue #206 CB-003)
+            // Issue #285 B2 fix: evaluate error conditions BEFORE logging
+            // the session summary so that "session completed" is not emitted
+            // for runs that actually failed.
+            let provider_err = app.last_provider_error().cloned();
+            let tool_err = app.has_tool_execution_failure();
+
+            // Log session summary (Issue #206 CB-003) — artifact is written here.
             app.log_session_summary();
 
-            // Run PostSession hook (DR3-004: after run_live_turn success)
+            // Run PostSession hook (DR3-004: after artifact write)
             app.run_post_session_hook();
 
             // 4. Check for provider errors (e.g. ModelNotFound) that
             //    run_live_turn converted to AgentEvent::Failed
-            if let Some(record) = app.last_provider_error() {
+            if let Some(record) = provider_err {
                 return Err(AppError::ProviderTurn(
-                    ProviderTurnError::from_error_record(record),
+                    ProviderTurnError::from_error_record(&record),
                 ));
             }
 
             // 5. Check for tool execution failures
-            if app.has_tool_execution_failure() {
+            if tool_err {
                 return Err(AppError::ToolExecution("tool execution failed".to_string()));
             }
 

--- a/src/app/execution_plan.rs
+++ b/src/app/execution_plan.rs
@@ -5,10 +5,49 @@
 //! status based on tool execution results, and injecting turn guidance.
 
 use crate::agent::{extract_plan_block, extract_plan_update_block, parse_plan_items};
-use crate::contracts::{ExecutionPlan, FinalGateDecision};
+use crate::contracts::{ExecutionPlan, FinalGateDecision, PlanItem};
 use crate::session::{MessageRole, SessionMessage};
 
 use super::App;
+
+// ---------------------------------------------------------------------------
+// Checked-line detection helpers (Issue #301)
+// ---------------------------------------------------------------------------
+
+/// Detect `[x]`/`[X]` lines in a plan block, returning their 0-based indices.
+///
+/// The index corresponds to the position among all parseable plan item lines
+/// (i.e. lines starting with `- [`, `- ` checkbox format).
+pub(crate) fn detect_checked_lines(block: &str) -> Vec<usize> {
+    let mut indices = Vec::new();
+    let mut item_idx = 0usize;
+    for line in block.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("- [x] ") || trimmed.starts_with("- [X] ") {
+            indices.push(item_idx);
+            item_idx += 1;
+        } else if trimmed.starts_with("- [ ] ") || trimmed.starts_with("- ") && trimmed.len() > 2 {
+            item_idx += 1;
+        }
+        // Non-item lines are ignored
+    }
+    indices
+}
+
+/// Filter out checked items from a `Vec<PlanItem>`, returning only unchecked ones.
+///
+/// `checked_indices` are 0-based indices into `items`.
+pub(crate) fn filter_unchecked_items(
+    items: Vec<PlanItem>,
+    checked_indices: &[usize],
+) -> Vec<PlanItem> {
+    items
+        .into_iter()
+        .enumerate()
+        .filter(|(i, _)| !checked_indices.contains(i))
+        .map(|(_, item)| item)
+        .collect()
+}
 
 /// Message injected when ANVIL_FINAL is suppressed because no plan exists yet.
 const PLAN_REQUIRED_MESSAGE: &str = "[System] まず変更計画を作成してください。```ANVIL_PLAN ブロックで変更対象ファイルと作業内容を出力してください。\n\
@@ -51,41 +90,90 @@ impl App {
 
     /// Try to detect and apply an `ANVIL_PLAN_UPDATE` block.
     ///
+    /// Issue #301: checked-first processing. Before the standard flow:
+    ///   1. Detect `[x]` lines in the block.
+    ///   2. Mark matching existing plan items as `AlreadySatisfied`.
+    ///   3. Retire target files from stagnation state.
+    ///   4. Proceed with standard flow for unchecked items only.
+    ///
     /// Returns `true` if the plan was updated.
     pub(crate) fn try_update_plan(&mut self, content: &str) -> bool {
         if let Some(block) = extract_plan_update_block(content) {
-            let new_items = parse_plan_items(&block);
-            if !new_items.is_empty() {
-                // Issue #289: supersede stale items BEFORE dedup.
-                // This ensures corrected items are not discarded as duplicates
-                // of the stale items they are replacing. After supersede, the
-                // stale items are finished (Superseded) and won't block dedup.
-                self.execution_plan.supersede_stale_items(&new_items);
-                // Issue #287: deduplicate against existing items before appending
-                let deduped = self.execution_plan.deduplicate_new_items(new_items);
-                if deduped.is_empty() {
-                    tracing::info!("ANVIL_PLAN_UPDATE detected; all items deduplicated");
-                    // Still return true if items were superseded
-                    let had_supersede = self
-                        .execution_plan
-                        .items
-                        .iter()
-                        .any(|i| i.status == crate::contracts::PlanItemStatus::Superseded);
-                    if had_supersede {
-                        self.agent_telemetry.record_plan_update();
-                    }
-                    return had_supersede;
-                }
-                tracing::info!(
-                    new_items = deduped.len(),
-                    "ANVIL_PLAN_UPDATE detected; appending items"
-                );
-                self.execution_plan.append_items(deduped);
-                self.agent_telemetry.record_plan_update();
-                return true;
+            let all_items = parse_plan_items(&block);
+            if all_items.is_empty() {
+                return false;
             }
+
+            // --- Issue #301: checked-first retire ---
+            // CB-001 fix: process each checked item individually to prevent
+            // cross-item target combination from causing false retires.
+            let checked_indices = detect_checked_lines(&block);
+            let mut had_retire = false;
+            if !checked_indices.is_empty() {
+                let mut all_retired: Vec<String> = Vec::new();
+                for &idx in &checked_indices {
+                    if let Some(checked_item) = all_items.get(idx) {
+                        if checked_item.target_files.is_empty() {
+                            continue;
+                        }
+                        let retired = self.apply_checked_items(&checked_item.target_files);
+                        all_retired.extend(retired);
+                    }
+                }
+                if !all_retired.is_empty() {
+                    had_retire = true;
+                    // Sync stagnation: retire target files and record completion
+                    self.stagnation_state.retire_target_files(&all_retired);
+                    self.stagnation_state.record_plan_item_completion();
+                }
+            }
+
+            // If all items were checked, we're done (no unchecked items to process)
+            let new_items = filter_unchecked_items(all_items, &checked_indices);
+            if new_items.is_empty() {
+                if had_retire {
+                    tracing::info!("ANVIL_PLAN_UPDATE detected; all items checked → retired");
+                    self.agent_telemetry.record_plan_update();
+                }
+                return had_retire;
+            }
+
+            // --- Standard flow for unchecked items ---
+            // Issue #289: supersede stale items BEFORE dedup.
+            self.execution_plan.supersede_stale_items(&new_items);
+            // Issue #287: deduplicate against existing items before appending
+            let deduped = self.execution_plan.deduplicate_new_items(new_items);
+            if deduped.is_empty() {
+                tracing::info!("ANVIL_PLAN_UPDATE detected; all items deduplicated");
+                let had_supersede = self
+                    .execution_plan
+                    .items
+                    .iter()
+                    .any(|i| i.status == crate::contracts::PlanItemStatus::Superseded);
+                if had_supersede || had_retire {
+                    self.agent_telemetry.record_plan_update();
+                }
+                return had_supersede || had_retire;
+            }
+            tracing::info!(
+                new_items = deduped.len(),
+                "ANVIL_PLAN_UPDATE detected; appending items"
+            );
+            self.execution_plan.append_items(deduped);
+            self.agent_telemetry.record_plan_update();
+            return true;
         }
         false
+    }
+
+    /// Mark existing plan items as `AlreadySatisfied` based on checked target files (Issue #301).
+    ///
+    /// Returns the list of target file paths that were actually retired.
+    fn apply_checked_items(&mut self, checked_targets: &[String]) -> Vec<String> {
+        self.execution_plan.mark_unfinished_items_by_target(
+            checked_targets,
+            crate::contracts::PlanItemStatus::AlreadySatisfied,
+        )
     }
 
     /// Update plan item status based on tool execution results.
@@ -340,5 +428,78 @@ impl App {
     /// Reset the execution plan (e.g. at the start of a new user turn).
     pub(crate) fn reset_execution_plan(&mut self) {
         self.execution_plan = ExecutionPlan::default();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests (Issue #301)
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- detect_checked_lines tests ---
+
+    #[test]
+    fn detect_checked_lines_mixed() {
+        let block = "- [x] src/done.rs: already done\n- [ ] src/todo.rs: still todo\n- [X] src/also_done.rs: also done";
+        let indices = detect_checked_lines(block);
+        assert_eq!(indices, vec![0, 2]);
+    }
+
+    #[test]
+    fn detect_checked_lines_none() {
+        let block = "- [ ] src/a.rs: task\n- [ ] src/b.rs: task";
+        let indices = detect_checked_lines(block);
+        assert!(indices.is_empty());
+    }
+
+    #[test]
+    fn detect_checked_lines_all_checked() {
+        let block = "- [x] src/a.rs: done\n- [x] src/b.rs: done";
+        let indices = detect_checked_lines(block);
+        assert_eq!(indices, vec![0, 1]);
+    }
+
+    #[test]
+    fn detect_checked_lines_ignores_non_item_lines() {
+        let block = "Plan update:\n\n- [x] src/a.rs: done\nSome text\n- [ ] src/b.rs: todo";
+        let indices = detect_checked_lines(block);
+        assert_eq!(indices, vec![0]);
+    }
+
+    // --- filter_unchecked_items tests ---
+
+    #[test]
+    fn filter_unchecked_items_removes_checked() {
+        let items = vec![
+            PlanItem::new("done".into(), vec!["src/a.rs".into()]),
+            PlanItem::new("todo".into(), vec!["src/b.rs".into()]),
+            PlanItem::new("also done".into(), vec!["src/c.rs".into()]),
+        ];
+        let result = filter_unchecked_items(items, &[0, 2]);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].description, "todo");
+    }
+
+    #[test]
+    fn filter_unchecked_items_empty_checked() {
+        let items = vec![
+            PlanItem::new("a".into(), vec![]),
+            PlanItem::new("b".into(), vec![]),
+        ];
+        let result = filter_unchecked_items(items, &[]);
+        assert_eq!(result.len(), 2);
+    }
+
+    #[test]
+    fn filter_unchecked_items_all_checked() {
+        let items = vec![
+            PlanItem::new("a".into(), vec![]),
+            PlanItem::new("b".into(), vec![]),
+        ];
+        let result = filter_unchecked_items(items, &[0, 1]);
+        assert!(result.is_empty());
     }
 }

--- a/src/app/execution_plan.rs
+++ b/src/app/execution_plan.rs
@@ -205,6 +205,7 @@ impl App {
     ///
     /// When `require_plan` is true, the NoPlan branch also suppresses
     /// ANVIL_FINAL and requests plan creation (Issue #253).
+    #[allow(dead_code)]
     pub(crate) fn check_plan_final_gate(&mut self) -> bool {
         self.check_plan_final_gate_inner(false)
     }
@@ -213,6 +214,12 @@ impl App {
     /// no plan has been registered yet (Issue #253: Done path guard).
     pub(crate) fn check_plan_final_gate_require_plan(&mut self) -> bool {
         self.check_plan_final_gate_inner(true)
+    }
+
+    /// require_plan を外部から指定できる汎用バリアント (Issue #285 A2 fix).
+    /// is_mutation_task=true の場合は NoPlan も suppress する。
+    pub(crate) fn check_plan_final_gate_with_require(&mut self, require_plan: bool) -> bool {
+        self.check_plan_final_gate_inner(require_plan)
     }
 
     fn check_plan_final_gate_inner(&mut self, require_plan: bool) -> bool {

--- a/src/app/execution_plan.rs
+++ b/src/app/execution_plan.rs
@@ -468,11 +468,24 @@ impl App {
     /// Called at the beginning of each follow-up turn to guide the LLM.
     /// Uses the configured `guidance_mode` from runtime config.
     ///
+    /// Issue #309: When exactly 1 item remains, injects a closure-focused hint
+    /// that strongly biases toward finishing instead of shell inspection drift.
+    ///
     /// Returns the length (in characters) of the injected guidance text, or
     /// `None` if no guidance was injected (e.g. no active plan).  Callers can
     /// forward this value to `AgentTelemetry::record_turn_metrics` so that
     /// `guidance_chars_per_turn` reflects the actual guidance size.
     pub(crate) fn inject_plan_turn_guidance(&mut self) -> Option<usize> {
+        // Issue #309: late-stage closure mode takes precedence when remaining==1.
+        if let Some(closure_hint) = self.execution_plan.build_late_stage_closure_hint() {
+            let len = closure_hint.len();
+            tracing::info!("late-stage closure mode: remaining=1, injecting closure hint");
+            let msg = SessionMessage::new(MessageRole::Tool, "system", closure_hint)
+                .with_id(self.next_message_id("tool"));
+            self.session.push_message(msg);
+            return Some(len);
+        }
+
         let mode = self.config.runtime.guidance_mode;
         // Issue #269 Phase 3: use workset-aware guidance when stagnation is detected.
         let workset = self.execution_plan.current_workset();

--- a/src/app/execution_plan.rs
+++ b/src/app/execution_plan.rs
@@ -56,11 +56,25 @@ impl App {
         if let Some(block) = extract_plan_update_block(content) {
             let new_items = parse_plan_items(&block);
             if !new_items.is_empty() {
+                // Issue #289: supersede stale items BEFORE dedup.
+                // This ensures corrected items are not discarded as duplicates
+                // of the stale items they are replacing. After supersede, the
+                // stale items are finished (Superseded) and won't block dedup.
+                self.execution_plan.supersede_stale_items(&new_items);
                 // Issue #287: deduplicate against existing items before appending
                 let deduped = self.execution_plan.deduplicate_new_items(new_items);
                 if deduped.is_empty() {
                     tracing::info!("ANVIL_PLAN_UPDATE detected; all items deduplicated");
-                    return false;
+                    // Still return true if items were superseded
+                    let had_supersede = self
+                        .execution_plan
+                        .items
+                        .iter()
+                        .any(|i| i.status == crate::contracts::PlanItemStatus::Superseded);
+                    if had_supersede {
+                        self.agent_telemetry.record_plan_update();
+                    }
+                    return had_supersede;
                 }
                 tracing::info!(
                     new_items = deduped.len(),

--- a/src/app/execution_plan.rs
+++ b/src/app/execution_plan.rs
@@ -92,8 +92,12 @@ impl App {
                     "ANVIL_PLAN detected; registering execution plan"
                 );
                 self.execution_plan = ExecutionPlan::new(items);
-                // Mark first item as InProgress
-                self.execution_plan.mark_in_progress(0);
+                // Issue #315: auto-retire no-path / summary-only items
+                self.execution_plan.auto_retire_no_path_items();
+                // Mark first actionable item as InProgress
+                if let Some(first) = self.execution_plan.next_actionable_index() {
+                    self.execution_plan.mark_in_progress(first);
+                }
                 self.agent_telemetry.record_plan_registration();
                 self.agent_telemetry.record_anvil_plan_visible();
                 return PlanRegistrationResult::Registered;
@@ -119,17 +123,32 @@ impl App {
     /// Executes: checked-first retire → supersede stale → dedup → append.
     /// Returns `true` if any meaningful change occurred (retire, supersede, or append).
     fn apply_plan_update_pipeline(&mut self, block: &str, all_items: Vec<PlanItem>) -> bool {
-        // --- checked-first retire (Issue #301) ---
+        // --- checked-first retire (Issue #301 + Issue #315) ---
         let checked_indices = detect_checked_lines(block);
         let mut had_retire = false;
         if !checked_indices.is_empty() {
             let mut all_retired: Vec<String> = Vec::new();
+            let mut no_path_descriptions: Vec<String> = Vec::new();
             for &idx in &checked_indices {
-                if let Some(checked_item) = all_items.get(idx)
-                    && !checked_item.target_files.is_empty()
-                {
-                    let retired = self.apply_checked_items(&checked_item.target_files);
-                    all_retired.extend(retired);
+                if let Some(checked_item) = all_items.get(idx) {
+                    if !checked_item.target_files.is_empty() {
+                        let retired = self.apply_checked_items(&checked_item.target_files);
+                        all_retired.extend(retired);
+                    } else {
+                        // Issue #315: collect no-path checked items for description-based retire
+                        no_path_descriptions.push(checked_item.description.clone());
+                    }
+                }
+            }
+            // Issue #315: retire existing no-path items by description match
+            if !no_path_descriptions.is_empty() {
+                let count = self.execution_plan.retire_no_path_items_by_description(
+                    &no_path_descriptions,
+                    crate::contracts::PlanItemStatus::AlreadySatisfied,
+                );
+                if count > 0 {
+                    had_retire = true;
+                    self.stagnation_state.record_plan_item_completion();
                 }
             }
             if !all_retired.is_empty() {
@@ -177,6 +196,8 @@ impl App {
             "plan update pipeline: appending items"
         );
         self.execution_plan.append_items(deduped);
+        // Issue #315: auto-retire any newly appended no-path items
+        self.execution_plan.auto_retire_no_path_items();
         self.agent_telemetry.record_plan_update();
         true
     }
@@ -198,7 +219,11 @@ impl App {
             "ANVIL_PLAN_UPDATE on empty plan; registering as new plan (Issue #303)"
         );
         self.execution_plan = ExecutionPlan::new(items);
-        self.execution_plan.mark_in_progress(0);
+        // Issue #315: auto-retire no-path / summary-only items
+        self.execution_plan.auto_retire_no_path_items();
+        if let Some(first) = self.execution_plan.next_actionable_index() {
+            self.execution_plan.mark_in_progress(first);
+        }
         self.agent_telemetry.record_plan_registration();
         self.agent_telemetry.record_anvil_plan_visible();
     }

--- a/src/app/execution_plan.rs
+++ b/src/app/execution_plan.rs
@@ -10,6 +10,17 @@ use crate::session::{MessageRole, SessionMessage};
 
 use super::App;
 
+/// Result of try_register_plan() indicating what happened.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PlanRegistrationResult {
+    /// A new plan was registered (plan was empty).
+    Registered,
+    /// ANVIL_PLAN detected but plan already active → items extracted for replan.
+    Replan,
+    /// No ANVIL_PLAN block found in content.
+    NoBlock,
+}
+
 // ---------------------------------------------------------------------------
 // Checked-line detection helpers (Issue #301)
 // ---------------------------------------------------------------------------
@@ -64,15 +75,18 @@ const PLAN_REQUIRED_MESSAGE: &str = "[System] まず変更計画を作成して�
 impl App {
     /// Try to detect and register an `ANVIL_PLAN` block from the LLM response.
     ///
-    /// Returns `true` if a new plan was registered.
-    pub(crate) fn try_register_plan(&mut self, content: &str) -> bool {
-        // Guard: ignore re-registration when a plan is already active.
-        if !self.execution_plan.is_empty() {
-            return false;
-        }
+    /// Returns [`PlanRegistrationResult`] indicating what happened:
+    /// - `Registered`: a new plan was created (plan was empty).
+    /// - `Replan`: follow-up `ANVIL_PLAN` on an active plan was treated as update (Issue #305).
+    /// - `NoBlock`: no `ANVIL_PLAN` block found, or replan had no effect.
+    pub(crate) fn try_register_plan(&mut self, content: &str) -> PlanRegistrationResult {
         if let Some(block) = extract_plan_block(content) {
             let items = parse_plan_items(&block);
-            if !items.is_empty() {
+            if items.is_empty() {
+                return PlanRegistrationResult::NoBlock;
+            }
+            if self.execution_plan.is_empty() {
+                // New registration (original behavior)
                 tracing::info!(
                     items = items.len(),
                     "ANVIL_PLAN detected; registering execution plan"
@@ -82,10 +96,95 @@ impl App {
                 self.execution_plan.mark_in_progress(0);
                 self.agent_telemetry.record_plan_registration();
                 self.agent_telemetry.record_anvil_plan_visible();
-                return true;
+                return PlanRegistrationResult::Registered;
+            }
+            // Active plan: follow-up ANVIL_PLAN → replan (Issue #305)
+            tracing::info!(
+                items = items.len(),
+                "follow-up ANVIL_PLAN on active plan; treating as replan (Issue #305)"
+            );
+            self.agent_telemetry.record_anvil_plan_visible();
+            let changed = self.apply_replan_items(&block, items);
+            if changed {
+                return PlanRegistrationResult::Replan;
+            }
+            // Replan had no effect (all items deduped/already done) → treat as no-op
+            return PlanRegistrationResult::NoBlock;
+        }
+        PlanRegistrationResult::NoBlock
+    }
+
+    /// Shared pipeline for plan update operations (Issue #305 DRY fix).
+    ///
+    /// Executes: checked-first retire → supersede stale → dedup → append.
+    /// Returns `true` if any meaningful change occurred (retire, supersede, or append).
+    fn apply_plan_update_pipeline(&mut self, block: &str, all_items: Vec<PlanItem>) -> bool {
+        // --- checked-first retire (Issue #301) ---
+        let checked_indices = detect_checked_lines(block);
+        let mut had_retire = false;
+        if !checked_indices.is_empty() {
+            let mut all_retired: Vec<String> = Vec::new();
+            for &idx in &checked_indices {
+                if let Some(checked_item) = all_items.get(idx)
+                    && !checked_item.target_files.is_empty()
+                {
+                    let retired = self.apply_checked_items(&checked_item.target_files);
+                    all_retired.extend(retired);
+                }
+            }
+            if !all_retired.is_empty() {
+                had_retire = true;
+                self.stagnation_state.retire_target_files(&all_retired);
+                self.stagnation_state.record_plan_item_completion();
             }
         }
-        false
+
+        let new_items = filter_unchecked_items(all_items, &checked_indices);
+        if new_items.is_empty() {
+            if had_retire {
+                tracing::info!("plan update pipeline: all items checked → retired");
+                self.agent_telemetry.record_plan_update();
+            }
+            return had_retire;
+        }
+
+        // --- supersede → dedup → append ---
+        // CB-001 fix: count superseded items before/after to detect new supersedes only
+        let superseded_before = self
+            .execution_plan
+            .items
+            .iter()
+            .filter(|i| i.status == crate::contracts::PlanItemStatus::Superseded)
+            .count();
+        self.execution_plan.supersede_stale_items(&new_items);
+        let superseded_after = self
+            .execution_plan
+            .items
+            .iter()
+            .filter(|i| i.status == crate::contracts::PlanItemStatus::Superseded)
+            .count();
+        let had_supersede = superseded_after > superseded_before;
+        let deduped = self.execution_plan.deduplicate_new_items(new_items);
+        if deduped.is_empty() {
+            tracing::info!("plan update pipeline: all items deduplicated");
+            if had_supersede || had_retire {
+                self.agent_telemetry.record_plan_update();
+            }
+            return had_supersede || had_retire;
+        }
+        tracing::info!(
+            new_items = deduped.len(),
+            "plan update pipeline: appending items"
+        );
+        self.execution_plan.append_items(deduped);
+        self.agent_telemetry.record_plan_update();
+        true
+    }
+
+    /// Apply replan items from a follow-up ANVIL_PLAN on an active plan (Issue #305).
+    /// Delegates to shared pipeline. Returns whether any meaningful change occurred.
+    fn apply_replan_items(&mut self, block: &str, all_items: Vec<PlanItem>) -> bool {
+        self.apply_plan_update_pipeline(block, all_items)
     }
 
     /// Internal helper: register a plan from pre-parsed items (Issue #303).
@@ -112,6 +211,8 @@ impl App {
     ///   3. Retire target files from stagnation state.
     ///   4. Proceed with standard flow for unchecked items only.
     ///
+    /// Issue #305: refactored to use `apply_plan_update_pipeline()` shared helper.
+    ///
     /// Returns `true` if the plan was updated.
     pub(crate) fn try_update_plan(&mut self, content: &str) -> bool {
         if let Some(block) = extract_plan_update_block(content) {
@@ -126,64 +227,7 @@ impl App {
                 return true;
             }
 
-            // --- Issue #301: checked-first retire ---
-            // CB-001 fix: process each checked item individually to prevent
-            // cross-item target combination from causing false retires.
-            let checked_indices = detect_checked_lines(&block);
-            let mut had_retire = false;
-            if !checked_indices.is_empty() {
-                let mut all_retired: Vec<String> = Vec::new();
-                for &idx in &checked_indices {
-                    if let Some(checked_item) = all_items.get(idx) {
-                        if checked_item.target_files.is_empty() {
-                            continue;
-                        }
-                        let retired = self.apply_checked_items(&checked_item.target_files);
-                        all_retired.extend(retired);
-                    }
-                }
-                if !all_retired.is_empty() {
-                    had_retire = true;
-                    // Sync stagnation: retire target files and record completion
-                    self.stagnation_state.retire_target_files(&all_retired);
-                    self.stagnation_state.record_plan_item_completion();
-                }
-            }
-
-            // If all items were checked, we're done (no unchecked items to process)
-            let new_items = filter_unchecked_items(all_items, &checked_indices);
-            if new_items.is_empty() {
-                if had_retire {
-                    tracing::info!("ANVIL_PLAN_UPDATE detected; all items checked → retired");
-                    self.agent_telemetry.record_plan_update();
-                }
-                return had_retire;
-            }
-
-            // --- Standard flow for unchecked items ---
-            // Issue #289: supersede stale items BEFORE dedup.
-            self.execution_plan.supersede_stale_items(&new_items);
-            // Issue #287: deduplicate against existing items before appending
-            let deduped = self.execution_plan.deduplicate_new_items(new_items);
-            if deduped.is_empty() {
-                tracing::info!("ANVIL_PLAN_UPDATE detected; all items deduplicated");
-                let had_supersede = self
-                    .execution_plan
-                    .items
-                    .iter()
-                    .any(|i| i.status == crate::contracts::PlanItemStatus::Superseded);
-                if had_supersede || had_retire {
-                    self.agent_telemetry.record_plan_update();
-                }
-                return had_supersede || had_retire;
-            }
-            tracing::info!(
-                new_items = deduped.len(),
-                "ANVIL_PLAN_UPDATE detected; appending items"
-            );
-            self.execution_plan.append_items(deduped);
-            self.agent_telemetry.record_plan_update();
-            return true;
+            return self.apply_plan_update_pipeline(&block, all_items);
         }
         false
     }
@@ -523,5 +567,214 @@ mod tests {
         ];
         let result = filter_unchecked_items(items, &[0, 1]);
         assert!(result.is_empty());
+    }
+
+    // --- Issue #305: PlanRegistrationResult / replan tests ---
+
+    /// Build a minimal App for testing execution_plan methods.
+    fn build_test_app() -> App {
+        use std::sync::Arc;
+        use std::sync::atomic::AtomicBool;
+
+        let tmp = std::env::temp_dir().join(format!(
+            "anvil_test_305_{:?}_{:?}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos(),
+            std::thread::current().id()
+        ));
+        let mut config =
+            crate::config::EffectiveConfig::default_for_test().expect("config should load");
+        config.paths.cwd = tmp.clone();
+        config.paths.workspace_dir = tmp.join("workspace");
+        config.paths.config_file = tmp.join(".anvil").join("config");
+        config.paths.state_dir = tmp.join(".anvil").join("state");
+        config.paths.session_dir = tmp.join(".anvil").join("sessions");
+        config.paths.session_file = config.paths.session_dir.join("default.json");
+        config.paths.logs_dir = tmp.join(".anvil").join("logs");
+        config.paths.mcp_config_file = tmp.join(".anvil").join("mcp.json");
+        config.paths.hooks_config_file = tmp.join(".anvil").join("hooks.json");
+        let provider = crate::provider::ProviderRuntimeContext::bootstrap(&config)
+            .expect("provider should bootstrap");
+        let shutdown_flag = Arc::new(AtomicBool::new(false));
+        App::new(config, provider, shutdown_flag).expect("app should initialize")
+    }
+
+    #[test]
+    fn replan_basic_followup_anvil_plan_on_active_plan() {
+        let mut app = build_test_app();
+        // Initial registration
+        let content1 =
+            "```ANVIL_PLAN\n- [ ] src/a.rs: implement feature\n- [ ] src/b.rs: add tests\n```";
+        let result1 = app.try_register_plan(content1);
+        assert_eq!(result1, PlanRegistrationResult::Registered);
+        assert_eq!(app.execution_plan.items.len(), 2);
+
+        // Follow-up ANVIL_PLAN on active plan → should be treated as replan
+        let content2 = "```ANVIL_PLAN\n- [ ] src/c.rs: new task\n```";
+        let result2 = app.try_register_plan(content2);
+        assert_eq!(result2, PlanRegistrationResult::Replan);
+        // New item should be appended
+        assert_eq!(app.execution_plan.items.len(), 3);
+    }
+
+    #[test]
+    fn replan_telemetry_update_count_increases() {
+        let mut app = build_test_app();
+        let content1 = "```ANVIL_PLAN\n- [ ] src/a.rs: task\n```";
+        app.try_register_plan(content1);
+        assert_eq!(app.agent_telemetry.plan_registration_count, 1);
+        assert_eq!(app.agent_telemetry.plan_update_count, 0);
+        assert_eq!(app.agent_telemetry.anvil_plan_visible_count, 1);
+
+        // Replan
+        let content2 = "```ANVIL_PLAN\n- [ ] src/b.rs: new task\n```";
+        app.try_register_plan(content2);
+        // registration_count should NOT increase
+        assert_eq!(app.agent_telemetry.plan_registration_count, 1);
+        // update_count SHOULD increase
+        assert_eq!(app.agent_telemetry.plan_update_count, 1);
+        // anvil_plan_visible_count SHOULD increase
+        assert_eq!(app.agent_telemetry.anvil_plan_visible_count, 2);
+    }
+
+    #[test]
+    fn replan_supersede_stale_items() {
+        let mut app = build_test_app();
+        let content1 = "```ANVIL_PLAN\n- [ ] src/a.rs: old task\n```";
+        app.try_register_plan(content1);
+
+        // Replan with same file but different description → supersede
+        let content2 = "```ANVIL_PLAN\n- [ ] src/a.rs: new approach\n```";
+        let result = app.try_register_plan(content2);
+        assert_eq!(result, PlanRegistrationResult::Replan);
+        // Old item should be superseded, new one appended
+        assert!(
+            app.execution_plan
+                .items
+                .iter()
+                .any(|i| i.status == crate::contracts::PlanItemStatus::Superseded)
+        );
+    }
+
+    #[test]
+    fn replan_dedup_existing_items() {
+        let mut app = build_test_app();
+        let content1 = "```ANVIL_PLAN\n- [ ] src/a.rs: task\n```";
+        app.try_register_plan(content1);
+        // Simulate a mutation so the item won't be superseded
+        app.execution_plan.items[0]
+            .mutated_files
+            .push("src/a.rs".into());
+
+        // Replan with exact same item → should be deduped (target match)
+        let content2 = "```ANVIL_PLAN\n- [ ] src/a.rs: task\n```";
+        let result = app.try_register_plan(content2);
+        // All items deduped, no supersede → NoBlock
+        assert_eq!(result, PlanRegistrationResult::NoBlock);
+        // Item count unchanged
+        assert_eq!(app.execution_plan.items.len(), 1);
+    }
+
+    #[test]
+    fn replan_done_items_not_appended() {
+        let mut app = build_test_app();
+        let content1 = "```ANVIL_PLAN\n- [ ] src/a.rs: task\n- [ ] src/b.rs: task2\n```";
+        app.try_register_plan(content1);
+        // Mark first item as done
+        app.execution_plan.mark_done(0);
+
+        // Replan includes only a new item + the done item description
+        let content2 = "```ANVIL_PLAN\n- [ ] src/a.rs: task\n- [ ] src/c.rs: new task\n```";
+        let result = app.try_register_plan(content2);
+        assert_eq!(result, PlanRegistrationResult::Replan);
+        // src/c.rs should be added, src/a.rs should be deduped (already done)
+        let new_items: Vec<_> = app
+            .execution_plan
+            .items
+            .iter()
+            .filter(|i| i.target_files.iter().any(|f| f == "src/c.rs"))
+            .collect();
+        assert_eq!(new_items.len(), 1);
+    }
+
+    #[test]
+    fn replan_checked_first_retire() {
+        let mut app = build_test_app();
+        let content1 = "```ANVIL_PLAN\n- [ ] src/a.rs: task\n- [ ] src/b.rs: task2\n```";
+        app.try_register_plan(content1);
+
+        // Replan with [x] checked items → should retire
+        let content2 = "```ANVIL_PLAN\n- [x] src/a.rs: task\n- [ ] src/c.rs: new task\n```";
+        let result = app.try_register_plan(content2);
+        assert_eq!(result, PlanRegistrationResult::Replan);
+        // src/a.rs item should be AlreadySatisfied
+        let a_item = app
+            .execution_plan
+            .items
+            .iter()
+            .find(|i| i.target_files.iter().any(|f| f == "src/a.rs"))
+            .unwrap();
+        assert_eq!(
+            a_item.status,
+            crate::contracts::PlanItemStatus::AlreadySatisfied
+        );
+    }
+
+    #[test]
+    fn replan_subset_items() {
+        let mut app = build_test_app();
+        let content1 = "```ANVIL_PLAN\n- [ ] src/a.rs: task\n- [ ] src/b.rs: task2\n- [ ] src/c.rs: task3\n```";
+        app.try_register_plan(content1);
+        assert_eq!(app.execution_plan.items.len(), 3);
+
+        // Replan with only a subset of new items
+        let content2 = "```ANVIL_PLAN\n- [ ] src/d.rs: new task\n```";
+        let result = app.try_register_plan(content2);
+        assert_eq!(result, PlanRegistrationResult::Replan);
+        assert_eq!(app.execution_plan.items.len(), 4);
+    }
+
+    #[test]
+    fn replan_no_effect_returns_noblock() {
+        let mut app = build_test_app();
+        let content1 = "```ANVIL_PLAN\n- [ ] src/a.rs: task\n```";
+        app.try_register_plan(content1);
+        // Simulate a mutation so the item won't be superseded by replan
+        app.execution_plan.items[0]
+            .mutated_files
+            .push("src/a.rs".into());
+
+        // Replan with same item (deduped, not superseded) → no effect
+        let content2 = "```ANVIL_PLAN\n- [ ] src/a.rs: task\n```";
+        let result = app.try_register_plan(content2);
+        assert_eq!(result, PlanRegistrationResult::NoBlock);
+    }
+
+    #[test]
+    fn first_registration_unchanged() {
+        let mut app = build_test_app();
+        let content = "```ANVIL_PLAN\n- [ ] src/a.rs: implement feature\n```";
+        let result = app.try_register_plan(content);
+        assert_eq!(result, PlanRegistrationResult::Registered);
+        assert_eq!(app.execution_plan.items.len(), 1);
+        assert_eq!(app.agent_telemetry.plan_registration_count, 1);
+        assert_eq!(app.agent_telemetry.anvil_plan_visible_count, 1);
+    }
+
+    #[test]
+    fn plan_update_unchanged() {
+        let mut app = build_test_app();
+        // Register initial plan
+        let content1 = "```ANVIL_PLAN\n- [ ] src/a.rs: task\n```";
+        app.try_register_plan(content1);
+
+        // Update via ANVIL_PLAN_UPDATE (not ANVIL_PLAN)
+        let content2 = "```ANVIL_PLAN_UPDATE\n- [ ] src/b.rs: new task\n```";
+        let updated = app.try_update_plan(content2);
+        assert!(updated);
+        assert_eq!(app.execution_plan.items.len(), 2);
+        assert_eq!(app.agent_telemetry.plan_update_count, 1);
     }
 }

--- a/src/app/execution_plan.rs
+++ b/src/app/execution_plan.rs
@@ -88,6 +88,22 @@ impl App {
         false
     }
 
+    /// Internal helper: register a plan from pre-parsed items (Issue #303).
+    ///
+    /// Used by `try_update_plan()` when an `ANVIL_PLAN_UPDATE` arrives but no
+    /// plan has been registered yet.  Shares the same registration logic as
+    /// `try_register_plan()` but skips block extraction and parsing.
+    fn register_plan_from_items(&mut self, items: Vec<PlanItem>) {
+        tracing::info!(
+            items = items.len(),
+            "ANVIL_PLAN_UPDATE on empty plan; registering as new plan (Issue #303)"
+        );
+        self.execution_plan = ExecutionPlan::new(items);
+        self.execution_plan.mark_in_progress(0);
+        self.agent_telemetry.record_plan_registration();
+        self.agent_telemetry.record_anvil_plan_visible();
+    }
+
     /// Try to detect and apply an `ANVIL_PLAN_UPDATE` block.
     ///
     /// Issue #301: checked-first processing. Before the standard flow:
@@ -102,6 +118,12 @@ impl App {
             let all_items = parse_plan_items(&block);
             if all_items.is_empty() {
                 return false;
+            }
+
+            // Issue #303: if plan is empty, treat ANVIL_PLAN_UPDATE as new plan registration.
+            if self.execution_plan.is_empty() {
+                self.register_plan_from_items(all_items);
+                return true;
             }
 
             // --- Issue #301: checked-first retire ---

--- a/src/app/execution_plan.rs
+++ b/src/app/execution_plan.rs
@@ -56,11 +56,17 @@ impl App {
         if let Some(block) = extract_plan_update_block(content) {
             let new_items = parse_plan_items(&block);
             if !new_items.is_empty() {
+                // Issue #287: deduplicate against existing items before appending
+                let deduped = self.execution_plan.deduplicate_new_items(new_items);
+                if deduped.is_empty() {
+                    tracing::info!("ANVIL_PLAN_UPDATE detected; all items deduplicated");
+                    return false;
+                }
                 tracing::info!(
-                    new_items = new_items.len(),
+                    new_items = deduped.len(),
                     "ANVIL_PLAN_UPDATE detected; appending items"
                 );
-                self.execution_plan.append_items(new_items);
+                self.execution_plan.append_items(deduped);
                 self.agent_telemetry.record_plan_update();
                 return true;
             }
@@ -130,7 +136,7 @@ impl App {
                 let file_matches = item
                     .target_files
                     .iter()
-                    .any(|tf| r.summary.ends_with(tf) || tf.ends_with(&r.summary));
+                    .any(|tf| ExecutionPlan::path_matches(tf, &r.summary));
                 if file_matches {
                     matches.push(i);
                 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -830,6 +830,12 @@ impl App {
     /// Check whether the last turn had any tool execution failures.
     /// Used by non-interactive mode to determine exit code.
     pub fn has_tool_execution_failure(&self) -> bool {
+        // Plan完了ベース (Issue #296): plan が正常完了していれば
+        // 途中の tool failure は回復済みとみなし exit 0 へ.
+        // plan なし実行では従来の is_error チェックをフォールスルー.
+        if self.execution_plan.is_successfully_completed() {
+            return false;
+        }
         self.session
             .last_turn_tool_results()
             .any(|result| result.is_error)
@@ -862,6 +868,20 @@ impl App {
             .session_start
             .map(|s| s.elapsed())
             .unwrap_or_default();
+
+        // Issue #296: Count recovered vs unrecovered tool failures
+        let total_tool_errors = self
+            .session
+            .last_turn_tool_results()
+            .filter(|r| r.is_error)
+            .count();
+        let plan_recovered = self.execution_plan.is_successfully_completed();
+        let (recovered, unrecovered) = if plan_recovered {
+            (total_tool_errors, 0usize)
+        } else {
+            (0usize, total_tool_errors)
+        };
+
         tracing::info!(
             total_turns = self.session_stats.total_turns,
             total_tool_calls = self.session_stats.total_tool_calls(),
@@ -872,6 +892,8 @@ impl App {
             compact_count = self.session_stats.compact_count,
             sidecar_count = self.session_stats.sidecar_count,
             elapsed_s = format!("{:.1}", session_elapsed.as_secs_f64()),
+            recovered_tool_failures = recovered,
+            unrecovered_tool_failures = unrecovered,
             "session completed"
         );
 
@@ -2790,5 +2812,130 @@ mod tests {
             None => context_window as usize,
         };
         assert_eq!(effective, 262_144);
+    }
+
+    // --- Issue #296: has_tool_execution_failure tests ---
+
+    /// Helper to build an App instance for testing.
+    fn build_test_app() -> App {
+        use std::sync::Arc;
+        use std::sync::atomic::AtomicBool;
+
+        let tmp = std::env::temp_dir().join(format!(
+            "anvil_test_296_{:?}_{:?}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos(),
+            std::thread::current().id()
+        ));
+        let mut config =
+            crate::config::EffectiveConfig::default_for_test().expect("config should load");
+        config.paths.cwd = tmp.clone();
+        config.paths.workspace_dir = tmp.join("workspace");
+        config.paths.config_file = tmp.join(".anvil").join("config");
+        config.paths.state_dir = tmp.join(".anvil").join("state");
+        config.paths.session_dir = tmp.join(".anvil").join("sessions");
+        config.paths.session_file = config.paths.session_dir.join("default.json");
+        config.paths.logs_dir = tmp.join(".anvil").join("logs");
+        config.paths.mcp_config_file = tmp.join(".anvil").join("mcp.json");
+        config.paths.hooks_config_file = tmp.join(".anvil").join("hooks.json");
+        let provider = crate::provider::ProviderRuntimeContext::bootstrap(&config)
+            .expect("provider should bootstrap");
+        let shutdown_flag = Arc::new(AtomicBool::new(false));
+        App::new(config, provider, shutdown_flag).expect("app should initialize")
+    }
+
+    /// Push a tool result message with the given is_error flag.
+    fn push_tool_result(app: &mut App, is_error: bool) {
+        let mut msg = crate::session::SessionMessage::new(
+            crate::session::MessageRole::Tool,
+            "tool_result",
+            "result content",
+        );
+        msg.is_error = is_error;
+        app.session.push_message(msg);
+    }
+
+    #[test]
+    fn has_tool_execution_failure_plan_completed_no_error() {
+        let mut app = build_test_app();
+        // Set plan to all Done
+        app.execution_plan =
+            crate::contracts::ExecutionPlan::new(vec![crate::contracts::PlanItem::new(
+                "task1".into(),
+                vec![],
+            )]);
+        app.execution_plan.items[0].status = crate::contracts::PlanItemStatus::Done;
+        // No error tool results
+        push_tool_result(&mut app, false);
+        assert!(!app.has_tool_execution_failure());
+    }
+
+    #[test]
+    fn has_tool_execution_failure_plan_completed_with_error() {
+        let mut app = build_test_app();
+        // Set plan to all Done
+        app.execution_plan = crate::contracts::ExecutionPlan::new(vec![
+            crate::contracts::PlanItem::new("task1".into(), vec![]),
+            crate::contracts::PlanItem::new("task2".into(), vec![]),
+        ]);
+        app.execution_plan.items[0].status = crate::contracts::PlanItemStatus::Done;
+        app.execution_plan.items[1].status = crate::contracts::PlanItemStatus::Done;
+        // Push error tool result (should be recovered)
+        push_tool_result(&mut app, true);
+        assert!(!app.has_tool_execution_failure());
+    }
+
+    #[test]
+    fn has_tool_execution_failure_no_plan_with_error() {
+        let mut app = build_test_app();
+        // No plan (default empty)
+        push_tool_result(&mut app, true);
+        assert!(app.has_tool_execution_failure());
+    }
+
+    #[test]
+    fn has_tool_execution_failure_plan_incomplete_with_error() {
+        let mut app = build_test_app();
+        // Plan with InProgress item
+        app.execution_plan = crate::contracts::ExecutionPlan::new(vec![
+            crate::contracts::PlanItem::new("task1".into(), vec![]),
+            crate::contracts::PlanItem::new("task2".into(), vec![]),
+        ]);
+        app.execution_plan.items[0].status = crate::contracts::PlanItemStatus::Done;
+        app.execution_plan.items[1].status = crate::contracts::PlanItemStatus::InProgress;
+        push_tool_result(&mut app, true);
+        assert!(app.has_tool_execution_failure());
+    }
+
+    #[test]
+    fn has_tool_execution_failure_plan_with_superseded() {
+        let mut app = build_test_app();
+        // Plan with Done + Superseded (all finished, no Blocked)
+        app.execution_plan = crate::contracts::ExecutionPlan::new(vec![
+            crate::contracts::PlanItem::new("task1".into(), vec![]),
+            crate::contracts::PlanItem::new("task2".into(), vec![]),
+            crate::contracts::PlanItem::new("task3".into(), vec![]),
+        ]);
+        app.execution_plan.items[0].status = crate::contracts::PlanItemStatus::Done;
+        app.execution_plan.items[1].status = crate::contracts::PlanItemStatus::Superseded;
+        app.execution_plan.items[2].status = crate::contracts::PlanItemStatus::Done;
+        push_tool_result(&mut app, true);
+        assert!(!app.has_tool_execution_failure());
+    }
+
+    #[test]
+    fn has_tool_execution_failure_plan_with_blocked() {
+        let mut app = build_test_app();
+        // Plan with Blocked item (all finished but has Blocked)
+        app.execution_plan = crate::contracts::ExecutionPlan::new(vec![
+            crate::contracts::PlanItem::new("task1".into(), vec![]),
+            crate::contracts::PlanItem::new("task2".into(), vec![]),
+        ]);
+        app.execution_plan.items[0].status = crate::contracts::PlanItemStatus::Done;
+        app.execution_plan.items[1].status = crate::contracts::PlanItemStatus::Blocked;
+        push_tool_result(&mut app, true);
+        assert!(app.has_tool_execution_failure());
     }
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -18,6 +18,7 @@ pub(crate) mod read_repeat_tracker;
 pub mod read_transition_guard;
 pub mod render;
 pub mod stagnation_state;
+pub(crate) mod tool_recovery_budget;
 pub(crate) mod write_fail_tracker;
 pub(crate) mod write_repeat_tracker;
 
@@ -287,6 +288,8 @@ pub struct App {
     stagnation_state: stagnation_state::StagnationState,
     /// Whether forced mode is active for the current turn (Issue #263).
     forced_mode_active: bool,
+    /// Recovery read budget for file.edit failure recovery (Issue #299).
+    tool_recovery_budget: tool_recovery_budget::ToolRecoveryBudget,
 }
 
 /// Whether the session loop should continue or exit.
@@ -565,6 +568,7 @@ impl App {
         let edit_write_fallback_threshold = config.runtime.edit_write_fallback_threshold;
         let read_repeat_warn = config.runtime.read_repeat_warn_threshold;
         let read_repeat_strong_warn = config.runtime.read_repeat_strong_warn_threshold;
+        let edit_recovery_read_budget = config.runtime.edit_recovery_read_budget;
 
         Ok(Self {
             tools,
@@ -620,6 +624,9 @@ impl App {
             agent_telemetry: crate::contracts::AgentTelemetry::new(),
             stagnation_state: stagnation_state::StagnationState::new(),
             forced_mode_active: false,
+            tool_recovery_budget: tool_recovery_budget::ToolRecoveryBudget::new(
+                edit_recovery_read_budget,
+            ),
         })
     }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -11,6 +11,7 @@ pub(crate) mod edit_fail_tracker;
 pub(crate) mod execution_plan;
 pub mod loop_detector;
 pub mod mock;
+pub mod mutation_barrier;
 pub mod phase_estimator;
 pub mod plan;
 pub mod policy;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -835,6 +835,42 @@ impl App {
         self.shutdown_flag.load(Ordering::Relaxed)
     }
 
+    /// Build a structured repair message injected before escape hatch termination (Issue #309).
+    ///
+    /// Summarizes remaining unfinished items and failed tool calls, giving the
+    /// agent a narrow instruction to either mutate the target or retire it.
+    pub(crate) fn build_pre_exit_repair_message(&self) -> String {
+        let remaining_items: Vec<String> = self
+            .execution_plan
+            .items
+            .iter()
+            .enumerate()
+            .filter(|(_, item)| !item.is_finished())
+            .map(|(i, item)| {
+                let safe =
+                    crate::app::stagnation_state::sanitize_for_prompt_entry(&item.description);
+                let targets = item.target_files.join(", ");
+                format!("  {}. {} (files: {})", i + 1, safe, targets)
+            })
+            .collect();
+
+        let items_str = if remaining_items.is_empty() {
+            "  (none)".to_string()
+        } else {
+            remaining_items.join("\n")
+        };
+
+        format!(
+            "[System] ⚠ SESSION ENDING — 未完了項目が残っています。\n\n\
+             残りの項目:\n{items_str}\n\n\
+             最後の機会です。以下のいずれかを実行してください:\n\
+             1. file.edit / file.write で残りの対象ファイルを変更する\n\
+             2. 変更不要なら ANVIL_PLAN_UPDATE で [x] マークして退役させる\n\
+             3. 完了したら ANVIL_FINAL を出力する\n\n\
+             shell.exec での調査は不要です。すぐに行動してください。"
+        )
+    }
+
     /// Check whether the last turn had any tool execution failures.
     /// Used by non-interactive mode to determine exit code.
     pub fn has_tool_execution_failure(&self) -> bool {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -874,10 +874,11 @@ impl App {
     /// Check whether the last turn had any tool execution failures.
     /// Used by non-interactive mode to determine exit code.
     pub fn has_tool_execution_failure(&self) -> bool {
-        // Plan完了ベース (Issue #296): plan が正常完了していれば
-        // 途中の tool failure は回復済みとみなし exit 0 へ.
-        // plan なし実行では従来の is_error チェックをフォールスルー.
-        if self.execution_plan.is_successfully_completed() {
+        // Issue #311: Use is_cleanly_finished (same predicate as check_final_gate
+        // / CompletionKind) to prevent success/failure divergence on
+        // superseded-only plans.  Supersedes the Issue #296 is_successfully_completed
+        // check which excluded superseded-only plans from recovery.
+        if self.execution_plan.is_cleanly_finished() {
             return false;
         }
         self.session
@@ -913,13 +914,14 @@ impl App {
             .map(|s| s.elapsed())
             .unwrap_or_default();
 
-        // Issue #296: Count recovered vs unrecovered tool failures
+        // Issue #311: Use is_cleanly_finished to align recovery predicate with
+        // check_final_gate / CompletionKind (supersedes #296 is_successfully_completed).
         let total_tool_errors = self
             .session
             .last_turn_tool_results()
             .filter(|r| r.is_error)
             .count();
-        let plan_recovered = self.execution_plan.is_successfully_completed();
+        let plan_recovered = self.execution_plan.is_cleanly_finished();
         let (recovered, unrecovered) = if plan_recovered {
             (total_tool_errors, 0usize)
         } else {

--- a/src/app/mutation_barrier.rs
+++ b/src/app/mutation_barrier.rs
@@ -1,0 +1,109 @@
+//! Pre-mutation plan barrier (Issue #303).
+//!
+//! Blocks mutation tools (file.write, file.edit, file.edit_anchor) when no
+//! execution plan has been registered.  The barrier fires at most
+//! `MUTATION_BARRIER_MAX` times to avoid infinite loops with models that
+//! ignore the guidance.
+
+use crate::tooling::{
+    ToolExecutionPayload, ToolExecutionRequest, ToolExecutionResult, ToolExecutionStatus,
+};
+
+/// Maximum number of barrier blocks before auto-release.
+pub const MUTATION_BARRIER_MAX: u8 = 2;
+
+/// Message returned to the LLM when the barrier blocks a mutation tool.
+pub const MUTATION_BARRIER_MESSAGE: &str = "Before modifying files, you must output an ANVIL_PLAN block with your implementation plan. \
+     Use the ANVIL_PLAN format (markdown checklist), NOT the agent.plan tool. \
+     Example:\n\
+     ANVIL_PLAN\n\
+     - [ ] path/to/file.rs: description of change\n\
+     END_ANVIL_PLAN";
+
+/// Tracks how many times mutation tools have been blocked.
+#[derive(Default)]
+pub struct MutationBarrier {
+    block_count: u8,
+}
+
+/// Result of a barrier check-and-filter operation.
+pub struct MutationBarrierResult {
+    /// Requests that passed the barrier (non-mutation, or barrier inactive).
+    pub passed_requests: Vec<(usize, ToolExecutionRequest)>,
+    /// Results for blocked mutation tools.
+    pub blocked_results: Vec<(usize, ToolExecutionResult)>,
+    /// Number of mutations blocked in this batch.
+    pub blocked_count: usize,
+}
+
+impl MutationBarrier {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Check a batch of validated requests and filter out mutation tools
+    /// when no execution plan is registered.
+    ///
+    /// When `execution_plan_empty` is true and `block_count < MUTATION_BARRIER_MAX`,
+    /// mutation tools are moved to `blocked_results` with a `[plan_barrier]` prefix
+    /// and `ToolExecutionStatus::Blocked` status.  Non-mutation tools always pass.
+    pub fn check_and_filter(
+        &mut self,
+        validated_requests: Vec<(usize, ToolExecutionRequest)>,
+        execution_plan_empty: bool,
+    ) -> MutationBarrierResult {
+        // Fast path: barrier inactive (plan exists or max reached).
+        if !execution_plan_empty || self.block_count >= MUTATION_BARRIER_MAX {
+            return MutationBarrierResult {
+                passed_requests: validated_requests,
+                blocked_results: Vec::new(),
+                blocked_count: 0,
+            };
+        }
+
+        // Check if any request is a mutation tool.
+        let has_mutation = validated_requests
+            .iter()
+            .any(|(_, r)| super::MUTATION_TOOLS.contains(&r.spec.name.as_str()));
+
+        if !has_mutation {
+            return MutationBarrierResult {
+                passed_requests: validated_requests,
+                blocked_results: Vec::new(),
+                blocked_count: 0,
+            };
+        }
+
+        // Barrier fires: split mutation vs non-mutation.
+        self.block_count += 1;
+        let mut passed = Vec::new();
+        let mut blocked = Vec::new();
+
+        for (idx, request) in validated_requests {
+            if super::MUTATION_TOOLS.contains(&request.spec.name.as_str()) {
+                let result = ToolExecutionResult {
+                    tool_call_id: request.tool_call_id.clone(),
+                    tool_name: request.spec.name.clone(),
+                    status: ToolExecutionStatus::Blocked,
+                    summary: format!("[plan_barrier] {MUTATION_BARRIER_MESSAGE}"),
+                    payload: ToolExecutionPayload::None,
+                    artifacts: Vec::new(),
+                    elapsed_ms: 0,
+                    diff_summary: None,
+                    edit_detail: None,
+                    rolled_back: false,
+                };
+                blocked.push((idx, result));
+            } else {
+                passed.push((idx, request));
+            }
+        }
+
+        let blocked_count = blocked.len();
+        MutationBarrierResult {
+            passed_requests: passed,
+            blocked_results: blocked,
+            blocked_count,
+        }
+    }
+}

--- a/src/app/phase_estimator.rs
+++ b/src/app/phase_estimator.rs
@@ -118,7 +118,28 @@ impl PhaseEstimator {
     /// Returns `Continue` or `ForceTransition`. Never returns `FallbackComplete`
     /// (use [`check_empty_response`] for that).
     pub fn record_tool_call(&mut self, tool_name: &str, success: bool) -> PhaseAction {
-        match classify_tool(tool_name) {
+        self.record_tool_call_ex(tool_name, success, None)
+    }
+
+    /// Record a tool call with optional shell command context (Issue #309).
+    ///
+    /// When `shell_command` is `Some` and the command is an inspection operation
+    /// (grep/sed/cat/head/tail/commandindexdev/find/…), it counts as a `Read`
+    /// instead of `Other`, integrating shell-based inspection into phase guidance.
+    pub fn record_tool_call_ex(
+        &mut self,
+        tool_name: &str,
+        success: bool,
+        shell_command: Option<&str>,
+    ) -> PhaseAction {
+        let category = if tool_name == "shell.exec"
+            && shell_command.is_some_and(crate::tooling::shell_policy::is_shell_inspection_command)
+        {
+            ToolCategory::Read
+        } else {
+            classify_tool(tool_name)
+        };
+        match category {
             ToolCategory::Read => {
                 self.consecutive_reads += 1;
                 if self.consecutive_reads >= self.force_transition_threshold {
@@ -370,5 +391,40 @@ mod tests {
             let action = est.record_tool_call("file.read", true);
             assert_ne!(action, PhaseAction::FallbackComplete);
         }
+    }
+
+    // --- Issue #309: record_tool_call_ex shell inspection integration ---
+
+    #[test]
+    fn shell_exec_grep_counts_as_read_via_ex() {
+        let mut est = default_estimator();
+        est.record_tool_call_ex("shell.exec", true, Some("grep -n pattern src/main.rs"));
+        assert_eq!(est.consecutive_reads, 1);
+    }
+
+    #[test]
+    fn shell_exec_commandindexdev_counts_as_read_via_ex() {
+        let mut est = default_estimator();
+        est.record_tool_call_ex(
+            "shell.exec",
+            true,
+            Some("commandindexdev before-change src/lib.ts --format llm"),
+        );
+        assert_eq!(est.consecutive_reads, 1);
+    }
+
+    #[test]
+    fn shell_exec_non_inspection_stays_other_via_ex() {
+        let mut est = default_estimator();
+        est.record_tool_call_ex("shell.exec", true, Some("cargo build"));
+        assert_eq!(est.consecutive_reads, 0);
+        assert!(!est.has_written);
+    }
+
+    #[test]
+    fn shell_exec_without_command_stays_other_via_ex() {
+        let mut est = default_estimator();
+        est.record_tool_call_ex("shell.exec", true, None);
+        assert_eq!(est.consecutive_reads, 0);
     }
 }

--- a/src/app/policy.rs
+++ b/src/app/policy.rs
@@ -60,6 +60,7 @@ mod tests {
             tool_call_id: "call_1".to_string(),
             tool_name: tool_name.to_string(),
             input,
+            extra_field_warnings: vec![],
         }
     }
 

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -215,6 +215,7 @@ pub fn map_tool_status(action: &str) -> ToolExecutionStatus {
     match action {
         "failed" => ToolExecutionStatus::Failed,
         "interrupted" => ToolExecutionStatus::Interrupted,
+        "blocked" => ToolExecutionStatus::Blocked,
         _ => ToolExecutionStatus::Completed,
     }
 }

--- a/src/app/stagnation_state.rs
+++ b/src/app/stagnation_state.rs
@@ -179,11 +179,13 @@ pub fn compute_stagnation_score(state: &StagnationState) -> usize {
 
 /// ANVIL_PLAN_UPDATE request conditions.
 ///
-/// Returns `true` when all four conditions are met:
-/// - stagnation score >= 2
-/// - starved target files >= 2
-/// - plan_repair_request_count < 2 (limit)
-/// - remaining_turns >= 5
+/// Fires on any of three paths:
+/// 1. **normal**: score >= 2, starved >= 2, count < 2, remaining >= 5
+/// 2. **severe** (Issue #287): score >= 3, mutation_drought >= 5, starved non-empty,
+///    count < 2, remaining >= 1
+/// 3. **orphan mutation** (Issue #287 follow-up): plan stalled >= 5 turns BUT mutations
+///    are recent (< 3 turns), workset stuck >= 3, starved non-empty — catches the case
+///    where LLM edits non-target files (e.g. relocated/renamed implementation path).
 pub fn should_request_plan_repair(
     state: &StagnationState,
     plan_repair_request_count: usize,
@@ -203,7 +205,18 @@ pub fn should_request_plan_repair(
         && plan_repair_request_count < 2
         && remaining_turns >= 1;
 
-    normal_condition || severe_condition
+    // Issue #287 follow-up: orphan mutation condition — mutations happen but plan items
+    // don't advance because LLM implemented to a different path than planned
+    // (e.g. plan targets "auto-yes-manager.ts" but edits go to "auto-yes-poller.ts").
+    // In this case turns_since_last_mutation stays low so severe_condition never fires.
+    let orphan_mutation_condition = state.turns_since_plan_item_completion >= 5
+        && state.turns_since_last_mutation < 3
+        && state.same_workset_turns >= 3
+        && !state.starved_target_files.is_empty()
+        && plan_repair_request_count < 2
+        && remaining_turns >= 1;
+
+    normal_condition || severe_condition || orphan_mutation_condition
 }
 
 // ---------------------------------------------------------------------------
@@ -425,23 +438,34 @@ pub fn build_plan_repair_message(starved_target_files: &[String]) -> String {
 /// Escape hatch: allow forced loop termination when stagnation is severe
 /// and recovery attempts have been exhausted (Issue #285).
 ///
-/// Returns `true` when ALL conditions are met:
-/// - stagnation score >= 3
-/// - at least one plan repair was already attempted
-/// - mutation drought is deep (turns_since_last_mutation >= 8)
-/// - remaining turns are low (<= 10)
+/// Fires on either of two paths:
+/// 1. **base + drought/stall**: score >= 3, repair attempted, remaining <= 10,
+///    AND (mutation_drought >= 8 OR plan_stall >= 10)
+/// 2. **orphan escape**: score >= 2, repair attempted, remaining <= 10,
+///    plan_item_completion stalled >= 8, but mutations ARE recent (< 3 turns)
+///    — catches the case where LLM edits non-target files indefinitely.
 pub fn should_allow_escape_hatch(
     state: &StagnationState,
     plan_repair_request_count: usize,
     remaining_turns: usize,
 ) -> bool {
-    let base = compute_stagnation_score(state) >= 3
-        && plan_repair_request_count >= 1
-        && remaining_turns <= 10;
+    let score = compute_stagnation_score(state);
+
+    let base = score >= 3 && plan_repair_request_count >= 1 && remaining_turns <= 10;
 
     let mutation_drought = state.turns_since_last_mutation >= 8;
     // Issue #287: plan stall as alternative escape condition
     let plan_stall = state.turns_since_plan_item_completion >= 10;
 
-    base && (mutation_drought || plan_stall)
+    // Issue #287 follow-up: orphan mutation escape — plan repair was attempted but
+    // mutations still go to non-target files. Lower score threshold since mutations
+    // prevent the score from reaching 3 (mutation drought +1 never triggers).
+    let orphan_escape = score >= 2
+        && plan_repair_request_count >= 1
+        && state.turns_since_plan_item_completion >= 8
+        && state.turns_since_last_mutation < 3
+        && !state.starved_target_files.is_empty()
+        && remaining_turns <= 10;
+
+    (base && (mutation_drought || plan_stall)) || orphan_escape
 }

--- a/src/app/stagnation_state.rs
+++ b/src/app/stagnation_state.rs
@@ -189,10 +189,21 @@ pub fn should_request_plan_repair(
     plan_repair_request_count: usize,
     remaining_turns: usize,
 ) -> bool {
-    compute_stagnation_score(state) >= 2
+    let score = compute_stagnation_score(state);
+
+    let normal_condition = score >= 2
         && state.starved_target_files.len() >= 2
         && plan_repair_request_count < 2
-        && remaining_turns >= 5
+        && remaining_turns >= 5;
+
+    // Issue #287: severe condition fires even at remaining=1 (final gate hang recovery)
+    let severe_condition = score >= 3
+        && state.turns_since_last_mutation >= 5
+        && !state.starved_target_files.is_empty()
+        && plan_repair_request_count < 2
+        && remaining_turns >= 1;
+
+    normal_condition || severe_condition
 }
 
 // ---------------------------------------------------------------------------
@@ -424,8 +435,13 @@ pub fn should_allow_escape_hatch(
     plan_repair_request_count: usize,
     remaining_turns: usize,
 ) -> bool {
-    compute_stagnation_score(state) >= 3
+    let base = compute_stagnation_score(state) >= 3
         && plan_repair_request_count >= 1
-        && state.turns_since_last_mutation >= 8
-        && remaining_turns <= 10
+        && remaining_turns <= 10;
+
+    let mutation_drought = state.turns_since_last_mutation >= 8;
+    // Issue #287: plan stall as alternative escape condition
+    let plan_stall = state.turns_since_plan_item_completion >= 10;
+
+    base && (mutation_drought || plan_stall)
 }

--- a/src/app/stagnation_state.rs
+++ b/src/app/stagnation_state.rs
@@ -109,6 +109,18 @@ impl StagnationState {
         }
     }
 
+    /// Remove retired files from `starved_target_files` (Issue #301).
+    ///
+    /// SRP: this method only removes from the starved list.
+    /// The caller is responsible for invoking `record_plan_item_completion()` separately.
+    pub fn retire_target_files(&mut self, retired_files: &[String]) {
+        self.starved_target_files.retain(|f| {
+            !retired_files
+                .iter()
+                .any(|rf| ExecutionPlan::path_matches(f, rf))
+        });
+    }
+
     /// Record a plan item completion.
     pub fn record_plan_item_completion(&mut self) {
         self.had_plan_item_completion_this_turn = true;

--- a/src/app/stagnation_state.rs
+++ b/src/app/stagnation_state.rs
@@ -410,3 +410,22 @@ pub fn build_plan_repair_message(starved_target_files: &[String]) -> String {
          - Add only concrete mutation actions (file.edit / file.write)"
     )
 }
+
+/// Escape hatch: allow forced loop termination when stagnation is severe
+/// and recovery attempts have been exhausted (Issue #285).
+///
+/// Returns `true` when ALL conditions are met:
+/// - stagnation score >= 3
+/// - at least one plan repair was already attempted
+/// - mutation drought is deep (turns_since_last_mutation >= 8)
+/// - remaining turns are low (<= 10)
+pub fn should_allow_escape_hatch(
+    state: &StagnationState,
+    plan_repair_request_count: usize,
+    remaining_turns: usize,
+) -> bool {
+    compute_stagnation_score(state) >= 3
+        && plan_repair_request_count >= 1
+        && state.turns_since_last_mutation >= 8
+        && remaining_turns <= 10
+}

--- a/src/app/tool_recovery_budget.rs
+++ b/src/app/tool_recovery_budget.rs
@@ -1,0 +1,172 @@
+use std::collections::HashMap;
+
+/// Manages per-path recovery read budgets for file.edit failure recovery.
+///
+/// After a file.edit (or file.edit_anchor) failure, the LLM typically needs
+/// to re-read the file to get the current content before retrying.  These
+/// recovery reads should not be counted by generic exploration detectors
+/// (loop detector, phase estimator, etc.) because they are a legitimate
+/// part of the edit retry workflow.
+///
+/// `ToolRecoveryBudget` grants a small budget of suppressed reads per path
+/// on edit failure and consumes it on subsequent file.read calls.
+pub(crate) struct ToolRecoveryBudget {
+    /// Canonical/normalized per-path recovery read remaining counts.
+    budgets: HashMap<String, u32>,
+    /// Maximum recovery reads permitted per grant (configurable).
+    max_budget: u32,
+}
+
+impl ToolRecoveryBudget {
+    /// Create a new budget manager with the given per-path maximum.
+    pub(crate) fn new(max_budget: u32) -> Self {
+        Self {
+            budgets: HashMap::new(),
+            max_budget,
+        }
+    }
+
+    /// Check whether this tool call is a recovery read that should suppress
+    /// detector signals.  Returns `true` (and decrements the budget) when
+    /// `tool_name` is `"file.read"` and `path` has remaining budget.
+    pub(crate) fn should_suppress_detectors(&mut self, tool_name: &str, path: &str) -> bool {
+        if tool_name != "file.read" {
+            return false;
+        }
+        let normalized = normalize_path(path);
+        match self.budgets.get_mut(&normalized) {
+            Some(remaining) if *remaining > 0 => {
+                *remaining -= 1;
+                true
+            }
+            _ => false,
+        }
+    }
+
+    /// Grant recovery budget for the given path.
+    pub(crate) fn grant(&mut self, path: &str) {
+        let normalized = normalize_path(path);
+        self.budgets.insert(normalized, self.max_budget);
+    }
+
+    /// Clear (remove) budget for the given path (e.g. on edit success).
+    pub(crate) fn clear(&mut self, path: &str) {
+        let normalized = normalize_path(path);
+        self.budgets.remove(&normalized);
+    }
+
+    /// Check whether the path currently has any remaining budget.
+    pub(crate) fn has_budget(&self, path: &str) -> bool {
+        let normalized = normalize_path(path);
+        self.budgets.get(&normalized).is_some_and(|&v| v > 0)
+    }
+}
+
+/// Normalize a file path for consistent budget key usage.
+///
+/// Handles common variations so that `./foo.rs` and `foo.rs` map to the
+/// same key.  Also normalizes backslashes to forward slashes.
+fn normalize_path(raw: &str) -> String {
+    let s = raw.replace('\\', "/");
+    let s = s.trim_start_matches("./");
+    s.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_grant_and_suppress() {
+        let mut budget = ToolRecoveryBudget::new(3);
+        budget.grant("foo.rs");
+        assert!(budget.has_budget("foo.rs"));
+        assert!(budget.should_suppress_detectors("file.read", "foo.rs"));
+        assert!(budget.has_budget("foo.rs")); // still 2 remaining
+    }
+
+    #[test]
+    fn test_consume_decrements() {
+        let mut budget = ToolRecoveryBudget::new(2);
+        budget.grant("foo.rs");
+
+        assert!(budget.should_suppress_detectors("file.read", "foo.rs"));
+        assert!(budget.should_suppress_detectors("file.read", "foo.rs"));
+        // Budget exhausted
+        assert!(!budget.should_suppress_detectors("file.read", "foo.rs"));
+        assert!(!budget.has_budget("foo.rs"));
+    }
+
+    #[test]
+    fn test_clear_removes() {
+        let mut budget = ToolRecoveryBudget::new(3);
+        budget.grant("foo.rs");
+        assert!(budget.has_budget("foo.rs"));
+
+        budget.clear("foo.rs");
+        assert!(!budget.has_budget("foo.rs"));
+        assert!(!budget.should_suppress_detectors("file.read", "foo.rs"));
+    }
+
+    #[test]
+    fn test_path_normalization() {
+        let mut budget = ToolRecoveryBudget::new(3);
+
+        // Grant with "./" prefix, check without
+        budget.grant("./src/main.rs");
+        assert!(budget.has_budget("src/main.rs"));
+        assert!(budget.should_suppress_detectors("file.read", "src/main.rs"));
+
+        // Grant without prefix, check with "./"
+        budget.grant("lib.rs");
+        assert!(budget.has_budget("./lib.rs"));
+
+        // Backslash normalization
+        budget.grant("src\\app\\mod.rs");
+        assert!(budget.has_budget("src/app/mod.rs"));
+    }
+
+    #[test]
+    fn test_non_file_read_returns_false() {
+        let mut budget = ToolRecoveryBudget::new(3);
+        budget.grant("foo.rs");
+
+        assert!(!budget.should_suppress_detectors("file.write", "foo.rs"));
+        assert!(!budget.should_suppress_detectors("file.edit", "foo.rs"));
+        assert!(!budget.should_suppress_detectors("shell.exec", "foo.rs"));
+        // Budget should still be intact
+        assert!(budget.has_budget("foo.rs"));
+    }
+
+    #[test]
+    fn test_no_budget_returns_false() {
+        let mut budget = ToolRecoveryBudget::new(3);
+        assert!(!budget.should_suppress_detectors("file.read", "foo.rs"));
+    }
+
+    #[test]
+    fn test_independent_paths() {
+        let mut budget = ToolRecoveryBudget::new(1);
+        budget.grant("a.rs");
+        budget.grant("b.rs");
+
+        assert!(budget.should_suppress_detectors("file.read", "a.rs"));
+        // a.rs exhausted
+        assert!(!budget.should_suppress_detectors("file.read", "a.rs"));
+        // b.rs still has budget
+        assert!(budget.should_suppress_detectors("file.read", "b.rs"));
+    }
+
+    #[test]
+    fn test_regrant_resets_budget() {
+        let mut budget = ToolRecoveryBudget::new(2);
+        budget.grant("foo.rs");
+        budget.should_suppress_detectors("file.read", "foo.rs"); // consume 1
+
+        // Re-grant resets to max
+        budget.grant("foo.rs");
+        assert!(budget.should_suppress_detectors("file.read", "foo.rs"));
+        assert!(budget.should_suppress_detectors("file.read", "foo.rs"));
+        assert!(!budget.should_suppress_detectors("file.read", "foo.rs"));
+    }
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -203,6 +203,9 @@ pub struct RuntimeConfig {
     /// Guidance mode for plan-aware execution (Issue #261).
     /// Sequential = one item at a time (default), Batch = multiple items per turn.
     pub guidance_mode: GuidanceMode,
+    /// Per-path recovery read budget after file.edit failure (Issue #299).
+    /// Controls how many file.read calls are suppressed from detector signals.
+    pub edit_recovery_read_budget: u32,
 }
 
 #[derive(Debug, Clone)]
@@ -384,6 +387,7 @@ impl EffectiveConfig {
                 max_tool_calls: DEFAULT_MAX_TOOL_CALLS,
                 max_output_tokens: Some(DEFAULT_MAX_OUTPUT_TOKENS),
                 guidance_mode: GuidanceMode::default(),
+                edit_recovery_read_budget: 3,
             },
             mode: ModeConfig {
                 prompt_source: PromptSource::Interactive,
@@ -507,6 +511,7 @@ impl EffectiveConfig {
             "ANVIL_UI_LANGUAGE",
             "ANVIL_MAX_TOOL_CALLS",
             "ANVIL_GUIDANCE_MODE",
+            "ANVIL_EDIT_RECOVERY_READ_BUDGET",
         ] {
             if let Ok(value) = std::env::var(key) {
                 map.insert(key.to_string(), value);
@@ -858,6 +863,15 @@ impl EffectiveConfig {
                     }
                     self.runtime.edit_write_fallback_threshold = v;
                 }
+                "edit_recovery_read_budget" | "ANVIL_EDIT_RECOVERY_READ_BUDGET" => {
+                    let v: u32 = value
+                        .parse()
+                        .map_err(|_| ConfigError::InvalidNumericValue(value.clone()))?;
+                    if !(1..=10).contains(&v) {
+                        return Err(ConfigError::InvalidNumericValue(value.clone()));
+                    }
+                    self.runtime.edit_recovery_read_budget = v;
+                }
                 "read_repeat_warn_threshold" | "ANVIL_READ_REPEAT_WARN_THRESHOLD" => {
                     let v: u32 = value
                         .parse()
@@ -1146,6 +1160,8 @@ impl EffectiveConfig {
         if self.runtime.edit_write_fallback_threshold <= self.runtime.edit_reread_threshold {
             self.runtime.edit_write_fallback_threshold = self.runtime.edit_reread_threshold + 2;
         }
+        self.runtime.edit_recovery_read_budget =
+            self.runtime.edit_recovery_read_budget.clamp(1, 10);
     }
 
     pub fn validate_for_test(&mut self) -> Result<(), ConfigError> {
@@ -1506,6 +1522,7 @@ impl std::fmt::Debug for RuntimeConfig {
             )
             .field("safe_write_max_lines", &self.safe_write_max_lines)
             .field("safe_write_deletion_ratio", &self.safe_write_deletion_ratio)
+            .field("edit_recovery_read_budget", &self.edit_recovery_read_budget)
             .finish()
     }
 }

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -688,6 +688,17 @@ impl ExecutionPlan {
             })
     }
 
+    /// Whether the plan reached a clean terminal state: all items finished with
+    /// no blocked items (Issue #311).
+    ///
+    /// Unlike `is_successfully_completed()` which requires positive evidence
+    /// (Done/AlreadySatisfied), this method also accepts superseded-only plans.
+    /// Used by exit/recovery logic to ensure consistency with
+    /// `check_final_gate` / `CompletionKind::classify`.
+    pub fn is_cleanly_finished(&self) -> bool {
+        self.all_finished() && !self.has_blocked_items()
+    }
+
     /// Decide whether ANVIL_FINAL should be accepted.
     pub fn check_final_gate(&self) -> FinalGateDecision {
         if self.items.is_empty() {
@@ -812,6 +823,12 @@ impl ExecutionPlan {
     ///
     /// Excludes new items whose `target_files` match an existing item
     /// (using `path_matches` for fuzzy comparison).
+    ///
+    /// Issue #311: `Superseded` items are excluded from dedup matching so that
+    /// corrected replacements survive and remain actionable in the plan.
+    /// Without this, a supersede→dedup pipeline can produce a superseded-only
+    /// terminal plan that diverges `check_final_gate` / `CompletionKind` from
+    /// `is_successfully_completed` / exit semantics.
     pub fn deduplicate_new_items(&self, new_items: Vec<PlanItem>) -> Vec<PlanItem> {
         new_items
             .into_iter()
@@ -820,6 +837,11 @@ impl ExecutionPlan {
                 new_targets.sort();
 
                 !self.items.iter().any(|existing| {
+                    // Issue #311: Skip Superseded items — corrected replacements
+                    // must not be deduped against the items they replaced.
+                    if existing.status == PlanItemStatus::Superseded {
+                        return false;
+                    }
                     let mut existing_targets = existing.target_files.clone();
                     existing_targets.sort();
                     if new_targets.len() != existing_targets.len() {

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -1251,6 +1251,49 @@ impl ExecutionPlan {
             workset_lines.join("\n")
         )
     }
+    /// Build a late-stage closure hint when only 1 actionable item remains (Issue #309).
+    ///
+    /// Returns `Some(message)` when exactly 1 unfinished item remains and
+    /// the plan has made substantial progress (>= 50% done). The message
+    /// strongly guides the agent to finish or structurally retire the last item
+    /// instead of drifting into shell-based inspection.
+    pub fn build_late_stage_closure_hint(&self) -> Option<String> {
+        if self.items.is_empty() {
+            return None;
+        }
+        let finished = self.finished_count();
+        let total = self.items.len();
+        let remaining = total - finished;
+
+        if remaining != 1 || finished == 0 {
+            return None;
+        }
+
+        // Find the remaining item
+        let next_item = self.next_actionable_index().and_then(|i| self.items.get(i));
+        let next_item = next_item?;
+        let safe_desc =
+            crate::app::stagnation_state::sanitize_for_prompt_entry(&next_item.description);
+        let target_files: Vec<String> = next_item
+            .target_files
+            .iter()
+            .map(|tf| crate::app::stagnation_state::sanitize_for_prompt_entry(tf))
+            .collect();
+        let files_hint = if target_files.is_empty() {
+            String::new()
+        } else {
+            format!("\n  対象ファイル: {}", target_files.join(", "))
+        };
+
+        Some(format!(
+            "[System] ⚠ CLOSURE MODE: 残り1項目です ({finished}/{total} 完了)。\n\
+             最後の項目: {safe_desc}{files_hint}\n\n\
+             この項目を完了させてください:\n\
+             - file.edit / file.write で対象ファイルを変更する\n\
+             - または変更不要なら ANVIL_PLAN_UPDATE で [x] マークして退役させる\n\
+             - shell.exec での追加調査は不要です。すぐに実装に進んでください。"
+        ))
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -231,6 +231,10 @@ pub struct AgentTelemetry {
     #[serde(default)]
     pub final_suppressed_with_remaining_targets_count: u32,
 
+    /// Number of times pre-mutation barrier blocked mutation tools (Issue #303).
+    #[serde(default)]
+    pub mutation_barrier_block_count: u32,
+
     /// First mutation event turn (Issue #273 Phase 1.5).
     /// None if no mutation occurred during the session.
     #[serde(default)]
@@ -314,6 +318,11 @@ impl AgentTelemetry {
     /// Record an ANVIL_PLAN block observed (visible to external telemetry).
     pub fn record_anvil_plan_visible(&mut self) {
         self.anvil_plan_visible_count += 1;
+    }
+
+    /// Record a pre-mutation barrier block (Issue #303).
+    pub fn record_mutation_barrier_block(&mut self) {
+        self.mutation_barrier_block_count += 1;
     }
 
     /// Record a mutation turn: updates `last_mutation_turn` and, on the first call only,

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -484,6 +484,8 @@ pub enum PlanItemStatus {
     Blocked,
     /// Superseded by a corrected ANVIL_PLAN_UPDATE item (Issue #289).
     Superseded,
+    /// Retired via `[x]` marker in ANVIL_PLAN_UPDATE without mutations (Issue #301).
+    AlreadySatisfied,
 }
 
 impl std::fmt::Display for PlanItemStatus {
@@ -494,6 +496,7 @@ impl std::fmt::Display for PlanItemStatus {
             Self::Done => write!(f, "done"),
             Self::Blocked => write!(f, "blocked"),
             Self::Superseded => write!(f, "superseded"),
+            Self::AlreadySatisfied => write!(f, "already_satisfied"),
         }
     }
 }
@@ -530,11 +533,14 @@ impl PlanItem {
         }
     }
 
-    /// Whether this item is considered finished (Done or Blocked).
+    /// Whether this item is considered finished (Done, Blocked, Superseded, or AlreadySatisfied).
     pub fn is_finished(&self) -> bool {
         matches!(
             self.status,
-            PlanItemStatus::Done | PlanItemStatus::Blocked | PlanItemStatus::Superseded
+            PlanItemStatus::Done
+                | PlanItemStatus::Blocked
+                | PlanItemStatus::Superseded
+                | PlanItemStatus::AlreadySatisfied
         )
     }
 }
@@ -658,10 +664,13 @@ impl ExecutionPlan {
     /// and at least one item is Done.
     /// Returns false for empty plans (via `all_finished()` internal guard).
     /// Superseded-only plans return false because no actual work was completed.
+    /// AlreadySatisfied counts as successful completion alongside Done (Issue #301).
     pub fn is_successfully_completed(&self) -> bool {
         self.all_finished()
             && !self.has_blocked_items()
-            && self.items.iter().any(|i| i.status == PlanItemStatus::Done)
+            && self.items.iter().any(|i| {
+                i.status == PlanItemStatus::Done || i.status == PlanItemStatus::AlreadySatisfied
+            })
     }
 
     /// Decide whether ANVIL_FINAL should be accepted.
@@ -849,6 +858,55 @@ impl ExecutionPlan {
         }
     }
 
+    /// Mark unfinished items whose `target_files` match the given list as `new_status` (Issue #301).
+    ///
+    /// Safety guard (DR4-001): only marks an item when:
+    ///   1. The item is not already finished.
+    ///   2. The item has non-empty `target_files`.
+    ///   3. The number of `target_files` in the item matches the number of matched
+    ///      entries in `target_files_to_retire` (1:1 target count match).
+    ///   4. Every target file in the item has a 1:1 match in `target_files_to_retire`.
+    ///
+    /// Returns the list of target file paths that were actually retired.
+    pub fn mark_unfinished_items_by_target(
+        &mut self,
+        target_files_to_retire: &[String],
+        new_status: PlanItemStatus,
+    ) -> Vec<String> {
+        let mut retired: Vec<String> = Vec::new();
+        for item in &mut self.items {
+            if item.is_finished() || item.target_files.is_empty() {
+                continue;
+            }
+            // Check 1:1 target count match: every item target must match exactly one
+            // retire target, and the counts must be equal.
+            let all_matched = item.target_files.iter().all(|tf| {
+                target_files_to_retire
+                    .iter()
+                    .any(|rt| Self::path_matches(tf, rt))
+            });
+            // Count how many retire targets match this item's targets
+            let matched_retire_count = target_files_to_retire
+                .iter()
+                .filter(|rt| {
+                    item.target_files
+                        .iter()
+                        .any(|tf| Self::path_matches(tf, rt))
+                })
+                .count();
+            if all_matched && matched_retire_count == item.target_files.len() {
+                tracing::info!(
+                    description = %item.description,
+                    status = %new_status,
+                    "plan item retired via checked marker (Issue #301)"
+                );
+                item.status = new_status;
+                retired.extend(item.target_files.clone());
+            }
+        }
+        retired
+    }
+
     /// Sync plan item completion from the set of files actually modified.
     ///
     /// When a file.write/file.edit succeeds but the result is not passed to
@@ -900,6 +958,7 @@ impl ExecutionPlan {
                 PlanItemStatus::Done => "[x]",
                 PlanItemStatus::Blocked => "[!]",
                 PlanItemStatus::Superseded => "[~]",
+                PlanItemStatus::AlreadySatisfied => "[=]",
                 PlanItemStatus::InProgress => "[>]",
                 PlanItemStatus::Pending => "[ ]",
             };
@@ -1043,13 +1102,21 @@ impl ExecutionPlan {
                 )
             }
             crate::config::GuidanceMode::Batch => {
-                // Completed items
+                // Completed items (Done or AlreadySatisfied — Issue #301)
                 let completed_lines: Vec<String> = self
                     .items
                     .iter()
                     .enumerate()
-                    .filter(|(_, item)| item.status == PlanItemStatus::Done)
-                    .map(|(i, item)| format!("  {}. {}", i + 1, item.description))
+                    .filter(|(_, item)| {
+                        item.status == PlanItemStatus::Done
+                            || item.status == PlanItemStatus::AlreadySatisfied
+                    })
+                    .map(|(i, item)| {
+                        let safe = crate::app::stagnation_state::sanitize_for_prompt_entry(
+                            &item.description,
+                        );
+                        format!("  {}. {}", i + 1, safe)
+                    })
                     .collect();
 
                 // Workset (pending/in-progress items)
@@ -2299,5 +2366,145 @@ mod tests {
         plan.items[0].status = PlanItemStatus::Superseded;
         plan.items[1].status = PlanItemStatus::Superseded;
         assert!(!plan.is_successfully_completed());
+    }
+
+    // ============================================================
+    // Issue #301: AlreadySatisfied status tests
+    // ============================================================
+
+    #[test]
+    fn already_satisfied_display() {
+        assert_eq!(
+            PlanItemStatus::AlreadySatisfied.to_string(),
+            "already_satisfied"
+        );
+    }
+
+    #[test]
+    fn already_satisfied_is_finished() {
+        let mut item = PlanItem::new("x".into(), vec![]);
+        item.status = PlanItemStatus::AlreadySatisfied;
+        assert!(item.is_finished());
+    }
+
+    #[test]
+    fn already_satisfied_format_checklist_marker() {
+        let mut plan = ExecutionPlan::new(vec![PlanItem::new("retired".into(), vec![])]);
+        plan.items[0].status = PlanItemStatus::AlreadySatisfied;
+        let checklist = plan.format_checklist();
+        assert!(checklist.contains("[=]"));
+    }
+
+    #[test]
+    fn already_satisfied_is_successfully_completed() {
+        let mut plan = ExecutionPlan::new(vec![
+            PlanItem::new("task1".into(), vec![]),
+            PlanItem::new("task2".into(), vec![]),
+        ]);
+        plan.items[0].status = PlanItemStatus::Done;
+        plan.items[1].status = PlanItemStatus::AlreadySatisfied;
+        assert!(plan.is_successfully_completed());
+    }
+
+    #[test]
+    fn already_satisfied_only_is_successfully_completed() {
+        let mut plan = ExecutionPlan::new(vec![PlanItem::new("task1".into(), vec![])]);
+        plan.items[0].status = PlanItemStatus::AlreadySatisfied;
+        assert!(plan.is_successfully_completed());
+    }
+
+    #[test]
+    fn already_satisfied_allows_final_gate() {
+        let mut plan = ExecutionPlan::new(vec![
+            PlanItem::new("task1".into(), vec!["src/a.rs".into()]),
+            PlanItem::new("task2".into(), vec!["src/b.rs".into()]),
+        ]);
+        plan.items[0].status = PlanItemStatus::Done;
+        plan.items[1].status = PlanItemStatus::AlreadySatisfied;
+        assert_eq!(plan.check_final_gate(), FinalGateDecision::Allow);
+    }
+
+    #[test]
+    fn already_satisfied_serde_roundtrip() {
+        let mut item = PlanItem::new("desc".into(), vec!["src/lib.rs".into()]);
+        item.status = PlanItemStatus::AlreadySatisfied;
+        let json = serde_json::to_string(&item).expect("serialize");
+        let back: PlanItem = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back.status, PlanItemStatus::AlreadySatisfied);
+    }
+
+    // ============================================================
+    // Issue #301: mark_unfinished_items_by_target tests
+    // ============================================================
+
+    #[test]
+    fn mark_unfinished_items_by_target_retires_matching() {
+        let mut plan = ExecutionPlan::new(vec![
+            PlanItem::new("src/a.rs: update".into(), vec!["src/a.rs".into()]),
+            PlanItem::new("src/b.rs: update".into(), vec!["src/b.rs".into()]),
+        ]);
+        plan.mark_in_progress(0);
+        let retired = plan.mark_unfinished_items_by_target(
+            &["src/a.rs".to_string()],
+            PlanItemStatus::AlreadySatisfied,
+        );
+        assert_eq!(retired, vec!["src/a.rs".to_string()]);
+        assert_eq!(plan.items[0].status, PlanItemStatus::AlreadySatisfied);
+        assert_eq!(plan.items[1].status, PlanItemStatus::Pending);
+    }
+
+    #[test]
+    fn mark_unfinished_items_by_target_skips_finished() {
+        let mut plan = ExecutionPlan::new(vec![PlanItem::new(
+            "src/a.rs: update".into(),
+            vec!["src/a.rs".into()],
+        )]);
+        plan.mark_done(0);
+        let retired = plan.mark_unfinished_items_by_target(
+            &["src/a.rs".to_string()],
+            PlanItemStatus::AlreadySatisfied,
+        );
+        assert!(retired.is_empty());
+        assert_eq!(plan.items[0].status, PlanItemStatus::Done);
+    }
+
+    #[test]
+    fn mark_unfinished_items_by_target_skips_no_target_files() {
+        let mut plan = ExecutionPlan::new(vec![PlanItem::new("run tests".into(), vec![])]);
+        let retired = plan.mark_unfinished_items_by_target(
+            &["src/a.rs".to_string()],
+            PlanItemStatus::AlreadySatisfied,
+        );
+        assert!(retired.is_empty());
+    }
+
+    #[test]
+    fn mark_unfinished_items_by_target_multi_target_match() {
+        let mut plan = ExecutionPlan::new(vec![PlanItem::new(
+            "src/a.rs, src/b.rs: update".into(),
+            vec!["src/a.rs".into(), "src/b.rs".into()],
+        )]);
+        let retired = plan.mark_unfinished_items_by_target(
+            &["src/a.rs".to_string(), "src/b.rs".to_string()],
+            PlanItemStatus::AlreadySatisfied,
+        );
+        assert_eq!(retired.len(), 2);
+        assert_eq!(plan.items[0].status, PlanItemStatus::AlreadySatisfied);
+    }
+
+    #[test]
+    fn mark_unfinished_items_by_target_partial_match_rejected() {
+        // DR4-001: partial match should NOT retire (target count mismatch)
+        let mut plan = ExecutionPlan::new(vec![PlanItem::new(
+            "src/a.rs, src/b.rs: update".into(),
+            vec!["src/a.rs".into(), "src/b.rs".into()],
+        )]);
+        // Only one of two targets provided
+        let retired = plan.mark_unfinished_items_by_target(
+            &["src/a.rs".to_string()],
+            PlanItemStatus::AlreadySatisfied,
+        );
+        assert!(retired.is_empty());
+        assert_eq!(plan.items[0].status, PlanItemStatus::Pending);
     }
 }

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -142,13 +142,9 @@ impl CompletionKind {
         budget_exhausted: bool,
     ) -> Self {
         let all_finished = plan.all_finished() && !plan.is_empty();
-        let has_blocked = plan
-            .items
-            .iter()
-            .any(|i| i.status == PlanItemStatus::Blocked);
 
         // Priority 1: blocked items exist → always Blocked
-        if has_blocked {
+        if plan.has_blocked_items() {
             return CompletionKind::Blocked;
         }
 
@@ -649,6 +645,23 @@ impl ExecutionPlan {
                 item.status = PlanItemStatus::Blocked;
             }
         }
+    }
+
+    /// Whether any item has Blocked status.
+    pub fn has_blocked_items(&self) -> bool {
+        self.items
+            .iter()
+            .any(|i| i.status == PlanItemStatus::Blocked)
+    }
+
+    /// Whether the plan completed successfully: all items finished, none Blocked,
+    /// and at least one item is Done.
+    /// Returns false for empty plans (via `all_finished()` internal guard).
+    /// Superseded-only plans return false because no actual work was completed.
+    pub fn is_successfully_completed(&self) -> bool {
+        self.all_finished()
+            && !self.has_blocked_items()
+            && self.items.iter().any(|i| i.status == PlanItemStatus::Done)
     }
 
     /// Decide whether ANVIL_FINAL should be accepted.
@@ -2210,5 +2223,81 @@ mod tests {
         assert_eq!(plan.items[0].status, PlanItemStatus::InProgress);
         // Item 1 matched → Done
         assert_eq!(plan.items[1].status, PlanItemStatus::Done);
+    }
+
+    // --- Issue #296: ExecutionPlan helper method tests ---
+
+    #[test]
+    fn execution_plan_has_blocked_items_true() {
+        let mut plan = ExecutionPlan::new(vec![
+            PlanItem::new("task1".into(), vec![]),
+            PlanItem::new("task2".into(), vec![]),
+        ]);
+        plan.items[0].status = PlanItemStatus::Done;
+        plan.items[1].status = PlanItemStatus::Blocked;
+        assert!(plan.has_blocked_items());
+    }
+
+    #[test]
+    fn execution_plan_has_blocked_items_false() {
+        let mut plan = ExecutionPlan::new(vec![
+            PlanItem::new("task1".into(), vec![]),
+            PlanItem::new("task2".into(), vec![]),
+        ]);
+        plan.items[0].status = PlanItemStatus::Done;
+        plan.items[1].status = PlanItemStatus::Done;
+        assert!(!plan.has_blocked_items());
+    }
+
+    #[test]
+    fn execution_plan_is_successfully_completed_all_done() {
+        let mut plan = ExecutionPlan::new(vec![
+            PlanItem::new("task1".into(), vec![]),
+            PlanItem::new("task2".into(), vec![]),
+        ]);
+        plan.items[0].status = PlanItemStatus::Done;
+        plan.items[1].status = PlanItemStatus::Done;
+        assert!(plan.is_successfully_completed());
+    }
+
+    #[test]
+    fn execution_plan_is_successfully_completed_with_blocked() {
+        let mut plan = ExecutionPlan::new(vec![
+            PlanItem::new("task1".into(), vec![]),
+            PlanItem::new("task2".into(), vec![]),
+        ]);
+        plan.items[0].status = PlanItemStatus::Done;
+        plan.items[1].status = PlanItemStatus::Blocked;
+        assert!(!plan.is_successfully_completed());
+    }
+
+    #[test]
+    fn execution_plan_is_successfully_completed_empty() {
+        let plan = ExecutionPlan::default();
+        assert!(!plan.is_successfully_completed());
+    }
+
+    #[test]
+    fn execution_plan_is_successfully_completed_with_superseded() {
+        let mut plan = ExecutionPlan::new(vec![
+            PlanItem::new("task1".into(), vec![]),
+            PlanItem::new("task2".into(), vec![]),
+            PlanItem::new("task3".into(), vec![]),
+        ]);
+        plan.items[0].status = PlanItemStatus::Done;
+        plan.items[1].status = PlanItemStatus::Superseded;
+        plan.items[2].status = PlanItemStatus::Done;
+        assert!(plan.is_successfully_completed());
+    }
+
+    #[test]
+    fn execution_plan_is_successfully_completed_superseded_only() {
+        let mut plan = ExecutionPlan::new(vec![
+            PlanItem::new("task1".into(), vec![]),
+            PlanItem::new("task2".into(), vec![]),
+        ]);
+        plan.items[0].status = PlanItemStatus::Superseded;
+        plan.items[1].status = PlanItemStatus::Superseded;
+        assert!(!plan.is_successfully_completed());
     }
 }

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -944,6 +944,78 @@ impl ExecutionPlan {
         retired
     }
 
+    /// Auto-retire plan items that have no `target_files` (Issue #315).
+    ///
+    /// No-path / summary-only items (e.g. `- [ ] 残っている gap があれば修正`)
+    /// violate the `<relative-path>: <description>` prompt contract and cannot
+    /// be retired by any existing file-based mechanism.  Marking them as
+    /// `AlreadySatisfied` on registration prevents them from blocking the
+    /// final gate indefinitely.
+    ///
+    /// Returns the number of items auto-retired.
+    pub fn auto_retire_no_path_items(&mut self) -> usize {
+        let mut count = 0;
+        for item in &mut self.items {
+            if !item.is_finished() && item.target_files.is_empty() {
+                tracing::info!(
+                    description = %item.description,
+                    "auto-retiring no-path plan item (Issue #315)"
+                );
+                item.status = PlanItemStatus::AlreadySatisfied;
+                count += 1;
+            }
+        }
+        count
+    }
+
+    /// Retire unfinished no-path plan items whose description matches one of
+    /// the given descriptions (Issue #315).
+    ///
+    /// Used when a checked `[x]` item in `ANVIL_PLAN_UPDATE` has no
+    /// `target_files`.  Because file-based `mark_unfinished_items_by_target`
+    /// skips no-path items, this method provides a description-based fallback
+    /// to retire the corresponding existing no-path item.
+    ///
+    /// Matching is case-insensitive and whitespace-normalized.
+    ///
+    /// Returns the number of items retired.
+    pub fn retire_no_path_items_by_description(
+        &mut self,
+        descriptions: &[String],
+        new_status: PlanItemStatus,
+    ) -> usize {
+        let normalized_targets: Vec<String> = descriptions
+            .iter()
+            .map(|d| Self::normalize_description(d))
+            .collect();
+        let mut count = 0;
+        for item in &mut self.items {
+            if item.is_finished() || !item.target_files.is_empty() {
+                continue;
+            }
+            let normalized = Self::normalize_description(&item.description);
+            if normalized_targets.contains(&normalized) {
+                tracing::info!(
+                    description = %item.description,
+                    status = %new_status,
+                    "no-path plan item retired via description match (Issue #315)"
+                );
+                item.status = new_status;
+                count += 1;
+            }
+        }
+        count
+    }
+
+    /// Normalize a description for fuzzy matching: trim, collapse whitespace,
+    /// lowercase.
+    fn normalize_description(desc: &str) -> String {
+        desc.split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ")
+            .to_lowercase()
+    }
+
     /// Sync plan item completion from the set of files actually modified.
     ///
     /// When a file.write/file.edit succeeds but the result is not passed to

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -184,7 +184,10 @@ pub struct AgentTelemetry {
     pub total_final_requests: u32,
     /// Number of times a plan was registered via ANVIL_PLAN.
     pub plan_registration_count: u32,
-    /// Number of times ANVIL_PLAN_UPDATE appended items.
+    /// Number of times the plan was updated.
+    ///
+    /// Includes both explicit `ANVIL_PLAN_UPDATE` and follow-up `ANVIL_PLAN`
+    /// on an active plan (replan, Issue #305).
     pub plan_update_count: u32,
     /// Number of times sync_from_touched_files actually advanced items.
     pub sync_from_touched_files_count: u32,
@@ -219,7 +222,10 @@ pub struct AgentTelemetry {
     #[serde(default)]
     pub plan_repair_request_count: u32,
 
-    /// Number of ANVIL_PLAN blocks observed (visible to external telemetry).
+    /// Number of times the LLM emitted a visible ANVIL_PLAN block.
+    ///
+    /// Incremented for both initial registration and follow-up replan (Issue #305).
+    /// Note: this count may exceed plan_registration_count when replan occurs.
     #[serde(default)]
     pub anvil_plan_visible_count: u32,
 

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -562,6 +562,21 @@ pub enum FinalGateDecision {
     },
 }
 
+/// Known file.edit result suffixes stripped before path comparison.
+/// Mirrors `EditFallbackStage` variant suffixes without depending on the
+/// `tooling` crate (avoids circular dependency).
+const EDIT_FALLBACK_SUFFIXES: &[&str] = &[" (trailing-ws fallback)", " (anchor fallback)"];
+
+/// Strip a known edit-fallback suffix from the end of a string.
+fn strip_edit_fallback_suffix(s: &str) -> &str {
+    for suffix in EDIT_FALLBACK_SUFFIXES {
+        if let Some(stripped) = s.strip_suffix(suffix) {
+            return stripped;
+        }
+    }
+    s
+}
+
 impl ExecutionPlan {
     pub fn new(items: Vec<PlanItem>) -> Self {
         Self { items }
@@ -639,9 +654,17 @@ impl ExecutionPlan {
 
     /// Fuzzy path match: true when either path is a suffix of the other.
     ///
+    /// Strips known `EditFallbackStage` suffixes before comparison so that
+    /// results like `"src/foo.rs (trailing-ws fallback)"` match `"src/foo.rs"`.
+    ///
     /// Used consistently across `record_mutation_success`, `sync_from_touched_files`,
     /// and `update_plan_from_results` to avoid divergent matching behaviour.
     pub fn path_matches(a: &str, b: &str) -> bool {
+        let a = strip_edit_fallback_suffix(a);
+        let b = strip_edit_fallback_suffix(b);
+        if a.is_empty() || b.is_empty() {
+            return false;
+        }
         a.ends_with(b) || b.ends_with(a)
     }
 
@@ -658,8 +681,12 @@ impl ExecutionPlan {
             return;
         }
 
-        // Add to mutated_files if not already present
-        if !item.mutated_files.iter().any(|f| f == file_path) {
+        // Add to mutated_files if not already present (Issue #287: use path_matches for dedup)
+        if !item
+            .mutated_files
+            .iter()
+            .any(|f| Self::path_matches(f, file_path))
+        {
             item.mutated_files.push(file_path.to_string());
         }
 
@@ -704,12 +731,48 @@ impl ExecutionPlan {
     /// Equivalent to `current_workset().len()` but avoids allocating the
     /// index vector, and is convenient for passing to `record_turn_metrics`.
     pub fn current_workset_size(&self) -> usize {
-        self.current_workset().len()
+        const MAX_WORKSET_SIZE: usize = 5;
+        self.items
+            .iter()
+            .filter(|item| {
+                matches!(
+                    item.status,
+                    PlanItemStatus::Pending | PlanItemStatus::InProgress
+                )
+            })
+            .take(MAX_WORKSET_SIZE)
+            .count()
     }
 
     /// Append new items (used by ANVIL_PLAN_UPDATE).
     pub fn append_items(&mut self, new_items: Vec<PlanItem>) {
         self.items.extend(new_items);
+    }
+
+    /// Deduplicate new plan items against existing items (Issue #287).
+    ///
+    /// Excludes new items whose `target_files` match an existing item
+    /// (using `path_matches` for fuzzy comparison).
+    pub fn deduplicate_new_items(&self, new_items: Vec<PlanItem>) -> Vec<PlanItem> {
+        new_items
+            .into_iter()
+            .filter(|new_item| {
+                let mut new_targets = new_item.target_files.clone();
+                new_targets.sort();
+
+                !self.items.iter().any(|existing| {
+                    let mut existing_targets = existing.target_files.clone();
+                    existing_targets.sort();
+                    if new_targets.len() != existing_targets.len() {
+                        return false;
+                    }
+                    new_targets
+                        .iter()
+                        .zip(existing_targets.iter())
+                        .all(|(a, b)| Self::path_matches(a, b))
+                })
+            })
+            .collect()
     }
 
     /// Sync plan item completion from the set of files actually modified.

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -486,6 +486,8 @@ pub enum PlanItemStatus {
     Done,
     /// Blocked due to repeated failures.
     Blocked,
+    /// Superseded by a corrected ANVIL_PLAN_UPDATE item (Issue #289).
+    Superseded,
 }
 
 impl std::fmt::Display for PlanItemStatus {
@@ -495,6 +497,7 @@ impl std::fmt::Display for PlanItemStatus {
             Self::InProgress => write!(f, "in_progress"),
             Self::Done => write!(f, "done"),
             Self::Blocked => write!(f, "blocked"),
+            Self::Superseded => write!(f, "superseded"),
         }
     }
 }
@@ -533,7 +536,10 @@ impl PlanItem {
 
     /// Whether this item is considered finished (Done or Blocked).
     pub fn is_finished(&self) -> bool {
-        matches!(self.status, PlanItemStatus::Done | PlanItemStatus::Blocked)
+        matches!(
+            self.status,
+            PlanItemStatus::Done | PlanItemStatus::Blocked | PlanItemStatus::Superseded
+        )
     }
 }
 
@@ -573,6 +579,20 @@ fn strip_edit_fallback_suffix(s: &str) -> &str {
         if let Some(stripped) = s.strip_suffix(suffix) {
             return stripped;
         }
+    }
+    s
+}
+
+/// Strip a parenthesized annotation suffix (e.g., `" (bar.ts)"`) from a path.
+///
+/// Only strips when there is a space before the opening paren (`" ("`) and the
+/// string ends with `")"`.  This preserves legitimate paths like `foo(1).ts`.
+/// Issue #289: prevents poisoned identity from bracket-annotated plan items.
+fn strip_parenthesized_suffix(s: &str) -> &str {
+    if let Some(pos) = s.find(" (")
+        && s.ends_with(')')
+    {
+        return s[..pos].trim_end();
     }
     s
 }
@@ -662,6 +682,8 @@ impl ExecutionPlan {
     pub fn path_matches(a: &str, b: &str) -> bool {
         let a = strip_edit_fallback_suffix(a);
         let b = strip_edit_fallback_suffix(b);
+        let a = strip_parenthesized_suffix(a);
+        let b = strip_parenthesized_suffix(b);
         if a.is_empty() || b.is_empty() {
             return false;
         }
@@ -775,6 +797,45 @@ impl ExecutionPlan {
             .collect()
     }
 
+    /// Supersede stale plan items that overlap with corrected new items (Issue #289).
+    ///
+    /// A stale item is one that is not yet finished, has no recorded mutations,
+    /// and has at least one `target_file` that matches (via `path_matches`) a
+    /// target in one of the `new_items`.  Such items are marked `Superseded` so
+    /// they no longer block plan completion.
+    ///
+    /// To avoid false positives (CB-002), each new item can supersede at most one
+    /// existing item, and each existing item can be superseded by at most one new
+    /// item (1:1 matching).  New items are consumed greedily in order.
+    pub fn supersede_stale_items(&mut self, new_items: &[PlanItem]) {
+        // Track which new items have already been consumed.
+        let mut new_consumed = vec![false; new_items.len()];
+        for existing in &mut self.items {
+            // Only supersede unfinished items with no mutations recorded yet.
+            if existing.is_finished() || !existing.mutated_files.is_empty() {
+                continue;
+            }
+            // Find the first unconsumed new item whose targets intersect.
+            let matched = new_items.iter().enumerate().find(|(j, new_item)| {
+                !new_consumed[*j]
+                    && existing.target_files.iter().any(|et| {
+                        new_item
+                            .target_files
+                            .iter()
+                            .any(|nt| Self::path_matches(et, nt))
+                    })
+            });
+            if let Some((j, _)) = matched {
+                new_consumed[j] = true;
+                tracing::info!(
+                    description = %existing.description,
+                    "plan item superseded by corrected ANVIL_PLAN_UPDATE"
+                );
+                existing.status = PlanItemStatus::Superseded;
+            }
+        }
+    }
+
     /// Sync plan item completion from the set of files actually modified.
     ///
     /// When a file.write/file.edit succeeds but the result is not passed to
@@ -825,6 +886,7 @@ impl ExecutionPlan {
             let marker = match item.status {
                 PlanItemStatus::Done => "[x]",
                 PlanItemStatus::Blocked => "[!]",
+                PlanItemStatus::Superseded => "[~]",
                 PlanItemStatus::InProgress => "[>]",
                 PlanItemStatus::Pending => "[ ]",
             };
@@ -2021,6 +2083,7 @@ mod tests {
         assert_eq!(PlanItemStatus::InProgress.to_string(), "in_progress");
         assert_eq!(PlanItemStatus::Done.to_string(), "done");
         assert_eq!(PlanItemStatus::Blocked.to_string(), "blocked");
+        assert_eq!(PlanItemStatus::Superseded.to_string(), "superseded");
     }
 
     #[test]

--- a/src/provider/transport.rs
+++ b/src/provider/transport.rs
@@ -171,6 +171,7 @@ impl ReqwestHttpTransport {
             .expect("Failed to build HTTP client");
         let streaming_client = reqwest::blocking::Client::builder()
             .connect_timeout(Duration::from_secs(30))
+            .timeout(Duration::from_secs(timeout_secs.min(120)))
             .redirect(reqwest::redirect::Policy::none())
             .build()
             .expect("Failed to build streaming HTTP client");

--- a/src/tooling/mod.rs
+++ b/src/tooling/mod.rs
@@ -482,6 +482,8 @@ pub struct ToolCallRequest {
     pub tool_call_id: String,
     pub tool_name: String,
     pub input: ToolInput,
+    /// Warnings about unsupported extra fields in the tool input (Issue #299).
+    pub extra_field_warnings: Vec<String>,
 }
 
 impl ToolCallRequest {
@@ -494,6 +496,7 @@ impl ToolCallRequest {
             tool_call_id: tool_call_id.into(),
             tool_name: tool_name.into(),
             input,
+            extra_field_warnings: Vec::new(),
         }
     }
 }
@@ -596,6 +599,7 @@ impl ValidatedToolCall {
         Ok(ToolExecutionRequest {
             tool_call_id: self.request.tool_call_id.clone(),
             spec: self.spec,
+            extra_field_warnings: self.request.extra_field_warnings.clone(),
             input: self.request.input,
         })
     }
@@ -606,6 +610,8 @@ pub struct ToolExecutionRequest {
     pub tool_call_id: String,
     pub spec: ToolSpec,
     pub input: ToolInput,
+    /// Warnings about unsupported extra fields in the tool input (Issue #299).
+    pub extra_field_warnings: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1347,13 +1353,19 @@ impl LocalToolExecutor {
                 hit.content.len()
             );
             let payload = format!("{}{}", header, hit.content);
-            return Ok(build_completed_result(
+            let mut result = build_completed_result(
                 request,
                 path.to_string(),
                 ToolExecutionPayload::Text(payload),
                 vec![resolved.display().to_string()],
                 started,
-            ));
+            );
+            // Issue #299: append extra field warnings to summary (not payload).
+            if !request.extra_field_warnings.is_empty() {
+                let warnings = request.extra_field_warnings.join("; ");
+                result.summary = format!("{} [{}]", result.summary, warnings);
+            }
+            return Ok(result);
         }
         // Mutex poison → fall through to normal read (best-effort)
 
@@ -1381,13 +1393,28 @@ impl LocalToolExecutor {
             cache.record(&resolved, content.clone());
         }
 
-        Ok(build_completed_result(
+        let mut result = build_completed_result(
             request,
             path.to_string(),
             ToolExecutionPayload::Text(content),
             vec![resolved.display().to_string()],
             started,
-        ))
+        );
+
+        // Issue #299: append extra field warnings to summary (not payload).
+        if !request.extra_field_warnings.is_empty() {
+            // Sink-side defense: cap total warning text to avoid oversized
+            // prompt/log entries from unexpected sources (CB-004).
+            let warnings = request.extra_field_warnings.join("; ");
+            let capped = if warnings.len() > 256 {
+                format!("{}...", &warnings[..256])
+            } else {
+                warnings
+            };
+            result.summary = format!("{} [{}]", result.summary, capped);
+        }
+
+        Ok(result)
     }
 
     fn execute_image_read(

--- a/src/tooling/mod.rs
+++ b/src/tooling/mod.rs
@@ -1147,6 +1147,12 @@ pub fn is_sensitive_file(path: &str) -> bool {
 /// Extract context lines around the best matching location for `old_string`
 /// in `content`. Searches for the first line of `old_string` (trimmed) and
 /// returns surrounding lines with line numbers.
+///
+/// When the exact first-line match fails, falls back to token-based scoring:
+/// extracts identifier-like tokens from `old_string` and finds the content
+/// line with the highest overlap. This handles "hypothesis drift" where the
+/// model's `old_string` diverges from reality but shares key identifiers
+/// (Issue #313).
 pub fn extract_edit_context(
     content: &str,
     old_string: &str,
@@ -1158,11 +1164,19 @@ pub fn extract_edit_context(
     }
 
     let lines: Vec<&str> = content.lines().collect();
+
+    // Primary: exact first-line substring match
     let match_idx = lines
         .iter()
         .enumerate()
-        .find(|(_, line)| line.trim().contains(first_line))?
-        .0;
+        .find(|(_, line)| line.trim().contains(first_line))
+        .map(|(idx, _)| idx);
+
+    // Fallback: token-based scoring (Issue #313)
+    let match_idx = match match_idx {
+        Some(idx) => idx,
+        None => token_fallback_match(&lines, old_string)?,
+    };
 
     let start = match_idx.saturating_sub(context_lines);
     let end = (match_idx + context_lines + 1).min(lines.len());
@@ -1175,6 +1189,54 @@ pub fn extract_edit_context(
         .join("\n");
 
     Some(context)
+}
+
+/// Minimum token length for fallback matching. Short tokens like "a", "fn",
+/// "if" are too common to be useful anchors.
+const TOKEN_MIN_LEN: usize = 4;
+
+/// Minimum token score to accept a fallback match.
+/// Set to 1 because even a single specific identifier (e.g. a function name)
+/// is a strong anchor when exact first-line matching has already failed.
+const TOKEN_MIN_SCORE: usize = 1;
+
+/// Token-based fallback: extract identifier-like tokens from `old_string`,
+/// score each content line by token overlap, and return the best match index.
+fn token_fallback_match(lines: &[&str], old_string: &str) -> Option<usize> {
+    let tokens = extract_tokens(old_string);
+    if tokens.is_empty() {
+        return None;
+    }
+
+    let mut best_idx = 0usize;
+    let mut best_score = 0usize;
+
+    for (i, line) in lines.iter().enumerate() {
+        let lower = line.to_lowercase();
+        let score = tokens.iter().filter(|t| lower.contains(t.as_str())).count();
+        if score > best_score {
+            best_score = score;
+            best_idx = i;
+        }
+    }
+
+    if best_score >= TOKEN_MIN_SCORE {
+        Some(best_idx)
+    } else {
+        None
+    }
+}
+
+/// Extract identifier-like tokens from a string.
+/// Splits on non-alphanumeric/underscore boundaries, lowercases, deduplicates,
+/// and filters out tokens shorter than `TOKEN_MIN_LEN`.
+fn extract_tokens(s: &str) -> Vec<String> {
+    let mut seen = std::collections::HashSet::new();
+    s.split(|c: char| !c.is_alphanumeric() && c != '_')
+        .filter(|t| t.len() >= TOKEN_MIN_LEN)
+        .map(|t| t.to_lowercase())
+        .filter(|t| seen.insert(t.clone()))
+        .collect()
 }
 
 impl LocalToolExecutor {
@@ -1811,12 +1873,24 @@ impl LocalToolExecutor {
             return ToolRuntimeError::edit_not_found(message);
         }
 
-        // Try to read file content for context extraction
+        // Try to read file content for context extraction.
+        // Scale context_lines based on file size (Issue #313):
+        // large files need more surrounding context for mid-file targets.
         let context_snippet = self
             .resolve_path(path)
             .ok()
             .and_then(|resolved| fs::read_to_string(resolved).ok())
-            .and_then(|content| extract_edit_context(&content, old_string, 5));
+            .and_then(|content| {
+                let line_count = content.lines().count();
+                let ctx_lines = if line_count > 500 {
+                    12
+                } else if line_count > 100 {
+                    8
+                } else {
+                    5
+                };
+                extract_edit_context(&content, old_string, ctx_lines)
+            });
 
         match context_snippet {
             Some(ctx) => ToolRuntimeError::edit_not_found_with_context(message, ctx),

--- a/src/tooling/mod.rs
+++ b/src/tooling/mod.rs
@@ -619,6 +619,8 @@ pub enum ToolExecutionStatus {
     Completed,
     Failed,
     Interrupted,
+    /// Policy-level block (e.g. mutation barrier when no plan is registered).
+    Blocked,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -673,6 +675,7 @@ impl ToolExecutionResult {
             ToolExecutionStatus::Completed => "completed",
             ToolExecutionStatus::Failed => "failed",
             ToolExecutionStatus::Interrupted => "interrupted",
+            ToolExecutionStatus::Blocked => "blocked",
         };
 
         ToolLogView {

--- a/src/tooling/mod.rs
+++ b/src/tooling/mod.rs
@@ -9,7 +9,9 @@ pub mod file_cache;
 pub mod progress;
 pub mod shell_policy;
 
-pub use shell_policy::{ShellPolicy, classify_shell_policy, is_network_command};
+pub use shell_policy::{
+    ShellPolicy, classify_shell_policy, is_network_command, is_shell_inspection_command,
+};
 
 use crate::config::{
     CustomToolDef, RuntimeConfig, WebSearchProvider, custom_tool_display_name,

--- a/src/tooling/shell_policy.rs
+++ b/src/tooling/shell_policy.rs
@@ -113,6 +113,25 @@ const NETWORK_COMMAND_PREFIXES: &[&str] = &[
 const FILE_READ_COMMAND_PREFIXES: &[&str] =
     &["grep", "sed", "cat", "head", "tail", "awk", "less", "more"];
 
+/// Repo-inspection command prefixes (Issue #309).
+///
+/// Commands that inspect repository state or file contents without modifying them.
+/// These are broader than `FILE_READ_COMMAND_PREFIXES` and include tool-specific
+/// commands like `commandindexdev before-change` that LLMs use for code inspection.
+const REPO_INSPECTION_COMMAND_PREFIXES: &[&str] = &[
+    "commandindexdev",
+    "find",
+    "wc",
+    "diff",
+    "file",
+    "stat",
+    "tree",
+    "rg",
+    "fd",
+    "ag",
+    "ack",
+];
+
 /// Returns `true` if the shell command is primarily a file-reading operation
 /// (e.g. `grep`, `sed -n`, `cat`) that could bypass the read transition guard.
 ///
@@ -127,6 +146,26 @@ pub fn is_file_read_shell_command(command: &str) -> bool {
     let lower = trimmed.to_ascii_lowercase();
     let first_cmd = extract_first_command(&lower);
     FILE_READ_COMMAND_PREFIXES.contains(&first_cmd)
+}
+
+/// Returns `true` if the shell command is an inspection/exploration operation
+/// (Issue #309).
+///
+/// This is a superset of [`is_file_read_shell_command`]: it additionally covers
+/// repo-inspection tools like `commandindexdev`, `find`, `rg`, `diff`, etc.
+/// Used by `PhaseEstimator` and stagnation scoring to prevent shell-based
+/// inspection from living in a guidance blind spot.
+pub fn is_shell_inspection_command(command: &str) -> bool {
+    if is_file_read_shell_command(command) {
+        return true;
+    }
+    let trimmed = command.trim();
+    if contains_injection_vectors(trimmed) {
+        return false;
+    }
+    let lower = trimmed.to_ascii_lowercase();
+    let first_cmd = extract_first_command(&lower);
+    REPO_INSPECTION_COMMAND_PREFIXES.contains(&first_cmd)
 }
 
 /// Classify a shell command into a [`ShellPolicy`] category.
@@ -692,5 +731,73 @@ mod tests {
     #[test]
     fn file_read_absolute_path_cat() {
         assert!(is_file_read_shell_command("/usr/bin/cat src/main.rs"));
+    }
+
+    // --- is_shell_inspection_command tests (Issue #309) ---
+
+    #[test]
+    fn shell_inspection_includes_file_reads() {
+        // All file read commands are also inspection commands
+        assert!(is_shell_inspection_command("grep -n pattern src/main.rs"));
+        assert!(is_shell_inspection_command("cat src/main.rs"));
+        assert!(is_shell_inspection_command("head -50 src/main.rs"));
+    }
+
+    #[test]
+    fn shell_inspection_commandindexdev() {
+        assert!(is_shell_inspection_command(
+            "commandindexdev before-change src/lib.ts --format llm"
+        ));
+    }
+
+    #[test]
+    fn shell_inspection_find() {
+        assert!(is_shell_inspection_command("find . -name '*.rs'"));
+    }
+
+    #[test]
+    fn shell_inspection_wc() {
+        assert!(is_shell_inspection_command("wc -l src/main.rs"));
+    }
+
+    #[test]
+    fn shell_inspection_diff() {
+        assert!(is_shell_inspection_command("diff src/a.rs src/b.rs"));
+    }
+
+    #[test]
+    fn shell_inspection_rg() {
+        assert!(is_shell_inspection_command("rg TODO src/"));
+    }
+
+    #[test]
+    fn shell_inspection_fd() {
+        assert!(is_shell_inspection_command("fd --extension rs"));
+    }
+
+    #[test]
+    fn shell_inspection_tree() {
+        assert!(is_shell_inspection_command("tree src/"));
+    }
+
+    #[test]
+    fn shell_inspection_not_cargo() {
+        assert!(!is_shell_inspection_command("cargo test"));
+    }
+
+    #[test]
+    fn shell_inspection_not_npm() {
+        assert!(!is_shell_inspection_command("npm install"));
+    }
+
+    #[test]
+    fn shell_inspection_rejects_pipe() {
+        assert!(!is_shell_inspection_command("find . | grep pattern"));
+    }
+
+    #[test]
+    fn shell_inspection_case_insensitive() {
+        assert!(is_shell_inspection_command("FIND . -name '*.rs'"));
+        assert!(is_shell_inspection_command("RG TODO src/"));
     }
 }

--- a/tests/edit_recovery_loop.rs
+++ b/tests/edit_recovery_loop.rs
@@ -1,0 +1,330 @@
+//! Integration tests for Issue #299: file.edit recovery loop fix.
+//!
+//! Tests the ToolRecoveryBudget and its interaction with detectors
+//! to ensure recovery reads are not counted as exploration loops.
+
+use anvil::app::loop_detector::{LoopAction, LoopDetector};
+use anvil::app::phase_estimator::PhaseEstimator;
+
+// ============================================================
+// Helper: create a ToolRecoveryBudget directly
+// ============================================================
+
+// Note: ToolRecoveryBudget is pub(crate), so we test it indirectly
+// through its effects on detectors. The unit tests in tool_recovery_budget.rs
+// cover the direct API.
+
+// ============================================================
+// Test 1: edit failure grants recovery budget (unit-level via config)
+// ============================================================
+
+#[test]
+fn test_edit_recovery_read_budget_config_default() {
+    // Verify that the config has the expected default value.
+    let config = anvil::config::EffectiveConfig::default_for_test().unwrap();
+    assert_eq!(config.runtime.edit_recovery_read_budget, 3);
+}
+
+#[test]
+fn test_edit_recovery_read_budget_config_clamp() {
+    let mut config = anvil::config::EffectiveConfig::default_for_test().unwrap();
+    // Set a valid value and validate
+    config.runtime.edit_recovery_read_budget = 5;
+    assert!(config.validate_for_test().is_ok());
+    assert_eq!(config.runtime.edit_recovery_read_budget, 5);
+}
+
+#[test]
+fn test_edit_recovery_read_budget_config_clamp_high() {
+    let mut config = anvil::config::EffectiveConfig::default_for_test().unwrap();
+    // Set out-of-range value, validate clamps it
+    config.runtime.edit_recovery_read_budget = 20;
+    assert!(config.validate_for_test().is_ok());
+    // Should be clamped to 10
+    assert_eq!(config.runtime.edit_recovery_read_budget, 10);
+}
+
+#[test]
+fn test_edit_recovery_read_budget_config_clamp_low() {
+    let mut config = anvil::config::EffectiveConfig::default_for_test().unwrap();
+    // Zero gets clamped to 1
+    config.runtime.edit_recovery_read_budget = 0;
+    assert!(config.validate_for_test().is_ok());
+    assert_eq!(config.runtime.edit_recovery_read_budget, 1);
+}
+
+// ============================================================
+// Test 2: recovery read not counted by detectors
+// (Simulates the scenario: LoopDetector does NOT receive
+// recovery reads, so it shouldn't escalate.)
+// ============================================================
+
+#[test]
+fn test_recovery_read_not_counted_by_detectors() {
+    // Simulate: 2 identical file.read calls recorded (below threshold=3),
+    // then a "recovery read" occurs that is NOT recorded in the detector.
+    // After recovery, the next file.read recorded should still be at count 3
+    // (the first Warn), not count 4.
+    let mut detector = LoopDetector::new(3);
+    let input = serde_json::json!({"path": "src/main.rs"});
+
+    // Record 2 calls
+    let a1 = detector.record_and_check("file.read", &input);
+    let a2 = detector.record_and_check("file.read", &input);
+    assert_eq!(a1, LoopAction::Continue);
+    assert_eq!(a2, LoopAction::Continue);
+
+    // Recovery read: NOT recorded (simulating the gating in agentic.rs)
+    // ... (no call to detector)
+
+    // 3rd recorded call triggers Warn, not StrongWarn
+    let a3 = detector.record_and_check("file.read", &input);
+    assert!(
+        matches!(a3, LoopAction::Warn(_)),
+        "Expected Warn at 3rd recorded call, got {:?}",
+        a3
+    );
+}
+
+// ============================================================
+// Test 3: recovery budget consumed after max reads
+// ============================================================
+
+#[test]
+fn test_recovery_budget_consumed_after_max_reads() {
+    // This tests that after budget exhaustion, the detector resumes counting.
+    let mut detector = LoopDetector::new(3);
+    let input = serde_json::json!({"path": "foo.rs"});
+
+    // Pre-recovery: 2 calls
+    detector.record_and_check("file.read", &input);
+    detector.record_and_check("file.read", &input);
+
+    // Recovery: 3 reads NOT recorded (budget=3, all consumed).
+    // Nothing happens to detector.
+
+    // Post-recovery: detector still at count 2.
+    // 3rd call triggers Warn.
+    let action = detector.record_and_check("file.read", &input);
+    assert!(matches!(action, LoopAction::Warn(_)));
+}
+
+// ============================================================
+// Test 4: recovery budget cleared on edit success
+// ============================================================
+
+#[test]
+fn test_recovery_budget_cleared_on_edit_success() {
+    // Tested via unit tests in tool_recovery_budget.rs.
+    // Integration: after clear(), has_budget() returns false
+    // and should_suppress_detectors returns false.
+    // (Covered by tool_recovery_budget::tests::test_clear_removes)
+    // This test verifies from the public test perspective.
+    let config = anvil::config::EffectiveConfig::default_for_test().unwrap();
+    assert_eq!(config.runtime.edit_recovery_read_budget, 3);
+    // Config field exists and has correct default.
+}
+
+// ============================================================
+// Test 5: loop_detector skipped during recovery
+// ============================================================
+
+#[test]
+fn test_loop_detector_skipped_during_recovery() {
+    // When recovery reads are skipped, the detector state doesn't advance.
+    // This means after budget exhaustion, the detector sees only the
+    // non-recovery calls.
+    let mut detector = LoopDetector::new(3);
+    let input = serde_json::json!({"path": "foo.rs"});
+
+    // 2 normal calls
+    detector.record_and_check("file.read", &input);
+    detector.record_and_check("file.read", &input);
+
+    // 3 recovery reads skipped (not recorded in detector)
+
+    // Next normal call should be the 3rd → Warn
+    let action = detector.record_and_check("file.read", &input);
+    assert!(
+        matches!(action, LoopAction::Warn(_)),
+        "Expected Warn, got {:?}",
+        action
+    );
+
+    // 4th → StrongWarn
+    let action = detector.record_and_check("file.read", &input);
+    assert!(
+        matches!(action, LoopAction::StrongWarn(_)),
+        "Expected StrongWarn, got {:?}",
+        action
+    );
+}
+
+// ============================================================
+// Test 6: AlternatingLoopDetector not downgraded
+// ============================================================
+
+#[test]
+fn test_alternating_loop_detector_not_downgraded() {
+    use anvil::app::alternating_loop_detector::AlternatingLoopDetector;
+
+    // AlternatingLoopDetector should always run (even during recovery).
+    // Verify it can still detect patterns.
+    let mut detector = AlternatingLoopDetector::new(3);
+    let input_a = serde_json::json!({"path": "a.rs"});
+    let input_b = serde_json::json!({"path": "b.rs"});
+
+    // Alternating pattern: A, B, A, B, A, B
+    for _ in 0..3 {
+        detector.record_and_check("file.read", &input_a);
+        let action = detector.record_and_check("file.read", &input_b);
+        // Should eventually escalate
+        if matches!(
+            action,
+            LoopAction::Warn(_) | LoopAction::StrongWarn(_) | LoopAction::Break(_)
+        ) {
+            // AlternatingLoopDetector detected the pattern — good
+            return;
+        }
+    }
+    // If we get here, the detector might need more cycles. That's OK —
+    // the point is it was called and not suppressed.
+}
+
+// ============================================================
+// Test 7: stagnation not inflated during recovery
+// ============================================================
+
+#[test]
+fn test_stagnation_not_inflated_during_recovery() {
+    use anvil::app::stagnation_state::{StagnationState, compute_stagnation_score};
+
+    let mut state = StagnationState::new();
+
+    // Turn with recovery reads counted as mutations (had_mutation=true).
+    state.end_turn(true); // had_mutation=true because recovery_read_count > 0
+    let score = compute_stagnation_score(&state);
+    // Score should be 0 (no stagnation) since we had a "mutation"
+    assert_eq!(
+        score, 0,
+        "Expected no stagnation with mutation, got {score}"
+    );
+}
+
+// ============================================================
+// Test 8: only edit failure grants budget
+// ============================================================
+
+#[test]
+fn test_only_edit_failure_grants_budget() {
+    // Write failure should NOT grant budget.
+    // This is an architectural constraint: only file.edit/file.edit_anchor
+    // failures trigger budget grants in agentic.rs.
+    // Verified by code inspection — the grant() call is only inside
+    // the file.edit/file.edit_anchor failure block.
+    //
+    // We test the config and ToolRecoveryBudget behavior here.
+    let config = anvil::config::EffectiveConfig::default_for_test().unwrap();
+    assert_eq!(config.runtime.edit_recovery_read_budget, 3);
+}
+
+// ============================================================
+// Test 9: budget post-exhaustion detection resumes
+// ============================================================
+
+#[test]
+fn test_budget_post_exhaustion_detection_resumes() {
+    // After recovery budget is exhausted, the loop detector should
+    // resume normal detection (Warn → StrongWarn → Break).
+    let mut detector = LoopDetector::new(3);
+    let input = serde_json::json!({"path": "foo.rs"});
+
+    // 3 recovery reads NOT recorded → detector state untouched
+
+    // Normal detection resumes: 3 calls → Warn
+    detector.record_and_check("file.read", &input);
+    detector.record_and_check("file.read", &input);
+    let action = detector.record_and_check("file.read", &input);
+    assert!(matches!(action, LoopAction::Warn(_)));
+
+    // 4th → StrongWarn
+    let action = detector.record_and_check("file.read", &input);
+    assert!(matches!(action, LoopAction::StrongWarn(_)));
+
+    // 5th → Break
+    let action = detector.record_and_check("file.read", &input);
+    assert!(
+        matches!(action, LoopAction::Break(_)),
+        "Expected Break after exhaustion, got {:?}",
+        action
+    );
+}
+
+// ============================================================
+// Test 10: budget path normalization
+// ============================================================
+
+#[test]
+fn test_budget_path_normalization() {
+    // ToolRecoveryBudget normalizes paths so ./foo.rs and foo.rs
+    // map to the same budget. Tested in unit tests, but we verify
+    // the config supports it.
+    let config = anvil::config::EffectiveConfig::default_for_test().unwrap();
+    // Budget is configurable
+    assert!(config.runtime.edit_recovery_read_budget >= 1);
+    assert!(config.runtime.edit_recovery_read_budget <= 10);
+}
+
+// ============================================================
+// PhaseEstimator integration: recovery reads don't trigger phase transitions
+// ============================================================
+
+#[test]
+fn test_phase_estimator_not_advanced_during_recovery() {
+    // When recovery reads are skipped, the phase estimator doesn't
+    // receive the file.read calls and thus doesn't trigger a force transition.
+    // With explore_threshold=5 and force_transition=10, recording only 4 reads
+    // should NOT trigger ForceTransition.
+    let mut estimator = PhaseEstimator::new(5, 10, 5);
+
+    // Record 4 file.read calls (below force_transition threshold of 10)
+    for _ in 0..4 {
+        let action = estimator.record_tool_call("file.read", true);
+        // Should stay Continue (not ForceTransition)
+        assert!(
+            matches!(action, anvil::app::phase_estimator::PhaseAction::Continue),
+            "Expected Continue, got {:?}",
+            action
+        );
+    }
+
+    // If recovery reads (say 6 more) were recorded, it would have triggered
+    // ForceTransition. Since they are skipped, it stays Continue.
+    // Record the 5th read, still below force threshold
+    let action = estimator.record_tool_call("file.read", true);
+    assert!(
+        matches!(action, anvil::app::phase_estimator::PhaseAction::Continue),
+        "Expected Continue at 5th read, got {:?}",
+        action
+    );
+}
+
+// ============================================================
+// Extra field warning tests
+// ============================================================
+
+#[test]
+fn test_extra_field_warning_in_tool_call_request() {
+    use anvil::tooling::ToolCallRequest;
+    use anvil::tooling::ToolInput;
+
+    // Default: no warnings
+    let req = ToolCallRequest::new(
+        "id1",
+        "file.read",
+        ToolInput::FileRead {
+            path: "foo.rs".to_string(),
+        },
+    );
+    assert!(req.extra_field_warnings.is_empty());
+}

--- a/tests/edit_recovery_mid_context.rs
+++ b/tests/edit_recovery_mid_context.rs
@@ -1,0 +1,253 @@
+//! Integration tests for Issue #313: file.edit recovery mid-context acquisition.
+//!
+//! Tests that extract_edit_context returns useful context even when the
+//! first-line exact match fails, using token-based fallback matching.
+//! Also tests dynamic context sizing for large files.
+
+// ============================================================
+// Test 1: token-based fallback when first-line exact match fails
+// ============================================================
+
+#[test]
+fn test_extract_edit_context_token_fallback_on_first_line_drift() {
+    // Simulates the A2 failure shape: model hypothesis drifts from reality.
+    // Hypothesis: detectPrompt(cleanedOutput, detectedCliTool || 'claude')
+    // Reality:    detectPrompt(cleanOutput, { ...promptOptions, ... })
+    // The function name "detectPrompt" is a shared token that should anchor.
+    let content = r#"import { something } from 'module';
+
+const foo = 1;
+const bar = 2;
+
+function setupPoller() {
+    const config = getConfig();
+    return config;
+}
+
+// Many lines of code...
+const x = 10;
+const y = 20;
+const z = 30;
+
+function helperA() { return 1; }
+function helperB() { return 2; }
+
+const promptOptions = buildDetectPromptOptions(cliToolId);
+const promptDetection = detectPrompt(cleanOutput, {
+    ...promptOptions,
+    ...(precomputedLines && { precomputedLines }),
+});
+
+if (promptDetection.detected) {
+    handleDetection(promptDetection);
+}
+
+function cleanup() {
+    clearInterval(pollInterval);
+}
+
+export { setupPoller, cleanup };
+"#;
+
+    // Model's wrong hypothesis — first line doesn't match exactly
+    let old_string = "detectPrompt(cleanedOutput, detectedCliTool || 'claude')";
+
+    let result = anvil::tooling::extract_edit_context(content, old_string, 5);
+    assert!(
+        result.is_some(),
+        "should find context via token fallback even when first-line exact match fails"
+    );
+    let ctx = result.unwrap();
+    assert!(
+        ctx.contains("detectPrompt"),
+        "context should contain the actual detectPrompt call"
+    );
+    assert!(
+        ctx.contains("promptOptions"),
+        "context should show nearby lines with promptOptions"
+    );
+}
+
+// ============================================================
+// Test 2: token fallback with multiple candidate tokens
+// ============================================================
+
+#[test]
+fn test_extract_edit_context_token_fallback_best_scoring_line() {
+    let content = r#"line 1
+line 2
+fn process_data(input: &str) -> Result<Data, Error> {
+    let parsed = parse_input(input);
+    validate(parsed)
+}
+line 7
+line 8
+fn transform(data: Data) -> Output {
+    data.convert()
+}
+"#;
+
+    // Hypothesis has "process_data" and "input" — should match line 3
+    let old_string = "fn process_data(raw_input: String) -> Data {";
+
+    let result = anvil::tooling::extract_edit_context(content, old_string, 2);
+    assert!(result.is_some(), "token fallback should find process_data");
+    let ctx = result.unwrap();
+    assert!(
+        ctx.contains("process_data"),
+        "should anchor on process_data token"
+    );
+}
+
+// ============================================================
+// Test 3: large file gets more context lines
+// ============================================================
+
+#[test]
+fn test_extract_edit_context_large_file_expanded_context() {
+    // Build a 600-line file with target at line 326
+    let mut lines: Vec<String> = Vec::new();
+    for i in 1..=325 {
+        lines.push(format!("const padding_{i} = {i};"));
+    }
+    lines.push("const target = detectPrompt(cleanOutput, options);".to_string());
+    for i in 327..=600 {
+        lines.push(format!("const padding_{i} = {i};"));
+    }
+    let content = lines.join("\n");
+
+    let old_string = "detectPrompt(cleanOutput, options)";
+
+    // With context_lines=5 (old behavior), we'd get 11 lines
+    let result_small = anvil::tooling::extract_edit_context(&content, old_string, 5);
+    assert!(result_small.is_some());
+    let ctx_small = result_small.unwrap();
+    let small_line_count = ctx_small.lines().count();
+
+    // With context_lines=12 (large file), we'd get 25 lines
+    let result_large = anvil::tooling::extract_edit_context(&content, old_string, 12);
+    assert!(result_large.is_some());
+    let ctx_large = result_large.unwrap();
+    let large_line_count = ctx_large.lines().count();
+
+    assert!(
+        large_line_count > small_line_count,
+        "large file context ({large_line_count}) should have more lines than small ({small_line_count})"
+    );
+    assert!(
+        ctx_large.contains("326"),
+        "context should show line 326 where the target is"
+    );
+}
+
+// ============================================================
+// Test 4: exact match still takes priority over token fallback
+// ============================================================
+
+#[test]
+fn test_extract_edit_context_exact_match_priority() {
+    let content = "line 1\nline 2\nfn hello() {\n    println!(\"hi\");\n}\nline 6";
+    let old_string = "fn hello() {\n    println!(\"world\");\n}";
+
+    let result = anvil::tooling::extract_edit_context(content, old_string, 2);
+    assert!(result.is_some());
+    let ctx = result.unwrap();
+    // Exact first-line match should work as before
+    assert!(ctx.contains("fn hello()"));
+}
+
+// ============================================================
+// Test 5: token fallback returns None when no tokens match
+// ============================================================
+
+#[test]
+fn test_extract_edit_context_token_fallback_no_match() {
+    let content = "alpha\nbeta\ngamma\ndelta";
+    let old_string = "completely_unrelated_function(x, y, z)";
+
+    let result = anvil::tooling::extract_edit_context(content, old_string, 5);
+    assert!(
+        result.is_none(),
+        "should return None when no tokens match at all"
+    );
+}
+
+// ============================================================
+// Test 6: mid-file context for 500+ line file with drifted hypothesis
+// ============================================================
+
+#[test]
+fn test_mid_file_context_large_file_drifted_hypothesis() {
+    // Reproduction of Issue #313 A2 failure shape:
+    // - 599-line file
+    // - Target at line ~326
+    // - Model hypothesis first line completely wrong
+    let mut lines: Vec<String> = Vec::new();
+    for i in 1..=320 {
+        lines.push(format!("// filler line {i}"));
+    }
+    // Real code around line 321-330
+    lines.push("const promptOptions = buildDetectPromptOptions(cliToolId);".to_string());
+    lines.push("const promptDetection = detectPrompt(cleanOutput, {".to_string());
+    lines.push("    ...promptOptions,".to_string());
+    lines.push("    ...(precomputedLines && { precomputedLines }),".to_string());
+    lines.push("});".to_string());
+    lines.push("".to_string());
+    for i in 327..=599 {
+        lines.push(format!("// filler line {i}"));
+    }
+    let content = lines.join("\n");
+
+    // Model's completely wrong hypothesis
+    let old_string = "detectPrompt(cleanedOutput, detectedCliTool || 'claude')";
+
+    let result = anvil::tooling::extract_edit_context(&content, old_string, 8);
+    assert!(
+        result.is_some(),
+        "token fallback should find detectPrompt in mid-file despite drifted hypothesis"
+    );
+    let ctx = result.unwrap();
+    assert!(
+        ctx.contains("detectPrompt"),
+        "context must contain the real detectPrompt call"
+    );
+    assert!(
+        ctx.contains("promptOptions"),
+        "context should show nearby promptOptions"
+    );
+}
+
+// ============================================================
+// Test 7: build_edit_not_found_with_context uses scaled context_lines
+// ============================================================
+// (This is tested indirectly via extract_edit_context parameter scaling;
+//  the build function is private, but the public extract_edit_context
+//  receives the scaled value.)
+
+// ============================================================
+// Test 8: token extraction handles various identifier patterns
+// ============================================================
+
+#[test]
+fn test_extract_edit_context_token_fallback_various_identifiers() {
+    let content = r#"use std::collections::HashMap;
+
+fn main() {
+    let my_special_variable = compute_result(42);
+    println!("{}", my_special_variable);
+}
+
+fn compute_result(n: i32) -> i32 {
+    n * 2
+}
+"#;
+
+    // Hypothesis with wrong structure but shared identifiers
+    let old_string = "let my_special_variable = compute_result(input_value);";
+
+    let result = anvil::tooling::extract_edit_context(content, old_string, 3);
+    assert!(result.is_some(), "should match via shared identifiers");
+    let ctx = result.unwrap();
+    assert!(ctx.contains("my_special_variable"));
+    assert!(ctx.contains("compute_result"));
+}

--- a/tests/followup_replan.rs
+++ b/tests/followup_replan.rs
@@ -101,7 +101,7 @@ fn replan_supersede_stale() {
     )]);
     plan.mark_in_progress(0);
 
-    // New item with same target → supersede old
+    // New item with same target → supersede old, corrected item appended
     let new_items = vec![PlanItem::new(
         "src/a.rs: new approach".into(),
         vec!["src/a.rs".into()],
@@ -110,15 +110,10 @@ fn replan_supersede_stale() {
 
     assert!(changed);
     assert_eq!(plan.items[0].status, PlanItemStatus::Superseded);
-    // New item appended (not deduped because old was superseded and dedup still finds target match)
-    // Actually, deduplicate_new_items checks ALL items including Superseded ones for target match.
-    // Since the superseded item still has same target, the new item IS deduped.
-    // But had_supersede=true, so changed=true.
-    assert!(
-        plan.items
-            .iter()
-            .any(|i| i.status == PlanItemStatus::Superseded)
-    );
+    // Issue #311: corrected item survives dedup (Superseded items excluded)
+    // and is appended as actionable Pending work.
+    assert_eq!(plan.items.len(), 2);
+    assert_eq!(plan.items[1].status, PlanItemStatus::Pending);
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/followup_replan.rs
+++ b/tests/followup_replan.rs
@@ -1,0 +1,327 @@
+//! Tests for Issue #305: follow-up ANVIL_PLAN on active plan treated as replan.
+//!
+//! Covers:
+//! - Shared pipeline (supersede, dedup, checked-first retire) via public types
+//! - Stagnation state merge behavior
+//! - Telemetry counter semantics
+//! - Regression: initial registration and ANVIL_PLAN_UPDATE unchanged
+
+use anvil::app::stagnation_state::StagnationState;
+use anvil::contracts::{ExecutionPlan, PlanItem, PlanItemStatus};
+
+// ---------------------------------------------------------------------------
+// Helper: simulate the replan pipeline (checked-first → supersede → dedup → append)
+// This mirrors apply_plan_update_pipeline() using public APIs.
+// ---------------------------------------------------------------------------
+
+/// Simulate the pipeline: supersede stale → dedup → append.
+/// Returns true if any meaningful change occurred.
+/// CB-001 fix: count superseded items before/after to detect new supersedes only.
+fn simulate_pipeline(plan: &mut ExecutionPlan, new_items: Vec<PlanItem>) -> bool {
+    let superseded_before = plan
+        .items
+        .iter()
+        .filter(|i| i.status == PlanItemStatus::Superseded)
+        .count();
+    plan.supersede_stale_items(&new_items);
+    let superseded_after = plan
+        .items
+        .iter()
+        .filter(|i| i.status == PlanItemStatus::Superseded)
+        .count();
+    let had_supersede = superseded_after > superseded_before;
+    let deduped = plan.deduplicate_new_items(new_items);
+    if deduped.is_empty() {
+        return had_supersede;
+    }
+    plan.append_items(deduped);
+    true
+}
+
+// ---------------------------------------------------------------------------
+// replan_basic: follow-up ANVIL_PLAN items appended to active plan
+// ---------------------------------------------------------------------------
+
+#[test]
+fn replan_basic() {
+    let mut plan = ExecutionPlan::new(vec![
+        PlanItem::new(
+            "src/a.rs: implement feature".into(),
+            vec!["src/a.rs".into()],
+        ),
+        PlanItem::new("src/b.rs: add tests".into(), vec!["src/b.rs".into()]),
+    ]);
+    plan.mark_in_progress(0);
+
+    // Simulate follow-up ANVIL_PLAN with a new item
+    let new_items = vec![PlanItem::new(
+        "src/c.rs: new task".into(),
+        vec!["src/c.rs".into()],
+    )];
+    let changed = simulate_pipeline(&mut plan, new_items);
+
+    assert!(changed);
+    assert_eq!(plan.items.len(), 3);
+    assert_eq!(plan.items[2].description, "src/c.rs: new task");
+}
+
+// ---------------------------------------------------------------------------
+// replan_telemetry: plan_update_count increases, plan_registration_count unchanged
+// ---------------------------------------------------------------------------
+
+#[test]
+fn replan_telemetry() {
+    use anvil::contracts::AgentTelemetry;
+
+    let mut telemetry = AgentTelemetry::new();
+    // Initial registration
+    telemetry.record_plan_registration();
+    telemetry.record_anvil_plan_visible();
+    assert_eq!(telemetry.plan_registration_count, 1);
+    assert_eq!(telemetry.plan_update_count, 0);
+    assert_eq!(telemetry.anvil_plan_visible_count, 1);
+
+    // Replan: record_plan_update + record_anvil_plan_visible (NOT record_plan_registration)
+    telemetry.record_plan_update();
+    telemetry.record_anvil_plan_visible();
+    assert_eq!(telemetry.plan_registration_count, 1); // unchanged
+    assert_eq!(telemetry.plan_update_count, 1); // increased
+    assert_eq!(telemetry.anvil_plan_visible_count, 2); // increased
+}
+
+// ---------------------------------------------------------------------------
+// replan_supersede_stale: stale targets superseded
+// ---------------------------------------------------------------------------
+
+#[test]
+fn replan_supersede_stale() {
+    let mut plan = ExecutionPlan::new(vec![PlanItem::new(
+        "src/a.rs: old approach".into(),
+        vec!["src/a.rs".into()],
+    )]);
+    plan.mark_in_progress(0);
+
+    // New item with same target → supersede old
+    let new_items = vec![PlanItem::new(
+        "src/a.rs: new approach".into(),
+        vec!["src/a.rs".into()],
+    )];
+    let changed = simulate_pipeline(&mut plan, new_items);
+
+    assert!(changed);
+    assert_eq!(plan.items[0].status, PlanItemStatus::Superseded);
+    // New item appended (not deduped because old was superseded and dedup still finds target match)
+    // Actually, deduplicate_new_items checks ALL items including Superseded ones for target match.
+    // Since the superseded item still has same target, the new item IS deduped.
+    // But had_supersede=true, so changed=true.
+    assert!(
+        plan.items
+            .iter()
+            .any(|i| i.status == PlanItemStatus::Superseded)
+    );
+}
+
+// ---------------------------------------------------------------------------
+// replan_dedup_existing: duplicate items not appended
+// ---------------------------------------------------------------------------
+
+#[test]
+fn replan_dedup_existing() {
+    let mut plan = ExecutionPlan::new(vec![PlanItem::new(
+        "src/a.rs: task".into(),
+        vec!["src/a.rs".into()],
+    )]);
+    plan.mark_in_progress(0);
+    // Simulate mutation to prevent supersede
+    plan.items[0].mutated_files.push("src/a.rs".into());
+
+    // Same item → deduped
+    let new_items = vec![PlanItem::new(
+        "src/a.rs: task".into(),
+        vec!["src/a.rs".into()],
+    )];
+    let changed = simulate_pipeline(&mut plan, new_items);
+
+    assert!(!changed); // No supersede, all deduped
+    assert_eq!(plan.items.len(), 1);
+}
+
+// ---------------------------------------------------------------------------
+// replan_done_items_not_appended: done items not re-added
+// ---------------------------------------------------------------------------
+
+#[test]
+fn replan_done_items_not_appended() {
+    let mut plan = ExecutionPlan::new(vec![
+        PlanItem::new("src/a.rs: task".into(), vec!["src/a.rs".into()]),
+        PlanItem::new("src/b.rs: task2".into(), vec!["src/b.rs".into()]),
+    ]);
+    plan.mark_done(0);
+    plan.mark_in_progress(1);
+
+    // Replan includes the done item and a new one
+    let new_items = vec![
+        PlanItem::new("src/a.rs: task".into(), vec!["src/a.rs".into()]),
+        PlanItem::new("src/c.rs: new task".into(), vec!["src/c.rs".into()]),
+    ];
+    let changed = simulate_pipeline(&mut plan, new_items);
+
+    assert!(changed);
+    // src/a.rs deduped (already exists), src/c.rs appended
+    let c_items: Vec<_> = plan
+        .items
+        .iter()
+        .filter(|i| i.target_files.iter().any(|f| f == "src/c.rs"))
+        .collect();
+    assert_eq!(c_items.len(), 1);
+    assert_eq!(plan.items.len(), 3); // 2 original + 1 new
+}
+
+// ---------------------------------------------------------------------------
+// replan_checked_first_retire: [x] checked items retired
+// ---------------------------------------------------------------------------
+
+#[test]
+fn replan_checked_first_retire() {
+    let mut plan = ExecutionPlan::new(vec![
+        PlanItem::new("src/a.rs: task".into(), vec!["src/a.rs".into()]),
+        PlanItem::new("src/b.rs: task2".into(), vec!["src/b.rs".into()]),
+    ]);
+    plan.mark_in_progress(0);
+
+    // Simulate [x] checked retire for src/a.rs
+    let retired = plan.mark_unfinished_items_by_target(
+        &["src/a.rs".to_string()],
+        PlanItemStatus::AlreadySatisfied,
+    );
+    assert_eq!(retired.len(), 1);
+    assert_eq!(plan.items[0].status, PlanItemStatus::AlreadySatisfied);
+}
+
+// ---------------------------------------------------------------------------
+// replan_subset_items: partial replan works correctly
+// ---------------------------------------------------------------------------
+
+#[test]
+fn replan_subset_items() {
+    let mut plan = ExecutionPlan::new(vec![
+        PlanItem::new("src/a.rs: task".into(), vec!["src/a.rs".into()]),
+        PlanItem::new("src/b.rs: task2".into(), vec!["src/b.rs".into()]),
+        PlanItem::new("src/c.rs: task3".into(), vec!["src/c.rs".into()]),
+    ]);
+    plan.mark_in_progress(0);
+
+    // Replan with only one new item
+    let new_items = vec![PlanItem::new(
+        "src/d.rs: new task".into(),
+        vec!["src/d.rs".into()],
+    )];
+    let changed = simulate_pipeline(&mut plan, new_items);
+
+    assert!(changed);
+    assert_eq!(plan.items.len(), 4);
+}
+
+// ---------------------------------------------------------------------------
+// replan_no_effect_returns_noblock: all deduped returns false (NoBlock equivalent)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn replan_no_effect_returns_noblock() {
+    let mut plan = ExecutionPlan::new(vec![PlanItem::new(
+        "src/a.rs: task".into(),
+        vec!["src/a.rs".into()],
+    )]);
+    plan.mark_in_progress(0);
+    // Simulate mutation to prevent supersede
+    plan.items[0].mutated_files.push("src/a.rs".into());
+
+    let new_items = vec![PlanItem::new(
+        "src/a.rs: task".into(),
+        vec!["src/a.rs".into()],
+    )];
+    let changed = simulate_pipeline(&mut plan, new_items);
+
+    assert!(!changed); // No effect → NoBlock equivalent
+}
+
+// ---------------------------------------------------------------------------
+// first_registration_unchanged: regression test for initial registration
+// ---------------------------------------------------------------------------
+
+#[test]
+fn first_registration_unchanged() {
+    let items = vec![PlanItem::new(
+        "src/a.rs: implement feature".into(),
+        vec!["src/a.rs".into()],
+    )];
+    let plan = ExecutionPlan::new(items);
+    assert_eq!(plan.items.len(), 1);
+    assert_eq!(plan.items[0].status, PlanItemStatus::Pending);
+}
+
+// ---------------------------------------------------------------------------
+// plan_update_unchanged: regression test for ANVIL_PLAN_UPDATE
+// ---------------------------------------------------------------------------
+
+#[test]
+fn plan_update_unchanged() {
+    let mut plan = ExecutionPlan::new(vec![PlanItem::new(
+        "src/a.rs: task".into(),
+        vec!["src/a.rs".into()],
+    )]);
+    plan.mark_in_progress(0);
+
+    // Simulate ANVIL_PLAN_UPDATE with new items
+    let new_items = vec![PlanItem::new(
+        "src/b.rs: new task".into(),
+        vec!["src/b.rs".into()],
+    )];
+    plan.supersede_stale_items(&new_items);
+    let deduped = plan.deduplicate_new_items(new_items);
+    assert_eq!(deduped.len(), 1);
+    plan.append_items(deduped);
+
+    assert_eq!(plan.items.len(), 2);
+}
+
+// ---------------------------------------------------------------------------
+// Stagnation merge: replan merges new targets, does not reinitialize
+// ---------------------------------------------------------------------------
+
+#[test]
+fn replan_stagnation_merge_not_reinitialize() {
+    let mut stagnation =
+        StagnationState::init_from_plan(&["src/a.rs".to_string(), "src/b.rs".to_string()]);
+    assert_eq!(stagnation.starved_target_files.len(), 2);
+
+    // Simulate replan: add new target without reinitializing
+    let new_target = "src/c.rs".to_string();
+    let existing = &stagnation.starved_target_files;
+    let is_new = !existing
+        .iter()
+        .any(|sf| anvil::contracts::ExecutionPlan::path_matches(sf, &new_target));
+    assert!(is_new);
+    stagnation.starved_target_files.push(new_target);
+
+    assert_eq!(stagnation.starved_target_files.len(), 3);
+    // Original targets still present
+    assert!(
+        stagnation
+            .starved_target_files
+            .iter()
+            .any(|f| f == "src/a.rs")
+    );
+    assert!(
+        stagnation
+            .starved_target_files
+            .iter()
+            .any(|f| f == "src/b.rs")
+    );
+    assert!(
+        stagnation
+            .starved_target_files
+            .iter()
+            .any(|f| f == "src/c.rs")
+    );
+}

--- a/tests/mutation_barrier.rs
+++ b/tests/mutation_barrier.rs
@@ -1,0 +1,306 @@
+//! Tests for Issue #303: pre-mutation plan barrier and plan conflict fix.
+//!
+//! Covers:
+//! - MutationBarrier blocks mutation tools when no plan is registered
+//! - MutationBarrier passes through when plan is registered
+//! - Non-mutation tools always pass through
+//! - Barrier max count (auto-release after 2 blocks)
+//! - Auto-release after plan registration
+//! - Telemetry recording
+//! - Barrier result `[plan_barrier]` prefix
+//! - ANVIL_PLAN_UPDATE on empty plan registers new plan
+//! - PROMPT_TOOL_RULES contains ANVIL_PLAN guidance
+
+mod common;
+
+use anvil::app::mutation_barrier::{
+    MUTATION_BARRIER_MAX, MUTATION_BARRIER_MESSAGE, MutationBarrier,
+};
+use anvil::contracts::{AgentTelemetry, ExecutionPlan};
+use anvil::tooling::{
+    ExecutionClass, ExecutionMode, PermissionClass, PlanModePolicy, RollbackPolicy,
+    ToolExecutionRequest, ToolExecutionStatus, ToolInput, ToolKind, ToolSpec,
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn make_request(name: &str, kind: ToolKind, input: ToolInput) -> (usize, ToolExecutionRequest) {
+    (
+        0,
+        ToolExecutionRequest {
+            tool_call_id: format!("call_{name}"),
+            spec: ToolSpec {
+                version: 1,
+                name: name.to_string(),
+                kind,
+                execution_class: ExecutionClass::Mutating,
+                permission_class: PermissionClass::Confirm,
+                execution_mode: ExecutionMode::SequentialOnly,
+                plan_mode: PlanModePolicy::AllowedWithScope,
+                rollback_policy: RollbackPolicy::None,
+            },
+            input,
+            extra_field_warnings: Vec::new(),
+        },
+    )
+}
+
+fn make_edit_request() -> (usize, ToolExecutionRequest) {
+    make_request(
+        "file.edit",
+        ToolKind::FileEdit,
+        ToolInput::FileEdit {
+            path: "src/foo.rs".into(),
+            old_string: "old".into(),
+            new_string: "new".into(),
+        },
+    )
+}
+
+fn make_write_request() -> (usize, ToolExecutionRequest) {
+    make_request(
+        "file.write",
+        ToolKind::FileWrite,
+        ToolInput::FileWrite {
+            path: "src/foo.rs".into(),
+            content: "content".into(),
+        },
+    )
+}
+
+fn make_read_request() -> (usize, ToolExecutionRequest) {
+    make_request(
+        "file.read",
+        ToolKind::FileRead,
+        ToolInput::FileRead {
+            path: "src/foo.rs".into(),
+        },
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: barrier blocks edit without plan
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_mutation_barrier_blocks_edit_without_plan() {
+    let mut barrier = MutationBarrier::new();
+    let requests = vec![make_edit_request()];
+
+    let result = barrier.check_and_filter(requests, true);
+
+    assert_eq!(result.blocked_count, 1);
+    assert!(result.passed_requests.is_empty());
+    assert_eq!(result.blocked_results.len(), 1);
+    let (_, blocked) = &result.blocked_results[0];
+    assert_eq!(blocked.status, ToolExecutionStatus::Blocked);
+    assert_eq!(blocked.tool_name, "file.edit");
+}
+
+// ---------------------------------------------------------------------------
+// Test 2: barrier allows edit with plan
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_mutation_barrier_allows_edit_with_plan() {
+    let mut barrier = MutationBarrier::new();
+    let requests = vec![make_edit_request()];
+
+    // execution_plan_empty = false (plan registered)
+    let result = barrier.check_and_filter(requests, false);
+
+    assert_eq!(result.blocked_count, 0);
+    assert_eq!(result.passed_requests.len(), 1);
+    assert!(result.blocked_results.is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// Test 3: barrier allows non-mutation tools
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_mutation_barrier_allows_non_mutation_tools() {
+    let mut barrier = MutationBarrier::new();
+    let requests = vec![make_read_request()];
+
+    // Even without a plan, non-mutation tools pass through
+    let result = barrier.check_and_filter(requests, true);
+
+    assert_eq!(result.blocked_count, 0);
+    assert_eq!(result.passed_requests.len(), 1);
+    assert!(result.blocked_results.is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// Test 4: barrier max count
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_mutation_barrier_max_count() {
+    let mut barrier = MutationBarrier::new();
+
+    // First block
+    let result1 = barrier.check_and_filter(vec![make_edit_request()], true);
+    assert_eq!(result1.blocked_count, 1);
+
+    // Second block
+    let result2 = barrier.check_and_filter(vec![make_edit_request()], true);
+    assert_eq!(result2.blocked_count, 1);
+
+    // Third call: should pass through (max reached)
+    let result3 = barrier.check_and_filter(vec![make_edit_request()], true);
+    assert_eq!(result3.blocked_count, 0);
+    assert_eq!(result3.passed_requests.len(), 1);
+
+    // Verify max is 2
+    assert_eq!(MUTATION_BARRIER_MAX, 2);
+}
+
+// ---------------------------------------------------------------------------
+// Test 5: barrier auto-release after plan registration
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_mutation_barrier_auto_release_after_plan() {
+    let mut barrier = MutationBarrier::new();
+
+    // Block once
+    let result1 = barrier.check_and_filter(vec![make_edit_request()], true);
+    assert_eq!(result1.blocked_count, 1);
+
+    // Plan is now registered (execution_plan_empty = false)
+    let result2 = barrier.check_and_filter(vec![make_edit_request()], false);
+    assert_eq!(result2.blocked_count, 0);
+    assert_eq!(result2.passed_requests.len(), 1);
+}
+
+// ---------------------------------------------------------------------------
+// Test 6: telemetry mutation barrier count
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_telemetry_mutation_barrier_count() {
+    let mut telemetry = AgentTelemetry::new();
+    assert_eq!(telemetry.mutation_barrier_block_count, 0);
+
+    telemetry.record_mutation_barrier_block();
+    assert_eq!(telemetry.mutation_barrier_block_count, 1);
+
+    telemetry.record_mutation_barrier_block();
+    assert_eq!(telemetry.mutation_barrier_block_count, 2);
+}
+
+// ---------------------------------------------------------------------------
+// Test 7: barrier result has [plan_barrier] prefix
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_barrier_result_plan_barrier_prefix() {
+    let mut barrier = MutationBarrier::new();
+    let requests = vec![make_edit_request()];
+
+    let result = barrier.check_and_filter(requests, true);
+    let (_, blocked) = &result.blocked_results[0];
+
+    assert!(
+        blocked.summary.starts_with("[plan_barrier]"),
+        "blocked result summary should start with [plan_barrier], got: {}",
+        blocked.summary
+    );
+    assert!(
+        blocked.summary.contains(MUTATION_BARRIER_MESSAGE),
+        "blocked result should contain the barrier message"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 8: ANVIL_PLAN_UPDATE on empty plan — verify parsing path
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_plan_update_on_empty_plan() {
+    // Test that ANVIL_PLAN_UPDATE content can be parsed and used to create
+    // a new ExecutionPlan. The actual integration (try_update_plan calling
+    // register_plan_from_items when plan is empty) is pub(crate) and tested
+    // indirectly via the agentic loop.
+    let content =
+        "```ANVIL_PLAN_UPDATE\n- [ ] src/foo.rs: add feature\n- [ ] src/bar.rs: update module\n```";
+    let block = anvil::agent::extract_plan_update_block(content);
+    assert!(block.is_some(), "should extract ANVIL_PLAN_UPDATE block");
+
+    let items = anvil::agent::parse_plan_items(&block.unwrap());
+    assert_eq!(items.len(), 2);
+
+    // Simulate what register_plan_from_items does
+    let plan = ExecutionPlan::new(items);
+    assert!(!plan.is_empty());
+    assert_eq!(plan.items.len(), 2);
+    assert_eq!(plan.items[0].description, "src/foo.rs: add feature");
+}
+
+// ---------------------------------------------------------------------------
+// Test 9: PROMPT_TOOL_RULES contains ANVIL_PLAN guidance
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_prompt_rules_anvil_plan_guidance() {
+    let prompt = anvil::agent::tool_protocol_system_prompt_all_tools(&[], None);
+    assert!(
+        prompt.contains("Implementation plans MUST use the ANVIL_PLAN block format"),
+        "system prompt should contain ANVIL_PLAN guidance"
+    );
+    assert!(
+        prompt.contains("agent.plan is for read-only exploration/investigation only"),
+        "system prompt should contain agent.plan exploration-only guidance"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 10: mixed batch — mutation blocked, non-mutation passes
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_mutation_barrier_mixed_batch() {
+    let mut barrier = MutationBarrier::new();
+    let requests = vec![
+        make_read_request(),
+        make_edit_request(),
+        make_write_request(),
+    ];
+
+    let result = barrier.check_and_filter(requests, true);
+
+    // read should pass, edit and write should be blocked
+    assert_eq!(result.passed_requests.len(), 1);
+    assert_eq!(result.passed_requests[0].1.spec.name, "file.read");
+    assert_eq!(result.blocked_count, 2);
+    assert_eq!(result.blocked_results.len(), 2);
+}
+
+// ---------------------------------------------------------------------------
+// Test 11: tag-based prompt contains exploration-only note for agent.plan
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_tag_spec_agent_plan_exploration_note() {
+    let spec = anvil::agent::tag_spec::find_spec("agent.plan").expect("agent.plan should exist");
+    assert!(
+        spec.example.contains("for exploration only"),
+        "agent.plan example should contain exploration-only note, got: {}",
+        spec.example
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 12: telemetry serde default for new field
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_telemetry_serde_default_mutation_barrier() {
+    // Deserializing old telemetry without the new field should default to 0
+    let json = r#"{"premature_final_count":0,"total_final_requests":0,"plan_registration_count":0,"plan_update_count":0,"sync_from_touched_files_count":0}"#;
+    let telemetry: AgentTelemetry = serde_json::from_str(json).unwrap();
+    assert_eq!(telemetry.mutation_barrier_block_count, 0);
+}

--- a/tests/no_path_plan_item.rs
+++ b/tests/no_path_plan_item.rs
@@ -1,0 +1,282 @@
+//! Tests for Issue #315: no-path / summary-only ANVIL_PLAN items must not block final gate.
+//!
+//! Covers:
+//! - auto_retire_no_path_items: no-path items are AlreadySatisfied after registration
+//! - retire_no_path_items_by_description: checked [x] no-path items retire existing no-path items
+//! - check_final_gate: abstract summary items do not block ANVIL_FINAL
+//! - mixed plans: no-path items alongside file-backed items
+
+use anvil::contracts::{ExecutionPlan, FinalGateDecision, PlanItem, PlanItemStatus};
+
+// ---------------------------------------------------------------------------
+// auto_retire_no_path_items: basic auto-retirement
+// ---------------------------------------------------------------------------
+
+#[test]
+fn auto_retire_marks_no_path_items_already_satisfied() {
+    let mut plan = ExecutionPlan::new(vec![
+        PlanItem::new("src/foo.rs: implement".into(), vec!["src/foo.rs".into()]),
+        PlanItem::new("残っている gap があれば修正".into(), vec![]),
+        PlanItem::new("src/bar.rs: update".into(), vec!["src/bar.rs".into()]),
+    ]);
+    let retired = plan.auto_retire_no_path_items();
+    assert_eq!(retired, 1);
+    assert_eq!(plan.items[0].status, PlanItemStatus::Pending);
+    assert_eq!(plan.items[1].status, PlanItemStatus::AlreadySatisfied);
+    assert_eq!(plan.items[2].status, PlanItemStatus::Pending);
+}
+
+#[test]
+fn auto_retire_multiple_no_path_items() {
+    let mut plan = ExecutionPlan::new(vec![
+        PlanItem::new("Add integration tests".into(), vec![]),
+        PlanItem::new("Update documentation".into(), vec![]),
+        PlanItem::new("src/a.rs: fix bug".into(), vec!["src/a.rs".into()]),
+    ]);
+    let retired = plan.auto_retire_no_path_items();
+    assert_eq!(retired, 2);
+    assert_eq!(plan.items[0].status, PlanItemStatus::AlreadySatisfied);
+    assert_eq!(plan.items[1].status, PlanItemStatus::AlreadySatisfied);
+    assert_eq!(plan.items[2].status, PlanItemStatus::Pending);
+}
+
+#[test]
+fn auto_retire_skips_already_finished_items() {
+    let mut plan = ExecutionPlan::new(vec![PlanItem::new("no-path item".into(), vec![])]);
+    plan.items[0].status = PlanItemStatus::Done;
+    let retired = plan.auto_retire_no_path_items();
+    assert_eq!(retired, 0);
+    assert_eq!(plan.items[0].status, PlanItemStatus::Done);
+}
+
+#[test]
+fn auto_retire_noop_when_all_have_paths() {
+    let mut plan = ExecutionPlan::new(vec![
+        PlanItem::new("src/a.rs: fix".into(), vec!["src/a.rs".into()]),
+        PlanItem::new("src/b.rs: fix".into(), vec!["src/b.rs".into()]),
+    ]);
+    let retired = plan.auto_retire_no_path_items();
+    assert_eq!(retired, 0);
+}
+
+// ---------------------------------------------------------------------------
+// final gate: no-path items do not block after auto-retire
+// ---------------------------------------------------------------------------
+
+#[test]
+fn final_gate_allows_after_auto_retire_no_path_items() {
+    let mut plan = ExecutionPlan::new(vec![
+        PlanItem::new("src/a.rs: implement".into(), vec!["src/a.rs".into()]),
+        PlanItem::new("監査結果: 全て正常".into(), vec![]),
+    ]);
+    plan.auto_retire_no_path_items();
+    plan.mark_done(0);
+
+    assert_eq!(plan.check_final_gate(), FinalGateDecision::Allow);
+}
+
+#[test]
+fn final_gate_incomplete_without_auto_retire_for_no_path() {
+    // Without auto-retire, no-path item blocks final gate
+    let mut plan = ExecutionPlan::new(vec![
+        PlanItem::new("src/a.rs: implement".into(), vec!["src/a.rs".into()]),
+        PlanItem::new("残っている gap があれば修正".into(), vec![]),
+    ]);
+    // Don't call auto_retire
+    plan.mark_done(0);
+
+    // No-path item blocks final gate
+    match plan.check_final_gate() {
+        FinalGateDecision::Incomplete { remaining, .. } => {
+            assert_eq!(remaining, 1);
+        }
+        other => panic!("expected Incomplete, got {:?}", other),
+    }
+}
+
+#[test]
+fn final_gate_allows_all_no_path_plan_after_auto_retire() {
+    // Plan with only no-path items (read-only audit scenario)
+    let mut plan = ExecutionPlan::new(vec![
+        PlanItem::new("監査結果: 全ての live path が正しく使用".into(), vec![]),
+        PlanItem::new("残っている gap があれば修正、なければ完了".into(), vec![]),
+    ]);
+    plan.auto_retire_no_path_items();
+
+    assert_eq!(plan.check_final_gate(), FinalGateDecision::Allow);
+    assert!(plan.is_cleanly_finished());
+}
+
+// ---------------------------------------------------------------------------
+// retire_no_path_items_by_description: description-based retirement
+// ---------------------------------------------------------------------------
+
+#[test]
+fn description_retire_matches_exact() {
+    let mut plan = ExecutionPlan::new(vec![
+        PlanItem::new("監査結果: 全て正常".into(), vec![]),
+        PlanItem::new("src/a.rs: fix".into(), vec!["src/a.rs".into()]),
+    ]);
+    let count = plan.retire_no_path_items_by_description(
+        &["監査結果: 全て正常".to_string()],
+        PlanItemStatus::AlreadySatisfied,
+    );
+    assert_eq!(count, 1);
+    assert_eq!(plan.items[0].status, PlanItemStatus::AlreadySatisfied);
+    // File-backed item is untouched
+    assert_eq!(plan.items[1].status, PlanItemStatus::Pending);
+}
+
+#[test]
+fn description_retire_case_insensitive() {
+    let mut plan = ExecutionPlan::new(vec![PlanItem::new("Add Integration Tests".into(), vec![])]);
+    let count = plan.retire_no_path_items_by_description(
+        &["add integration tests".to_string()],
+        PlanItemStatus::AlreadySatisfied,
+    );
+    assert_eq!(count, 1);
+    assert_eq!(plan.items[0].status, PlanItemStatus::AlreadySatisfied);
+}
+
+#[test]
+fn description_retire_whitespace_normalized() {
+    let mut plan = ExecutionPlan::new(vec![PlanItem::new("監査結果:  全て  正常".into(), vec![])]);
+    let count = plan.retire_no_path_items_by_description(
+        &["監査結果: 全て 正常".to_string()],
+        PlanItemStatus::AlreadySatisfied,
+    );
+    assert_eq!(count, 1);
+}
+
+#[test]
+fn description_retire_skips_file_backed_items() {
+    let mut plan = ExecutionPlan::new(vec![PlanItem::new(
+        "src/a.rs: fix".into(),
+        vec!["src/a.rs".into()],
+    )]);
+    let count = plan.retire_no_path_items_by_description(
+        &["src/a.rs: fix".to_string()],
+        PlanItemStatus::AlreadySatisfied,
+    );
+    assert_eq!(count, 0);
+    assert_eq!(plan.items[0].status, PlanItemStatus::Pending);
+}
+
+#[test]
+fn description_retire_skips_already_finished() {
+    let mut plan = ExecutionPlan::new(vec![PlanItem::new("no-path item".into(), vec![])]);
+    plan.items[0].status = PlanItemStatus::Done;
+    let count = plan.retire_no_path_items_by_description(
+        &["no-path item".to_string()],
+        PlanItemStatus::AlreadySatisfied,
+    );
+    assert_eq!(count, 0);
+}
+
+#[test]
+fn description_retire_no_match_returns_zero() {
+    let mut plan = ExecutionPlan::new(vec![PlanItem::new("item A".into(), vec![])]);
+    let count = plan.retire_no_path_items_by_description(
+        &["item B".to_string()],
+        PlanItemStatus::AlreadySatisfied,
+    );
+    assert_eq!(count, 0);
+    assert_eq!(plan.items[0].status, PlanItemStatus::Pending);
+}
+
+// ---------------------------------------------------------------------------
+// B1 scenario: read-only audit with generic summary item
+// ---------------------------------------------------------------------------
+
+#[test]
+fn b1_scenario_generic_summary_item_does_not_block() {
+    // Simulates B1 from the issue: plan with 8 items, 7 file-backed (done),
+    // 1 no-path generic summary item
+    let mut plan = ExecutionPlan::new(vec![
+        PlanItem::new("src/a.rs: check".into(), vec!["src/a.rs".into()]),
+        PlanItem::new("src/b.rs: check".into(), vec!["src/b.rs".into()]),
+        PlanItem::new("src/c.rs: check".into(), vec!["src/c.rs".into()]),
+        PlanItem::new("src/d.rs: check".into(), vec!["src/d.rs".into()]),
+        PlanItem::new("src/e.rs: check".into(), vec!["src/e.rs".into()]),
+        PlanItem::new("src/f.rs: check".into(), vec!["src/f.rs".into()]),
+        PlanItem::new("src/g.rs: check".into(), vec!["src/g.rs".into()]),
+        PlanItem::new(
+            "残っている gap があれば修正、なければ already done として完了".into(),
+            vec![],
+        ),
+    ]);
+
+    // Auto-retire the no-path item
+    plan.auto_retire_no_path_items();
+
+    // Mark file-backed items as Done
+    for i in 0..7 {
+        plan.mark_done(i);
+    }
+
+    // Final gate should Allow
+    assert_eq!(plan.check_final_gate(), FinalGateDecision::Allow);
+    assert!(plan.is_successfully_completed());
+}
+
+// ---------------------------------------------------------------------------
+// A2 scenario: checked no-path item in ANVIL_PLAN_UPDATE
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a2_scenario_checked_no_path_retires_existing() {
+    // Simulates A2: model outputs [x] for a no-path summary item
+    let mut plan = ExecutionPlan::new(vec![
+        PlanItem::new("src/a.rs: implement".into(), vec!["src/a.rs".into()]),
+        PlanItem::new(
+            "監査結果: 全ての live path が buildDetectPromptOptions() を正しく使用しており、numbered list 対応の実装は既に存在".into(),
+            vec![],
+        ),
+    ]);
+
+    // Even without auto-retire, description-based retire should work
+    let count = plan.retire_no_path_items_by_description(
+        &["監査結果: 全ての live path が buildDetectPromptOptions() を正しく使用しており、numbered list 対応の実装は既に存在".to_string()],
+        PlanItemStatus::AlreadySatisfied,
+    );
+    assert_eq!(count, 1);
+
+    plan.mark_done(0);
+    assert_eq!(plan.check_final_gate(), FinalGateDecision::Allow);
+}
+
+// ---------------------------------------------------------------------------
+// next_actionable_index skips auto-retired no-path items
+// ---------------------------------------------------------------------------
+
+#[test]
+fn next_actionable_skips_auto_retired_no_path() {
+    let mut plan = ExecutionPlan::new(vec![
+        PlanItem::new("summary item".into(), vec![]),
+        PlanItem::new("src/a.rs: real work".into(), vec!["src/a.rs".into()]),
+    ]);
+    plan.auto_retire_no_path_items();
+
+    // next_actionable should skip the auto-retired item 0 and return item 1
+    assert_eq!(plan.next_actionable_index(), Some(1));
+}
+
+// ---------------------------------------------------------------------------
+// closure mode: no-path remaining==1 does not cause empty spin
+// ---------------------------------------------------------------------------
+
+#[test]
+fn closure_mode_no_path_remaining_does_not_block() {
+    // If all file-backed items are done but a no-path item remains,
+    // auto-retire should have already handled it
+    let mut plan = ExecutionPlan::new(vec![
+        PlanItem::new("src/a.rs: fix".into(), vec!["src/a.rs".into()]),
+        PlanItem::new("conclusion summary".into(), vec![]),
+    ]);
+    plan.auto_retire_no_path_items();
+    plan.mark_done(0);
+
+    // Plan should be fully finished, not stuck in closure mode
+    assert!(plan.all_finished());
+    assert_eq!(plan.check_final_gate(), FinalGateDecision::Allow);
+}

--- a/tests/plan_item_retire.rs
+++ b/tests/plan_item_retire.rs
@@ -1,0 +1,256 @@
+//! Tests for Issue #301: stale plan item retire via ANVIL_PLAN_UPDATE [x] markers.
+//!
+//! Covers:
+//! - PlanItemStatus::AlreadySatisfied integration with final gate
+//! - StagnationState::retire_target_files
+//! - mark_unfinished_items_by_target end-to-end
+//! - try_register_plan [x] items stay Pending (parse_plan_items unchanged)
+
+use anvil::app::stagnation_state::StagnationState;
+use anvil::contracts::{ExecutionPlan, FinalGateDecision, PlanItem, PlanItemStatus};
+
+// ---------------------------------------------------------------------------
+// End-to-end: ANVIL_PLAN_UPDATE [x] → AlreadySatisfied → final gate Allow
+// ---------------------------------------------------------------------------
+
+#[test]
+fn plan_update_checked_items_allow_final_gate() {
+    // Setup: plan with 3 items, item 0 Done, items 1+2 pending
+    let mut plan = ExecutionPlan::new(vec![
+        PlanItem::new(
+            "src/a.rs: implement feature".into(),
+            vec!["src/a.rs".into()],
+        ),
+        PlanItem::new("src/b.rs: update module".into(), vec!["src/b.rs".into()]),
+        PlanItem::new("src/c.rs: add tests".into(), vec!["src/c.rs".into()]),
+    ]);
+    plan.mark_done(0);
+    plan.mark_in_progress(1);
+
+    // Simulate [x] markers retiring items 1 and 2
+    let retired = plan.mark_unfinished_items_by_target(
+        &["src/b.rs".to_string(), "src/c.rs".to_string()],
+        PlanItemStatus::AlreadySatisfied,
+    );
+
+    assert_eq!(retired.len(), 2);
+    assert!(retired.contains(&"src/b.rs".to_string()));
+    assert!(retired.contains(&"src/c.rs".to_string()));
+
+    // Verify statuses
+    assert_eq!(plan.items[0].status, PlanItemStatus::Done);
+    assert_eq!(plan.items[1].status, PlanItemStatus::AlreadySatisfied);
+    assert_eq!(plan.items[2].status, PlanItemStatus::AlreadySatisfied);
+
+    // Final gate should Allow
+    assert_eq!(plan.check_final_gate(), FinalGateDecision::Allow);
+    assert!(plan.is_successfully_completed());
+}
+
+// ---------------------------------------------------------------------------
+// Stagnation excludes retired targets
+// ---------------------------------------------------------------------------
+
+#[test]
+fn stagnation_retire_target_files_removes_from_starved() {
+    let mut stagnation = StagnationState::init_from_plan(&[
+        "src/a.rs".to_string(),
+        "src/b.rs".to_string(),
+        "src/c.rs".to_string(),
+    ]);
+    assert_eq!(stagnation.starved_target_files.len(), 3);
+
+    // Retire src/a.rs and src/c.rs
+    stagnation.retire_target_files(&["src/a.rs".to_string(), "src/c.rs".to_string()]);
+
+    assert_eq!(stagnation.starved_target_files.len(), 1);
+    assert_eq!(stagnation.starved_target_files[0], "src/b.rs");
+}
+
+#[test]
+fn stagnation_retire_target_files_empty_list_noop() {
+    let mut stagnation = StagnationState::init_from_plan(&["src/a.rs".to_string()]);
+    stagnation.retire_target_files(&[]);
+    assert_eq!(stagnation.starved_target_files.len(), 1);
+}
+
+#[test]
+fn stagnation_retire_target_files_suffix_matching() {
+    let mut stagnation = StagnationState::init_from_plan(&["src/app/mod.rs".to_string()]);
+    // Retire with a shorter suffix path
+    stagnation.retire_target_files(&["mod.rs".to_string()]);
+    assert!(stagnation.starved_target_files.is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// try_register_plan [x] stays Pending
+// ---------------------------------------------------------------------------
+
+#[test]
+fn parse_plan_items_checked_items_stay_pending() {
+    // parse_plan_items should NOT change based on [x] — all items start as Pending
+    let block = "- [x] src/done.rs: already done\n- [ ] src/todo.rs: still todo";
+    let items = anvil::agent::parse_plan_items(block);
+    assert_eq!(items.len(), 2);
+    assert_eq!(items[0].status, PlanItemStatus::Pending);
+    assert_eq!(items[1].status, PlanItemStatus::Pending);
+}
+
+// ---------------------------------------------------------------------------
+// AlreadySatisfied + Done mixed plan is successfully completed
+// ---------------------------------------------------------------------------
+
+#[test]
+fn mixed_already_satisfied_and_done_is_successful() {
+    let mut plan = ExecutionPlan::new(vec![
+        PlanItem::new("task1".into(), vec!["src/a.rs".into()]),
+        PlanItem::new("task2".into(), vec!["src/b.rs".into()]),
+        PlanItem::new("task3".into(), vec!["src/c.rs".into()]),
+    ]);
+    plan.items[0].status = PlanItemStatus::Done;
+    plan.items[1].status = PlanItemStatus::AlreadySatisfied;
+    plan.items[2].status = PlanItemStatus::Done;
+    assert!(plan.is_successfully_completed());
+    assert!(plan.all_finished());
+}
+
+// ---------------------------------------------------------------------------
+// AlreadySatisfied-only plan is successfully completed
+// ---------------------------------------------------------------------------
+
+#[test]
+fn already_satisfied_only_plan_is_successful() {
+    let mut plan = ExecutionPlan::new(vec![PlanItem::new("task1".into(), vec!["src/a.rs".into()])]);
+    plan.items[0].status = PlanItemStatus::AlreadySatisfied;
+    assert!(plan.is_successfully_completed());
+}
+
+// ---------------------------------------------------------------------------
+// AlreadySatisfied not counted as Blocked
+// ---------------------------------------------------------------------------
+
+#[test]
+fn already_satisfied_not_blocked() {
+    let mut plan = ExecutionPlan::new(vec![PlanItem::new("task1".into(), vec![])]);
+    plan.items[0].status = PlanItemStatus::AlreadySatisfied;
+    assert!(!plan.has_blocked_items());
+}
+
+// ---------------------------------------------------------------------------
+// Format checklist shows [=] for AlreadySatisfied
+// ---------------------------------------------------------------------------
+
+#[test]
+fn format_checklist_shows_already_satisfied_marker() {
+    let mut plan = ExecutionPlan::new(vec![
+        PlanItem::new("done task".into(), vec![]),
+        PlanItem::new("retired task".into(), vec![]),
+        PlanItem::new("pending task".into(), vec![]),
+    ]);
+    plan.items[0].status = PlanItemStatus::Done;
+    plan.items[1].status = PlanItemStatus::AlreadySatisfied;
+    let checklist = plan.format_checklist();
+    assert!(checklist.contains("[x] done task"));
+    assert!(checklist.contains("[=] retired task"));
+    assert!(checklist.contains("[ ] pending task"));
+}
+
+// ---------------------------------------------------------------------------
+// DR4-001: partial target match does not retire
+// ---------------------------------------------------------------------------
+
+#[test]
+fn dr4_001_partial_target_match_no_retire() {
+    let mut plan = ExecutionPlan::new(vec![PlanItem::new(
+        "src/a.rs, src/b.rs: update both".into(),
+        vec!["src/a.rs".into(), "src/b.rs".into()],
+    )]);
+    // Only provide one of two targets
+    let retired = plan.mark_unfinished_items_by_target(
+        &["src/a.rs".to_string()],
+        PlanItemStatus::AlreadySatisfied,
+    );
+    assert!(retired.is_empty());
+    assert_eq!(plan.items[0].status, PlanItemStatus::Pending);
+}
+
+// ---------------------------------------------------------------------------
+// Stagnation + retire integration: retired files excluded from stagnation scoring
+// ---------------------------------------------------------------------------
+
+#[test]
+fn stagnation_after_retire_excludes_retired_from_score() {
+    let mut plan = ExecutionPlan::new(vec![
+        PlanItem::new("src/a.rs: update".into(), vec!["src/a.rs".into()]),
+        PlanItem::new("src/b.rs: update".into(), vec!["src/b.rs".into()]),
+    ]);
+    let mut stagnation =
+        StagnationState::init_from_plan(&["src/a.rs".to_string(), "src/b.rs".to_string()]);
+
+    // Retire src/a.rs via checked marker
+    let retired = plan.mark_unfinished_items_by_target(
+        &["src/a.rs".to_string()],
+        PlanItemStatus::AlreadySatisfied,
+    );
+    stagnation.retire_target_files(&retired);
+
+    // Only src/b.rs should remain starved
+    assert_eq!(stagnation.starved_target_files.len(), 1);
+    assert_eq!(stagnation.starved_target_files[0], "src/b.rs");
+}
+
+// ---------------------------------------------------------------------------
+// Workset excludes AlreadySatisfied items
+// ---------------------------------------------------------------------------
+
+#[test]
+fn current_workset_excludes_already_satisfied() {
+    let mut plan = ExecutionPlan::new(vec![
+        PlanItem::new("task1".into(), vec!["src/a.rs".into()]),
+        PlanItem::new("task2".into(), vec!["src/b.rs".into()]),
+        PlanItem::new("task3".into(), vec!["src/c.rs".into()]),
+    ]);
+    plan.items[0].status = PlanItemStatus::AlreadySatisfied;
+    plan.mark_in_progress(1);
+
+    let workset = plan.current_workset();
+    // Should only contain indices 1 and 2 (not 0 which is AlreadySatisfied)
+    assert!(!workset.contains(&0));
+    assert!(workset.contains(&1));
+    assert!(workset.contains(&2));
+}
+
+// ---------------------------------------------------------------------------
+// CB-001 regression: separate [x] items must NOT combine targets for retire
+// ---------------------------------------------------------------------------
+
+#[test]
+fn cb001_separate_checked_items_do_not_combine_targets() {
+    // Existing plan has a multi-target item: src/a.rs, src/b.rs
+    let mut plan = ExecutionPlan::new(vec![PlanItem::new(
+        "multi-target task".into(),
+        vec!["src/a.rs".into(), "src/b.rs".into()],
+    )]);
+    plan.mark_in_progress(0);
+
+    // Two separate [x] items each with ONE target should NOT retire the
+    // multi-target item because each checked item individually has only 1
+    // target while the existing item has 2 (DR4-001 target-count safety).
+    let targets_a = vec!["src/a.rs".into()];
+    let retired_a =
+        plan.mark_unfinished_items_by_target(&targets_a, PlanItemStatus::AlreadySatisfied);
+    let targets_b = vec!["src/b.rs".into()];
+    let retired_b =
+        plan.mark_unfinished_items_by_target(&targets_b, PlanItemStatus::AlreadySatisfied);
+
+    // Neither call should retire the multi-target item (target count mismatch: 1 vs 2)
+    assert!(
+        retired_a.is_empty(),
+        "should not retire with partial target match"
+    );
+    assert!(
+        retired_b.is_empty(),
+        "should not retire with partial target match"
+    );
+    assert_eq!(plan.items[0].status, PlanItemStatus::InProgress);
+}

--- a/tests/prose_retire_fallback.rs
+++ b/tests/prose_retire_fallback.rs
@@ -1,0 +1,171 @@
+//! Tests for Issue #307: prose-only "already implemented" confirmation from LLMs
+//! doesn't get converted to structured plan retirement, causing fallback
+//! completion to classify as `partial`.
+//!
+//! Covers:
+//! - FallbackComplete suppression when plan has unfinished items
+//! - FallbackComplete fires when plan is all-finished or empty
+//! - ANVIL_PLAN_UPDATE [x] marker retirement completing a plan
+//! - PROMPT_TOOL_RULES contains [x] retirement guidance
+
+use anvil::app::phase_estimator::{PhaseAction, PhaseEstimator};
+use anvil::contracts::{ExecutionPlan, PlanItem, PlanItemStatus};
+
+// ---------------------------------------------------------------------------
+// Helper: simulate the FallbackComplete suppression condition from agentic.rs
+// ---------------------------------------------------------------------------
+
+/// Mirrors the logic added in Issue #307 to agentic.rs:
+/// Returns `true` if FallbackComplete should be suppressed (plan is non-empty
+/// and has unfinished items), `false` if it should fire normally.
+fn should_suppress_fallback(plan: &ExecutionPlan, action: &PhaseAction) -> bool {
+    if let PhaseAction::FallbackComplete = action {
+        !plan.is_empty() && !plan.all_finished()
+    } else {
+        false
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: FallbackComplete suppressed when plan has unfinished items
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fallback_complete_suppressed_when_plan_incomplete() {
+    // Create a plan with 2 items: one done, one pending
+    let mut plan = ExecutionPlan::new(vec![
+        PlanItem::new(
+            "src/a.rs: implement feature".into(),
+            vec!["src/a.rs".into()],
+        ),
+        PlanItem::new("src/b.rs: add tests".into(), vec!["src/b.rs".into()]),
+    ]);
+    plan.mark_done(0);
+    // Item 1 is still Pending
+
+    assert!(!plan.is_empty());
+    assert!(!plan.all_finished());
+
+    // PhaseEstimator returns FallbackComplete
+    let mut estimator = PhaseEstimator::new(3, 6, 2);
+    // Simulate: write succeeded + enough reads
+    estimator.record_tool_call("file.write", true);
+    estimator.record_tool_call("file.read", true);
+    estimator.record_tool_call("file.read", true);
+    let action = estimator.check_empty_response();
+    assert_eq!(action, PhaseAction::FallbackComplete);
+
+    // With unfinished plan items, FallbackComplete should be SUPPRESSED
+    assert!(
+        should_suppress_fallback(&plan, &action),
+        "FallbackComplete must be suppressed when plan has unfinished items"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 2: FallbackComplete fires when all plan items finished
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fallback_complete_fires_when_plan_finished() {
+    // Create a plan with 2 items: both done
+    let mut plan = ExecutionPlan::new(vec![
+        PlanItem::new(
+            "src/a.rs: implement feature".into(),
+            vec!["src/a.rs".into()],
+        ),
+        PlanItem::new("src/b.rs: add tests".into(), vec!["src/b.rs".into()]),
+    ]);
+    plan.mark_done(0);
+    plan.mark_done(1);
+
+    assert!(!plan.is_empty());
+    assert!(plan.all_finished());
+
+    let action = PhaseAction::FallbackComplete;
+
+    // With all items finished, FallbackComplete should NOT be suppressed
+    assert!(
+        !should_suppress_fallback(&plan, &action),
+        "FallbackComplete must fire when all plan items are finished"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 3: FallbackComplete fires when no plan exists
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fallback_complete_fires_when_no_plan() {
+    let plan = ExecutionPlan::default();
+    assert!(plan.is_empty());
+
+    let action = PhaseAction::FallbackComplete;
+
+    // With empty plan, FallbackComplete should NOT be suppressed
+    assert!(
+        !should_suppress_fallback(&plan, &action),
+        "FallbackComplete must fire when plan is empty"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 4: [x] marker retirement via ANVIL_PLAN_UPDATE completes plan
+// ---------------------------------------------------------------------------
+
+#[test]
+fn checked_marker_retirement_completes_plan() {
+    // Create a plan with 3 items: item 0 done, items 1+2 pending
+    let mut plan = ExecutionPlan::new(vec![
+        PlanItem::new(
+            "src/a.rs: implement feature".into(),
+            vec!["src/a.rs".into()],
+        ),
+        PlanItem::new("src/b.rs: update module".into(), vec!["src/b.rs".into()]),
+        PlanItem::new("src/c.rs: add tests".into(), vec!["src/c.rs".into()]),
+    ]);
+    plan.mark_done(0);
+
+    // Before retirement: plan is not finished
+    assert!(!plan.all_finished());
+
+    // Simulate [x] markers retiring items 1 and 2 (AlreadySatisfied)
+    let retired = plan.mark_unfinished_items_by_target(
+        &["src/b.rs".to_string(), "src/c.rs".to_string()],
+        PlanItemStatus::AlreadySatisfied,
+    );
+
+    assert_eq!(retired.len(), 2);
+    assert_eq!(plan.items[1].status, PlanItemStatus::AlreadySatisfied);
+    assert_eq!(plan.items[2].status, PlanItemStatus::AlreadySatisfied);
+
+    // After retirement: plan IS finished
+    assert!(
+        plan.all_finished(),
+        "plan must be all_finished after [x] retirement"
+    );
+
+    // FallbackComplete should now fire (not suppressed)
+    let action = PhaseAction::FallbackComplete;
+    assert!(
+        !should_suppress_fallback(&plan, &action),
+        "FallbackComplete must fire after [x] retirement completes plan"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 5: PROMPT_TOOL_RULES contains [x] retirement guidance
+// ---------------------------------------------------------------------------
+
+#[test]
+fn prompt_tool_rules_contains_checked_retirement_guidance() {
+    let prompt = anvil::agent::tool_protocol_system_prompt_all_tools(&[], None);
+    assert!(
+        prompt.contains("[x] in ANVIL_PLAN_UPDATE"),
+        "system prompt should contain [x] retirement guidance for ANVIL_PLAN_UPDATE. \
+         Got prompt excerpt around ANVIL_PLAN_UPDATE: {:?}",
+        prompt
+            .find("ANVIL_PLAN_UPDATE")
+            .map(|pos| &prompt[pos.saturating_sub(50)..prompt.len().min(pos + 100)])
+    );
+}

--- a/tests/provider_integration.rs
+++ b/tests/provider_integration.rs
@@ -195,6 +195,9 @@ fn live_turn_executes_structured_file_write_response_without_approval() {
         events: vec![ProviderEvent::Agent(AgentEvent::Done {
             status: "Done. session saved".to_string(),
             assistant_message: concat!(
+                "```ANVIL_PLAN\n",
+                "- [ ] sandbox/test1_001/index.html: create game shell\n",
+                "```\n",
                 "```ANVIL_TOOL\n",
                 "{\"id\":\"call_write_001\",\"tool\":\"file.write\",\"path\":\"./sandbox/test1_001/index.html\",\"content\":\"<html><body>invaders</body></html>\"}\n",
                 "```\n",
@@ -268,6 +271,9 @@ fn live_turn_executes_complete_structured_response_from_token_stream() {
         seen_requests: Rc::new(RefCell::new(Vec::new())),
         events: vec![ProviderEvent::TokenDelta(
             concat!(
+                "```ANVIL_PLAN\n",
+                "- [ ] sandbox/test1_001/index.html: create game shell\n",
+                "```\n",
                 "```ANVIL_TOOL\n",
                 "{\"id\":\"call_write_001\",\"tool\":\"file.write\",\"path\":\"./sandbox/test1_001/index.html\",\"content\":\"<html><body>streamed invaders</body></html>\"}\n",
                 "```\n",
@@ -342,6 +348,9 @@ fn live_turn_executes_malformed_structured_file_write_response() {
         events: vec![ProviderEvent::Agent(AgentEvent::Done {
             status: "Done. session saved".to_string(),
             assistant_message: concat!(
+                "```ANVIL_PLAN\n",
+                "- [ ] sandbox/test1_002/Invader.html: create game\n",
+                "```\n",
                 "```ANVIL_TOOL\n",
                 "{\"id\":\"call_write_001\",\"tool\":\"file.write\",\"path\":\"./sandbox/test1_002/Invader.html\",\"content\":\"<html>\n",
                 "<body>\n",
@@ -681,7 +690,7 @@ fn live_turn_executes_structured_response_from_openai_compatible_provider() {
         seen_headers: Rc::new(RefCell::new(Vec::new())),
         response: HttpResponse {
             status_code: 200,
-            body: br#"{"choices":[{"message":{"role":"assistant","content":"```ANVIL_TOOL\n{\"id\":\"call_write_001\",\"tool\":\"file.write\",\"path\":\"./sandbox/openai/index.html\",\"content\":\"<html><body>openai parity</body></html>\"}\n```\n```ANVIL_FINAL\nOpenAI-compatible backend created the file and reviewed the output.\n```"}}]}"#.to_vec(),
+            body: br#"{"choices":[{"message":{"role":"assistant","content":"```ANVIL_PLAN\n- [ ] sandbox/openai/index.html: create file\n```\n```ANVIL_TOOL\n{\"id\":\"call_write_001\",\"tool\":\"file.write\",\"path\":\"./sandbox/openai/index.html\",\"content\":\"<html><body>openai parity</body></html>\"}\n```\n```ANVIL_FINAL\nOpenAI-compatible backend created the file and reviewed the output.\n```"}}]}"#.to_vec(),
         },
         get_response: None,
     };
@@ -729,7 +738,7 @@ fn live_turn_executes_native_tool_calls_response_from_openai_compatible_provider
         seen_headers: Rc::new(RefCell::new(Vec::new())),
         response: HttpResponse {
             status_code: 200,
-            body: br#"{"choices":[{"message":{"role":"assistant","content":"","tool_calls":[{"id":"call_native_write_001","type":"function","function":{"name":"file_write","arguments":"{\"path\":\"./sandbox/native/nonstream.html\",\"content\":\"<html><body>native non-stream</body></html>\"}"}}]}}],"stats":{},"system_fingerprint":"qwen3.5"}"#.to_vec(),
+            body: br#"{"choices":[{"message":{"role":"assistant","content":"```ANVIL_PLAN\n- [ ] sandbox/native/nonstream.html: create file\n```","tool_calls":[{"id":"call_native_write_001","type":"function","function":{"name":"file_write","arguments":"{\"path\":\"./sandbox/native/nonstream.html\",\"content\":\"<html><body>native non-stream</body></html>\"}"}}]}}],"stats":{},"system_fingerprint":"qwen3.5"}"#.to_vec(),
         },
         get_response: None,
     };
@@ -778,6 +787,7 @@ fn live_turn_executes_streaming_native_tool_calls_response_from_openai_compatibl
         response: HttpResponse {
             status_code: 200,
             body: concat!(
+                "data: {\"choices\":[{\"delta\":{\"content\":\"```ANVIL_PLAN\\n- [ ] sandbox/native/stream.html: create file\\n```\\n\"},\"finish_reason\":null}]}\n",
                 "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_stream_write_001\",\"type\":\"function\",\"function\":{\"name\":\"file_write\",\"arguments\":\"{\\\"path\\\":\\\"./sandbox/native/stream.html\\\",\"}}]},\"finish_reason\":null}]}\n",
                 "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"\\\"content\\\":\\\"<html><body>native stream</body></html>\\\"}\"}}]},\"finish_reason\":null}]}\n",
                 "data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"tool_calls\"}],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":5}}\n",
@@ -3663,6 +3673,9 @@ fn anvil_final_guard_does_not_fire_when_file_write_was_executed() {
         events: vec![ProviderEvent::Agent(AgentEvent::Done {
             status: "Done. session saved".to_string(),
             assistant_message: concat!(
+                "```ANVIL_PLAN\n",
+                "- [ ] output.txt: create file\n",
+                "```\n",
                 "```ANVIL_TOOL\n",
                 "{\"id\":\"call_001\",\"tool\":\"file.write\",\"path\":\"./output.txt\",\"content\":\"hello world\"}\n",
                 "```\n",

--- a/tests/shell_inspection_drift.rs
+++ b/tests/shell_inspection_drift.rs
@@ -1,0 +1,346 @@
+//! Tests for Issue #309: shell.exec inspection drift under active unfinished plans.
+//!
+//! Covers:
+//! - PhaseEstimator classifies shell inspection commands as Read (not Other)
+//! - is_shell_inspection_command detects repo-inspection commands
+//! - Late-stage closure hint when remaining==1
+//! - Structured repair message for unfinished plans
+//! - Shell inspection contributes to exploration streaks (not resetting them)
+
+use anvil::app::phase_estimator::{PhaseAction, PhaseEstimator};
+use anvil::contracts::{ExecutionPlan, PlanItem};
+use anvil::tooling::shell_policy::is_shell_inspection_command;
+
+// ---------------------------------------------------------------------------
+// Test 1: PhaseEstimator counts shell.exec grep as Read via record_tool_call_ex
+// ---------------------------------------------------------------------------
+
+#[test]
+fn phase_estimator_shell_grep_counts_as_read() {
+    let mut est = PhaseEstimator::new(3, 6, 3);
+    // 3 shell.exec grep calls should trigger exploring phase
+    est.record_tool_call_ex("shell.exec", true, Some("grep -n pattern src/main.rs"));
+    est.record_tool_call_ex("shell.exec", true, Some("grep -rn TODO src/lib.rs"));
+    est.record_tool_call_ex("shell.exec", true, Some("grep -n detect src/app.rs"));
+    assert_eq!(
+        est.current_phase(),
+        anvil::app::phase_estimator::Phase::Exploring,
+        "shell.exec grep should count as read and trigger Exploring phase"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 2: PhaseEstimator counts shell.exec head/tail as Read
+// ---------------------------------------------------------------------------
+
+#[test]
+fn phase_estimator_shell_head_tail_counts_as_read() {
+    let mut est = PhaseEstimator::new(3, 6, 3);
+    est.record_tool_call_ex("shell.exec", true, Some("head -50 src/main.rs"));
+    est.record_tool_call_ex("shell.exec", true, Some("tail -20 src/lib.rs"));
+    est.record_tool_call_ex("shell.exec", true, Some("cat src/app.rs"));
+    assert_eq!(
+        est.current_phase(),
+        anvil::app::phase_estimator::Phase::Exploring,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 3: PhaseEstimator counts commandindexdev as Read
+// ---------------------------------------------------------------------------
+
+#[test]
+fn phase_estimator_commandindexdev_counts_as_read() {
+    let mut est = PhaseEstimator::new(3, 6, 3);
+    est.record_tool_call_ex(
+        "shell.exec",
+        true,
+        Some("commandindexdev before-change src/lib/detection/prompt-detector.ts --format llm"),
+    );
+    est.record_tool_call_ex(
+        "shell.exec",
+        true,
+        Some("commandindexdev before-change src/lib/detection/cli-patterns.ts --format llm"),
+    );
+    est.record_tool_call_ex(
+        "shell.exec",
+        true,
+        Some("commandindexdev before-change src/lib/polling/response-poller.ts --format llm"),
+    );
+    assert_eq!(
+        est.current_phase(),
+        anvil::app::phase_estimator::Phase::Exploring,
+        "commandindexdev should count as read/exploration"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 4: Shell inspection triggers ForceTransition at threshold
+// ---------------------------------------------------------------------------
+
+#[test]
+fn phase_estimator_shell_inspection_triggers_force_transition() {
+    let mut est = PhaseEstimator::new(3, 6, 3);
+    for i in 0..6 {
+        let action = est.record_tool_call_ex("shell.exec", true, Some("grep -n pattern file.rs"));
+        if i < 5 {
+            assert_eq!(action, PhaseAction::Continue);
+        } else {
+            assert!(
+                matches!(action, PhaseAction::ForceTransition(_)),
+                "shell.exec grep should trigger ForceTransition at threshold"
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test 5: Non-inspection shell.exec (cargo build) still classified as Other
+// ---------------------------------------------------------------------------
+
+#[test]
+fn phase_estimator_non_inspection_shell_still_other() {
+    let mut est = PhaseEstimator::new(3, 6, 3);
+    // cargo build is not inspection → should not count as read
+    est.record_tool_call_ex("shell.exec", true, Some("cargo build"));
+    est.record_tool_call_ex("shell.exec", true, Some("npm install"));
+    est.record_tool_call_ex("shell.exec", true, Some("cargo test"));
+    assert_eq!(
+        est.current_phase(),
+        anvil::app::phase_estimator::Phase::Unknown,
+        "non-inspection shell.exec should not affect phase"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 6: Mixed file.read and shell inspection accumulate together
+// ---------------------------------------------------------------------------
+
+#[test]
+fn phase_estimator_mixed_reads_and_shell_inspection() {
+    let mut est = PhaseEstimator::new(3, 6, 3);
+    est.record_tool_call("file.read", true);
+    est.record_tool_call_ex("shell.exec", true, Some("grep -n pattern src/main.rs"));
+    est.record_tool_call("file.read", true);
+    assert_eq!(
+        est.current_phase(),
+        anvil::app::phase_estimator::Phase::Exploring,
+        "mixed file.read + shell grep should accumulate for phase estimation"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 7: Successful write resets shell inspection counter
+// ---------------------------------------------------------------------------
+
+#[test]
+fn phase_estimator_write_resets_shell_inspection_count() {
+    let mut est = PhaseEstimator::new(3, 6, 3);
+    est.record_tool_call_ex("shell.exec", true, Some("grep -n pattern src/main.rs"));
+    est.record_tool_call_ex("shell.exec", true, Some("head -50 src/lib.rs"));
+    // Write should reset
+    est.record_tool_call("file.edit", true);
+    // Need 3 more to reach threshold again
+    est.record_tool_call_ex("shell.exec", true, Some("grep -n other src/app.rs"));
+    assert_eq!(
+        est.current_phase(),
+        anvil::app::phase_estimator::Phase::Implementing,
+        "after write, consecutive_reads should reset; one read is not enough for Exploring"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 8: is_shell_inspection_command detects all expected commands
+// ---------------------------------------------------------------------------
+
+#[test]
+fn is_shell_inspection_command_covers_file_read_commands() {
+    // All file read commands are also inspection commands
+    assert!(is_shell_inspection_command("grep -n pattern src/main.rs"));
+    assert!(is_shell_inspection_command("sed -n '10,20p' src/main.rs"));
+    assert!(is_shell_inspection_command("cat src/main.rs"));
+    assert!(is_shell_inspection_command("head -50 src/main.rs"));
+    assert!(is_shell_inspection_command("tail -20 src/main.rs"));
+    assert!(is_shell_inspection_command(
+        "awk '/pattern/ {print}' src/main.rs"
+    ));
+}
+
+#[test]
+fn is_shell_inspection_command_covers_repo_inspection() {
+    assert!(is_shell_inspection_command(
+        "commandindexdev before-change src/lib.ts --format llm"
+    ));
+    assert!(is_shell_inspection_command("find . -name '*.rs'"));
+    assert!(is_shell_inspection_command("wc -l src/main.rs"));
+    assert!(is_shell_inspection_command("diff src/a.rs src/b.rs"));
+    assert!(is_shell_inspection_command("rg TODO src/"));
+    assert!(is_shell_inspection_command("fd --extension rs"));
+    assert!(is_shell_inspection_command("tree src/"));
+}
+
+#[test]
+fn is_shell_inspection_command_rejects_non_inspection() {
+    assert!(!is_shell_inspection_command("cargo test"));
+    assert!(!is_shell_inspection_command("npm install"));
+    assert!(!is_shell_inspection_command("rm -rf target/"));
+    assert!(!is_shell_inspection_command("curl https://example.com"));
+}
+
+#[test]
+fn is_shell_inspection_command_rejects_injection() {
+    // Pipe/chain commands are excluded (injection vectors)
+    assert!(!is_shell_inspection_command("grep pattern file | head -5"));
+    assert!(!is_shell_inspection_command("find . && rm -rf /"));
+}
+
+// ---------------------------------------------------------------------------
+// Test 9: Late-stage closure hint fires when remaining==1
+// ---------------------------------------------------------------------------
+
+#[test]
+fn late_stage_closure_hint_fires_at_remaining_one() {
+    let mut plan = ExecutionPlan::new(vec![
+        PlanItem::new("src/a.rs: done".into(), vec!["src/a.rs".into()]),
+        PlanItem::new("src/b.rs: done".into(), vec!["src/b.rs".into()]),
+        PlanItem::new(
+            "tests/test.rs: add tests".into(),
+            vec!["tests/test.rs".into()],
+        ),
+    ]);
+    plan.mark_done(0);
+    plan.mark_done(1);
+    // Item 2 is still Pending → remaining==1
+
+    let hint = plan.build_late_stage_closure_hint();
+    assert!(hint.is_some(), "closure hint should fire when remaining==1");
+    let hint_text = hint.unwrap();
+    assert!(
+        hint_text.contains("CLOSURE MODE"),
+        "hint should contain CLOSURE MODE marker"
+    );
+    assert!(
+        hint_text.contains("tests/test.rs"),
+        "hint should mention the remaining target file"
+    );
+    assert!(
+        hint_text.contains("shell.exec"),
+        "hint should discourage shell.exec usage"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 10: Late-stage closure hint does NOT fire when remaining > 1
+// ---------------------------------------------------------------------------
+
+#[test]
+fn late_stage_closure_hint_not_fired_when_remaining_gt_one() {
+    let mut plan = ExecutionPlan::new(vec![
+        PlanItem::new("src/a.rs: done".into(), vec!["src/a.rs".into()]),
+        PlanItem::new("src/b.rs: todo".into(), vec!["src/b.rs".into()]),
+        PlanItem::new("src/c.rs: todo".into(), vec!["src/c.rs".into()]),
+    ]);
+    plan.mark_done(0);
+    // Items 1+2 pending → remaining==2
+
+    let hint = plan.build_late_stage_closure_hint();
+    assert!(
+        hint.is_none(),
+        "closure hint should NOT fire when remaining > 1"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 11: Late-stage closure hint does NOT fire when no progress
+// ---------------------------------------------------------------------------
+
+#[test]
+fn late_stage_closure_hint_not_fired_when_no_progress() {
+    let plan = ExecutionPlan::new(vec![PlanItem::new(
+        "src/a.rs: todo".into(),
+        vec!["src/a.rs".into()],
+    )]);
+    // 1 item, 0 finished → finished==0, should not fire
+
+    let hint = plan.build_late_stage_closure_hint();
+    assert!(
+        hint.is_none(),
+        "closure hint should NOT fire when no progress has been made"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 12: Late-stage closure hint does NOT fire for empty plan
+// ---------------------------------------------------------------------------
+
+#[test]
+fn late_stage_closure_hint_not_fired_for_empty_plan() {
+    let plan = ExecutionPlan::default();
+    let hint = plan.build_late_stage_closure_hint();
+    assert!(
+        hint.is_none(),
+        "closure hint should NOT fire for empty plan"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 13: FallbackComplete with shell inspection after write (A2 scenario)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fallback_complete_with_shell_inspection_after_write() {
+    // Reproduce the A2 failure shape:
+    // 1. Write succeeded (has_written=true)
+    // 2. Model drifts into shell-based inspection (grep, head, commandindexdev)
+    // 3. With Issue #309 fix, these count as reads → FallbackComplete detection
+    let mut est = PhaseEstimator::new(3, 6, 3);
+
+    // Step 1: Successful write
+    est.record_tool_call("file.edit", true);
+    assert_eq!(
+        est.current_phase(),
+        anvil::app::phase_estimator::Phase::Implementing
+    );
+
+    // Step 2: Shell inspection drift (3+ inspection calls)
+    est.record_tool_call_ex("shell.exec", true, Some("grep -n detectPrompt route.ts"));
+    est.record_tool_call_ex("shell.exec", true, Some("grep -n detectPrompt manager.ts"));
+    est.record_tool_call_ex("shell.exec", true, Some("grep -n detectPrompt detector.ts"));
+
+    // Step 3: FallbackComplete should detect completion
+    // (has_written=true + consecutive_reads >= completion_read_threshold=3)
+    let action = est.check_empty_response();
+    assert_eq!(
+        action,
+        PhaseAction::FallbackComplete,
+        "shell inspection after write should trigger FallbackComplete"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 14: Without fix, shell inspection does NOT trigger FallbackComplete
+// (verifies the old behavior was broken)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn old_behavior_shell_inspection_no_fallback_complete() {
+    // Using record_tool_call (without _ex) simulates the old behavior
+    // where shell.exec is classified as Other
+    let mut est = PhaseEstimator::new(3, 6, 3);
+
+    // Successful write
+    est.record_tool_call("file.edit", true);
+
+    // Shell.exec without command info → classified as Other (old behavior)
+    est.record_tool_call("shell.exec", true);
+    est.record_tool_call("shell.exec", true);
+    est.record_tool_call("shell.exec", true);
+
+    // Without shell command context, these are Other → consecutive_reads stays 0
+    let action = est.check_empty_response();
+    assert_eq!(
+        action,
+        PhaseAction::Continue,
+        "without shell command context, shell.exec should not trigger FallbackComplete"
+    );
+}

--- a/tests/stagnation_control.rs
+++ b/tests/stagnation_control.rs
@@ -172,8 +172,13 @@ fn plan_repair_request_conditions() {
     // Now should be true: score >= 2, starved >= 2, count < 2, remaining >= 5
     assert!(should_request_plan_repair(&state, 0, 10));
 
-    // remaining_turns < 5 → false
-    assert!(!should_request_plan_repair(&state, 0, 4));
+    // remaining_turns < 5 → normal_condition is false, but severe_condition fires
+    // (score=3 >= 3, turns_since_last_mutation=5 >= 5, starved non-empty, count < 2, remaining >= 1)
+    // Issue #287: severe_condition allows plan repair even at low remaining turns
+    assert!(should_request_plan_repair(&state, 0, 4));
+
+    // remaining_turns=0 → even severe_condition requires >= 1, so false
+    assert!(!should_request_plan_repair(&state, 0, 0));
 }
 
 #[test]
@@ -733,4 +738,174 @@ fn escape_hatch_boundary_turns_since_mutation_8() {
     let state = build_stagnation_state(8, true);
     assert!(state.turns_since_last_mutation >= 8);
     assert!(should_allow_escape_hatch(&state, 1, 10));
+}
+
+// ---------------------------------------------------------------------------
+// Issue #287: path_matches suffix normalization regression tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_path_matches_strips_trailing_ws_suffix() {
+    assert!(ExecutionPlan::path_matches(
+        "src/foo.rs (trailing-ws fallback)",
+        "src/foo.rs"
+    ));
+}
+
+#[test]
+fn test_path_matches_strips_anchor_suffix() {
+    assert!(ExecutionPlan::path_matches(
+        "src/bar.rs (anchor fallback)",
+        "src/bar.rs"
+    ));
+}
+
+#[test]
+fn test_path_matches_both_sides_suffix() {
+    // Both sides have suffix — should still match
+    assert!(ExecutionPlan::path_matches(
+        "src/foo.rs (trailing-ws fallback)",
+        "src/foo.rs (anchor fallback)"
+    ));
+}
+
+#[test]
+fn test_path_matches_no_suffix_still_works() {
+    assert!(ExecutionPlan::path_matches("src/foo.rs", "src/foo.rs"));
+    assert!(ExecutionPlan::path_matches("./src/foo.rs", "src/foo.rs"));
+}
+
+#[test]
+fn test_last_item_completes_with_fallback_suffix() {
+    // Issue #287 reproduction test: last plan item with fallback suffix should
+    // be marked Done when record_mutation_success is called with suffixed path.
+    let mut plan = ExecutionPlan::new(vec![PlanItem::new(
+        "edit foo.rs".to_string(),
+        vec!["src/foo.rs".to_string()],
+    )]);
+    plan.mark_in_progress(0);
+    plan.record_mutation_success(0, "src/foo.rs (trailing-ws fallback)");
+    assert!(plan.items[0].is_finished());
+    assert!(plan.all_finished());
+}
+
+#[test]
+fn test_last_item_completes_with_anchor_suffix() {
+    let mut plan = ExecutionPlan::new(vec![PlanItem::new(
+        "edit bar.rs".to_string(),
+        vec!["src/bar.rs".to_string()],
+    )]);
+    plan.mark_in_progress(0);
+    plan.record_mutation_success(0, "src/bar.rs (anchor fallback)");
+    assert!(plan.items[0].is_finished());
+    assert!(plan.all_finished());
+}
+
+#[test]
+fn test_record_mutation_success_dedup_with_path_matches() {
+    // Same file with different suffixes should not create duplicates
+    let mut plan = ExecutionPlan::new(vec![PlanItem::new(
+        "edit foo.rs".to_string(),
+        vec!["src/foo.rs".to_string()],
+    )]);
+    plan.mark_in_progress(0);
+    plan.record_mutation_success(0, "src/foo.rs");
+    plan.record_mutation_success(0, "src/foo.rs (trailing-ws fallback)");
+    // Should be deduplicated to 1 entry
+    assert_eq!(plan.items[0].mutated_files.len(), 1);
+}
+
+#[test]
+fn test_deduplicate_new_items_basic() {
+    let plan = ExecutionPlan::new(vec![PlanItem::new("task1".into(), vec!["src/a.rs".into()])]);
+    let new_items = vec![
+        PlanItem::new("task1 redo".into(), vec!["src/a.rs".into()]),
+        PlanItem::new("task2".into(), vec!["src/b.rs".into()]),
+    ];
+    let result = plan.deduplicate_new_items(new_items);
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].target_files, vec!["src/b.rs".to_string()]);
+}
+
+// ---------------------------------------------------------------------------
+// Issue #287: stagnation recovery tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn plan_repair_severe_condition_fires_at_remaining_one() {
+    // Build a state with score >= 3, turns_since_last_mutation >= 5, starved non-empty
+    let mut state = StagnationState::new();
+    state.starved_target_files = vec!["src/a.rs".to_string()];
+    // 5 turns without mutation, same workset → score = 3
+    for _ in 0..5 {
+        state.begin_turn(&[0, 1]);
+        state.end_turn(false);
+    }
+    let score = compute_stagnation_score(&state);
+    assert!(score >= 3, "expected score >= 3, got {}", score);
+
+    // remaining_turns=1: normal_condition would require >= 5, but severe fires at >= 1
+    assert!(should_request_plan_repair(&state, 0, 1));
+    // remaining_turns=0: even severe requires >= 1
+    assert!(!should_request_plan_repair(&state, 0, 0));
+}
+
+#[test]
+fn plan_repair_severe_not_fire_with_empty_starved() {
+    let mut state = StagnationState::new();
+    // No starved files
+    for _ in 0..5 {
+        state.begin_turn(&[0, 1]);
+        state.end_turn(false);
+    }
+    assert!(compute_stagnation_score(&state) >= 3);
+    // severe requires !starved.is_empty()
+    assert!(!should_request_plan_repair(&state, 0, 1));
+}
+
+#[test]
+fn escape_hatch_fires_on_plan_stall() {
+    // Build a state with score >= 3, plan_repair >= 1, remaining <= 10,
+    // but turns_since_last_mutation < 8 (mutation drought NOT met).
+    // Instead, turns_since_plan_item_completion >= 10 (plan stall).
+    let mut state = StagnationState::new();
+
+    // 10 turns without plan item completion, same workset, no mutation for some
+    // but with occasional mutations to keep turns_since_last_mutation low
+    for i in 0..10 {
+        state.begin_turn(&[0, 1]);
+        // Mutate every 4th turn to keep turns_since_last_mutation < 8
+        let had_mutation = i % 4 == 0;
+        state.end_turn(had_mutation);
+    }
+
+    assert!(
+        state.turns_since_plan_item_completion >= 10,
+        "expected >= 10, got {}",
+        state.turns_since_plan_item_completion
+    );
+    // turns_since_last_mutation should be < 8 due to periodic mutations
+    assert!(
+        state.turns_since_last_mutation < 8,
+        "expected < 8, got {}",
+        state.turns_since_last_mutation
+    );
+    let score = compute_stagnation_score(&state);
+    assert!(score >= 3, "expected score >= 3, got {}", score);
+
+    // plan_stall should fire
+    assert!(should_allow_escape_hatch(&state, 1, 10));
+}
+
+#[test]
+fn escape_hatch_not_fire_on_plan_stall_without_repair() {
+    let mut state = StagnationState::new();
+    for i in 0..10 {
+        state.begin_turn(&[0, 1]);
+        let had_mutation = i % 4 == 0;
+        state.end_turn(had_mutation);
+    }
+    assert!(state.turns_since_plan_item_completion >= 10);
+    // plan_repair_request_count = 0 → base condition not met
+    assert!(!should_allow_escape_hatch(&state, 0, 10));
 }

--- a/tests/stagnation_control.rs
+++ b/tests/stagnation_control.rs
@@ -521,3 +521,216 @@ fn telemetry_serde_backward_compatibility() {
     assert_eq!(telemetry.first_mutation_event_elapsed_s, None);
     assert_eq!(telemetry.first_mutation_event_tool, None);
 }
+
+// ---------------------------------------------------------------------------
+// Issue #285: follow-up completion fix regression tests
+// ---------------------------------------------------------------------------
+
+use anvil::app::stagnation_state::should_allow_escape_hatch;
+
+// --- E-1: B1 type regression test (follow-up empty-tool path) ---
+// Tested via check_plan_final_gate_require_plan() behavior on empty plan.
+// Since check_plan_final_gate_require_plan is on App (not easily constructible
+// in tests), we verify the underlying gate logic by testing that
+// should_request_plan_repair and should_allow_escape_hatch interact correctly.
+
+// --- E-3: results_contain_successful_mutation() helper unit tests ---
+
+use anvil::app::agentic::results_contain_successful_mutation;
+use anvil::tooling::{ToolExecutionPayload, ToolExecutionResult, ToolExecutionStatus};
+
+fn make_result(
+    tool_name: &str,
+    status: ToolExecutionStatus,
+    rolled_back: bool,
+    diff_summary: Option<String>,
+) -> ToolExecutionResult {
+    ToolExecutionResult {
+        tool_call_id: "tc_1".to_string(),
+        tool_name: tool_name.to_string(),
+        status,
+        summary: String::new(),
+        payload: ToolExecutionPayload::None,
+        artifacts: vec![],
+        elapsed_ms: 0,
+        diff_summary,
+        edit_detail: None,
+        rolled_back,
+    }
+}
+
+#[test]
+fn results_contain_successful_mutation_true_on_completed_write() {
+    let results = vec![make_result(
+        "file.write",
+        ToolExecutionStatus::Completed,
+        false,
+        Some("+1 line".to_string()),
+    )];
+    assert!(results_contain_successful_mutation(&results));
+}
+
+#[test]
+fn results_contain_successful_mutation_true_on_completed_edit() {
+    let results = vec![make_result(
+        "file.edit",
+        ToolExecutionStatus::Completed,
+        false,
+        Some("+2 -1".to_string()),
+    )];
+    assert!(results_contain_successful_mutation(&results));
+}
+
+#[test]
+fn results_contain_successful_mutation_true_on_edit_anchor() {
+    let results = vec![make_result(
+        "file.edit_anchor",
+        ToolExecutionStatus::Completed,
+        false,
+        Some("+3 -2".to_string()),
+    )];
+    assert!(results_contain_successful_mutation(&results));
+}
+
+#[test]
+fn results_contain_successful_mutation_false_on_rolled_back() {
+    let results = vec![make_result(
+        "file.edit",
+        ToolExecutionStatus::Completed,
+        true, // rolled back
+        Some("+1".to_string()),
+    )];
+    assert!(!results_contain_successful_mutation(&results));
+}
+
+#[test]
+fn results_contain_successful_mutation_false_on_read_only() {
+    let results = vec![make_result(
+        "file.read",
+        ToolExecutionStatus::Completed,
+        false,
+        None,
+    )];
+    assert!(!results_contain_successful_mutation(&results));
+}
+
+#[test]
+fn results_contain_successful_mutation_false_on_failed_write() {
+    let results = vec![make_result(
+        "file.write",
+        ToolExecutionStatus::Failed,
+        false,
+        None,
+    )];
+    assert!(!results_contain_successful_mutation(&results));
+}
+
+#[test]
+fn results_contain_successful_mutation_false_on_no_diff() {
+    let results = vec![make_result(
+        "file.write",
+        ToolExecutionStatus::Completed,
+        false,
+        None, // no diff_summary
+    )];
+    assert!(!results_contain_successful_mutation(&results));
+}
+
+#[test]
+fn results_contain_successful_mutation_false_on_empty() {
+    assert!(!results_contain_successful_mutation(&[]));
+}
+
+// --- E-4: should_allow_escape_hatch boundary tests ---
+
+/// Build a StagnationState with a specific stagnation score by simulating turns.
+fn build_stagnation_state(turns_without_mutation: usize, same_workset: bool) -> StagnationState {
+    let mut state = StagnationState::new();
+    let workset: Vec<usize> = if same_workset { vec![0, 1] } else { vec![] };
+    for i in 0..turns_without_mutation {
+        let ws = if same_workset {
+            workset.clone()
+        } else {
+            vec![i] // different workset each turn
+        };
+        state.begin_turn(&ws);
+        state.end_turn(false);
+    }
+    state
+}
+
+#[test]
+fn escape_hatch_triggers_at_score3_with_repair_history() {
+    // Build score >= 3: 8 turns without mutation, same workset, read-only
+    let state = build_stagnation_state(8, true);
+    let score = compute_stagnation_score(&state);
+    assert!(score >= 3, "expected score >= 3, got {}", score);
+
+    // All conditions met
+    assert!(should_allow_escape_hatch(&state, 1, 10));
+}
+
+#[test]
+fn escape_hatch_not_triggered_without_prior_repair() {
+    let state = build_stagnation_state(8, true);
+    let score = compute_stagnation_score(&state);
+    assert!(score >= 3, "expected score >= 3, got {}", score);
+
+    // plan_repair_request_count == 0 → false
+    assert!(!should_allow_escape_hatch(&state, 0, 10));
+}
+
+#[test]
+fn escape_hatch_not_triggered_with_many_remaining_turns() {
+    let state = build_stagnation_state(8, true);
+    let score = compute_stagnation_score(&state);
+    assert!(score >= 3, "expected score >= 3, got {}", score);
+
+    // remaining_turns > 10 → false
+    assert!(!should_allow_escape_hatch(&state, 1, 11));
+}
+
+#[test]
+fn escape_hatch_not_triggered_at_low_score() {
+    // Only 3 turns → score should be < 3
+    let state = build_stagnation_state(3, true);
+    let score = compute_stagnation_score(&state);
+
+    // Even with all other conditions, low score should prevent escape
+    assert!(!should_allow_escape_hatch(&state, 1, 5));
+    // Verify the score is indeed < 3 (the actual boundary)
+    if score >= 3 {
+        // If score is actually >= 3 at 3 turns, adjust: use 2 turns
+        let state2 = build_stagnation_state(2, true);
+        assert!(!should_allow_escape_hatch(&state2, 1, 5));
+    }
+}
+
+#[test]
+fn escape_hatch_not_triggered_with_recent_mutation() {
+    let mut state = build_stagnation_state(8, true);
+    // Record a mutation to reset turns_since_last_mutation
+    state.begin_turn(&[0, 1]);
+    state.record_mutation("src/a.rs");
+    state.end_turn(true);
+    // turns_since_last_mutation is now 0, which is < 8
+    assert!(!should_allow_escape_hatch(&state, 1, 5));
+}
+
+#[test]
+fn escape_hatch_boundary_remaining_turns_10() {
+    let state = build_stagnation_state(8, true);
+    assert!(compute_stagnation_score(&state) >= 3);
+    // Exactly 10 remaining turns → should trigger (<=10)
+    assert!(should_allow_escape_hatch(&state, 1, 10));
+    // 11 remaining turns → should not trigger
+    assert!(!should_allow_escape_hatch(&state, 1, 11));
+}
+
+#[test]
+fn escape_hatch_boundary_turns_since_mutation_8() {
+    // Exactly 8 turns without mutation
+    let state = build_stagnation_state(8, true);
+    assert!(state.turns_since_last_mutation >= 8);
+    assert!(should_allow_escape_hatch(&state, 1, 10));
+}

--- a/tests/stagnation_control.rs
+++ b/tests/stagnation_control.rs
@@ -1046,10 +1046,9 @@ fn format_checklist_superseded_marker() {
     );
 }
 
-// CB-001: After supersede, the stale item becomes Superseded (finished).
-// The corrected item should then be deduped against it and not appended
-// (it's effectively the same work). But the overall update returns true
-// because a supersede occurred.
+// CB-001 / Issue #311: After supersede, the stale item becomes Superseded.
+// The corrected item must NOT be deduped against the Superseded item so it
+// remains actionable in the plan (prevents superseded-only terminal state).
 #[test]
 fn supersede_then_dedup_flow() {
     // Existing plan has a stale item (Pending, no mutations).
@@ -1065,15 +1064,19 @@ fn supersede_then_dedup_flow() {
     // Step 1: supersede — stale item becomes Superseded
     plan.supersede_stale_items(&new_items);
     assert_eq!(plan.items[0].status, PlanItemStatus::Superseded);
-    // Step 2: dedup — corrected item is deduped against now-finished Superseded item
+    // Step 2: dedup — corrected item survives (Superseded items excluded from dedup)
     let deduped = plan.deduplicate_new_items(new_items);
     assert_eq!(
         deduped.len(),
-        0,
-        "corrected item should be deduped after stale item is superseded (same work)"
+        1,
+        "corrected item must survive dedup after stale item is superseded (Issue #311)"
     );
-    // Plan still has the superseded item, which is finished.
-    assert!(plan.all_finished());
+    // After appending corrected item, plan has actionable work.
+    plan.append_items(deduped);
+    assert!(!plan.all_finished(), "plan has Pending corrected item");
+    assert_eq!(plan.items.len(), 2);
+    assert_eq!(plan.items[0].status, PlanItemStatus::Superseded);
+    assert_eq!(plan.items[1].status, PlanItemStatus::Pending);
 }
 
 // CB-001 variant: corrected item with DIFFERENT target (not matching stale)

--- a/tests/stagnation_control.rs
+++ b/tests/stagnation_control.rs
@@ -909,3 +909,241 @@ fn escape_hatch_not_fire_on_plan_stall_without_repair() {
     // plan_repair_request_count = 0 → base condition not met
     assert!(!should_allow_escape_hatch(&state, 0, 10));
 }
+
+// ---------------------------------------------------------------------------
+// Issue #289: stale/alias plan item supersede tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn path_matches_strips_parenthesized_suffix() {
+    assert!(ExecutionPlan::path_matches(
+        "src/foo.ts (bar.ts)",
+        "src/foo.ts"
+    ));
+}
+
+#[test]
+fn path_matches_parenthesized_both_sides() {
+    assert!(ExecutionPlan::path_matches("src/a.ts (x)", "src/a.ts (y)"));
+}
+
+#[test]
+fn supersede_stale_item_on_plan_update() {
+    let mut plan = ExecutionPlan::new(vec![PlanItem::new(
+        "stale item".into(),
+        vec!["src/lib/polling/auto-yes-manager.ts".into()],
+    )]);
+    plan.mark_in_progress(0);
+
+    let new_items = vec![PlanItem::new(
+        "corrected item".into(),
+        vec!["src/lib/polling/auto-yes-manager.ts".into()],
+    )];
+    plan.supersede_stale_items(&new_items);
+    assert_eq!(plan.items[0].status, PlanItemStatus::Superseded);
+}
+
+#[test]
+fn supersede_skips_with_mutated_files() {
+    let mut plan = ExecutionPlan::new(vec![PlanItem::new(
+        "item with mutation".into(),
+        vec!["src/foo.ts".into()],
+    )]);
+    plan.mark_in_progress(0);
+    plan.record_mutation_success(0, "src/foo.ts");
+
+    let new_items = vec![PlanItem::new(
+        "corrected item".into(),
+        vec!["src/foo.ts".into()],
+    )];
+    plan.supersede_stale_items(&new_items);
+    // Should NOT be superseded because mutated_files is non-empty
+    assert_ne!(plan.items[0].status, PlanItemStatus::Superseded);
+}
+
+#[test]
+fn supersede_false_positive_prevention() {
+    // src/utils.ts should NOT be superseded by src/test-utils.ts
+    let mut plan = ExecutionPlan::new(vec![PlanItem::new(
+        "utils work".into(),
+        vec!["src/utils.ts".into()],
+    )]);
+    plan.mark_in_progress(0);
+
+    let new_items = vec![PlanItem::new(
+        "test utils work".into(),
+        vec!["src/test-utils.ts".into()],
+    )];
+    plan.supersede_stale_items(&new_items);
+    // path_matches("src/utils.ts", "src/test-utils.ts") → "src/test-utils.ts".ends_with("src/utils.ts")
+    // is true because of suffix matching — however this is the existing behavior.
+    // The design doc acknowledges this and relies on the mutated_files guard.
+    // For a strict false-positive test, use a non-suffix case:
+    assert_ne!(
+        plan.items[0].status,
+        PlanItemStatus::Superseded,
+        "src/utils.ts must NOT be superseded by src/test-utils.ts"
+    );
+}
+
+#[test]
+fn supersede_false_positive_prevention_strict() {
+    // Truly different file: src/app.ts should NOT be superseded by src/config.ts
+    let mut plan = ExecutionPlan::new(vec![PlanItem::new(
+        "app work".into(),
+        vec!["src/app.ts".into()],
+    )]);
+    plan.mark_in_progress(0);
+
+    let new_items = vec![PlanItem::new(
+        "config work".into(),
+        vec!["src/config.ts".into()],
+    )];
+    plan.supersede_stale_items(&new_items);
+    assert_ne!(plan.items[0].status, PlanItemStatus::Superseded);
+}
+
+#[test]
+fn completion_kind_with_superseded() {
+    use anvil::contracts::CompletionKind;
+
+    let mut plan = ExecutionPlan::new(vec![
+        PlanItem::new("item1".into(), vec!["src/a.ts".into()]),
+        PlanItem::new("item2".into(), vec!["src/b.ts".into()]),
+    ]);
+    // Mark item1 as Done, item2 as Superseded
+    plan.items[0].status = PlanItemStatus::Done;
+    plan.items[1].status = PlanItemStatus::Superseded;
+
+    // All items are finished, no Blocked → should be CompleteUnverified (not Blocked)
+    let kind = CompletionKind::classify(&plan, None, false);
+    assert_eq!(kind, CompletionKind::CompleteUnverified);
+}
+
+#[test]
+fn superseded_item_is_finished() {
+    let mut item = PlanItem::new("test".into(), vec!["src/x.ts".into()]);
+    item.status = PlanItemStatus::Superseded;
+    assert!(item.is_finished());
+}
+
+#[test]
+fn plan_item_status_display_superseded() {
+    assert_eq!(PlanItemStatus::Superseded.to_string(), "superseded");
+}
+
+#[test]
+fn format_checklist_superseded_marker() {
+    let mut plan = ExecutionPlan::new(vec![PlanItem::new(
+        "superseded task".into(),
+        vec!["src/x.ts".into()],
+    )]);
+    plan.items[0].status = PlanItemStatus::Superseded;
+    let checklist = plan.format_checklist();
+    assert!(
+        checklist.contains("[~]"),
+        "superseded items should use [~] marker"
+    );
+}
+
+// CB-001: After supersede, the stale item becomes Superseded (finished).
+// The corrected item should then be deduped against it and not appended
+// (it's effectively the same work). But the overall update returns true
+// because a supersede occurred.
+#[test]
+fn supersede_then_dedup_flow() {
+    // Existing plan has a stale item (Pending, no mutations).
+    let mut plan = ExecutionPlan::new(vec![PlanItem::new(
+        "src/lib/polling/auto-yes-manager.ts: change".into(),
+        vec!["src/lib/polling/auto-yes-manager.ts".into()],
+    )]);
+    // Corrected item has the same target.
+    let new_items = vec![PlanItem::new(
+        "src/lib/polling/auto-yes-manager.ts: corrected change".into(),
+        vec!["src/lib/polling/auto-yes-manager.ts".into()],
+    )];
+    // Step 1: supersede — stale item becomes Superseded
+    plan.supersede_stale_items(&new_items);
+    assert_eq!(plan.items[0].status, PlanItemStatus::Superseded);
+    // Step 2: dedup — corrected item is deduped against now-finished Superseded item
+    let deduped = plan.deduplicate_new_items(new_items);
+    assert_eq!(
+        deduped.len(),
+        0,
+        "corrected item should be deduped after stale item is superseded (same work)"
+    );
+    // Plan still has the superseded item, which is finished.
+    assert!(plan.all_finished());
+}
+
+// CB-001 variant: corrected item with DIFFERENT target (not matching stale)
+// should NOT be deduped and should be appended.
+#[test]
+fn supersede_with_different_target_keeps_corrected() {
+    let mut plan = ExecutionPlan::new(vec![PlanItem::new(
+        "src/lib/polling/auto-yes-manager.ts (auto-yes-poller.ts): change".into(),
+        vec!["src/lib/polling/auto-yes-manager.ts".into()],
+    )]);
+    // Corrected item targets a completely different file.
+    let new_items = vec![PlanItem::new(
+        "src/lib/auto-yes-poller.ts: corrected change".into(),
+        vec!["src/lib/auto-yes-poller.ts".into()],
+    )];
+    // Step 1: supersede — stale item NOT superseded (different paths even after normalization)
+    plan.supersede_stale_items(&new_items);
+    // auto-yes-manager.ts does NOT match auto-yes-poller.ts (different basenames)
+    assert_ne!(plan.items[0].status, PlanItemStatus::Superseded);
+    // Step 2: dedup — no match, so corrected item survives
+    let deduped = plan.deduplicate_new_items(new_items);
+    assert_eq!(
+        deduped.len(),
+        1,
+        "corrected item with different target should survive dedup"
+    );
+}
+
+// CB-001 corollary: dedup should still work against finished items.
+#[test]
+fn dedup_still_works_against_finished_items() {
+    let mut plan = ExecutionPlan::new(vec![PlanItem::new(
+        "src/foo.ts: task".into(),
+        vec!["src/foo.ts".into()],
+    )]);
+    plan.items[0].status = PlanItemStatus::Done;
+    let duplicate = vec![PlanItem::new(
+        "src/foo.ts: same task".into(),
+        vec!["src/foo.ts".into()],
+    )];
+    let deduped = plan.deduplicate_new_items(duplicate);
+    assert_eq!(
+        deduped.len(),
+        0,
+        "new item matching a Done item should be deduplicated"
+    );
+}
+
+// CB-002: same file different tasks should not both be superseded.
+#[test]
+fn supersede_respects_one_to_one_matching() {
+    let mut plan = ExecutionPlan::new(vec![
+        PlanItem::new("src/app.ts: refactor API".into(), vec!["src/app.ts".into()]),
+        PlanItem::new("src/app.ts: add tests".into(), vec!["src/app.ts".into()]),
+    ]);
+    plan.items[0].status = PlanItemStatus::InProgress;
+    // Only one corrected item targeting src/app.ts.
+    let new_items = vec![PlanItem::new(
+        "src/app.ts: corrected refactor".into(),
+        vec!["src/app.ts".into()],
+    )];
+    plan.supersede_stale_items(&new_items);
+    // Only one item should be superseded (1:1), not both.
+    let superseded_count = plan
+        .items
+        .iter()
+        .filter(|i| i.status == PlanItemStatus::Superseded)
+        .count();
+    assert_eq!(
+        superseded_count, 1,
+        "only one item should be superseded per corrected item (1:1 matching)"
+    );
+}

--- a/tests/stagnation_control.rs
+++ b/tests/stagnation_control.rs
@@ -1147,3 +1147,117 @@ fn supersede_respects_one_to_one_matching() {
         "only one item should be superseded per corrected item (1:1 matching)"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Issue #287 follow-up: orphan mutation tests
+// ---------------------------------------------------------------------------
+
+/// Reproduce the Issue #287 follow-up scenario:
+/// LLM edits non-target files (e.g. renamed path) — mutations happen every turn
+/// but no plan item advances. The orphan_mutation_condition must fire.
+#[test]
+fn plan_repair_orphan_mutation_fires_when_mutations_happen_but_plan_stalls() {
+    let mut state = StagnationState::new();
+    state.starved_target_files = vec!["src/lib/polling/auto-yes-manager.ts".to_string()];
+
+    // 6 turns: mutation every turn (to a different file), same workset, no plan completion
+    for _ in 0..6 {
+        state.begin_turn(&[0]);
+        state.record_mutation("src/lib/auto-yes-poller.ts");
+        state.end_turn(true); // had_mutation = true
+    }
+
+    // Verify the orphan mutation pattern:
+    assert_eq!(
+        state.turns_since_last_mutation, 0,
+        "mutations are happening"
+    );
+    assert!(
+        state.turns_since_plan_item_completion >= 5,
+        "plan items not advancing: got {}",
+        state.turns_since_plan_item_completion
+    );
+    assert!(
+        state.same_workset_turns >= 3,
+        "same workset stuck: got {}",
+        state.same_workset_turns
+    );
+
+    // Stagnation score should be only 2 (workset staleness + plan no-progress),
+    // NOT 3, because mutations prevent mutation drought and read domination.
+    let score = compute_stagnation_score(&state);
+    assert!(
+        score < 3,
+        "score should be < 3 in orphan mutation case, got {}",
+        score
+    );
+
+    // normal_condition requires starved >= 2: fails (only 1 starved file)
+    // severe_condition requires turns_since_last_mutation >= 5: fails (it's 0)
+    // But orphan_mutation_condition should fire
+    assert!(should_request_plan_repair(&state, 0, 1));
+}
+
+#[test]
+fn plan_repair_orphan_mutation_not_fire_without_starved_files() {
+    let mut state = StagnationState::new();
+    // No starved files
+    for _ in 0..6 {
+        state.begin_turn(&[0]);
+        state.record_mutation("src/lib/auto-yes-poller.ts");
+        state.end_turn(true);
+    }
+    assert_eq!(state.turns_since_last_mutation, 0);
+    assert!(state.turns_since_plan_item_completion >= 5);
+    // orphan_mutation_condition requires !starved.is_empty()
+    assert!(!should_request_plan_repair(&state, 0, 1));
+}
+
+#[test]
+fn plan_repair_orphan_mutation_not_fire_at_max_repair_count() {
+    let mut state = StagnationState::new();
+    state.starved_target_files = vec!["src/a.ts".to_string()];
+    for _ in 0..6 {
+        state.begin_turn(&[0]);
+        state.record_mutation("src/b.ts");
+        state.end_turn(true);
+    }
+    // plan_repair_request_count = 2 (max) → orphan_mutation_condition should not fire
+    assert!(!should_request_plan_repair(&state, 2, 1));
+}
+
+#[test]
+fn escape_hatch_orphan_escape_fires_after_repair_attempt() {
+    let mut state = StagnationState::new();
+    state.starved_target_files = vec!["src/lib/polling/auto-yes-manager.ts".to_string()];
+
+    // 9 turns: mutation every turn, same workset, no plan completion
+    for _ in 0..9 {
+        state.begin_turn(&[0]);
+        state.record_mutation("src/lib/auto-yes-poller.ts");
+        state.end_turn(true);
+    }
+
+    assert_eq!(state.turns_since_last_mutation, 0);
+    assert!(state.turns_since_plan_item_completion >= 8);
+    let score = compute_stagnation_score(&state);
+    assert!(score >= 2, "expected score >= 2, got {}", score);
+
+    // Plan repair was attempted once, remaining <= 10
+    assert!(should_allow_escape_hatch(&state, 1, 10));
+}
+
+#[test]
+fn escape_hatch_orphan_escape_not_fire_without_repair_attempt() {
+    let mut state = StagnationState::new();
+    state.starved_target_files = vec!["src/a.ts".to_string()];
+
+    for _ in 0..9 {
+        state.begin_turn(&[0]);
+        state.record_mutation("src/b.ts");
+        state.end_turn(true);
+    }
+
+    // plan_repair_request_count = 0 → orphan_escape requires >= 1
+    assert!(!should_allow_escape_hatch(&state, 0, 10));
+}

--- a/tests/superseded_plan_exit.rs
+++ b/tests/superseded_plan_exit.rs
@@ -1,0 +1,309 @@
+//! Tests for Issue #311: superseded-only terminal plan exit semantics.
+//!
+//! Covers:
+//! - AC6-1: contract-level supersede→dedup consistency (check_final_gate, CompletionKind, is_successfully_completed)
+//! - AC6-2: is_cleanly_finished for superseded-only plans
+//! - AC6-3: CompletionKind + is_cleanly_finished consistency (no complete_* + failure divergence)
+//! - AC6-4: corrected replan with touched_files retains Done evidence
+//! - AC6-5: genuinely unrecovered tool failure preserves failure semantics
+
+use anvil::contracts::{
+    CompletionKind, ExecutionPlan, FinalGateDecision, PlanItem, PlanItemStatus,
+};
+
+// ---------------------------------------------------------------------------
+// AC6-1: contract-level supersede→dedup consistency
+// After supersede→dedup, the plan must not produce a state where
+// check_final_gate==Allow + CompletionKind==complete_* but
+// is_successfully_completed==false.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn ac6_1_supersede_dedup_retains_corrected_item() {
+    // Simulate the B2 scenario: replan with corrected items targeting same files.
+    let mut plan = ExecutionPlan::new(vec![
+        PlanItem::new(
+            "prompt-detector.ts: fix parsing".into(),
+            vec!["src/prompt-detector.ts".into()],
+        ),
+        PlanItem::new(
+            "response-poller.ts: update polling".into(),
+            vec!["src/response-poller.ts".into()],
+        ),
+    ]);
+
+    // Corrected items with same targets
+    let new_items = vec![
+        PlanItem::new(
+            "prompt-detector.ts: corrected fix".into(),
+            vec!["src/prompt-detector.ts".into()],
+        ),
+        PlanItem::new(
+            "response-poller.ts: corrected update".into(),
+            vec!["src/response-poller.ts".into()],
+        ),
+    ];
+
+    // Pipeline: supersede → dedup → append
+    plan.supersede_stale_items(&new_items);
+    assert_eq!(plan.items[0].status, PlanItemStatus::Superseded);
+    assert_eq!(plan.items[1].status, PlanItemStatus::Superseded);
+
+    let deduped = plan.deduplicate_new_items(new_items);
+    // Issue #311: corrected items survive dedup
+    assert_eq!(deduped.len(), 2, "corrected items must survive dedup");
+    plan.append_items(deduped);
+
+    // Plan has 4 items: 2 Superseded + 2 Pending
+    assert_eq!(plan.items.len(), 4);
+    assert!(!plan.all_finished(), "Pending corrected items remain");
+
+    // Simulate agent completing work on corrected items
+    plan.items[2].status = PlanItemStatus::Done;
+    plan.items[3].status = PlanItemStatus::Done;
+
+    // Now all predicates agree:
+    assert!(plan.all_finished());
+    assert!(plan.is_successfully_completed());
+    assert!(plan.is_cleanly_finished());
+    assert_eq!(plan.check_final_gate(), FinalGateDecision::Allow);
+    assert_eq!(
+        CompletionKind::classify(&plan, None, false),
+        CompletionKind::CompleteUnverified
+    );
+}
+
+// ---------------------------------------------------------------------------
+// AC6-2: is_cleanly_finished for superseded-only plans (safety net)
+// Even if a superseded-only plan somehow occurs, is_cleanly_finished
+// aligns with check_final_gate / CompletionKind.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn ac6_2_superseded_only_cleanly_finished() {
+    let mut plan = ExecutionPlan::new(vec![
+        PlanItem::new("task1".into(), vec!["src/a.ts".into()]),
+        PlanItem::new("task2".into(), vec!["src/b.ts".into()]),
+    ]);
+    plan.items[0].status = PlanItemStatus::Superseded;
+    plan.items[1].status = PlanItemStatus::Superseded;
+
+    // is_successfully_completed requires Done/AlreadySatisfied → false
+    assert!(!plan.is_successfully_completed());
+    // is_cleanly_finished only requires all_finished + no blocked → true
+    assert!(plan.is_cleanly_finished());
+    // check_final_gate uses all_finished → Allow
+    assert_eq!(plan.check_final_gate(), FinalGateDecision::Allow);
+    // CompletionKind uses all_finished → CompleteUnverified
+    assert_eq!(
+        CompletionKind::classify(&plan, None, false),
+        CompletionKind::CompleteUnverified
+    );
+
+    // Exit logic (has_tool_execution_failure) now uses is_cleanly_finished,
+    // so there is no divergence: all four agree on "clean terminal state".
+}
+
+// ---------------------------------------------------------------------------
+// AC6-3: CompletionKind + is_cleanly_finished consistency
+// Verify that for all terminal plan states, CompletionKind::complete_* implies
+// is_cleanly_finished==true (no divergence possible).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn ac6_3_complete_kind_implies_cleanly_finished() {
+    // Case 1: All Done
+    let mut plan = ExecutionPlan::new(vec![
+        PlanItem::new("t1".into(), vec![]),
+        PlanItem::new("t2".into(), vec![]),
+    ]);
+    plan.items[0].status = PlanItemStatus::Done;
+    plan.items[1].status = PlanItemStatus::Done;
+    let kind = CompletionKind::classify(&plan, None, false);
+    assert_eq!(kind, CompletionKind::CompleteUnverified);
+    assert!(plan.is_cleanly_finished());
+
+    // Case 2: Done + Superseded
+    let mut plan = ExecutionPlan::new(vec![
+        PlanItem::new("t1".into(), vec![]),
+        PlanItem::new("t2".into(), vec![]),
+    ]);
+    plan.items[0].status = PlanItemStatus::Done;
+    plan.items[1].status = PlanItemStatus::Superseded;
+    let kind = CompletionKind::classify(&plan, None, false);
+    assert_eq!(kind, CompletionKind::CompleteUnverified);
+    assert!(plan.is_cleanly_finished());
+
+    // Case 3: Done + AlreadySatisfied
+    let mut plan = ExecutionPlan::new(vec![
+        PlanItem::new("t1".into(), vec![]),
+        PlanItem::new("t2".into(), vec![]),
+    ]);
+    plan.items[0].status = PlanItemStatus::Done;
+    plan.items[1].status = PlanItemStatus::AlreadySatisfied;
+    let kind = CompletionKind::classify(&plan, None, false);
+    assert_eq!(kind, CompletionKind::CompleteUnverified);
+    assert!(plan.is_cleanly_finished());
+
+    // Case 4: Superseded-only (safety net)
+    let mut plan = ExecutionPlan::new(vec![PlanItem::new("t1".into(), vec![])]);
+    plan.items[0].status = PlanItemStatus::Superseded;
+    let kind = CompletionKind::classify(&plan, None, false);
+    assert_eq!(kind, CompletionKind::CompleteUnverified);
+    assert!(plan.is_cleanly_finished());
+
+    // Case 5: Blocked → CompletionKind::Blocked, not cleanly_finished
+    let mut plan = ExecutionPlan::new(vec![PlanItem::new("t1".into(), vec![])]);
+    plan.items[0].status = PlanItemStatus::Blocked;
+    let kind = CompletionKind::classify(&plan, None, false);
+    assert_eq!(kind, CompletionKind::Blocked);
+    assert!(!plan.is_cleanly_finished());
+}
+
+// ---------------------------------------------------------------------------
+// AC6-4: corrected replan with touched_files retains Done evidence
+// When corrected items are appended and then completed, the plan
+// has positive Done evidence in its terminal state.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn ac6_4_corrected_replan_with_mutations_reaches_done() {
+    let mut plan = ExecutionPlan::new(vec![
+        PlanItem::new(
+            "src/prompt-detector.ts: fix".into(),
+            vec!["src/prompt-detector.ts".into()],
+        ),
+        PlanItem::new("src/route.ts: update".into(), vec!["src/route.ts".into()]),
+    ]);
+
+    // Simulate replan: supersede → dedup → append
+    let corrected = vec![
+        PlanItem::new(
+            "src/prompt-detector.ts: corrected fix".into(),
+            vec!["src/prompt-detector.ts".into()],
+        ),
+        PlanItem::new(
+            "src/route.ts: corrected update".into(),
+            vec!["src/route.ts".into()],
+        ),
+    ];
+    plan.supersede_stale_items(&corrected);
+    let deduped = plan.deduplicate_new_items(corrected);
+    plan.append_items(deduped);
+
+    // Simulate agent editing files (records mutation + marks Done)
+    plan.mark_in_progress(2);
+    plan.record_mutation_success(2, "src/prompt-detector.ts");
+    plan.mark_done(2);
+    plan.mark_in_progress(3);
+    plan.record_mutation_success(3, "src/route.ts");
+    plan.mark_done(3);
+
+    // Terminal state has Done evidence
+    assert!(plan.is_successfully_completed());
+    assert!(plan.is_cleanly_finished());
+    assert_eq!(plan.check_final_gate(), FinalGateDecision::Allow);
+
+    // Mutations are preserved in corrected items
+    assert!(!plan.items[2].mutated_files.is_empty());
+    assert!(!plan.items[3].mutated_files.is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// AC6-5: genuinely unrecovered tool failure preserves failure semantics
+// When the plan has unfinished/blocked items, is_cleanly_finished is false
+// and exit should still report failure.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn ac6_5_genuinely_unrecovered_blocked_plan() {
+    let mut plan = ExecutionPlan::new(vec![
+        PlanItem::new("t1".into(), vec!["src/a.ts".into()]),
+        PlanItem::new("t2".into(), vec!["src/b.ts".into()]),
+    ]);
+    plan.items[0].status = PlanItemStatus::Done;
+    plan.items[1].status = PlanItemStatus::Blocked;
+
+    assert!(!plan.is_successfully_completed());
+    assert!(!plan.is_cleanly_finished());
+    assert_eq!(
+        CompletionKind::classify(&plan, None, false),
+        CompletionKind::Blocked
+    );
+}
+
+#[test]
+fn ac6_5_genuinely_unrecovered_partial_plan() {
+    let mut plan = ExecutionPlan::new(vec![
+        PlanItem::new("t1".into(), vec!["src/a.ts".into()]),
+        PlanItem::new("t2".into(), vec!["src/b.ts".into()]),
+    ]);
+    plan.items[0].status = PlanItemStatus::Done;
+    // t2 still Pending
+    assert!(!plan.is_cleanly_finished());
+    assert!(!plan.is_successfully_completed());
+    assert_eq!(
+        CompletionKind::classify(&plan, None, false),
+        CompletionKind::Partial
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Dedup still works against non-Superseded finished items
+// ---------------------------------------------------------------------------
+
+#[test]
+fn dedup_works_against_done_items() {
+    let mut plan = ExecutionPlan::new(vec![PlanItem::new(
+        "src/foo.ts: task".into(),
+        vec!["src/foo.ts".into()],
+    )]);
+    plan.items[0].status = PlanItemStatus::Done;
+    let duplicate = vec![PlanItem::new(
+        "src/foo.ts: same task".into(),
+        vec!["src/foo.ts".into()],
+    )];
+    let deduped = plan.deduplicate_new_items(duplicate);
+    assert_eq!(
+        deduped.len(),
+        0,
+        "new item matching a Done item should still be deduplicated"
+    );
+}
+
+#[test]
+fn dedup_works_against_already_satisfied_items() {
+    let mut plan = ExecutionPlan::new(vec![PlanItem::new(
+        "src/bar.ts: task".into(),
+        vec!["src/bar.ts".into()],
+    )]);
+    plan.items[0].status = PlanItemStatus::AlreadySatisfied;
+    let duplicate = vec![PlanItem::new(
+        "src/bar.ts: same task".into(),
+        vec!["src/bar.ts".into()],
+    )];
+    let deduped = plan.deduplicate_new_items(duplicate);
+    assert_eq!(
+        deduped.len(),
+        0,
+        "new item matching an AlreadySatisfied item should still be deduplicated"
+    );
+}
+
+#[test]
+fn dedup_works_against_pending_items() {
+    let plan = ExecutionPlan::new(vec![PlanItem::new(
+        "src/baz.ts: task".into(),
+        vec!["src/baz.ts".into()],
+    )]);
+    let duplicate = vec![PlanItem::new(
+        "src/baz.ts: same task".into(),
+        vec!["src/baz.ts".into()],
+    )];
+    let deduped = plan.deduplicate_new_items(duplicate);
+    assert_eq!(
+        deduped.len(),
+        0,
+        "new item matching a Pending item should still be deduplicated"
+    );
+}

--- a/tests/tooling_system.rs
+++ b/tests/tooling_system.rs
@@ -407,6 +407,7 @@ fn local_tool_executor_reads_directory_as_listing() {
             input: ToolInput::FileRead {
                 path: "./sandbox/test1_001".to_string(),
             },
+            extra_field_warnings: vec![],
         })
         .expect("directory listing should succeed");
 
@@ -1637,6 +1638,7 @@ fn file_edit_execution_replaces_unique_match() {
                 old_string: "hello".to_string(),
                 new_string: "goodbye".to_string(),
             },
+            extra_field_warnings: vec![],
         })
         .expect("edit should succeed");
 
@@ -1665,6 +1667,7 @@ fn file_edit_old_string_not_found() {
                 old_string: "nonexistent".to_string(),
                 new_string: "replacement".to_string(),
             },
+            extra_field_warnings: vec![],
         })
         .expect_err("should fail when old_string not found");
 
@@ -1691,6 +1694,7 @@ fn file_edit_old_string_multiple_matches() {
                 old_string: "aaa".to_string(),
                 new_string: "ccc".to_string(),
             },
+            extra_field_warnings: vec![],
         })
         .expect_err("should fail when old_string matches multiple times");
 
@@ -1718,6 +1722,7 @@ fn file_edit_empty_new_string_deletes() {
                 old_string: " world".to_string(),
                 new_string: "".to_string(),
             },
+            extra_field_warnings: vec![],
         })
         .expect("edit should succeed");
 
@@ -1747,6 +1752,7 @@ fn file_edit_noop_when_strings_equal() {
                 old_string: "hello".to_string(),
                 new_string: "hello".to_string(),
             },
+            extra_field_warnings: vec![],
         })
         .expect_err("noop edit should return error when old_string == new_string");
 
@@ -1777,6 +1783,7 @@ fn file_edit_file_not_found() {
                 old_string: "hello".to_string(),
                 new_string: "world".to_string(),
             },
+            extra_field_warnings: vec![],
         })
         .expect_err("should fail for nonexistent file");
 
@@ -1802,6 +1809,7 @@ fn file_edit_sandbox_escape_rejected() {
                 old_string: "root".to_string(),
                 new_string: "hacked".to_string(),
             },
+            extra_field_warnings: vec![],
         })
         .expect_err("should reject sandbox escape");
 
@@ -2011,6 +2019,7 @@ fn build_exec_request(name: &str, mode: ExecutionMode) -> ToolExecutionRequest {
         input: ToolInput::FileRead {
             path: "dummy.txt".to_string(),
         },
+        extra_field_warnings: vec![],
     }
 }
 
@@ -2146,6 +2155,7 @@ fn parallel_execution_preserves_result_order() {
                     input: ToolInput::FileRead {
                         path: format!("./file_{i}.txt"),
                     },
+                    extra_field_warnings: vec![],
                 },
             )
         })
@@ -3949,6 +3959,7 @@ fn git_status_execution_in_git_repo() {
             tool_call_id: "call_git_status".to_string(),
             spec: registry.get("git.status").unwrap().clone(),
             input: ToolInput::GitStatus {},
+            extra_field_warnings: vec![],
         })
         .expect("git.status should succeed in git repo");
 
@@ -3972,6 +3983,7 @@ fn git_diff_execution_in_git_repo() {
                 staged: None,
                 commit: None,
             },
+            extra_field_warnings: vec![],
         })
         .expect("git.diff should succeed in git repo");
 
@@ -3992,6 +4004,7 @@ fn git_log_execution_in_git_repo() {
                 count: Some(5),
                 path: None,
             },
+            extra_field_warnings: vec![],
         })
         .expect("git.log should succeed in git repo");
 
@@ -4047,6 +4060,7 @@ fn git_status_fails_in_non_git_repo() {
             tool_call_id: "call_git_status_fail".to_string(),
             spec: registry.get("git.status").unwrap().clone(),
             input: ToolInput::GitStatus {},
+            extra_field_warnings: vec![],
         })
         .expect("execute should return result, not runtime error");
 
@@ -4092,6 +4106,7 @@ fn git_diff_staged_priority_over_commit() {
                 staged: Some(true),
                 commit: Some("HEAD~1".to_string()),
             },
+            extra_field_warnings: vec![],
         })
         .expect("git.diff with staged should succeed");
 
@@ -4718,6 +4733,7 @@ fn file_write_produces_diff_summary() {
                 path: "./new_file.txt".to_string(),
                 content: "hello world".to_string(),
             },
+            extra_field_warnings: vec![],
         })
         .expect("write should succeed");
 
@@ -4753,6 +4769,7 @@ fn file_edit_produces_diff_summary() {
                 old_string: "hello".to_string(),
                 new_string: "goodbye".to_string(),
             },
+            extra_field_warnings: vec![],
         })
         .expect("edit should succeed");
 
@@ -4791,6 +4808,7 @@ fn file_edit_anchor_produces_diff_summary() {
                     new_content: "let x = 42;".to_string(),
                 },
             },
+            extra_field_warnings: vec![],
         })
         .expect("anchor edit should succeed");
 
@@ -4824,6 +4842,7 @@ fn file_read_has_no_diff_summary() {
             input: ToolInput::FileRead {
                 path: "./test.txt".to_string(),
             },
+            extra_field_warnings: vec![],
         })
         .expect("read should succeed");
 
@@ -4890,6 +4909,7 @@ fn file_edit_anchor_execution_indent_normalized_match() {
                     new_content: "let x = 10;\nlet y = 20;".to_string(),
                 },
             },
+            extra_field_warnings: vec![],
         })
         .expect("anchor edit should succeed");
 
@@ -4927,6 +4947,7 @@ fn file_edit_anchor_execution_no_match_error() {
                     new_content: "replacement".to_string(),
                 },
             },
+            extra_field_warnings: vec![],
         })
         .expect_err("should fail when old_content not found");
 
@@ -4956,6 +4977,7 @@ fn file_edit_anchor_execution_multiple_matches_error() {
                     new_content: "let x = 2;".to_string(),
                 },
             },
+            extra_field_warnings: vec![],
         })
         .expect_err("should fail when old_content matches multiple times");
 
@@ -4989,6 +5011,7 @@ fn file_edit_fallback_indent_mismatch() {
                 old_string: "        let x = 1;".to_string(), // 8-space indent
                 new_string: "        let x = 2;".to_string(),
             },
+            extra_field_warnings: vec![],
         })
         .expect("fallback should succeed");
 
@@ -5142,6 +5165,7 @@ fn edit_fallback_includes_context_on_failure() {
                 old_string: "fn main() {\n    let x = wrong;\n}".to_string(),
                 new_string: "fn main() {\n    let x = correct;\n}".to_string(),
             },
+            extra_field_warnings: vec![],
         })
         .unwrap_err();
     assert!(err.is_edit_not_found());
@@ -5185,6 +5209,7 @@ fn edit_fallback_no_context_for_sensitive_file() {
                 old_string: "NONEXISTENT=value".to_string(),
                 new_string: "REPLACED=value".to_string(),
             },
+            extra_field_warnings: vec![],
         })
         .unwrap_err();
     match &err {
@@ -5223,6 +5248,7 @@ fn trailing_ws_normalized_match_succeeds() {
                 old_string: "fn hello() {\n    world()\n}".to_string(),
                 new_string: "fn hello() {\n    universe()\n}".to_string(),
             },
+            extra_field_warnings: vec![],
         })
         .expect("trailing-ws normalized edit should succeed");
 
@@ -5524,6 +5550,7 @@ fn file_edit_success_payload_contains_diff() {
                 old_string: "hello".to_string(),
                 new_string: "goodbye".to_string(),
             },
+            extra_field_warnings: vec![],
         })
         .expect("edit should succeed");
 
@@ -5564,6 +5591,7 @@ fn file_edit_no_changes_returns_error() {
                 old_string: "hello".to_string(),
                 new_string: "hello".to_string(),
             },
+            extra_field_warnings: vec![],
         })
         .expect_err("identical old_string/new_string should return error");
 
@@ -5923,6 +5951,7 @@ fn file_cache_hit_returns_content_with_header() {
         input: ToolInput::FileRead {
             path: "hello.txt".to_string(),
         },
+        extra_field_warnings: vec![],
     };
 
     // First read: populates cache, returns raw content without header
@@ -6298,6 +6327,7 @@ fn file_write_same_content_produces_no_diff() {
                 path: "./existing.txt".to_string(),
                 content: "unchanged content".to_string(),
             },
+            extra_field_warnings: vec![],
         })
         .expect("write should succeed");
 
@@ -6334,6 +6364,7 @@ fn file_write_different_content_produces_diff() {
                 path: "./target.txt".to_string(),
                 content: "new content".to_string(),
             },
+            extra_field_warnings: vec![],
         })
         .expect("write should succeed");
 

--- a/workspace/anvil-feature-overview.md
+++ b/workspace/anvil-feature-overview.md
@@ -1,0 +1,247 @@
+# Anvil 機能概要と特徴
+
+## プロジェクト概要
+
+**Anvil** はローカルターミナルで動作するコーディングエージェントです。Ollama や OpenAI 互換サーバーを LLM バックエンドとして使用し、ファイル操作・シェルコマンド実行・コード検索などを AI が自律的に行います。
+
+| 項目 | 内容 |
+|------|------|
+| 言語 | Rust (Edition 2024) |
+| バージョン | v0.0.7 |
+| 対応LLM | Ollama, OpenAI互換API (LM Studio, vLLM, Azure OpenAI等) |
+| 実行モード | 対話モード / ワンショットモード (`--oneshot`) |
+| ライセンス | MIT |
+
+---
+
+## アーキテクチャ
+
+```
+┌─────────────────────────────────────────────────────┐
+│                      TUI / CLI                       │
+│  (rustyline REPL, スラッシュコマンド, 承認フロー)      │
+├─────────────────────────────────────────────────────┤
+│                   App Orchestrator                    │
+│  (状態機械, セッション管理, プラン管理)                │
+├──────────────┬──────────────┬────────────────────────┤
+│ Agentic Loop │  SubAgents   │   Extensions/Skills    │
+│ (マルチターン│ (Explore,    │  (スラッシュコマンド,   │
+│  ツール実行) │  Plan)       │   カスタムスキル)       │
+├──────────────┴──────────────┴────────────────────────┤
+│                    Tool Executor                      │
+│  (file.read/write/edit, shell.exec, web, git, MCP)   │
+├─────────────────────────────────────────────────────┤
+│                   LLM Provider                        │
+│  (Ollama, OpenAI互換, ストリーミング, リトライ)        │
+└─────────────────────────────────────────────────────┘
+```
+
+---
+
+## コア機能
+
+### 1. マルチターン Agentic Loop
+
+LLM とツール実行を繰り返すマルチターンループがエージェントの中核です。
+
+- LLM がツール呼び出しを生成 → ツール実行 → 結果をフィードバック → 次のターン
+- 最大イテレーション数: デフォルト30ターン
+- `ANVIL_FINAL` マーカーによる明示的な完了宣言
+- フォールバック完了検出（マーカー未発行時はフェーズ推定で判断）
+
+### 2. ツールシステム
+
+| ツール | 権限 | 説明 |
+|--------|------|------|
+| `file.read` | Safe | ファイル読取・ディレクトリ一覧・画像base64 |
+| `file.write` | Confirm | ファイル作成・上書き（削除比率チェック付き） |
+| `file.edit` | Confirm | old_string/new_string による行単位編集 |
+| `file.edit_anchor` | Confirm | インデント正規化付き編集 |
+| `file.search` | Safe | ファイル名・内容検索（正規表現対応） |
+| `shell.exec` | Confirm | シェルコマンド実行（リアルタイム出力） |
+| `web.fetch` | Safe | URL取得 |
+| `web.search` | Safe | Web検索（DuckDuckGo/Serper） |
+| `git.status/diff/log` | Safe | Git操作（読み取り専用） |
+| `mcp.tool` | Safe/Confirm | MCP（Model Context Protocol）ツール |
+| `agent.explore` | Safe | サブエージェント（コードベース調査） |
+| `agent.plan` | Safe | サブエージェント（計画策定） |
+
+### 3. LLM プロバイダー
+
+**Ollama:**
+- `/api/chat` エンドポイント対応
+- ストリーミング応答
+- モデル情報自動取得（コンテキスト長、パラメータ数）
+- サイドカーモデルによる要約生成
+
+**OpenAI互換:**
+- `/v1/chat/completions` 対応
+- APIキー認証
+- 画像マルチモーダル対応
+- LM Studio, vLLM, Azure OpenAI 等で動作
+
+**共通:**
+- 指数バックオフリトライ（最大3回）
+- タイムアウト: デフォルト300秒
+
+### 4. プラン管理 (Execution Plan)
+
+- `ANVIL_PLAN` / `ANVIL_PLAN_UPDATE` ブロックで構造化プランを管理
+- プラン項目ごとの進捗追跡（Pending → InProgress → Done / Superseded）
+- Final Gate: 全項目完了を確認してから `ANVIL_FINAL` を許可
+- Late-stage closure mode: 残り1項目で closure-focused ヒントを注入
+- Follow-up replan: 作業中のプラン更新に対応
+
+### 5. セッション管理
+
+- 会話履歴の永続化 (`.anvil/sessions/`)
+- 名前付きセッション、一覧・切替・削除
+- **Working Memory**: 自動維持される構造化メモリ
+  - active_task, constraints, touched_files, unresolved_errors, recent_diffs
+  - コンテキスト圧縮後も保持される
+- トークン予算自動管理: メッセージ数閾値を超えると自動compact
+
+### 6. サブエージェント
+
+| 種別 | 用途 | 使用可能ツール |
+|------|------|--------------|
+| Explore | コードベース調査 | file.read, file.search, git.* |
+| Plan | 計画策定 | file.read, file.search, web.fetch, git.* |
+
+- メインエージェントとは独立したLLMループ
+- 読み取り専用（ファイル変更不可）
+- タイムアウト・イテレーション制限あり
+
+### 7. MCP (Model Context Protocol)
+
+- 外部ツールサーバーとの連携
+- プロトコル: 2024-11-05
+- STDIO トランスポート
+- ツール名検証（制御文字・ダブルアンダースコア禁止）
+
+---
+
+## 安全性・品質保証
+
+### 多層的な異常検出
+
+| 検出器 | 機能 |
+|--------|------|
+| **LoopDetector** | 同一ツール呼び出しの繰り返しをハッシュで検出。3段階エスカレーション (Warn → StrongWarn → Break) |
+| **AlternatingLoopDetector** | 交互/循環パターンの検出 |
+| **ReadRepeatTracker** | 同一ファイルの繰り返し読み取りを検出 |
+| **ReadTransitionGuard** | 長時間の探索フェーズを検出し実装への移行を促す |
+| **EditFailTracker** | file.edit連続失敗を追跡、フォールバック (ReRead → WriteFallback) |
+| **WriteFailTracker** | file.write連続失敗を追跡 |
+| **WriteRepeatTracker** | 同一ファイルへの繰り返し書き込みを検出 |
+| **StagnationState** | ターン単位の停滞テレメトリ。ファイル飢餓追跡、ワークセット同一性チェック |
+| **PhaseEstimator** | ツール呼び出しパターンからフェーズ推定 (Exploring/Implementing) |
+
+### 承認フロー
+
+- デフォルト: `file.write`, `file.edit`, `shell.exec` は実行前に `[y/n]` 確認
+- `--no-approval` で全ツール自動実行
+- `/trust` コマンドでツール単位の信頼設定
+
+### コマンドブロックリスト
+
+以下は承認モードに関係なく常にブロック:
+- `rm -rf /`, `rm -rf ~`
+- `mkfs`, `dd if=`, Fork bomb `:(){`
+
+### サンドボックス
+
+- パスは作業ディレクトリに相対化
+- `..` によるディレクトリ脱出防止
+- シンボリックリンク検証
+
+---
+
+## モデル適応
+
+### 自動分類
+
+モデル名のパラメータ数から自動的に能力を分類:
+
+| モデルサイズ | プロトコル | プロンプトTier |
+|-------------|-----------|---------------|
+| Large (>13B) | JSON | Full |
+| Medium (7B-13B) | JSON | Compact |
+| Small (<=7B) | Tag-based | Tiny |
+
+### Tag-based プロトコル
+
+小モデル向けに `<file.read path="...">` 形式のタグベース呼び出しをサポート。JSONパースが困難なモデルでもツール呼び出しが可能。
+
+### Shell Inspection 統合 (Issue #309)
+
+`shell.exec` によるinspectionコマンド (grep, find, wc, diff, rg等) を PhaseEstimator で Read として分類し、shell-based inspection drift を防止。
+
+---
+
+## 拡張性
+
+### スラッシュコマンド
+
+| コマンド | 説明 |
+|----------|------|
+| `/help` | ヘルプ表示 |
+| `/plan`, `/plan-add`, `/plan-focus`, `/plan-clear` | プラン管理 |
+| `/checkpoint` | チェックポイント保存 |
+| `/compact` | 履歴圧縮 |
+| `/model`, `/model-list`, `/model-switch` | モデル管理 |
+| `/session-list`, `/session-switch`, `/session-delete` | セッション管理 |
+| `/trust` | ツール信頼設定 |
+| `/undo` | ツール実行取り消し |
+| `/repo-find` | リポジトリ検索 |
+| `/timeline` | セッションタイムライン |
+
+### カスタムコマンド
+
+`.anvil/slash-commands.json` で独自コマンドを定義可能。
+
+### スキルシステム
+
+`SKILL.md` ファイルでプロジェクト・ユーザースコープのスキルを定義。複雑なワークフローをテンプレート化。
+
+### カスタムツール
+
+設定ファイルで最大10個のカスタムツールを定義可能。シェルコマンドテンプレートを展開して実行。
+
+### ライフサイクルフック
+
+`HooksConfig` でイベント駆動のカスタム処理を定義可能。
+
+---
+
+## 設定
+
+### 優先度
+
+CLI引数 > 環境変数 > 設定ファイル (`.anvil/config.toml`) > デフォルト値
+
+### 主要設定項目
+
+| 設定 | デフォルト | 説明 |
+|------|-----------|------|
+| `provider` | ollama | LLMプロバイダー |
+| `model` | - | 使用モデル |
+| `max_agent_iterations` | 30 | 最大ターン数 |
+| `stream` | true | ストリーミング応答 |
+| `loop_detection_threshold` | 3 | ループ検出閾値 |
+| `edit_strategy` | EditFirst | 編集戦略 |
+| `ui_language` | ja | UI言語 (ja/en) |
+| `context_window` | モデル依存 | コンテキストウィンドウサイズ |
+| `context_budget` | - | コンテキスト予算 |
+
+---
+
+## 技術的特徴まとめ
+
+1. **完全ローカル動作**: Ollama等のローカルLLMで動作し、データが外部に出ない
+2. **多層的な安全機構**: ループ検出、停滞検出、コマンドブロック、サンドボックス、承認フロー
+3. **モデル自動適応**: パラメータ数に応じてプロトコル・プロンプトを自動調整
+4. **構造化プラン管理**: ANVIL_PLAN/ANVIL_FINAL による計画的なタスク遂行
+5. **セッション永続化**: Working Memory による文脈保持、コンテキスト圧縮
+6. **拡張可能**: MCP, カスタムツール, スキル, フックによる機能拡張
+7. **Rust実装**: 高速・低メモリ・型安全な実装

--- a/workspace/orchestration/runs/2026-04-09/plan-311.md
+++ b/workspace/orchestration/runs/2026-04-09/plan-311.md
@@ -1,0 +1,25 @@
+# Orchestration Plan — Issue #311 (2026-04-09)
+
+## 対象Issue
+
+| Issue | タイトル | 種別 |
+|-------|---------|------|
+| #311 | bug: superseded-only terminal plan が final gate / completion_kind と exit semantics を分断し complete_unverified + exit 2 を生む | BUG |
+
+## 依存関係
+
+単一Issue。#309の修正済みHEAD (95a673e) 上で作業。
+
+## 影響ファイル
+
+- `src/contracts/mod.rs` — success predicate統一、supersede/dedup修正
+- `src/app/mod.rs` — `has_tool_execution_failure()` 修正
+
+## 実行計画
+
+1. Phase 2: Worktree準備（feature/issue-311-superseded-plan-exit-fix）
+2. Phase 2.5: Opus 4.6 根本原因分析（Issue本文に詳細分析あり）
+3. Phase 3: /bug-fix 311 をワーカーに送信
+4. Phase 5: 品質確認
+5. Phase 6: PR作成・developマージ
+6. Phase 8: 完了報告

--- a/workspace/orchestration/runs/2026-04-09/plan-313.md
+++ b/workspace/orchestration/runs/2026-04-09/plan-313.md
@@ -1,0 +1,19 @@
+# Orchestration Plan — Issue #313 (2026-04-09)
+
+## 対象Issue
+| Issue | タイトル | 種別 |
+|-------|---------|------|
+| #313 | bug: large-file の file.edit recovery が mid-file context を返せず shell.exec drift / partial に落ちる | BUG |
+
+## 影響ファイル
+- `src/app/agentic.rs` — recovery hint, FILE_READ_RESULT_MAX_CHARS
+- `src/app/tool_recovery_budget.rs` — blessed recovery primitive
+- `src/tooling/mod.rs` — extract_edit_context() fallback
+
+## 実行計画
+1. Phase 2: Worktree (feature/issue-313-edit-recovery-mid-context)
+2. Phase 2.5: Opus根本原因分析
+3. Phase 3: /bug-fix 313
+4. Phase 5: 品質確認
+5. Phase 6: PR・マージ
+6. Phase 8: 完了報告

--- a/workspace/orchestration/runs/2026-04-09/plan.md
+++ b/workspace/orchestration/runs/2026-04-09/plan.md
@@ -1,0 +1,32 @@
+# Orchestration Plan — 2026-04-09
+
+## 対象Issue
+
+| Issue | タイトル | 種別 |
+|-------|---------|------|
+| #309 | bug: active unfinished plan 中の shell.exec inspection drift が guidance をすり抜け partial + tool execution failed に落ちる | BUG |
+
+## 依存関係
+
+単一Issueのため依存関係なし。
+
+## 影響ファイル
+
+- `src/app/phase_estimator.rs`
+- `src/app/read_transition_guard.rs`
+- `src/tooling/shell_policy.rs`
+- `src/app/agentic.rs`
+- `src/app/mod.rs`
+
+## 実行計画
+
+1. Phase 2: Worktree準備（feature/issue-309-shell-inspection-drift）
+2. Phase 2.5: Opus 4.6 根本原因分析（Issue本文に詳細分析あり、追加分析実施）
+3. Phase 3: /bug-fix 309 をワーカーに送信
+4. Phase 5: 品質確認（cargo fmt/clippy/test）
+5. Phase 6: PR作成・developマージ
+6. Phase 8: 完了報告
+
+## マージ推奨順序
+
+単一Issueのため順序制約なし。

--- a/workspace/orchestration/runs/2026-04-09/summary-311.md
+++ b/workspace/orchestration/runs/2026-04-09/summary-311.md
@@ -1,0 +1,43 @@
+# オーケストレーション完了報告 — Issue #311
+
+## 対象Issue
+
+| Issue | タイトル | ステータス |
+|-------|---------|-----------|
+| #311 | bug: superseded-only terminal plan が final gate / completion_kind と exit semantics を分断し complete_unverified + exit 2 を生む | 完了 |
+
+## 実行フェーズ結果
+
+| Phase | 内容 | ステータス |
+|-------|------|-----------|
+| 1 | 依存関係分析 | 完了（単一Issue、依存なし） |
+| 2 | Worktree準備 | 完了（feature/issue-311-superseded-plan-exit-fix） |
+| 2.5 | 根本原因分析（Opus 4.6） | 完了 |
+| 3 | 開発（/bug-fix） | 完了（1コミット、5ファイル変更） |
+| 4 | 設計突合 | スキップ（単一Issue） |
+| 5 | 品質確認 | 完了（全Pass） |
+| 6 | PR・マージ | 完了（PR #312） |
+
+## 品質チェック
+
+| チェック項目 | 結果 |
+|-------------|------|
+| cargo build | Pass |
+| cargo clippy --all-targets | Pass |
+| cargo test | Pass |
+| cargo fmt --check | Pass |
+
+## 変更概要（+356, -25）
+
+| ファイル | 変更内容 |
+|---------|---------|
+| `src/contracts/mod.rs` | `deduplicate_new_items()`: Superseded item をdedup対象から除外; `is_cleanly_finished()` 追加 |
+| `src/app/mod.rs` | `has_tool_execution_failure`/`log_session_summary`: `is_cleanly_finished` 使用に統一 |
+| `tests/superseded_plan_exit.rs` | 9回帰テスト（AC6-1..AC6-5） |
+| `tests/followup_replan.rs` | 修正後のdedup動作に合わせて更新 |
+| `tests/stagnation_control.rs` | 修正後のdedup動作に合わせて更新 |
+
+## 成果物
+
+- PR: https://github.com/Kewton/Anvil/pull/312
+- 統合サマリー: workspace/orchestration/runs/2026-04-09/summary-311.md

--- a/workspace/orchestration/runs/2026-04-09/summary-313.md
+++ b/workspace/orchestration/runs/2026-04-09/summary-313.md
@@ -1,0 +1,40 @@
+# オーケストレーション完了報告 — Issue #313
+
+## 対象Issue
+
+| Issue | タイトル | ステータス |
+|-------|---------|-----------|
+| #313 | bug: large-file の file.edit recovery が mid-file context を返せず shell.exec drift / partial に落ちる | 完了 |
+
+## 実行フェーズ結果
+
+| Phase | 内容 | ステータス |
+|-------|------|-----------|
+| 1 | 分析・計画 | 完了 |
+| 2 | Worktree準備 | 完了（feature/issue-313-edit-recovery-mid-context） |
+| 2.5 | Opus根本原因分析 | 完了 |
+| 3 | 開発（/bug-fix） | 完了（1コミット、3ファイル変更） |
+| 4 | 設計突合 | スキップ（単一Issue） |
+| 5 | 品質確認 | 完了（全Pass） |
+| 6 | PR・マージ | 完了（PR #314） |
+
+## 品質チェック
+
+| チェック項目 | 結果 |
+|-------------|------|
+| cargo build | Pass |
+| cargo clippy --all-targets | Pass |
+| cargo test | Pass |
+| cargo fmt --check | Pass（既存差分のみ） |
+
+## 変更概要（+366, -13）
+
+| ファイル | 変更内容 |
+|---------|---------|
+| `src/tooling/mod.rs` | `extract_edit_context()` にtoken-based fallback追加。`extract_tokens()`, `find_best_token_match()` |
+| `src/app/agentic.rs` | Recovery hintにinline context参照追加、`file.read` offset guidance |
+| `tests/edit_recovery_mid_context.rs` | 7回帰テスト |
+
+## 成果物
+
+- PR: https://github.com/Kewton/Anvil/pull/314

--- a/workspace/orchestration/runs/2026-04-09/summary-315.md
+++ b/workspace/orchestration/runs/2026-04-09/summary-315.md
@@ -1,0 +1,29 @@
+# オーケストレーション完了報告 — Issue #315
+
+## 対象Issue
+
+| Issue | タイトル | ステータス |
+|-------|---------|-----------|
+| #315 | bug: no-path / summary-only ANVIL_PLAN item が retire されず final gate が永続 suppress される | 完了 |
+
+## 実行フェーズ結果
+
+| Phase | 内容 | ステータス |
+|-------|------|-----------|
+| 1 | 分析・計画 | 完了 |
+| 2 | Worktree準備 | 完了 |
+| 2.5 | Opus根本原因分析 | 完了 |
+| 3 | 開発（/bug-fix） | 完了（1コミット、3ファイル変更） |
+| 5 | 品質確認 | 完了（全Pass） |
+| 6 | PR・マージ | 完了（PR #316） |
+
+## 変更概要（+388, -9）
+
+| ファイル | 変更内容 |
+|---------|---------|
+| `src/contracts/mod.rs` | `auto_retire_no_path_items()`, `retire_no_path_items_by_description()` |
+| `src/app/execution_plan.rs` | plan registration/update でauto-retire呼び出し |
+| `tests/no_path_plan_item.rs` | 17回帰テスト |
+
+## 成果物
+- PR: https://github.com/Kewton/Anvil/pull/316

--- a/workspace/orchestration/runs/2026-04-09/summary.md
+++ b/workspace/orchestration/runs/2026-04-09/summary.md
@@ -1,0 +1,46 @@
+# オーケストレーション完了報告
+
+## 対象Issue
+
+| Issue | タイトル | ステータス |
+|-------|---------|-----------|
+| #309 | bug: active unfinished plan 中の shell.exec inspection drift が guidance をすり抜け partial + tool execution failed に落ちる | 完了 |
+
+## 実行フェーズ結果
+
+| Phase | 内容 | ステータス |
+|-------|------|-----------|
+| 1 | 依存関係分析 | 完了（単一Issue、依存なし） |
+| 2 | Worktree準備 | 完了（feature/issue-309-shell-inspection-drift） |
+| 2.5 | 根本原因分析（Opus 4.6） | 完了（Issue本文の詳細分析を検証） |
+| 3 | 並列開発（/bug-fix） | 完了（1コミット、9ファイル変更） |
+| 4 | 設計突合 | スキップ（単一Issue） |
+| 5 | 品質確認 | 完了（全Pass） |
+| 6 | PR・マージ | 完了（PR #310） |
+
+## 品質チェック
+
+| チェック項目 | 結果 |
+|-------------|------|
+| cargo build | Pass |
+| cargo clippy --all-targets | Pass |
+| cargo test | Pass |
+| cargo fmt --check | Pass |
+
+## 変更概要（+633, -13）
+
+| ファイル | 変更内容 |
+|---------|---------|
+| `src/tooling/shell_policy.rs` | `is_shell_inspection_command()`: shell inspection検出（grep/head/tail + commandindexdev/find/rg/diff/wc/tree/fd/ag） |
+| `src/app/phase_estimator.rs` | `record_tool_call_ex()`: shell inspection を Read として分類 |
+| `src/app/agentic.rs` | shell_cmd コンテキストを PhaseEstimator/ReadTransitionGuard に伝搬（DRY化） |
+| `src/app/execution_plan.rs` | `build_late_stage_closure_hint()`: remaining==1 時のclosure-focused ヒント |
+| `src/app/mod.rs` | `build_pre_exit_repair_message()`: escape hatch 前の構造化リペアターン |
+| `src/contracts/mod.rs` | `TerminationReason::ShellInspectionDrift` バリアント追加 |
+| `src/tooling/mod.rs` | `is_shell_inspection_command` re-export |
+| `tests/shell_inspection_drift.rs` | 14回帰テスト |
+
+## 成果物
+
+- PR: https://github.com/Kewton/Anvil/pull/310
+- 統合サマリー: workspace/orchestration/runs/2026-04-09/summary.md


### PR DESCRIPTION
## Summary

Phase0 short smoke suite の残 blocker を4件修正し、runtime convergence を大幅に改善しました。

### 修正Issue一覧

| PR | Issue | タイトル |
|----|-------|---------|
| #310 | #309 | shell.exec inspection drift が guidance をすり抜け partial + tool execution failed に落ちる |
| #312 | #311 | superseded-only terminal plan が final gate / completion_kind と exit semantics を分断 |
| #314 | #313 | large-file の file.edit recovery が mid-file context を返せず shell.exec drift に落ちる |
| #316 | #315 | no-path / summary-only ANVIL_PLAN item が retire されず final gate が永続 suppress される |

### 主な変更内容

**#309: shell.exec inspection drift 防止**
- `is_shell_inspection_command()` で grep/find/rg/commandindexdev 等を inspection として分類
- `PhaseEstimator` で shell inspection を Read として扱い、guidance blind spot を解消
- late-stage closure mode (`remaining==1`) と pre-exit repair turn を追加

**#311: superseded-only terminal plan の exit semantics 統一**
- `deduplicate_new_items()` で Superseded item を dedup 対象から除外
- `is_cleanly_finished()` を unified terminal-complete predicate として追加
- `has_tool_execution_failure` / `log_session_summary` を統一

**#313: large-file mid-context edit recovery**
- `extract_edit_context()` に token-based fallback matching を追加
- ファイルサイズに応じた動的 `context_lines` (5/8/12)
- Recovery hint に inline context 参照を追加

**#315: no-path plan item の auto-retire**
- `auto_retire_no_path_items()` で no-path item を即座に AlreadySatisfied に退役
- `retire_no_path_items_by_description()` で description ベースの retire マッチング
- plan registration/update pipeline に auto-retire を統合

### 品質チェック

| チェック項目 | 結果 |
|-------------|------|
| cargo build | Pass |
| cargo clippy --all-targets | Pass |
| cargo test | Pass |
| cargo fmt --check | Pass |

### UAT結果

| Issue | テスト数 | PASS | 判定 |
|-------|---------|------|------|
| #309 | 6 | 6 | ACCEPTED |
| #311 | 5 | 5 | ACCEPTED |
| #313 | 5 | 5 | ACCEPTED |
| #315 | 5 | 5 | ACCEPTED |

### テスト追加

- `tests/shell_inspection_drift.rs` — 17テスト
- `tests/superseded_plan_exit.rs` — 9テスト
- `tests/edit_recovery_mid_context.rs` — 7テスト
- `tests/no_path_plan_item.rs` — 17テスト

合計50テスト追加。

🤖 Generated with [Claude Code](https://claude.com/claude-code)