### PR TITLE
fix(issue-329): add pack validation gate for benchmark expectation mismatch

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -919,7 +919,7 @@ impl App {
     ///
     /// Should be called once when the session actually ends (interactive exit
     /// or non-interactive completion), not per-turn.
-    pub(crate) fn log_session_summary(&self) {
+    pub(crate) fn log_session_summary(&mut self) {
         let session_elapsed = self
             .session_stats
             .session_start
@@ -978,6 +978,35 @@ impl App {
                 pre_exit_repair_consumed_count = tel.pre_exit_repair_consumed_count,
                 "agent telemetry"
             );
+        }
+
+        // Issue #329: Validate pack expectation gate before writing artifact.
+        {
+            let result = self.agent_telemetry.validate_pack_expectation();
+            match &result {
+                crate::contracts::PackValidationResult::NoExpectation => {}
+                crate::contracts::PackValidationResult::Satisfied => {
+                    tracing::info!(
+                        pack_expectation = %self.agent_telemetry.pack_expectation
+                            .map(|e| e.to_string())
+                            .unwrap_or_default(),
+                        "pack validation gate: satisfied"
+                    );
+                }
+                crate::contracts::PackValidationResult::Mismatch {
+                    expectation,
+                    reason,
+                } => {
+                    tracing::warn!(
+                        pack_expectation = %expectation,
+                        reason = %reason,
+                        mutation_observed = self.agent_telemetry.mutation_observed,
+                        worker_observed = self.agent_telemetry.worker_observed,
+                        repair_turn_observed = self.agent_telemetry.repair_turn_observed,
+                        "pack validation gate: expectation mismatch"
+                    );
+                }
+            }
         }
 
         // Issue #271: Write telemetry artifact (opt-in via ANVIL_TELEMETRY_DIR).

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -114,6 +114,87 @@ pub struct FixSliceProposal {
 }
 
 // ---------------------------------------------------------------------------
+// Pack expectation / validation gate (Issue #329)
+// ---------------------------------------------------------------------------
+
+/// Declares what a benchmark pack expects from the session.
+///
+/// Read from `$ANVIL_PACK_EXPECTATION` at session start.
+/// When unset the harness applies no pack-level gate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PackExpectation {
+    /// The prompt is a follow-up audit; a no-op / zero-mutation completion is
+    /// a valid success path.
+    AuditOnly,
+    /// The pack requires at least one real file mutation (`changed_files > 0`).
+    RequiresMutation,
+    /// The pack requires observable worker-path evidence: fix_slice escalation,
+    /// pre-exit repair turn, *or* mutation.
+    RequiresWorkerObservation,
+}
+
+impl PackExpectation {
+    /// Parse from the raw env-var value.  Returns `None` for unknown strings.
+    pub fn from_env_str(s: &str) -> Option<Self> {
+        match s {
+            "audit_only" => Some(Self::AuditOnly),
+            "requires_mutation" => Some(Self::RequiresMutation),
+            "requires_worker_observation" => Some(Self::RequiresWorkerObservation),
+            _ => None,
+        }
+    }
+
+    /// Read from `$ANVIL_PACK_EXPECTATION`.  Returns `None` when unset or empty.
+    pub fn from_env() -> Option<Self> {
+        let raw = std::env::var("ANVIL_PACK_EXPECTATION").ok()?;
+        if raw.is_empty() {
+            return None;
+        }
+        Self::from_env_str(&raw)
+    }
+}
+
+impl std::fmt::Display for PackExpectation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::AuditOnly => write!(f, "audit_only"),
+            Self::RequiresMutation => write!(f, "requires_mutation"),
+            Self::RequiresWorkerObservation => write!(f, "requires_worker_observation"),
+        }
+    }
+}
+
+/// Result of validating telemetry against a pack expectation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PackValidationResult {
+    /// No pack expectation was set — nothing to validate.
+    NoExpectation,
+    /// Telemetry satisfies the expectation.
+    Satisfied,
+    /// Telemetry does NOT satisfy the expectation.
+    Mismatch {
+        expectation: PackExpectation,
+        reason: String,
+    },
+}
+
+impl std::fmt::Display for PackValidationResult {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NoExpectation => write!(f, "no_expectation"),
+            Self::Satisfied => write!(f, "satisfied"),
+            Self::Mismatch {
+                expectation,
+                reason,
+            } => {
+                write!(f, "mismatch({expectation}): {reason}")
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Completion taxonomy (Issue #255: AgentPhase integration)
 // ---------------------------------------------------------------------------
 
@@ -306,6 +387,28 @@ pub struct AgentTelemetry {
     /// Number of pending plan items after repair turn (Issue #327).
     #[serde(default)]
     pub repair_turn_pending_after: Option<u32>,
+
+    // ---- Pack validation gate (Issue #329) ----
+    /// Whether at least one mutation (file change) was observed during the session.
+    #[serde(default)]
+    pub mutation_observed: bool,
+
+    /// Whether the worker path (fix_slice escalation) was observed.
+    #[serde(default)]
+    pub worker_observed: bool,
+
+    /// Whether a pre-exit repair turn was observed.
+    #[serde(default)]
+    pub repair_turn_observed: bool,
+
+    /// Pack expectation that was active for this session (from `$ANVIL_PACK_EXPECTATION`).
+    #[serde(default)]
+    pub pack_expectation: Option<PackExpectation>,
+
+    /// Mismatch reason when the session did not satisfy the pack expectation.
+    /// `None` when expectation is satisfied or unset.
+    #[serde(default)]
+    pub expectation_mismatch_reason: Option<String>,
 }
 
 impl AgentTelemetry {
@@ -380,11 +483,13 @@ impl AgentTelemetry {
     /// Record a pre-exit repair turn injection (Issue #325).
     pub fn record_pre_exit_repair_injected(&mut self) {
         self.pre_exit_repair_injected_count += 1;
+        self.repair_turn_observed = true;
     }
 
     /// Record a pre-exit repair turn consumed by LLM (Issue #325).
     pub fn record_pre_exit_repair_consumed(&mut self) {
         self.pre_exit_repair_consumed_count += 1;
+        self.repair_turn_observed = true;
     }
 
     /// Record unchecked items rejected during repair closure mode (Issue #327).
@@ -419,6 +524,7 @@ impl AgentTelemetry {
     /// (i.e. from `crate::app::MUTATION_TOOLS`) to avoid storing arbitrary strings.
     pub fn record_mutation_turn(&mut self, turn: u32, elapsed_s: Option<f64>, tool_name: &str) {
         self.last_mutation_turn = turn;
+        self.mutation_observed = true;
         if self.first_mutation_event_turn.is_none() {
             self.first_mutation_event_turn = Some(turn);
             self.first_mutation_event_elapsed_s = elapsed_s;
@@ -434,6 +540,7 @@ impl AgentTelemetry {
     /// Record a fix_slice escalation event (Issue #321).
     pub fn record_fixslice_escalation(&mut self) {
         self.fixslice_escalation_count += 1;
+        self.worker_observed = true;
     }
 
     /// Threshold: mutations after this turn are considered "late".
@@ -541,6 +648,12 @@ impl AgentTelemetry {
             "first_mutation_event_elapsed_s": self.first_mutation_event_elapsed_s,
             "first_mutation_event_tool": self.first_mutation_event_tool,
             "first_mutation_event_semantic_basis": "runtime_lower_bound",
+            // Issue #329: pack validation gate observability fields
+            "mutation_observed": self.mutation_observed,
+            "worker_observed": self.worker_observed,
+            "repair_turn_observed": self.repair_turn_observed,
+            "pack_expectation": self.pack_expectation.map(|e| e.to_string()),
+            "expectation_mismatch_reason": self.expectation_mismatch_reason,
         });
 
         let json_bytes = serde_json::to_vec_pretty(&payload)?;
@@ -556,6 +669,61 @@ impl AgentTelemetry {
         file.write_all(&json_bytes)?;
 
         Ok(())
+    }
+
+    /// Validate telemetry against the active pack expectation (Issue #329).
+    ///
+    /// Reads `$ANVIL_PACK_EXPECTATION` from the environment.
+    /// Call this after `completion_kind` is set.  Updates `pack_expectation`
+    /// and `expectation_mismatch_reason` fields.
+    pub fn validate_pack_expectation(&mut self) -> PackValidationResult {
+        let expectation = match PackExpectation::from_env() {
+            Some(exp) => exp,
+            None => return PackValidationResult::NoExpectation,
+        };
+        self.validate_against(expectation)
+    }
+
+    /// Validate telemetry against the given expectation (Issue #329).
+    ///
+    /// This is the testable core; `validate_pack_expectation` is the
+    /// env-reading convenience wrapper.
+    pub fn validate_against(&mut self, expectation: PackExpectation) -> PackValidationResult {
+        self.pack_expectation = Some(expectation);
+
+        match expectation {
+            PackExpectation::AuditOnly => PackValidationResult::Satisfied,
+
+            PackExpectation::RequiresMutation => {
+                if self.mutation_observed {
+                    PackValidationResult::Satisfied
+                } else {
+                    let reason =
+                        "pack requires mutation but session completed with zero file changes"
+                            .to_string();
+                    self.expectation_mismatch_reason = Some(reason.clone());
+                    PackValidationResult::Mismatch {
+                        expectation,
+                        reason,
+                    }
+                }
+            }
+
+            PackExpectation::RequiresWorkerObservation => {
+                if self.worker_observed || self.repair_turn_observed || self.mutation_observed {
+                    PackValidationResult::Satisfied
+                } else {
+                    let reason = "pack requires worker observation but no worker path, \
+                                  repair turn, or mutation was observed"
+                        .to_string();
+                    self.expectation_mismatch_reason = Some(reason.clone());
+                    PackValidationResult::Mismatch {
+                        expectation,
+                        reason,
+                    }
+                }
+            }
+        }
     }
 
     /// Premature Final Request Rate: ratio of suppressed finals to total finals.

--- a/tests/pack_validation_gate.rs
+++ b/tests/pack_validation_gate.rs
@@ -1,0 +1,274 @@
+//! Tests for pack validation gate (Issue #329).
+//!
+//! Verifies that `PackExpectation` parsing, `AgentTelemetry` observability
+//! fields, and the validation gate behave correctly.
+
+use anvil::contracts::{AgentTelemetry, PackExpectation, PackValidationResult};
+
+// ---------------------------------------------------------------------------
+// PackExpectation parsing
+// ---------------------------------------------------------------------------
+
+#[test]
+fn pack_expectation_from_env_str_valid() {
+    assert_eq!(
+        PackExpectation::from_env_str("audit_only"),
+        Some(PackExpectation::AuditOnly)
+    );
+    assert_eq!(
+        PackExpectation::from_env_str("requires_mutation"),
+        Some(PackExpectation::RequiresMutation)
+    );
+    assert_eq!(
+        PackExpectation::from_env_str("requires_worker_observation"),
+        Some(PackExpectation::RequiresWorkerObservation)
+    );
+}
+
+#[test]
+fn pack_expectation_from_env_str_unknown() {
+    assert_eq!(PackExpectation::from_env_str("unknown_value"), None);
+    assert_eq!(PackExpectation::from_env_str(""), None);
+}
+
+#[test]
+fn pack_expectation_display_roundtrip() {
+    for (variant, expected) in [
+        (PackExpectation::AuditOnly, "audit_only"),
+        (PackExpectation::RequiresMutation, "requires_mutation"),
+        (
+            PackExpectation::RequiresWorkerObservation,
+            "requires_worker_observation",
+        ),
+    ] {
+        assert_eq!(variant.to_string(), expected);
+        assert_eq!(PackExpectation::from_env_str(expected), Some(variant));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Observability flags set by record_* methods
+// ---------------------------------------------------------------------------
+
+#[test]
+fn mutation_observed_set_by_record_mutation_turn() {
+    let mut tel = AgentTelemetry::new();
+    assert!(!tel.mutation_observed);
+    tel.record_mutation_turn(1, Some(0.5), "file.write");
+    assert!(tel.mutation_observed);
+}
+
+#[test]
+fn worker_observed_set_by_record_fixslice_escalation() {
+    let mut tel = AgentTelemetry::new();
+    assert!(!tel.worker_observed);
+    tel.record_fixslice_escalation();
+    assert!(tel.worker_observed);
+}
+
+#[test]
+fn repair_turn_observed_set_by_record_pre_exit_repair_injected() {
+    let mut tel = AgentTelemetry::new();
+    assert!(!tel.repair_turn_observed);
+    tel.record_pre_exit_repair_injected();
+    assert!(tel.repair_turn_observed);
+}
+
+#[test]
+fn repair_turn_observed_set_by_record_pre_exit_repair_consumed() {
+    let mut tel = AgentTelemetry::new();
+    assert!(!tel.repair_turn_observed);
+    tel.record_pre_exit_repair_consumed();
+    assert!(tel.repair_turn_observed);
+}
+
+// ---------------------------------------------------------------------------
+// validate_against: audit_only
+// ---------------------------------------------------------------------------
+
+#[test]
+fn validate_audit_only_satisfied_with_no_mutation() {
+    let mut tel = AgentTelemetry::new();
+    let result = tel.validate_against(PackExpectation::AuditOnly);
+    assert_eq!(result, PackValidationResult::Satisfied);
+    assert_eq!(tel.pack_expectation, Some(PackExpectation::AuditOnly));
+    assert!(tel.expectation_mismatch_reason.is_none());
+}
+
+#[test]
+fn validate_audit_only_satisfied_with_mutation() {
+    let mut tel = AgentTelemetry::new();
+    tel.record_mutation_turn(1, Some(0.5), "file.write");
+    let result = tel.validate_against(PackExpectation::AuditOnly);
+    assert_eq!(result, PackValidationResult::Satisfied);
+}
+
+// ---------------------------------------------------------------------------
+// validate_against: requires_mutation
+// ---------------------------------------------------------------------------
+
+#[test]
+fn validate_requires_mutation_mismatch_when_no_mutation() {
+    let mut tel = AgentTelemetry::new();
+    let result = tel.validate_against(PackExpectation::RequiresMutation);
+    match &result {
+        PackValidationResult::Mismatch {
+            expectation,
+            reason,
+        } => {
+            assert_eq!(*expectation, PackExpectation::RequiresMutation);
+            assert!(reason.contains("zero file changes"), "reason: {reason}");
+        }
+        other => panic!("expected Mismatch, got {other:?}"),
+    }
+    assert!(tel.expectation_mismatch_reason.is_some());
+}
+
+#[test]
+fn validate_requires_mutation_satisfied_when_mutation_observed() {
+    let mut tel = AgentTelemetry::new();
+    tel.record_mutation_turn(3, Some(1.0), "file.edit");
+    let result = tel.validate_against(PackExpectation::RequiresMutation);
+    assert_eq!(result, PackValidationResult::Satisfied);
+    assert!(tel.expectation_mismatch_reason.is_none());
+}
+
+// ---------------------------------------------------------------------------
+// validate_against: requires_worker_observation
+// ---------------------------------------------------------------------------
+
+#[test]
+fn validate_requires_worker_observation_mismatch_when_nothing_observed() {
+    let mut tel = AgentTelemetry::new();
+    let result = tel.validate_against(PackExpectation::RequiresWorkerObservation);
+    match &result {
+        PackValidationResult::Mismatch {
+            expectation,
+            reason,
+        } => {
+            assert_eq!(*expectation, PackExpectation::RequiresWorkerObservation);
+            assert!(reason.contains("no worker path"), "reason: {reason}");
+        }
+        other => panic!("expected Mismatch, got {other:?}"),
+    }
+}
+
+#[test]
+fn validate_requires_worker_observation_satisfied_by_fixslice() {
+    let mut tel = AgentTelemetry::new();
+    tel.record_fixslice_escalation();
+    let result = tel.validate_against(PackExpectation::RequiresWorkerObservation);
+    assert_eq!(result, PackValidationResult::Satisfied);
+}
+
+#[test]
+fn validate_requires_worker_observation_satisfied_by_repair_turn() {
+    let mut tel = AgentTelemetry::new();
+    tel.record_pre_exit_repair_injected();
+    let result = tel.validate_against(PackExpectation::RequiresWorkerObservation);
+    assert_eq!(result, PackValidationResult::Satisfied);
+}
+
+#[test]
+fn validate_requires_worker_observation_satisfied_by_mutation() {
+    let mut tel = AgentTelemetry::new();
+    tel.record_mutation_turn(2, Some(0.5), "file.write");
+    let result = tel.validate_against(PackExpectation::RequiresWorkerObservation);
+    assert_eq!(result, PackValidationResult::Satisfied);
+}
+
+// ---------------------------------------------------------------------------
+// Telemetry artifact includes pack validation fields (Issue #329)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn telemetry_artifact_includes_pack_validation_fields() {
+    let dir = tempfile::tempdir().unwrap();
+    let session_id = format!("test_pack_fields_{}", std::process::id());
+    let dir_str = dir.path().to_str().unwrap();
+
+    let mut tel = AgentTelemetry::new();
+    tel.record_mutation_turn(1, Some(0.3), "file.write");
+    tel.record_fixslice_escalation();
+    tel.record_pre_exit_repair_injected();
+    tel.pack_expectation = Some(PackExpectation::RequiresWorkerObservation);
+
+    tel.write_artifact_to_dir(dir_str, &session_id).unwrap();
+
+    let file_path = dir.path().join(format!("{session_id}_telemetry.json"));
+    let contents = std::fs::read_to_string(&file_path).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&contents).unwrap();
+
+    assert_eq!(json["mutation_observed"], true);
+    assert_eq!(json["worker_observed"], true);
+    assert_eq!(json["repair_turn_observed"], true);
+    assert_eq!(json["pack_expectation"], "requires_worker_observation");
+    assert!(json["expectation_mismatch_reason"].is_null());
+}
+
+#[test]
+fn telemetry_artifact_pack_fields_default_false() {
+    let dir = tempfile::tempdir().unwrap();
+    let session_id = format!("test_pack_defaults_{}", std::process::id());
+    let dir_str = dir.path().to_str().unwrap();
+
+    let tel = AgentTelemetry::new();
+    tel.write_artifact_to_dir(dir_str, &session_id).unwrap();
+
+    let file_path = dir.path().join(format!("{session_id}_telemetry.json"));
+    let contents = std::fs::read_to_string(&file_path).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&contents).unwrap();
+
+    assert_eq!(json["mutation_observed"], false);
+    assert_eq!(json["worker_observed"], false);
+    assert_eq!(json["repair_turn_observed"], false);
+    assert!(json["pack_expectation"].is_null());
+    assert!(json["expectation_mismatch_reason"].is_null());
+}
+
+#[test]
+fn telemetry_artifact_mismatch_reason_persisted() {
+    let dir = tempfile::tempdir().unwrap();
+    let session_id = format!("test_pack_mismatch_{}", std::process::id());
+    let dir_str = dir.path().to_str().unwrap();
+
+    let mut tel = AgentTelemetry::new();
+    // No mutations, no worker, no repair → mismatch for requires_mutation
+    tel.validate_against(PackExpectation::RequiresMutation);
+
+    tel.write_artifact_to_dir(dir_str, &session_id).unwrap();
+
+    let file_path = dir.path().join(format!("{session_id}_telemetry.json"));
+    let contents = std::fs::read_to_string(&file_path).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&contents).unwrap();
+
+    assert_eq!(json["pack_expectation"], "requires_mutation");
+    assert!(
+        json["expectation_mismatch_reason"]
+            .as_str()
+            .unwrap()
+            .contains("zero file changes")
+    );
+}
+
+// ---------------------------------------------------------------------------
+// PackValidationResult Display
+// ---------------------------------------------------------------------------
+
+#[test]
+fn pack_validation_result_display() {
+    assert_eq!(
+        PackValidationResult::NoExpectation.to_string(),
+        "no_expectation"
+    );
+    assert_eq!(PackValidationResult::Satisfied.to_string(), "satisfied");
+
+    let mismatch = PackValidationResult::Mismatch {
+        expectation: PackExpectation::RequiresMutation,
+        reason: "no changes".to_string(),
+    };
+    assert_eq!(
+        mismatch.to_string(),
+        "mismatch(requires_mutation): no changes"
+    );
+}

--- a/tests/telemetry_artifact.rs
+++ b/tests/telemetry_artifact.rs
@@ -138,6 +138,12 @@ fn telemetry_artifact_all_fields_present() {
         "first_mutation_event_elapsed_s",
         "first_mutation_event_tool",
         "first_mutation_event_semantic_basis",
+        // Issue #329: pack validation gate
+        "mutation_observed",
+        "worker_observed",
+        "repair_turn_observed",
+        "pack_expectation",
+        "expectation_mismatch_reason",
     ];
 
     for key in &expected_keys {


### PR DESCRIPTION
## Summary
- Pack validation gate を導入し、`requires_mutation` / `requires_worker_observation` pack が zero mutation で `complete_unverified` 終了した場合に `expectation_mismatch` として明示分類
- `worker_observed`, `repair_turn_observed`, `mutation_observed`, `pack_expectation`, `expectation_mismatch_reason` をテレメトリに追加
- ベンチマーク結果の解釈曖昧性を排除

## Test plan
- [ ] `cargo test --test pack_validation_gate` で新規回帰テスト全パス
- [ ] `cargo clippy --all-targets` 警告0件
- [ ] `cargo test` 全テストパス
- [ ] `cargo fmt --check` 差分なし

Fixes #329

🤖 Generated with [Claude Code](https://claude.com/claude-code)