### PR TITLE
feat(issue-291): add agent.fix_slice microtask sub-agent

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,7 +101,7 @@ src/
 ├── agent/
 │   ├── mod.rs           # エージェントループ・プロトコル
 │   ├── model_classifier.rs # モデル分類・ToolProtocolMode判定
-│   ├── subagent.rs      # サブエージェント実行ループ（Explore/Plan、構造化payload・JSON ANVIL_FINAL対応）
+│   ├── subagent.rs      # サブエージェント実行ループ（Explore/Plan/FixSlice、構造化payload・JSON ANVIL_FINAL対応・FixSliceProposalパース）
 │   ├── tag_parser.rs    # タグベースツール呼び出しパーサー（多層プロトコル対応）
 │   └── tag_spec.rs      # ツールタグ仕様テーブル（TOOL_TAG_SPECS）
 ├── app/
@@ -125,7 +125,7 @@ src/
 │   └── mock.rs          # テスト用モック
 ├── config/mod.rs        # 設定管理
 ├── contracts/
-│   ├── mod.rs           # 共通型定義（TerminationReason, Finding, SubAgentPayload含む）
+│   ├── mod.rs           # 共通型定義（TerminationReason, Finding, SubAgentPayload, FixSliceProposal含む）
 │   └── tokens.rs        # トークン推定（CJK対応ヒューリスティック・モデル実測値ベースEMA補正）
 ├── extensions/
 │   ├── mod.rs           # スラッシュコマンド・拡張
@@ -175,6 +175,7 @@ tests/
 ├── followup_replan.rs   # follow-up ANVIL_PLAN replan テスト（Issue #305）
 ├── prose_retire_fallback.rs # prose-only確認のplan retire変換テスト（Issue #307）
 ├── shell_inspection_drift.rs # shell.exec inspection drift テスト（Issue #309）
+├── fixslice_subagent.rs # FixSliceサブエージェント統合テスト（Issue #291）
 └── walk_system.rs       # ディレクトリウォーカーテスト
 ```
 

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -789,6 +789,16 @@ const TOOL_DESC_AGENT_PLAN: &str = concat!(
     "\n",
 );
 
+const TOOL_DESC_AGENT_FIX_SLICE: &str = concat!(
+    "10. agent.fix_slice — launch a microtask sub-agent to propose a targeted fix for a specific file:\n",
+    "```ANVIL_TOOL\n",
+    "{\"id\":\"call_010\",\"tool\":\"agent.fix_slice\",\"target_path\":\"./src/main.rs\",\"goal\":\"Fix the compilation error in function foo\",\"max_lines\":50}\n",
+    "```\n",
+    "The sub-agent reads the target file, proposes a minimal line-range replacement, and the parent applies it via file.rewrite.\n",
+    "Use this for small, focused fixes where you know the target file and the nature of the problem.\n",
+    "\n",
+);
+
 /// Data-driven definition of optional tools: (tool_name, tool_description, catalog_one_liner).
 /// Note: web.fetch and web.search were moved to basic tools (always included)
 /// because LLMs cannot discover them without prompt descriptions. See Issue #114.
@@ -802,6 +812,11 @@ const OPTIONAL_TOOLS: &[(&str, &str, &str)] = &[
         "agent.plan",
         TOOL_DESC_AGENT_PLAN,
         "agent.plan: launch a read-only sub-agent to create an implementation plan",
+    ),
+    (
+        "agent.fix_slice",
+        TOOL_DESC_AGENT_FIX_SLICE,
+        "agent.fix_slice: launch a microtask sub-agent to propose a targeted fix for a file",
     ),
 ];
 

--- a/src/agent/subagent.rs
+++ b/src/agent/subagent.rs
@@ -5,7 +5,7 @@
 
 use crate::app::policy::{OFFLINE_BLOCK_PAYLOAD, check_offline_blocked};
 use crate::config::EffectiveConfig;
-use crate::contracts::{Finding, SubAgentPayload, TerminationReason};
+use crate::contracts::{Finding, FixSliceProposal, SubAgentPayload, TerminationReason};
 use crate::provider::{ProviderClient, ProviderEvent, ProviderTurnError};
 use crate::session::{MessageRole, SessionMessage, SessionRecord};
 use crate::tooling::{
@@ -25,6 +25,17 @@ use std::time::{Duration, Instant};
 // ---------------------------------------------------------------------------
 // Sub-agent system prompt constants
 // ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// FixSlice budget constants (Issue #291, DR1-004: code-level const)
+// ---------------------------------------------------------------------------
+
+/// Maximum iterations for a FixSlice sub-agent run.
+pub const FIXSLICE_MAX_ITERATIONS: u32 = 3;
+/// Wall-clock timeout (seconds) for a FixSlice sub-agent run.
+pub const FIXSLICE_TIMEOUT_SECS: u64 = 60;
+/// Maximum allowed value for `max_lines` in agent.fix_slice input.
+pub const MAX_FIXSLICE_LINES: u32 = 200;
 
 const SUBAGENT_PROTOCOL_BASE: &str = r#"You are a sub-agent of Anvil, a local coding agent.
 
@@ -137,6 +148,46 @@ You are a Plan sub-agent specializing in implementation planning.
 - Note: Offline mode is active. Web access is unavailable.
 "#;
 
+// ---------------------------------------------------------------------------
+// FixSlice sub-agent prompts (Issue #291, DR2-007)
+// ---------------------------------------------------------------------------
+
+const FIXSLICE_PROTOCOL_BASE: &str = r#"You are a sub-agent of Anvil, a local coding agent.
+
+## Tool protocol
+When you need to read files, respond using fenced blocks.
+
+After you have analysed the target file, output your fix proposal as JSON inside:
+```ANVIL_FINAL
+{
+  "target_path": "relative/path/to/file.rs",
+  "start_line": 10,
+  "end_line": 15,
+  "replacement_content": "replacement lines here\n",
+  "rationale": "Short explanation of the fix"
+}
+```
+
+Rules:
+- All paths must be relative (start with ./ or a directory name).
+- Do not use any other tool syntax.
+- Always include ANVIL_FINAL when you are done.
+- You MUST output ANVIL_FINAL to signal completion.
+- Output valid JSON in ANVIL_FINAL. The JSON must contain target_path, start_line, end_line, and replacement_content.
+- start_line and end_line are 1-based, inclusive.
+- Keep the replacement scope minimal — only the lines that need to change.
+
+"#;
+
+const FIXSLICE_ROLE_PROMPT: &str = r#"## Your role
+You are a FixSlice sub-agent specializing in targeted, local code fixes.
+- Use file.read to read the target file and understand the context.
+- Identify the minimal set of lines that need to change.
+- Produce a FixSliceProposal in ANVIL_FINAL with the exact line range and replacement.
+- Keep the fix within the specified max_lines budget.
+- You only have read-only access: file.read.
+"#;
+
 /// Options for sub-agent system prompt generation (Issue #162).
 pub struct SubAgentPromptOptions<'a> {
     pub offline: bool,
@@ -153,10 +204,11 @@ pub fn build_subagent_system_prompt(
 ) -> String {
     use crate::config::{effective_ui_language_code, language_constraint_prompt};
 
+    // FixSlice uses its own protocol base; Explore/Plan share SUBAGENT_PROTOCOL_BASE.
     let mut prompt = String::new();
-    prompt.push_str(SUBAGENT_PROTOCOL_BASE);
     match kind {
         SubAgentKind::Explore => {
+            prompt.push_str(SUBAGENT_PROTOCOL_BASE);
             prompt.push_str(TOOL_DESC_FILE_READ);
             prompt.push_str(TOOL_DESC_FILE_SEARCH);
             prompt.push_str(TOOL_DESC_GIT_STATUS);
@@ -165,6 +217,7 @@ pub fn build_subagent_system_prompt(
             prompt.push_str(EXPLORE_ROLE_PROMPT);
         }
         SubAgentKind::Plan => {
+            prompt.push_str(SUBAGENT_PROTOCOL_BASE);
             prompt.push_str(TOOL_DESC_FILE_READ);
             prompt.push_str(TOOL_DESC_FILE_SEARCH);
             if !opts.offline {
@@ -176,6 +229,11 @@ pub fn build_subagent_system_prompt(
             } else {
                 PLAN_ROLE_PROMPT
             });
+        }
+        SubAgentKind::FixSlice => {
+            prompt.push_str(FIXSLICE_PROTOCOL_BASE);
+            prompt.push_str(TOOL_DESC_FILE_READ);
+            prompt.push_str(FIXSLICE_ROLE_PROMPT);
         }
     }
 
@@ -190,11 +248,13 @@ pub fn build_subagent_system_prompt(
 // Public types
 // ---------------------------------------------------------------------------
 
-/// Sub-agent kind (Explore or Plan).
+/// Sub-agent kind (Explore, Plan, or FixSlice).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SubAgentKind {
     Explore,
     Plan,
+    /// Microtask fix-slice worker (Issue #291).
+    FixSlice,
 }
 
 impl SubAgentKind {
@@ -203,12 +263,15 @@ impl SubAgentKind {
         match input {
             ToolInput::AgentExplore { .. } => Some(SubAgentKind::Explore),
             ToolInput::AgentPlan { .. } => Some(SubAgentKind::Plan),
+            ToolInput::AgentFixSlice { .. } => Some(SubAgentKind::FixSlice),
             _ => None,
         }
     }
 }
 
 /// Result returned by a successful sub-agent run.
+// TODO(DR1-001): When a 4th sub-agent kind is added, refactor SubAgentResult
+// into an enum to avoid accumulating Option fields.
 pub struct SubAgentResult {
     /// 構造化ペイロード
     pub payload: SubAgentPayload,
@@ -216,6 +279,8 @@ pub struct SubAgentResult {
     pub estimated_tokens: usize,
     /// 使用したイテレーション数
     pub iterations_used: u32,
+    /// FixSlice proposal extracted from ANVIL_FINAL (Issue #291).
+    pub fix_proposal: Option<FixSliceProposal>,
 }
 
 impl SubAgentResult {
@@ -302,7 +367,7 @@ impl SubAgentError {
 /// Outcome of a single sub-agent turn.
 enum TurnOutcome {
     /// The sub-agent produced a final answer.
-    Finished(SubAgentResult),
+    Finished(Box<SubAgentResult>),
     /// The sub-agent wants to continue (tool calls were executed).
     Continue,
 }
@@ -440,6 +505,7 @@ impl<'a, C: ProviderClient> SubAgentSession<'a, C> {
         match kind {
             SubAgentKind::Explore => registry.register_explore_tools(),
             SubAgentKind::Plan => registry.register_plan_tools(),
+            SubAgentKind::FixSlice => registry.register_fixslice_tools(),
         }
 
         // 3. Dedicated system prompt
@@ -527,12 +593,41 @@ impl<'a, C: ProviderClient> SubAgentSession<'a, C> {
                 &token_buffer,
                 crate::contracts::tokens::ContentKind::Text,
             );
+
+            // FixSlice: parse ANVIL_FINAL as FixSliceProposal (Issue #291, DR1-007)
+            if self.kind == SubAgentKind::FixSlice {
+                let fix_proposal =
+                    serde_json::from_str::<FixSliceProposal>(&structured.final_response).ok();
+                let payload = SubAgentPayload::fallback(
+                    if fix_proposal.is_some() {
+                        "fix-slice proposal parsed successfully".to_string()
+                    } else {
+                        format!(
+                            "fix-slice proposal parse failed: {}",
+                            &structured
+                                .final_response
+                                .chars()
+                                .take(200)
+                                .collect::<String>()
+                        )
+                    },
+                    TerminationReason::Completed,
+                );
+                return Ok(TurnOutcome::Finished(Box::new(SubAgentResult {
+                    payload,
+                    estimated_tokens: tokens,
+                    iterations_used: self.iterations_used,
+                    fix_proposal,
+                })));
+            }
+
             let payload = parse_final_response_to_payload(&structured.final_response);
-            return Ok(TurnOutcome::Finished(SubAgentResult {
+            return Ok(TurnOutcome::Finished(Box::new(SubAgentResult {
                 payload,
                 estimated_tokens: tokens,
                 iterations_used: self.iterations_used,
-            }));
+                fix_proposal: None,
+            })));
         }
 
         // Validate and execute tool calls
@@ -628,11 +723,21 @@ impl<'a, C: ProviderClient> SubAgentSession<'a, C> {
         let kind_label = match self.kind {
             SubAgentKind::Explore => "explore",
             SubAgentKind::Plan => "plan",
+            SubAgentKind::FixSlice => "fix_slice",
         };
         eprintln!("[subagent:{kind_label}] Starting...");
         let start = Instant::now();
-        let max_iterations = self.config.runtime.subagent_max_iterations;
-        let timeout = Duration::from_secs(self.config.runtime.subagent_timeout_secs);
+        let (max_iterations, timeout) = if self.kind == SubAgentKind::FixSlice {
+            (
+                FIXSLICE_MAX_ITERATIONS,
+                Duration::from_secs(FIXSLICE_TIMEOUT_SECS),
+            )
+        } else {
+            (
+                self.config.runtime.subagent_max_iterations,
+                Duration::from_secs(self.config.runtime.subagent_timeout_secs),
+            )
+        };
 
         for iteration in 0..max_iterations {
             // Wall-clock timeout -> partial result with Ok
@@ -657,7 +762,7 @@ impl<'a, C: ProviderClient> SubAgentSession<'a, C> {
             );
 
             match self.run_turn()? {
-                TurnOutcome::Finished(result) => return Ok(result),
+                TurnOutcome::Finished(result) => return Ok(*result),
                 TurnOutcome::Continue => continue,
             }
         }
@@ -691,6 +796,7 @@ impl<'a, C: ProviderClient> SubAgentSession<'a, C> {
             },
             estimated_tokens: 0,
             iterations_used: iterations,
+            fix_proposal: None,
         }
     }
 }

--- a/src/agent/tag_parser.rs
+++ b/src/agent/tag_parser.rs
@@ -286,6 +286,20 @@ fn build_tool_input(
                 .ok_or_else(|| "missing prompt element for agent.plan".to_string())?,
             scope: get_attr("scope"),
         },
+        "agent.fix_slice" => {
+            let target_path = get_attr("target_path")
+                .ok_or_else(|| "missing target_path attribute for agent.fix_slice".to_string())?;
+            let goal = get_child("goal")
+                .ok_or_else(|| "missing goal element for agent.fix_slice".to_string())?;
+            let max_lines: u32 = get_attr("max_lines")
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(50);
+            ToolInput::AgentFixSlice {
+                target_path,
+                goal,
+                max_lines,
+            }
+        }
         "file.rewrite" => {
             let path = get_attr("path")
                 .ok_or_else(|| "missing path attribute for file.rewrite".to_string())?;

--- a/src/agent/tag_spec.rs
+++ b/src/agent/tag_spec.rs
@@ -83,6 +83,12 @@ pub const TOOL_TAG_SPECS: &[ToolTagSpec] = &[
         child_elements: &["content"],
         example: r#"<tool name="file.rewrite" path="./src/main.rs" start_line="10" end_line="15"><content>replacement lines here</content></tool>"#,
     },
+    ToolTagSpec {
+        name: "agent.fix_slice",
+        attributes: &["target_path", "max_lines"],
+        child_elements: &["goal"],
+        example: r#"<tool name="agent.fix_slice" target_path="./src/main.rs" max_lines="50"><goal>Fix the compilation error in function foo</goal></tool>"#,
+    },
 ];
 
 /// ツール名からスペックを検索

--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -350,9 +350,35 @@ impl App {
             }
 
             let kind = SubAgentKind::from_tool_input(&call.input).unwrap();
-            let (prompt, scope) = match &call.input {
-                ToolInput::AgentExplore { prompt, scope } => (prompt.as_str(), scope.as_deref()),
-                ToolInput::AgentPlan { prompt, scope } => (prompt.as_str(), scope.as_deref()),
+
+            // Extract prompt, scope, and optional FixSlice parameters.
+            // We pre-compute the FixSlice parent_dir so the borrow lives long enough.
+            let fixslice_parent_dir: Option<String> = match &call.input {
+                ToolInput::AgentFixSlice { target_path, .. } => {
+                    std::path::Path::new(target_path.as_str())
+                        .parent()
+                        .map(|p| p.to_string_lossy().to_string())
+                        .filter(|s| !s.is_empty())
+                }
+                _ => None,
+            };
+            let (prompt, scope, fixslice_params) = match &call.input {
+                ToolInput::AgentExplore { prompt, scope } => {
+                    (prompt.as_str(), scope.as_deref(), None)
+                }
+                ToolInput::AgentPlan { prompt, scope } => (prompt.as_str(), scope.as_deref(), None),
+                ToolInput::AgentFixSlice {
+                    target_path,
+                    goal,
+                    max_lines,
+                } => {
+                    // DR2-010: goal → prompt, target_path parent dir → scope
+                    (
+                        goal.as_str(),
+                        fixslice_parent_dir.as_deref(),
+                        Some((target_path.clone(), *max_lines)),
+                    )
+                }
                 _ => unreachable!(),
             };
 
@@ -387,6 +413,31 @@ impl App {
                 self.config.paths.cwd.clone()
             };
 
+            // CB-002: FixSlice is PermissionClass::Confirm, so require approval
+            // before launching the sub-agent. Explore/Plan are Safe and skip this.
+            if kind == SubAgentKind::FixSlice && self.config.mode.approval_required {
+                let spec = self.tools.get("agent.fix_slice");
+                let effective_perm = spec
+                    .map(|s| effective_permission_class(&call.input, s))
+                    .unwrap_or(PermissionClass::Confirm);
+                let tool_kind = spec.map(|s| s.kind).unwrap_or(ToolKind::AgentFixSlice);
+                let trusted = is_trusted(
+                    &call.tool_name,
+                    tool_kind,
+                    effective_perm,
+                    self.trust_all,
+                    &self.trusted_tools,
+                );
+                if !trusted {
+                    let summary = tool_call_approval_summary(call);
+                    let approved = prompt_inline_approval(&summary, None);
+                    if !approved {
+                        agent_results.push(build_failed_result(call, "denied by user".to_string()));
+                        continue;
+                    }
+                }
+            }
+
             let overrides = SubAgentOverrides {
                 model: self.active_model.clone(),
                 context_window: self.active_context_window,
@@ -401,13 +452,99 @@ impl App {
                 overrides,
             );
             let result = session.run();
-            agent_results.push(match result {
-                Ok(r) => r.into_tool_execution_result(call),
-                Err(e) => e.into_tool_execution_result(call),
-            });
+
+            // FixSlice: validate proposal and apply via file.rewrite (Issue #291)
+            if let Some((ref original_target_path, max_lines)) = fixslice_params {
+                match result {
+                    Ok(sub_result) => {
+                        let fix_results = self.handle_fixslice_result(
+                            sub_result,
+                            call,
+                            original_target_path,
+                            max_lines,
+                        );
+                        agent_results.extend(fix_results);
+                    }
+                    Err(e) => {
+                        agent_results.push(e.into_tool_execution_result(call));
+                    }
+                }
+            } else {
+                agent_results.push(match result {
+                    Ok(r) => r.into_tool_execution_result(call),
+                    Err(e) => e.into_tool_execution_result(call),
+                });
+            }
         }
 
         (agent_results, normal_calls)
+    }
+
+    // -----------------------------------------------------------------------
+    // FixSlice result handling (Issue #291)
+    // -----------------------------------------------------------------------
+
+    /// Handle a FixSlice sub-agent result: validate proposal, apply via
+    /// file.rewrite, and return result(s).
+    ///
+    /// Returns up to 2 results: file.rewrite result (if applied) + agent.fix_slice summary.
+    fn handle_fixslice_result(
+        &mut self,
+        sub_result: crate::agent::subagent::SubAgentResult,
+        call: &ToolCallRequest,
+        original_target_path: &str,
+        max_lines: u32,
+    ) -> Vec<ToolExecutionResult> {
+        let proposal = match sub_result.fix_proposal {
+            Some(p) => p,
+            None => {
+                // Worker finished without a valid proposal
+                let reason = sub_result.payload.termination_reason;
+                let summary = format!("fix-slice worker {reason}: no valid proposal produced");
+                return vec![build_failed_result_with_text(call, summary)];
+            }
+        };
+
+        // Validate the proposal
+        if let Err(reason) = validate_fix_proposal(
+            &proposal,
+            original_target_path,
+            max_lines,
+            &self.config.paths.cwd,
+        ) {
+            let summary = format!("fix-slice validation failed: {reason}");
+            return vec![build_failed_result_with_text(call, summary)];
+        }
+
+        // Build file.rewrite execution request and actually execute it (CB-001).
+        let rewrite_request = build_rewrite_request(&proposal, &call.tool_call_id);
+        let rewrite_result = self.execute_single(rewrite_request);
+
+        // Build agent.fix_slice summary result
+        let rationale = sanitize_for_display(&proposal.rationale);
+        let fix_summary = ToolExecutionResult {
+            tool_call_id: call.tool_call_id.clone(),
+            tool_name: call.tool_name.clone(),
+            status: ToolExecutionStatus::Completed,
+            summary: format!("fix-slice applied: {rationale}"),
+            payload: ToolExecutionPayload::Text(
+                serde_json::json!({
+                    "target_path": proposal.target_path,
+                    "start_line": proposal.start_line,
+                    "end_line": proposal.end_line,
+                    "rationale": rationale,
+                })
+                .to_string(),
+            ),
+            artifacts: Vec::new(),
+            elapsed_ms: 0,
+            diff_summary: None,
+            edit_detail: None,
+            rolled_back: false,
+        };
+
+        // DR3-001: file.rewrite first, then agent.fix_slice summary
+        vec![rewrite_result, fix_summary]
     }
 
     /// Check if the ANVIL_FINAL guard should activate.
@@ -2508,6 +2645,12 @@ pub(crate) fn infer_plan_from_structured_response(
             } => {
                 format!("rewrite {path} (lines {start_line}-{end_line})")
             }
+            crate::tooling::ToolInput::AgentFixSlice {
+                target_path, goal, ..
+            } => {
+                let truncated = truncate_chars(goal, 50);
+                format!("fix_slice: {target_path} — {truncated}")
+            }
         };
         plan.push(item);
     }
@@ -2671,6 +2814,25 @@ fn build_failed_result(
     }
 }
 
+/// Build a failed [`ToolExecutionResult`] with the summary echoed as text payload.
+fn build_failed_result_with_text(
+    call: &crate::tooling::ToolCallRequest,
+    summary: String,
+) -> ToolExecutionResult {
+    ToolExecutionResult {
+        tool_call_id: call.tool_call_id.clone(),
+        tool_name: call.tool_name.clone(),
+        status: crate::tooling::ToolExecutionStatus::Failed,
+        summary: summary.clone(),
+        payload: crate::tooling::ToolExecutionPayload::Text(summary),
+        artifacts: Vec::new(),
+        elapsed_ms: 0,
+        diff_summary: None,
+        edit_detail: None,
+        rolled_back: false,
+    }
+}
+
 /// Produce a human-readable summary of a tool call for the approval prompt.
 fn tool_call_approval_summary(call: &crate::tooling::ToolCallRequest) -> String {
     match &call.input {
@@ -2719,6 +2881,12 @@ fn tool_call_approval_summary(call: &crate::tooling::ToolCallRequest) -> String 
             let truncated = truncate_chars(prompt, 100);
             format!("agent.plan [scope: {scope_info}]: {truncated}")
         }
+        crate::tooling::ToolInput::AgentFixSlice {
+            target_path, goal, ..
+        } => {
+            let truncated = truncate_chars(goal, 100);
+            format!("agent.fix_slice [target: {target_path}]: {truncated}")
+        }
         _ => call.tool_name.clone(),
     }
 }
@@ -2739,6 +2907,97 @@ fn prompt_inline_approval(summary: &str, diff_preview: Option<&str>) -> bool {
     } else {
         false
     }
+}
+
+// ---------------------------------------------------------------------------
+// FixSlice helpers (Issue #291)
+// ---------------------------------------------------------------------------
+
+/// Validate a FixSlice proposal from the sub-agent.
+///
+/// Checks:
+/// - `target_path` matches the parent-specified path
+/// - `replacement_content` is non-empty
+/// - Line range fits within `max_lines`
+/// - `target_path` resolves within the sandbox
+/// - No control characters in `target_path`
+pub fn validate_fix_proposal(
+    proposal: &crate::contracts::FixSliceProposal,
+    original_target_path: &str,
+    max_lines: u32,
+    sandbox_root: &std::path::Path,
+) -> Result<(), String> {
+    // Control character check
+    if proposal.target_path.chars().any(|c| c.is_control()) {
+        return Err("target_path contains control characters".to_string());
+    }
+
+    // Path match check
+    if proposal.target_path != original_target_path {
+        return Err(format!(
+            "target_path mismatch: proposal '{}' != original '{}'",
+            proposal.target_path, original_target_path
+        ));
+    }
+
+    // Sandbox check
+    if resolve_sandbox_path(sandbox_root, &proposal.target_path).is_err() {
+        return Err(format!(
+            "target_path sandbox violation: {}",
+            proposal.target_path
+        ));
+    }
+
+    // Non-empty replacement
+    if proposal.replacement_content.is_empty() {
+        return Err("replacement_content must not be empty".to_string());
+    }
+
+    // Line range within max_lines
+    let span = proposal.end_line.saturating_sub(proposal.start_line) + 1;
+    if span > max_lines {
+        return Err(format!(
+            "line range ({} lines) exceeds max_lines ({})",
+            span, max_lines
+        ));
+    }
+
+    Ok(())
+}
+
+/// Build a `ToolExecutionRequest` for applying a FixSlice proposal via file.rewrite.
+pub fn build_rewrite_request(
+    proposal: &crate::contracts::FixSliceProposal,
+    parent_call_id: &str,
+) -> ToolExecutionRequest {
+    use crate::tooling::{ExecutionClass, PlanModePolicy, RollbackPolicy, ToolSpec};
+    ToolExecutionRequest {
+        spec: ToolSpec {
+            version: 1,
+            name: "file.rewrite".to_string(),
+            kind: ToolKind::FileRewrite,
+            execution_class: ExecutionClass::Mutating,
+            permission_class: PermissionClass::Confirm,
+            execution_mode: ExecutionMode::SequentialOnly,
+            plan_mode: PlanModePolicy::Allowed,
+            rollback_policy: RollbackPolicy::CheckpointBeforeWrite,
+        },
+        input: ToolInput::FileRewrite {
+            path: proposal.target_path.clone(),
+            start_line: proposal.start_line,
+            end_line: proposal.end_line,
+            content: proposal.replacement_content.clone(),
+        },
+        tool_call_id: format!("{parent_call_id}_rewrite"),
+        extra_field_warnings: Vec::new(),
+    }
+}
+
+/// Remove control characters from a string for safe display in summaries.
+fn sanitize_for_display(s: &str) -> String {
+    s.chars()
+        .filter(|c| !c.is_control() || *c == '\n')
+        .collect()
 }
 
 /// Truncate a string to at most `max_chars` Unicode characters, appending

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -503,6 +503,7 @@ impl App {
         // Register sub-agent tools separately (design decision #6, DR1-008)
         tools.register_agent_explore();
         tools.register_agent_plan();
+        tools.register_agent_fix_slice();
         if let Some(ref manager) = mcp_manager {
             let mcp_tools = manager.get_tools();
             for (server_name, tool_list) in &mcp_tools {

--- a/src/config/custom_tools.rs
+++ b/src/config/custom_tools.rs
@@ -19,6 +19,7 @@ const BUILTIN_TOOL_NAMES: &[&str] = &[
     "web.search",
     "agent.explore",
     "agent.plan",
+    "agent.fix_slice",
     "git.status",
     "git.diff",
     "git.log",

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -91,6 +91,29 @@ impl SubAgentPayload {
 }
 
 // ---------------------------------------------------------------------------
+// FixSlice proposal (Issue #291)
+// ---------------------------------------------------------------------------
+
+/// A structured proposal returned by the FixSlice sub-agent.
+///
+/// The sub-agent produces this as its ANVIL_FINAL output; the parent validates
+/// and applies it via the normal `file.rewrite` execution path.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FixSliceProposal {
+    /// Target file path (relative, must match the parent-specified path).
+    pub target_path: String,
+    /// First line of the replacement range (1-based, inclusive).
+    pub start_line: u32,
+    /// Last line of the replacement range (1-based, inclusive).
+    pub end_line: u32,
+    /// The replacement content for the specified line range.
+    pub replacement_content: String,
+    /// Human-readable rationale for the change.
+    #[serde(default)]
+    pub rationale: String,
+}
+
+// ---------------------------------------------------------------------------
 // Completion taxonomy (Issue #255: AgentPhase integration)
 // ---------------------------------------------------------------------------
 

--- a/src/provider/openai.rs
+++ b/src/provider/openai.rs
@@ -226,6 +226,7 @@ fn normalize_openai_tool_name(name: &str) -> String {
         "web_search" => "web.search".to_string(),
         "agent_explore" => "agent.explore".to_string(),
         "agent_plan" => "agent.plan".to_string(),
+        "agent_fix_slice" => "agent.fix_slice".to_string(),
         "git_status" => "git.status".to_string(),
         "git_diff" => "git.diff".to_string(),
         "git_log" => "git.log".to_string(),

--- a/src/tooling/diff.rs
+++ b/src/tooling/diff.rs
@@ -74,7 +74,9 @@ pub fn generate_diff_preview(
         // MCP tools do not have diff previews
         ToolInput::Mcp { .. } => None,
         // Agent tools do not have diff previews
-        ToolInput::AgentExplore { .. } | ToolInput::AgentPlan { .. } => None,
+        ToolInput::AgentExplore { .. }
+        | ToolInput::AgentPlan { .. }
+        | ToolInput::AgentFixSlice { .. } => None,
         _ => None,
     }
 }

--- a/src/tooling/mod.rs
+++ b/src/tooling/mod.rs
@@ -102,6 +102,7 @@ pub enum ToolKind {
     Mcp,
     AgentExplore,
     AgentPlan,
+    AgentFixSlice,
     GitStatus,
     GitDiff,
     GitLog,
@@ -189,6 +190,12 @@ pub enum ToolInput {
         end_line: u32,
         content: String,
     },
+    /// Microtask fix-slice sub-agent (Issue #291).
+    AgentFixSlice {
+        target_path: String,
+        goal: String,
+        max_lines: u32,
+    },
 }
 
 impl ToolInput {
@@ -209,6 +216,7 @@ impl ToolInput {
             Self::GitLog { .. } => ToolKind::GitLog,
             Self::FileEditAnchor { .. } => ToolKind::FileEditAnchor,
             Self::FileRewrite { .. } => ToolKind::FileRewrite,
+            Self::AgentFixSlice { .. } => ToolKind::AgentFixSlice,
         }
     }
 
@@ -387,6 +395,31 @@ impl ToolInput {
                     },
                 })
             }
+            "agent.fix_slice" => {
+                let target_path = value
+                    .get("target_path")
+                    .and_then(serde_json::Value::as_str)
+                    .map(String::from)
+                    .ok_or_else(|| {
+                        "missing target_path in agent.fix_slice tool block".to_string()
+                    })?;
+                let goal = value
+                    .get("goal")
+                    .and_then(serde_json::Value::as_str)
+                    .map(String::from)
+                    .ok_or_else(|| "missing goal in agent.fix_slice tool block".to_string())?;
+                let max_lines = match value.get("max_lines").and_then(serde_json::Value::as_u64) {
+                    Some(v) => u32::try_from(v).map_err(|_| {
+                        format!("max_lines value {v} exceeds u32 range in agent.fix_slice")
+                    })?,
+                    None => 50,
+                };
+                Ok(ToolInput::AgentFixSlice {
+                    target_path,
+                    goal,
+                    max_lines,
+                })
+            }
             "file.rewrite" => {
                 let path = value
                     .get("path")
@@ -492,6 +525,18 @@ impl ToolInput {
                 prompt: extract_simple(block, "prompt")?,
                 scope: extract_simple(block, "scope"),
             }),
+            "agent.fix_slice" => {
+                let target_path = extract_simple(block, "target_path")?;
+                let goal = extract_simple(block, "goal")?;
+                let max_lines = extract_simple(block, "max_lines")
+                    .and_then(|v| v.parse::<u32>().ok())
+                    .unwrap_or(50);
+                Some(ToolInput::AgentFixSlice {
+                    target_path,
+                    goal,
+                    max_lines,
+                })
+            }
             "git.status" => Some(ToolInput::GitStatus {}),
             "git.diff" => Some(ToolInput::GitDiff {
                 path: extract_simple(block, "path"),
@@ -979,6 +1024,25 @@ impl ToolRegistry {
         self.register_git_status();
     }
 
+    /// Register the agent.fix_slice tool (Issue #291).
+    pub fn register_agent_fix_slice(&mut self) {
+        self.register(ToolSpec {
+            version: 1,
+            name: "agent.fix_slice".to_string(),
+            kind: ToolKind::AgentFixSlice,
+            execution_class: ExecutionClass::Mutating,
+            permission_class: PermissionClass::Confirm,
+            execution_mode: ExecutionMode::SequentialOnly,
+            plan_mode: PlanModePolicy::Allowed,
+            rollback_policy: RollbackPolicy::None,
+        });
+    }
+
+    /// Register the subset of tools available to the FixSlice sub-agent (Issue #291).
+    pub fn register_fixslice_tools(&mut self) {
+        self.register_file_read();
+    }
+
     pub fn register_standard_tools(&mut self) {
         self.register_file_read();
         self.register_file_write();
@@ -1440,7 +1504,9 @@ impl LocalToolExecutor {
                 ref content,
             } => self.execute_file_rewrite(&request, path, start_line, end_line, content, started),
             ToolInput::Mcp { .. } => unreachable!("MCP tools are dispatched in agentic.rs"),
-            ToolInput::AgentExplore { .. } | ToolInput::AgentPlan { .. } => {
+            ToolInput::AgentExplore { .. }
+            | ToolInput::AgentPlan { .. }
+            | ToolInput::AgentFixSlice { .. } => {
                 unreachable!("agent tools are dispatched in agentic.rs")
             }
         };
@@ -2983,6 +3049,48 @@ fn validate_required_fields(input: &ToolInput) -> Result<(), ToolValidationError
                         "prompt length {} exceeds maximum of {} characters",
                         prompt.len(),
                         MAX_PROMPT_LENGTH
+                    ),
+                });
+            }
+        }
+        ToolInput::AgentFixSlice {
+            target_path,
+            goal,
+            max_lines,
+        } => {
+            if target_path.trim().is_empty() {
+                return Err(ToolValidationError::MissingRequiredField(
+                    "target_path".to_string(),
+                ));
+            }
+            if target_path.chars().any(|c| c.is_control()) {
+                return Err(ToolValidationError::InvalidFieldValue {
+                    field: "target_path".to_string(),
+                    reason: "target_path must not contain control characters".to_string(),
+                });
+            }
+            if goal.trim().is_empty() {
+                return Err(ToolValidationError::MissingRequiredField(
+                    "goal".to_string(),
+                ));
+            }
+            const MAX_GOAL_LENGTH: usize = 10000;
+            if goal.len() > MAX_GOAL_LENGTH {
+                return Err(ToolValidationError::InvalidFieldValue {
+                    field: "goal".to_string(),
+                    reason: format!(
+                        "goal length {} exceeds maximum of {} characters",
+                        goal.len(),
+                        MAX_GOAL_LENGTH
+                    ),
+                });
+            }
+            if *max_lines < 1 || *max_lines > crate::agent::subagent::MAX_FIXSLICE_LINES {
+                return Err(ToolValidationError::InvalidFieldValue {
+                    field: "max_lines".to_string(),
+                    reason: format!(
+                        "max_lines must be between 1 and {}",
+                        crate::agent::subagent::MAX_FIXSLICE_LINES
                     ),
                 });
             }

--- a/tests/fixslice_subagent.rs
+++ b/tests/fixslice_subagent.rs
@@ -1,0 +1,553 @@
+//! Integration tests for the FixSlice sub-agent (Issue #291).
+
+use anvil::agent::subagent::{
+    FIXSLICE_MAX_ITERATIONS, FIXSLICE_TIMEOUT_SECS, MAX_FIXSLICE_LINES, SubAgentKind,
+};
+use anvil::agent::tag_spec::find_spec;
+use anvil::app::agentic::{build_rewrite_request, validate_fix_proposal};
+use anvil::contracts::FixSliceProposal;
+use anvil::tooling::{
+    ExecutionClass, ExecutionMode, PermissionClass, ToolCallRequest, ToolInput, ToolKind,
+    ToolRegistry, ToolValidationError,
+};
+
+// ---------------------------------------------------------------------------
+// Task 1.1: FixSliceProposal serde
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_fixslice_proposal_serde() {
+    let proposal = FixSliceProposal {
+        target_path: "src/main.rs".to_string(),
+        start_line: 10,
+        end_line: 15,
+        replacement_content: "fn fixed() {}\n".to_string(),
+        rationale: "Fix compilation error".to_string(),
+    };
+
+    let json = serde_json::to_string(&proposal).expect("serialize");
+    let deserialized: FixSliceProposal = serde_json::from_str(&json).expect("deserialize");
+    assert_eq!(proposal, deserialized);
+}
+
+#[test]
+fn test_fixslice_proposal_serde_default_rationale() {
+    // rationale has #[serde(default)], so it can be omitted in JSON
+    let json = r#"{
+        "target_path": "src/lib.rs",
+        "start_line": 1,
+        "end_line": 5,
+        "replacement_content": "new content"
+    }"#;
+    let proposal: FixSliceProposal = serde_json::from_str(json).expect("deserialize");
+    assert_eq!(proposal.target_path, "src/lib.rs");
+    assert_eq!(proposal.start_line, 1);
+    assert_eq!(proposal.end_line, 5);
+    assert_eq!(proposal.replacement_content, "new content");
+    assert_eq!(proposal.rationale, ""); // default
+}
+
+// ---------------------------------------------------------------------------
+// Task 2.1: ToolRegistry
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_fixslice_tool_registry() {
+    let mut registry = ToolRegistry::new();
+    registry.register_fixslice_tools();
+
+    // file.read should be registered
+    assert!(
+        registry.get("file.read").is_some(),
+        "file.read should be registered for FixSlice worker"
+    );
+
+    // Other tools should NOT be registered
+    assert!(registry.get("file.write").is_none());
+    assert!(registry.get("file.edit").is_none());
+    assert!(registry.get("file.search").is_none());
+    assert!(registry.get("shell.exec").is_none());
+    assert!(registry.get("agent.explore").is_none());
+    assert!(registry.get("agent.plan").is_none());
+}
+
+#[test]
+fn test_fixslice_permission_class_confirm() {
+    let mut registry = ToolRegistry::new();
+    registry.register_agent_fix_slice();
+
+    let spec = registry
+        .get("agent.fix_slice")
+        .expect("agent.fix_slice should be registered");
+    assert_eq!(spec.kind, ToolKind::AgentFixSlice);
+    assert_eq!(spec.execution_class, ExecutionClass::Mutating);
+    assert_eq!(spec.permission_class, PermissionClass::Confirm);
+    assert_eq!(spec.execution_mode, ExecutionMode::SequentialOnly);
+}
+
+// ---------------------------------------------------------------------------
+// Task 2.3: Budget defaults
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_fixslice_config_defaults() {
+    assert_eq!(FIXSLICE_MAX_ITERATIONS, 3);
+    assert_eq!(FIXSLICE_TIMEOUT_SECS, 60);
+    assert_eq!(MAX_FIXSLICE_LINES, 200);
+}
+
+// ---------------------------------------------------------------------------
+// Task 1.2: SubAgentKind::FixSlice
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_fixslice_subagent_kind_from_tool_input() {
+    let input = ToolInput::AgentFixSlice {
+        target_path: "src/main.rs".to_string(),
+        goal: "fix bug".to_string(),
+        max_lines: 50,
+    };
+    assert_eq!(
+        SubAgentKind::from_tool_input(&input),
+        Some(SubAgentKind::FixSlice)
+    );
+
+    // Explore/Plan should still work
+    let explore = ToolInput::AgentExplore {
+        prompt: "test".to_string(),
+        scope: None,
+    };
+    assert_eq!(
+        SubAgentKind::from_tool_input(&explore),
+        Some(SubAgentKind::Explore)
+    );
+
+    // Non-agent tools should return None
+    let read = ToolInput::FileRead {
+        path: "test".to_string(),
+    };
+    assert_eq!(SubAgentKind::from_tool_input(&read), None);
+}
+
+// ---------------------------------------------------------------------------
+// Task 1.3: ToolInput from_json
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_fixslice_json_parse() {
+    let value = serde_json::json!({
+        "target_path": "src/main.rs",
+        "goal": "fix the compilation error",
+        "max_lines": 100
+    });
+    let input = ToolInput::from_json("agent.fix_slice", &value).expect("parse should succeed");
+    match input {
+        ToolInput::AgentFixSlice {
+            target_path,
+            goal,
+            max_lines,
+        } => {
+            assert_eq!(target_path, "src/main.rs");
+            assert_eq!(goal, "fix the compilation error");
+            assert_eq!(max_lines, 100);
+        }
+        _ => panic!("expected AgentFixSlice"),
+    }
+}
+
+#[test]
+fn test_fixslice_json_parse_default_max_lines() {
+    let value = serde_json::json!({
+        "target_path": "src/main.rs",
+        "goal": "fix bug"
+    });
+    let input = ToolInput::from_json("agent.fix_slice", &value).expect("parse should succeed");
+    match input {
+        ToolInput::AgentFixSlice { max_lines, .. } => {
+            assert_eq!(max_lines, 50, "default max_lines should be 50");
+        }
+        _ => panic!("expected AgentFixSlice"),
+    }
+}
+
+#[test]
+fn test_fixslice_json_parse_missing_target_path() {
+    let value = serde_json::json!({
+        "goal": "fix bug"
+    });
+    let err = ToolInput::from_json("agent.fix_slice", &value).unwrap_err();
+    assert!(err.contains("missing target_path"));
+}
+
+#[test]
+fn test_fixslice_json_parse_missing_goal() {
+    let value = serde_json::json!({
+        "target_path": "src/main.rs"
+    });
+    let err = ToolInput::from_json("agent.fix_slice", &value).unwrap_err();
+    assert!(err.contains("missing goal"));
+}
+
+// ---------------------------------------------------------------------------
+// Task 3.2: Validation
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_fixslice_validation_good_proposal() {
+    let tmp = tempfile::tempdir().unwrap();
+    let sandbox_root = tmp.path();
+    // Create target directory and file
+    std::fs::create_dir_all(sandbox_root.join("src")).unwrap();
+    std::fs::write(sandbox_root.join("src/main.rs"), "line1\nline2\nline3\n").unwrap();
+
+    let proposal = FixSliceProposal {
+        target_path: "src/main.rs".to_string(),
+        start_line: 1,
+        end_line: 2,
+        replacement_content: "fixed\n".to_string(),
+        rationale: "fix bug".to_string(),
+    };
+
+    let result = validate_fix_proposal(&proposal, "src/main.rs", 50, sandbox_root);
+    assert!(result.is_ok(), "valid proposal should pass: {:?}", result);
+}
+
+#[test]
+fn test_fixslice_validation_bad_lines() {
+    let tmp = tempfile::tempdir().unwrap();
+    let sandbox_root = tmp.path();
+
+    let proposal = FixSliceProposal {
+        target_path: "src/main.rs".to_string(),
+        start_line: 1,
+        end_line: 100,
+        replacement_content: "fixed\n".to_string(),
+        rationale: "".to_string(),
+    };
+
+    // max_lines = 50, but range is 100 lines
+    let result = validate_fix_proposal(&proposal, "src/main.rs", 50, sandbox_root);
+    assert!(result.is_err());
+    assert!(result.unwrap_err().contains("exceeds max_lines"));
+}
+
+#[test]
+fn test_fixslice_sandbox_violation() {
+    let tmp = tempfile::tempdir().unwrap();
+    let sandbox_root = tmp.path();
+
+    let proposal = FixSliceProposal {
+        target_path: "../../../etc/passwd".to_string(),
+        start_line: 1,
+        end_line: 2,
+        replacement_content: "hacked\n".to_string(),
+        rationale: "".to_string(),
+    };
+
+    let result = validate_fix_proposal(&proposal, "../../../etc/passwd", 50, sandbox_root);
+    assert!(result.is_err());
+    assert!(result.unwrap_err().contains("sandbox violation"));
+}
+
+#[test]
+fn test_fixslice_control_char_rejected() {
+    let tmp = tempfile::tempdir().unwrap();
+    let sandbox_root = tmp.path();
+
+    let proposal = FixSliceProposal {
+        target_path: "src/main\0.rs".to_string(),
+        start_line: 1,
+        end_line: 2,
+        replacement_content: "fixed\n".to_string(),
+        rationale: "".to_string(),
+    };
+
+    let result = validate_fix_proposal(&proposal, "src/main\0.rs", 50, sandbox_root);
+    assert!(result.is_err());
+    assert!(result.unwrap_err().contains("control characters"));
+}
+
+#[test]
+fn test_fixslice_target_path_mismatch() {
+    let tmp = tempfile::tempdir().unwrap();
+    let sandbox_root = tmp.path();
+
+    let proposal = FixSliceProposal {
+        target_path: "src/other.rs".to_string(),
+        start_line: 1,
+        end_line: 2,
+        replacement_content: "fixed\n".to_string(),
+        rationale: "".to_string(),
+    };
+
+    let result = validate_fix_proposal(&proposal, "src/main.rs", 50, sandbox_root);
+    assert!(result.is_err());
+    assert!(result.unwrap_err().contains("mismatch"));
+}
+
+#[test]
+fn test_fixslice_empty_replacement_content() {
+    let tmp = tempfile::tempdir().unwrap();
+    let sandbox_root = tmp.path();
+
+    let proposal = FixSliceProposal {
+        target_path: "src/main.rs".to_string(),
+        start_line: 1,
+        end_line: 2,
+        replacement_content: "".to_string(),
+        rationale: "".to_string(),
+    };
+
+    let result = validate_fix_proposal(&proposal, "src/main.rs", 50, sandbox_root);
+    assert!(result.is_err());
+    assert!(result.unwrap_err().contains("must not be empty"));
+}
+
+// ---------------------------------------------------------------------------
+// Task 3.2: build_rewrite_request
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_fixslice_build_rewrite_request() {
+    let proposal = FixSliceProposal {
+        target_path: "src/main.rs".to_string(),
+        start_line: 10,
+        end_line: 15,
+        replacement_content: "new code\n".to_string(),
+        rationale: "fix bug".to_string(),
+    };
+
+    let request = build_rewrite_request(&proposal, "call_001");
+    assert_eq!(request.spec.name, "file.rewrite");
+    assert_eq!(request.spec.kind, ToolKind::FileRewrite);
+    assert_eq!(request.tool_call_id, "call_001_rewrite");
+    match &request.input {
+        ToolInput::FileRewrite {
+            path,
+            start_line,
+            end_line,
+            content,
+        } => {
+            assert_eq!(path, "src/main.rs");
+            assert_eq!(*start_line, 10);
+            assert_eq!(*end_line, 15);
+            assert_eq!(content, "new code\n");
+        }
+        _ => panic!("expected FileRewrite input"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// No replacement_content in failure summary
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_fixslice_no_replacement_content_in_failure() {
+    let tmp = tempfile::tempdir().unwrap();
+    let sandbox_root = tmp.path();
+
+    let proposal = FixSliceProposal {
+        target_path: "src/other.rs".to_string(), // mismatch
+        start_line: 1,
+        end_line: 2,
+        replacement_content: "SECRET_CONTENT_SHOULD_NOT_LEAK".to_string(),
+        rationale: "".to_string(),
+    };
+
+    let err = validate_fix_proposal(&proposal, "src/main.rs", 50, sandbox_root).unwrap_err();
+    assert!(
+        !err.contains("SECRET_CONTENT_SHOULD_NOT_LEAK"),
+        "replacement_content should not appear in error message"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Task 4.1: Tag spec and parser
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_fixslice_tag_spec() {
+    let spec = find_spec("agent.fix_slice").expect("agent.fix_slice should be in TOOL_TAG_SPECS");
+    assert_eq!(spec.name, "agent.fix_slice");
+    assert_eq!(spec.attributes, &["target_path", "max_lines"]);
+    assert_eq!(spec.child_elements, &["goal"]);
+    assert!(!spec.example.is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// Task 2.2: System prompt
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_fixslice_system_prompt_contents() {
+    use anvil::agent::subagent::{SubAgentPromptOptions, build_subagent_system_prompt};
+
+    let opts = SubAgentPromptOptions {
+        offline: false,
+        ui_language: None,
+    };
+    let prompt = build_subagent_system_prompt(&SubAgentKind::FixSlice, &opts);
+
+    assert!(
+        prompt.contains("ANVIL_FINAL"),
+        "FixSlice prompt should mention ANVIL_FINAL"
+    );
+    assert!(
+        prompt.contains("start_line"),
+        "FixSlice prompt should mention start_line"
+    );
+    assert!(
+        prompt.contains("end_line"),
+        "FixSlice prompt should mention end_line"
+    );
+    assert!(
+        prompt.contains("target_path"),
+        "FixSlice prompt should mention target_path"
+    );
+    assert!(
+        prompt.contains("replacement_content"),
+        "FixSlice prompt should mention replacement_content"
+    );
+    assert!(
+        prompt.contains("file.read"),
+        "FixSlice prompt should describe file.read tool"
+    );
+    assert!(
+        prompt.contains("FixSlice"),
+        "FixSlice prompt should mention FixSlice role"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Validation via ToolRegistry
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_fixslice_validation_empty_target_path() {
+    let mut registry = ToolRegistry::new();
+    registry.register_agent_fix_slice();
+
+    let call = ToolCallRequest::new(
+        "call_001",
+        "agent.fix_slice",
+        ToolInput::AgentFixSlice {
+            target_path: "".to_string(),
+            goal: "fix bug".to_string(),
+            max_lines: 50,
+        },
+    );
+
+    let err = registry.validate(call).unwrap_err();
+    assert_eq!(
+        err,
+        ToolValidationError::MissingRequiredField("target_path".to_string())
+    );
+}
+
+#[test]
+fn test_fixslice_validation_empty_goal() {
+    let mut registry = ToolRegistry::new();
+    registry.register_agent_fix_slice();
+
+    let call = ToolCallRequest::new(
+        "call_001",
+        "agent.fix_slice",
+        ToolInput::AgentFixSlice {
+            target_path: "src/main.rs".to_string(),
+            goal: "".to_string(),
+            max_lines: 50,
+        },
+    );
+
+    let err = registry.validate(call).unwrap_err();
+    assert_eq!(
+        err,
+        ToolValidationError::MissingRequiredField("goal".to_string())
+    );
+}
+
+#[test]
+fn test_fixslice_validation_max_lines_zero() {
+    let mut registry = ToolRegistry::new();
+    registry.register_agent_fix_slice();
+
+    let call = ToolCallRequest::new(
+        "call_001",
+        "agent.fix_slice",
+        ToolInput::AgentFixSlice {
+            target_path: "src/main.rs".to_string(),
+            goal: "fix bug".to_string(),
+            max_lines: 0,
+        },
+    );
+
+    let err = registry.validate(call).unwrap_err();
+    match err {
+        ToolValidationError::InvalidFieldValue { field, .. } => {
+            assert_eq!(field, "max_lines");
+        }
+        _ => panic!("expected InvalidFieldValue for max_lines"),
+    }
+}
+
+#[test]
+fn test_fixslice_validation_max_lines_exceeds_limit() {
+    let mut registry = ToolRegistry::new();
+    registry.register_agent_fix_slice();
+
+    let call = ToolCallRequest::new(
+        "call_001",
+        "agent.fix_slice",
+        ToolInput::AgentFixSlice {
+            target_path: "src/main.rs".to_string(),
+            goal: "fix bug".to_string(),
+            max_lines: MAX_FIXSLICE_LINES + 1,
+        },
+    );
+
+    let err = registry.validate(call).unwrap_err();
+    match err {
+        ToolValidationError::InvalidFieldValue { field, .. } => {
+            assert_eq!(field, "max_lines");
+        }
+        _ => panic!("expected InvalidFieldValue for max_lines"),
+    }
+}
+
+#[test]
+fn test_fixslice_validation_control_char_in_target_path() {
+    let mut registry = ToolRegistry::new();
+    registry.register_agent_fix_slice();
+
+    let call = ToolCallRequest::new(
+        "call_001",
+        "agent.fix_slice",
+        ToolInput::AgentFixSlice {
+            target_path: "src/main\x00.rs".to_string(),
+            goal: "fix bug".to_string(),
+            max_lines: 50,
+        },
+    );
+
+    let err = registry.validate(call).unwrap_err();
+    match err {
+        ToolValidationError::InvalidFieldValue { field, .. } => {
+            assert_eq!(field, "target_path");
+        }
+        _ => panic!("expected InvalidFieldValue for target_path"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ToolInput::kind() mapping
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_fixslice_tool_kind_mapping() {
+    let input = ToolInput::AgentFixSlice {
+        target_path: "src/main.rs".to_string(),
+        goal: "fix bug".to_string(),
+        max_lines: 50,
+    };
+    assert_eq!(input.kind(), ToolKind::AgentFixSlice);
+}

--- a/tests/tag_spec_system.rs
+++ b/tests/tag_spec_system.rs
@@ -3,8 +3,8 @@
 use anvil::agent::tag_spec::{TOOL_TAG_SPECS, find_spec};
 
 #[test]
-fn tool_tag_specs_has_eleven_entries() {
-    assert_eq!(TOOL_TAG_SPECS.len(), 11);
+fn tool_tag_specs_has_twelve_entries() {
+    assert_eq!(TOOL_TAG_SPECS.len(), 12);
 }
 
 #[test]

--- a/tests/tooling_system.rs
+++ b/tests/tooling_system.rs
@@ -3043,6 +3043,7 @@ fn subagent_result_into_tool_execution_result_json_payload() {
         },
         estimated_tokens: 100,
         iterations_used: 2,
+        fix_proposal: None,
     };
 
     let tool_result = result.into_tool_execution_result(&call);
@@ -3079,6 +3080,7 @@ fn subagent_result_timeout_into_tool_execution_result() {
         payload: SubAgentPayload::fallback("partial work".to_string(), TerminationReason::Timeout),
         estimated_tokens: 0,
         iterations_used: 5,
+        fix_proposal: None,
     };
 
     let tool_result = result.into_tool_execution_result(&call);


### PR DESCRIPTION
## Summary

- Add `agent.fix_slice` microtask sub-agent with parent-applies-change contract
- FixSlice worker runs a constrained LLM loop producing a structured `FixSliceProposal`
- Parent applies the proposal via `file.rewrite`, maintaining full mutation control

## Changes

| File | Description |
|------|-------------|
| `src/agent/subagent.rs` | `SubAgentKind::FixSlice`, dedicated system prompt, budget |
| `src/contracts/mod.rs` | `FixSliceProposal` struct |
| `src/app/agentic.rs` | `agent.fix_slice` execution, proposal parsing, `file.rewrite` application |
| `src/agent/mod.rs` | Tool definition for JSON protocol |
| `src/agent/tag_spec.rs` | Tag spec for tag-based protocol |
| `src/tooling/mod.rs` | Validation and integration |
| `tests/fixslice_subagent.rs` | Integration tests |

## Test plan

- [x] `cargo fmt --check` — no diff
- [x] `cargo clippy --all-targets` — 0 warnings
- [x] `cargo test` — all tests pass

Fixes #291

🤖 Generated with [Claude Code](https://claude.com/claude-code)