### PR TITLE
fix(issue-321): add reactive fix_slice escalation from repeated edit failures

### DIFF
--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -2160,6 +2160,23 @@ impl App {
                                 ));
                             }
                         }
+                        crate::app::edit_fail_tracker::EditFallbackAction::FixSliceEscalation => {
+                            tracing::warn!(
+                                tool = "file.edit",
+                                path = %path,
+                                count = count,
+                                "fixslice_escalation_triggered"
+                            );
+                            self.agent_telemetry.record_fixslice_escalation();
+                            edit_hint = Some(format!(
+                                "\n\n[Anvil ESCALATION] file.edit has failed {count} consecutive \
+                                 times for '{path}'. You MUST use agent.fix_slice to repair this \
+                                 file. Call agent.fix_slice with target_path=\"{path}\" and a goal \
+                                 describing what needs to be changed. The fix_slice worker will \
+                                 read the file, produce a bounded replacement, and apply it. \
+                                 Do NOT retry file.edit on this path — use agent.fix_slice now."
+                            ));
+                        }
                     }
                 }
             } else if result.status == ToolExecutionStatus::Completed {

--- a/src/app/edit_fail_tracker.rs
+++ b/src/app/edit_fail_tracker.rs
@@ -33,7 +33,7 @@ impl FromStr for EditStrategy {
     }
 }
 
-/// Recommended action after a file.edit failure (Issue #158).
+/// Recommended action after a file.edit failure (Issue #158, #321).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum EditFallbackAction {
     /// Normal continuation (failure count < reread_threshold).
@@ -42,17 +42,22 @@ pub enum EditFallbackAction {
     ReRead,
     /// Recommend switching to file.write.
     WriteFallback,
+    /// Escalate to agent.fix_slice for bounded single-file repair (Issue #321).
+    FixSliceEscalation,
 }
 
 /// Determine the fallback action based on failure count and thresholds.
 ///
 /// Separated from `EditFailTracker` to maintain SRP (counter vs policy).
-pub(crate) fn determine_fallback_action(
+pub fn determine_fallback_action(
     count: u32,
     reread_threshold: u32,
     write_fallback_threshold: u32,
+    fixslice_threshold: u32,
 ) -> EditFallbackAction {
-    if count >= write_fallback_threshold {
+    if fixslice_threshold > 0 && count >= fixslice_threshold {
+        EditFallbackAction::FixSliceEscalation
+    } else if count >= write_fallback_threshold {
         EditFallbackAction::WriteFallback
     } else if count >= reread_threshold {
         EditFallbackAction::ReRead
@@ -63,40 +68,53 @@ pub(crate) fn determine_fallback_action(
 
 /// Tracks consecutive file.edit failures per file path.
 /// Used to detect when the LLM is stuck retrying edits on the same file
-/// and should be prompted to try an alternative approach (Issue #158).
-pub(crate) struct EditFailTracker {
+/// and should be prompted to try an alternative approach (Issue #158, #321).
+pub struct EditFailTracker {
     consecutive_failures: HashMap<String, u32>,
     reread_threshold: u32,
     write_fallback_threshold: u32,
+    /// Threshold for escalating to agent.fix_slice (Issue #321).
+    /// 0 = disabled.
+    fixslice_threshold: u32,
 }
 
 impl EditFailTracker {
-    pub(crate) fn new(reread_threshold: u32, write_fallback_threshold: u32) -> Self {
+    pub fn new(
+        reread_threshold: u32,
+        write_fallback_threshold: u32,
+        fixslice_threshold: u32,
+    ) -> Self {
         Self {
             consecutive_failures: HashMap::new(),
             reread_threshold,
             write_fallback_threshold,
+            fixslice_threshold,
         }
     }
 
     /// Record a file.edit failure for the given path.
     /// Returns the recommended fallback action based on the cumulative failure count.
-    pub(crate) fn record_failure(&mut self, path: &str) -> EditFallbackAction {
+    pub fn record_failure(&mut self, path: &str) -> EditFallbackAction {
         let count = self
             .consecutive_failures
             .entry(path.to_string())
             .or_insert(0);
         *count += 1;
-        determine_fallback_action(*count, self.reread_threshold, self.write_fallback_threshold)
+        determine_fallback_action(
+            *count,
+            self.reread_threshold,
+            self.write_fallback_threshold,
+            self.fixslice_threshold,
+        )
     }
 
     /// Record a successful file.edit, resetting the failure count for that path.
-    pub(crate) fn record_success(&mut self, path: &str) {
+    pub fn record_success(&mut self, path: &str) {
         self.consecutive_failures.remove(path);
     }
 
     /// Get the current failure count for a path.
-    pub(crate) fn failure_count(&self, path: &str) -> u32 {
+    pub fn failure_count(&self, path: &str) -> u32 {
         self.consecutive_failures.get(path).copied().unwrap_or(0)
     }
 }
@@ -143,38 +161,59 @@ mod tests {
 
     #[test]
     fn test_determine_fallback_action() {
-        // N=3, M=5
+        // N=3, M=5, fixslice=0 (disabled)
         assert_eq!(
-            determine_fallback_action(0, 3, 5),
+            determine_fallback_action(0, 3, 5, 0),
             EditFallbackAction::Continue
         );
         assert_eq!(
-            determine_fallback_action(1, 3, 5),
+            determine_fallback_action(1, 3, 5, 0),
             EditFallbackAction::Continue
         );
         assert_eq!(
-            determine_fallback_action(2, 3, 5),
+            determine_fallback_action(2, 3, 5, 0),
             EditFallbackAction::Continue
         );
         assert_eq!(
-            determine_fallback_action(3, 3, 5),
+            determine_fallback_action(3, 3, 5, 0),
             EditFallbackAction::ReRead
         );
         assert_eq!(
-            determine_fallback_action(4, 3, 5),
+            determine_fallback_action(4, 3, 5, 0),
             EditFallbackAction::ReRead
         );
         assert_eq!(
-            determine_fallback_action(5, 3, 5),
+            determine_fallback_action(5, 3, 5, 0),
             EditFallbackAction::WriteFallback
         );
         assert_eq!(
-            determine_fallback_action(6, 3, 5),
+            determine_fallback_action(6, 3, 5, 0),
             EditFallbackAction::WriteFallback
         );
         assert_eq!(
-            determine_fallback_action(100, 3, 5),
+            determine_fallback_action(100, 3, 5, 0),
             EditFallbackAction::WriteFallback
+        );
+    }
+
+    #[test]
+    fn test_determine_fallback_action_fixslice_escalation() {
+        // N=3, M=5, fixslice=7
+        assert_eq!(
+            determine_fallback_action(5, 3, 5, 7),
+            EditFallbackAction::WriteFallback
+        );
+        assert_eq!(
+            determine_fallback_action(6, 3, 5, 7),
+            EditFallbackAction::WriteFallback
+        );
+        assert_eq!(
+            determine_fallback_action(7, 3, 5, 7),
+            EditFallbackAction::FixSliceEscalation
+        );
+        assert_eq!(
+            determine_fallback_action(10, 3, 5, 7),
+            EditFallbackAction::FixSliceEscalation
         );
     }
 
@@ -182,7 +221,7 @@ mod tests {
 
     #[test]
     fn test_tracker_basic_flow() {
-        let mut tracker = EditFailTracker::new(3, 5);
+        let mut tracker = EditFailTracker::new(3, 5, 0);
 
         // 1st and 2nd failure: Continue
         assert_eq!(
@@ -208,7 +247,7 @@ mod tests {
 
     #[test]
     fn test_tracker_success_resets() {
-        let mut tracker = EditFailTracker::new(3, 5);
+        let mut tracker = EditFailTracker::new(3, 5, 0);
 
         tracker.record_failure("foo.rs");
         tracker.record_failure("foo.rs");
@@ -224,7 +263,7 @@ mod tests {
 
     #[test]
     fn test_tracker_independent_paths() {
-        let mut tracker = EditFailTracker::new(3, 5);
+        let mut tracker = EditFailTracker::new(3, 5, 0);
 
         tracker.record_failure("foo.rs");
         assert_eq!(
@@ -245,7 +284,7 @@ mod tests {
 
     #[test]
     fn test_tracker_custom_thresholds() {
-        let mut tracker = EditFailTracker::new(2, 4);
+        let mut tracker = EditFailTracker::new(2, 4, 0);
         assert_eq!(tracker.record_failure("a.rs"), EditFallbackAction::Continue); // 1st
         assert_eq!(tracker.record_failure("a.rs"), EditFallbackAction::ReRead); // 2nd = reread
         assert_eq!(tracker.record_failure("a.rs"), EditFallbackAction::ReRead); // 3rd
@@ -257,11 +296,11 @@ mod tests {
 
     #[test]
     fn test_tracker_write_fallback_persists() {
-        let mut tracker = EditFailTracker::new(3, 5);
+        let mut tracker = EditFailTracker::new(3, 5, 0);
         for _ in 0..5 {
             tracker.record_failure("a.rs");
         }
-        // Beyond threshold, still WriteFallback
+        // Beyond threshold, still WriteFallback (fixslice disabled)
         assert_eq!(
             tracker.record_failure("a.rs"),
             EditFallbackAction::WriteFallback
@@ -271,5 +310,56 @@ mod tests {
             EditFallbackAction::WriteFallback
         );
         assert_eq!(tracker.failure_count("a.rs"), 7);
+    }
+
+    // --- FixSlice escalation tests (Issue #321) ---
+
+    #[test]
+    fn test_tracker_fixslice_escalation() {
+        // reread=3, write_fallback=5, fixslice=7
+        let mut tracker = EditFailTracker::new(3, 5, 7);
+
+        // 1-2: Continue
+        assert_eq!(tracker.record_failure("a.rs"), EditFallbackAction::Continue);
+        assert_eq!(tracker.record_failure("a.rs"), EditFallbackAction::Continue);
+        // 3-4: ReRead
+        assert_eq!(tracker.record_failure("a.rs"), EditFallbackAction::ReRead);
+        assert_eq!(tracker.record_failure("a.rs"), EditFallbackAction::ReRead);
+        // 5-6: WriteFallback
+        assert_eq!(
+            tracker.record_failure("a.rs"),
+            EditFallbackAction::WriteFallback
+        );
+        assert_eq!(
+            tracker.record_failure("a.rs"),
+            EditFallbackAction::WriteFallback
+        );
+        // 7+: FixSliceEscalation
+        assert_eq!(
+            tracker.record_failure("a.rs"),
+            EditFallbackAction::FixSliceEscalation
+        );
+        assert_eq!(tracker.failure_count("a.rs"), 7);
+        // Persists beyond threshold
+        assert_eq!(
+            tracker.record_failure("a.rs"),
+            EditFallbackAction::FixSliceEscalation
+        );
+    }
+
+    #[test]
+    fn test_tracker_fixslice_escalation_resets_on_success() {
+        let mut tracker = EditFailTracker::new(3, 5, 7);
+        for _ in 0..7 {
+            tracker.record_failure("a.rs");
+        }
+        assert_eq!(
+            tracker.record_failure("a.rs"),
+            EditFallbackAction::FixSliceEscalation
+        );
+
+        tracker.record_success("a.rs");
+        assert_eq!(tracker.failure_count("a.rs"), 0);
+        assert_eq!(tracker.record_failure("a.rs"), EditFallbackAction::Continue);
     }
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -7,7 +7,7 @@ pub mod agentic;
 pub mod alternating_loop_detector;
 pub mod cli;
 mod context;
-pub(crate) mod edit_fail_tracker;
+pub mod edit_fail_tracker;
 pub(crate) mod execution_plan;
 pub mod loop_detector;
 pub mod mock;
@@ -573,6 +573,7 @@ impl App {
         let read_transition_reinject_interval = config.runtime.read_transition_reinject_interval;
         let edit_reread_threshold = config.runtime.edit_reread_threshold;
         let edit_write_fallback_threshold = config.runtime.edit_write_fallback_threshold;
+        let edit_fixslice_threshold = config.runtime.edit_fixslice_threshold;
         let read_repeat_warn = config.runtime.read_repeat_warn_threshold;
         let read_repeat_strong_warn = config.runtime.read_repeat_strong_warn_threshold;
         let edit_recovery_read_budget = config.runtime.edit_recovery_read_budget;
@@ -608,6 +609,7 @@ impl App {
             edit_fail_tracker: edit_fail_tracker::EditFailTracker::new(
                 edit_reread_threshold,
                 edit_write_fallback_threshold,
+                edit_fixslice_threshold,
             ),
             phase_estimator: phase_estimator::PhaseEstimator::new(
                 phase_explore,
@@ -967,6 +969,7 @@ impl App {
                 no_op_mutation_count = tel.no_op_mutation_count,
                 rolled_back_mutation_count = tel.rolled_back_mutation_count,
                 initial_plan_miss_count = tel.initial_plan_miss_count,
+                fixslice_escalation_count = tel.fixslice_escalation_count,
                 "agent telemetry"
             );
         }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -183,6 +183,9 @@ pub struct RuntimeConfig {
     pub edit_reread_threshold: u32,
     /// Consecutive edit failures before write fallback hint (Issue #158).
     pub edit_write_fallback_threshold: u32,
+    /// Consecutive edit failures before agent.fix_slice escalation (Issue #321).
+    /// 0 = disabled.
+    pub edit_fixslice_threshold: u32,
     /// Maximum line count for file.write on existing files (0 = disabled, Issue #156).
     pub safe_write_max_lines: usize,
     /// Deletion ratio threshold for diff warning (0.0-1.0, Issue #156).
@@ -379,6 +382,7 @@ impl EffectiveConfig {
                 edit_strategy: crate::app::edit_fail_tracker::EditStrategy::EditFirst,
                 edit_reread_threshold: 3,
                 edit_write_fallback_threshold: 5,
+                edit_fixslice_threshold: 7,
                 safe_write_max_lines: 500,
                 safe_write_deletion_ratio: 0.5,
                 read_repeat_warn_threshold: 3,
@@ -863,6 +867,15 @@ impl EffectiveConfig {
                     }
                     self.runtime.edit_write_fallback_threshold = v;
                 }
+                "edit_fixslice_threshold" | "ANVIL_EDIT_FIXSLICE_THRESHOLD" => {
+                    let v: u32 = value
+                        .parse()
+                        .map_err(|_| ConfigError::InvalidNumericValue(value.clone()))?;
+                    if v > 20 {
+                        return Err(ConfigError::InvalidNumericValue(value.clone()));
+                    }
+                    self.runtime.edit_fixslice_threshold = v;
+                }
                 "edit_recovery_read_budget" | "ANVIL_EDIT_RECOVERY_READ_BUDGET" => {
                     let v: u32 = value
                         .parse()
@@ -1159,6 +1172,15 @@ impl EffectiveConfig {
         // Ensure write_fallback > reread
         if self.runtime.edit_write_fallback_threshold <= self.runtime.edit_reread_threshold {
             self.runtime.edit_write_fallback_threshold = self.runtime.edit_reread_threshold + 2;
+        }
+        // Issue #321: clamp fixslice threshold (0 = disabled, otherwise must be > write_fallback)
+        if self.runtime.edit_fixslice_threshold > 0 {
+            self.runtime.edit_fixslice_threshold =
+                self.runtime.edit_fixslice_threshold.clamp(1, 20);
+            if self.runtime.edit_fixslice_threshold <= self.runtime.edit_write_fallback_threshold {
+                self.runtime.edit_fixslice_threshold =
+                    self.runtime.edit_write_fallback_threshold + 2;
+            }
         }
         self.runtime.edit_recovery_read_budget =
             self.runtime.edit_recovery_read_budget.clamp(1, 10);
@@ -1520,6 +1542,7 @@ impl std::fmt::Debug for RuntimeConfig {
                 "edit_write_fallback_threshold",
                 &self.edit_write_fallback_threshold,
             )
+            .field("edit_fixslice_threshold", &self.edit_fixslice_threshold)
             .field("safe_write_max_lines", &self.safe_write_max_lines)
             .field("safe_write_deletion_ratio", &self.safe_write_deletion_ratio)
             .field("edit_recovery_read_budget", &self.edit_recovery_read_budget)

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -278,6 +278,10 @@ pub struct AgentTelemetry {
     /// None if no mutation occurred during the session.
     #[serde(default)]
     pub first_mutation_event_tool: Option<String>,
+
+    /// Number of times fix_slice escalation was triggered (Issue #321).
+    #[serde(default)]
+    pub fixslice_escalation_count: u32,
 }
 
 impl AgentTelemetry {
@@ -371,6 +375,11 @@ impl AgentTelemetry {
     /// Record an ANVIL_FINAL suppression with remaining core targets.
     pub fn record_final_suppressed_with_remaining_targets(&mut self) {
         self.final_suppressed_with_remaining_targets_count += 1;
+    }
+
+    /// Record a fix_slice escalation event (Issue #321).
+    pub fn record_fixslice_escalation(&mut self) {
+        self.fixslice_escalation_count += 1;
     }
 
     /// Threshold: mutations after this turn are considered "late".

--- a/tests/fixslice_escalation.rs
+++ b/tests/fixslice_escalation.rs
@@ -1,0 +1,248 @@
+//! Integration tests for Issue #321: fix_slice escalation path.
+//!
+//! Tests that repeated single-file edit failures escalate to
+//! agent.fix_slice via EditFallbackAction::FixSliceEscalation.
+
+use anvil::app::edit_fail_tracker::{
+    EditFailTracker, EditFallbackAction, determine_fallback_action,
+};
+use anvil::app::stagnation_state::{StagnationState, compute_stagnation_score};
+use anvil::contracts::AgentTelemetry;
+
+// ============================================================
+// Test 1: config default for edit_fixslice_threshold
+// ============================================================
+
+#[test]
+fn test_fixslice_threshold_config_default() {
+    let config = anvil::config::EffectiveConfig::default_for_test().unwrap();
+    assert_eq!(
+        config.runtime.edit_fixslice_threshold, 7,
+        "default fixslice threshold should be 7"
+    );
+}
+
+#[test]
+fn test_fixslice_threshold_config_clamp_must_exceed_write_fallback() {
+    let mut config = anvil::config::EffectiveConfig::default_for_test().unwrap();
+    // Set fixslice to same as write_fallback (5) — should be bumped to write_fallback + 2
+    config.runtime.edit_fixslice_threshold = 5;
+    assert!(config.validate_for_test().is_ok());
+    assert!(
+        config.runtime.edit_fixslice_threshold > config.runtime.edit_write_fallback_threshold,
+        "fixslice threshold ({}) must be > write_fallback threshold ({})",
+        config.runtime.edit_fixslice_threshold,
+        config.runtime.edit_write_fallback_threshold,
+    );
+}
+
+#[test]
+fn test_fixslice_threshold_config_zero_disables() {
+    let mut config = anvil::config::EffectiveConfig::default_for_test().unwrap();
+    config.runtime.edit_fixslice_threshold = 0;
+    assert!(config.validate_for_test().is_ok());
+    assert_eq!(
+        config.runtime.edit_fixslice_threshold, 0,
+        "0 should remain 0 (disabled)"
+    );
+}
+
+// ============================================================
+// Test 2: determine_fallback_action escalation chain
+// ============================================================
+
+#[test]
+fn test_escalation_chain_with_fixslice() {
+    // reread=3, write_fallback=5, fixslice=7
+    // Verify the complete escalation chain
+    assert_eq!(
+        determine_fallback_action(1, 3, 5, 7),
+        EditFallbackAction::Continue
+    );
+    assert_eq!(
+        determine_fallback_action(3, 3, 5, 7),
+        EditFallbackAction::ReRead
+    );
+    assert_eq!(
+        determine_fallback_action(5, 3, 5, 7),
+        EditFallbackAction::WriteFallback
+    );
+    assert_eq!(
+        determine_fallback_action(7, 3, 5, 7),
+        EditFallbackAction::FixSliceEscalation
+    );
+    // Beyond threshold, persists
+    assert_eq!(
+        determine_fallback_action(10, 3, 5, 7),
+        EditFallbackAction::FixSliceEscalation
+    );
+}
+
+#[test]
+fn test_escalation_chain_fixslice_disabled() {
+    // fixslice=0 (disabled) — WriteFallback is the ceiling
+    assert_eq!(
+        determine_fallback_action(7, 3, 5, 0),
+        EditFallbackAction::WriteFallback
+    );
+    assert_eq!(
+        determine_fallback_action(100, 3, 5, 0),
+        EditFallbackAction::WriteFallback
+    );
+}
+
+// ============================================================
+// Test 3: EditFailTracker escalation flow
+// ============================================================
+
+#[test]
+fn test_tracker_fixslice_escalation_flow() {
+    // reread=3, write_fallback=5, fixslice=7
+    let mut tracker = EditFailTracker::new(3, 5, 7);
+    let path = "src/lib/auto-yes-poller.ts";
+
+    // Failures 1-2: Continue
+    assert_eq!(tracker.record_failure(path), EditFallbackAction::Continue);
+    assert_eq!(tracker.record_failure(path), EditFallbackAction::Continue);
+
+    // Failures 3-4: ReRead
+    assert_eq!(tracker.record_failure(path), EditFallbackAction::ReRead);
+    assert_eq!(tracker.record_failure(path), EditFallbackAction::ReRead);
+
+    // Failures 5-6: WriteFallback
+    assert_eq!(
+        tracker.record_failure(path),
+        EditFallbackAction::WriteFallback
+    );
+    assert_eq!(
+        tracker.record_failure(path),
+        EditFallbackAction::WriteFallback
+    );
+
+    // Failure 7+: FixSliceEscalation
+    assert_eq!(
+        tracker.record_failure(path),
+        EditFallbackAction::FixSliceEscalation
+    );
+    assert_eq!(tracker.failure_count(path), 7);
+
+    // Persists
+    assert_eq!(
+        tracker.record_failure(path),
+        EditFallbackAction::FixSliceEscalation
+    );
+}
+
+#[test]
+fn test_tracker_fixslice_independent_paths() {
+    let mut tracker = EditFailTracker::new(3, 5, 7);
+
+    // Drive path A to fixslice threshold
+    for _ in 0..7 {
+        tracker.record_failure("a.ts");
+    }
+    assert_eq!(
+        tracker.record_failure("a.ts"),
+        EditFallbackAction::FixSliceEscalation
+    );
+
+    // Path B should still be at Continue
+    assert_eq!(tracker.record_failure("b.ts"), EditFallbackAction::Continue);
+}
+
+#[test]
+fn test_tracker_fixslice_reset_on_success() {
+    let mut tracker = EditFailTracker::new(3, 5, 7);
+
+    // Drive to fixslice
+    for _ in 0..7 {
+        tracker.record_failure("a.ts");
+    }
+    assert_eq!(
+        tracker.record_failure("a.ts"),
+        EditFallbackAction::FixSliceEscalation
+    );
+
+    // Success resets
+    tracker.record_success("a.ts");
+    assert_eq!(tracker.failure_count("a.ts"), 0);
+    assert_eq!(tracker.record_failure("a.ts"), EditFallbackAction::Continue);
+}
+
+// ============================================================
+// Test 4: Stagnation + single-file edit failure reproduces Issue #321
+// ============================================================
+
+#[test]
+fn test_stagnation_with_single_file_edit_drift() {
+    // Reproduce the observed pattern from Issue #321:
+    // - Same file edited repeatedly with failures
+    // - Stagnation score rises
+    // - But fix_slice was never invoked
+    //
+    // After the fix, EditFailTracker returns FixSliceEscalation at count >= 7
+
+    let mut stagnation = StagnationState::new();
+    let mut tracker = EditFailTracker::new(3, 5, 7);
+    let path = "src/lib/auto-yes-poller.ts";
+
+    // Simulate 5 turns of same-file edit failures (no mutation)
+    let workset = vec![0usize];
+    for _ in 0..5 {
+        stagnation.begin_turn(&workset);
+        stagnation.end_turn(false); // no mutation
+    }
+    let score = compute_stagnation_score(&stagnation);
+    assert!(score >= 1, "Expected stagnation score >= 1, got {score}");
+
+    // After 7 consecutive edit failures, escalation should trigger
+    for _ in 0..6 {
+        tracker.record_failure(path);
+    }
+    let action = tracker.record_failure(path);
+    assert_eq!(
+        action,
+        EditFallbackAction::FixSliceEscalation,
+        "7th consecutive edit failure should trigger FixSliceEscalation"
+    );
+}
+
+// ============================================================
+// Test 5: AgentTelemetry records escalation
+// ============================================================
+
+#[test]
+fn test_agent_telemetry_fixslice_escalation() {
+    let mut tel = AgentTelemetry::new();
+    assert_eq!(tel.fixslice_escalation_count, 0);
+
+    tel.record_fixslice_escalation();
+    assert_eq!(tel.fixslice_escalation_count, 1);
+
+    tel.record_fixslice_escalation();
+    assert_eq!(tel.fixslice_escalation_count, 2);
+}
+
+#[test]
+fn test_agent_telemetry_fixslice_serialization() {
+    let mut tel = AgentTelemetry::new();
+    tel.record_fixslice_escalation();
+
+    let json = serde_json::to_string(&tel).unwrap();
+    assert!(
+        json.contains("\"fixslice_escalation_count\":1"),
+        "fixslice_escalation_count should appear in serialized telemetry"
+    );
+
+    // Deserialize back
+    let tel2: AgentTelemetry = serde_json::from_str(&json).unwrap();
+    assert_eq!(tel2.fixslice_escalation_count, 1);
+}
+
+#[test]
+fn test_agent_telemetry_fixslice_default_zero() {
+    // Backward compatibility: missing field defaults to 0
+    let json = r#"{"premature_final_count":0,"total_final_requests":0,"plan_registration_count":0,"plan_update_count":0,"sync_from_touched_files_count":0,"completion_kind":null}"#;
+    let tel: AgentTelemetry = serde_json::from_str(json).unwrap();
+    assert_eq!(tel.fixslice_escalation_count, 0);
+}


### PR DESCRIPTION
## Summary

- Add reactive `agent.fix_slice` escalation when repeated `file.edit` failures occur on the same path
- `EditFailTracker` now tracks a configurable `fixslice_threshold` (default: 5) and returns `EditFallbackStage::FixSlice` when exceeded
- Agentic loop injects a structured FixSlice escalation hint with target path and goal
- `AgentTelemetry` tracks `fixslice_escalation_count` for bench artifact visibility

## Changes

| File | Description |
|------|-------------|
| `src/app/edit_fail_tracker.rs` | Add `FixSlice` stage, `fixslice_threshold`, escalation logic |
| `src/app/agentic.rs` | Inject FixSlice escalation hint on threshold breach |
| `src/config/mod.rs` | `edit_fixslice_threshold` config parameter |
| `src/contracts/mod.rs` | `fixslice_escalation_count` in `AgentTelemetry` |
| `src/app/mod.rs` | Wire config → tracker |
| `tests/fixslice_escalation.rs` | 12 regression tests |

## Test plan

- [x] `cargo fmt --check` — no diff
- [x] `cargo clippy --all-targets` — 0 warnings
- [x] `cargo test` — all tests pass

Fixes #321

🤖 Generated with [Claude Code](https://claude.com/claude-code)