### PR TITLE
chore: release v0.0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,43 @@
 
 ## [Unreleased]
 
+## [0.0.10] - 2026-04-09
+
+### Added
+- Plan-execute mode with `ANVIL_PLAN` and checklist-managed `ANVIL_FINAL` control (#249)
+- Plan-aware stagnation control for workset steering (#263)
+- Plan-aware batch guidance and correctness fixes (#261)
+- CompletionKind taxonomy, AgentTelemetry, and strengthened item completion (#255)
+- Telemetry artifact infrastructure for comparison baseline repair (#271)
+- First-mutation telemetry for pre-mutation transition diagnosis (#273)
+- Post-mutation stagnation decomposition telemetry (#275)
+- File-role telemetry and mutation order measurement (#277)
+- Parallel tool progress display (#240)
+- Session note extraction with logging (#241)
+- Phase estimation in turn summary logs (#242)
+- Baseline optimization — guidance lightening and metrics contract (#269)
+- Orphan mutation detection to prevent final gate hang (#287)
+
+### Fixed
+- Prevent plan mode from becoming permanent across turns (#253)
+- Sync plan completion from touched_files before ANVIL_FINAL gate check (#251)
+- Align files_modified with actual disk changes (#259)
+- Detect file-reading shell.exec commands in read_guard (#265)
+- Reject file.edit when old_string == new_string (#266)
+- Prevent no-plan/no-op completion with success-style logs in follow-up paths (#285)
+- Prevent final gate hang on last plan item and fix Ollama streaming timeout (#287)
+- Prevent stale/alias plan item remaining after ANVIL_PLAN_UPDATE (#289)
+- Prevent recovered tool failure from polluting non-interactive exit code (#296)
+- Prevent edit recovery from triggering loop detector termination (#299)
+- Retire already-satisfied/verification-only plan items to prevent stale target pollution (#301)
+- Prevent agent.plan and ANVIL_PLAN conflict allowing unplanned mutations (#303)
+- Allow follow-up ANVIL_PLAN to replace active plan during replan (#305)
+- Convert prose-only already-implemented confirmation to plan retire (#307)
+- Integrate shell.exec inspection into phase/stagnation guidance (#309)
+- Unify superseded-only terminal plan exit semantics (#311)
+- Add token-based fallback to extract_edit_context for mid-file recovery (#313)
+- Auto-retire no-path plan items to prevent final gate deadlock (#315)
+
 ## [0.0.9] - 2026-03-31
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,7 +72,7 @@ dependencies = [
 
 [[package]]
 name = "anvil"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anvil"
-version = "0.0.9"
+version = "0.0.10"
 edition = "2024"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ```bash
 # macOS (Apple Silicon)
-curl -L https://github.com/Kewton/Anvil/releases/download/v0.0.9/anvil-darwin-arm64.gz -o anvil.gz
+curl -L https://github.com/Kewton/Anvil/releases/download/v0.0.10/anvil-darwin-arm64.gz -o anvil.gz
 gunzip anvil.gz
 chmod +x anvil
 sudo mv anvil /usr/local/bin/


### PR DESCRIPTION
## Summary
- Bump version from 0.0.9 to 0.0.10
- Update CHANGELOG.md with all changes since v0.0.9
- Update README.md download link to v0.0.10

### Highlights
- **Plan-execute mode**: `ANVIL_PLAN` / `ANVIL_FINAL` によるチェックリスト駆動の実行制御 (#249)
- **Stagnation control**: プラン認識型の停滞検出・ワークセットステアリング (#263)
- **Telemetry infrastructure**: ミューテーション遷移診断・ファイルロールテレメトリ (#271, #273, #275, #277)
- **Parallel tool progress**: 並列ツール実行の進捗表示 (#240)
- **17件のバグ修正**: プラン完了ゲート、エディットリカバリ、ループ検出等の安定性改善

🤖 Generated with [Claude Code](https://claude.com/claude-code)