### PR TITLE
fix(issue-332): broaden fix_slice escalation to cover cross-path drift

### DIFF
--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -1000,6 +1000,44 @@ impl App {
                 );
             }
 
+            // Issue #332: broadened fix_slice escalation.
+            //
+            // The original same-path escalation in EditFailTracker only fires
+            // when one path accumulates `edit_fixslice_threshold` consecutive
+            // failures. In the real drift pattern the model spreads failures
+            // across multiple files, so that threshold is never reached and
+            // the worker path is never observed. Trigger escalation here when
+            // cumulative failures + stagnation score cross the configured
+            // stagnation thresholds and fix_slice has not already escalated.
+            if !self.agent_telemetry.worker_observed
+                && crate::app::edit_fail_tracker::should_escalate_for_stagnation(
+                    self.edit_fail_tracker.total_failures(),
+                    stagnation_score as u32,
+                    self.config.runtime.edit_fixslice_stagnation_total_threshold,
+                    self.config.runtime.edit_fixslice_stagnation_score_threshold,
+                )
+            {
+                tracing::warn!(
+                    score = stagnation_score,
+                    total_failures = self.edit_fail_tracker.total_failures(),
+                    "fixslice_escalation_triggered (stagnation)"
+                );
+                self.agent_telemetry.record_fixslice_escalation_stagnation();
+                let hint = format!(
+                    "\n\n[Anvil ESCALATION] {n} file.edit failures have occurred across \
+                     multiple files and the session has stagnated (score={score}/4). \
+                     You MUST use agent.fix_slice to repair the most troubled file. \
+                     Call agent.fix_slice with target_path pointing at the file you have been \
+                     trying to modify, and a goal describing the intended change. Do NOT \
+                     retry file.edit on the same paths — use agent.fix_slice now.",
+                    n = self.edit_fail_tracker.total_failures(),
+                    score = stagnation_score,
+                );
+                let msg = SessionMessage::new(MessageRole::Tool, "system", hint)
+                    .with_id(self.next_message_id("tool"));
+                self.session.push_message(msg);
+            }
+
             // Issue #285: staged stagnation recovery.
             let remaining_turns = max_iterations.saturating_sub(iteration + 1);
             let plan_repair_count_before_this_turn =

--- a/src/app/edit_fail_tracker.rs
+++ b/src/app/edit_fail_tracker.rs
@@ -66,6 +66,25 @@ pub fn determine_fallback_action(
     }
 }
 
+/// Decide whether to escalate to the worker path based on cumulative failures
+/// and stagnation score (Issue #332).
+///
+/// This is the broadened escalation policy: fires when the model spreads
+/// edit failures across multiple paths so no single path reaches
+/// `edit_fixslice_threshold`, but the session is clearly stagnating.
+///
+/// `failures_threshold == 0` disables the trigger.
+pub fn should_escalate_for_stagnation(
+    total_failures: u32,
+    stagnation_score: u32,
+    failures_threshold: u32,
+    score_threshold: u32,
+) -> bool {
+    failures_threshold > 0
+        && total_failures >= failures_threshold
+        && stagnation_score >= score_threshold
+}
+
 /// Tracks consecutive file.edit failures per file path.
 /// Used to detect when the LLM is stuck retrying edits on the same file
 /// and should be prompted to try an alternative approach (Issue #158, #321).
@@ -76,6 +95,13 @@ pub struct EditFailTracker {
     /// Threshold for escalating to agent.fix_slice (Issue #321).
     /// 0 = disabled.
     fixslice_threshold: u32,
+    /// Cumulative failure count across all paths (Issue #332).
+    ///
+    /// Not reset on `record_success`, because the broadened stagnation
+    /// escalation uses it to detect the drift pattern where the model
+    /// scatters failures across multiple files and no single path accumulates
+    /// enough to hit `fixslice_threshold`.
+    total_failures: u32,
 }
 
 impl EditFailTracker {
@@ -89,6 +115,7 @@ impl EditFailTracker {
             reread_threshold,
             write_fallback_threshold,
             fixslice_threshold,
+            total_failures: 0,
         }
     }
 
@@ -100,6 +127,7 @@ impl EditFailTracker {
             .entry(path.to_string())
             .or_insert(0);
         *count += 1;
+        self.total_failures = self.total_failures.saturating_add(1);
         determine_fallback_action(
             *count,
             self.reread_threshold,
@@ -116,6 +144,11 @@ impl EditFailTracker {
     /// Get the current failure count for a path.
     pub fn failure_count(&self, path: &str) -> u32 {
         self.consecutive_failures.get(path).copied().unwrap_or(0)
+    }
+
+    /// Cumulative failure count across all paths in this session (Issue #332).
+    pub fn total_failures(&self) -> u32 {
+        self.total_failures
     }
 }
 
@@ -361,5 +394,39 @@ mod tests {
         tracker.record_success("a.rs");
         assert_eq!(tracker.failure_count("a.rs"), 0);
         assert_eq!(tracker.record_failure("a.rs"), EditFallbackAction::Continue);
+    }
+
+    // --- Issue #332: cumulative total_failures & stagnation helper ---
+
+    #[test]
+    fn test_total_failures_accumulates_across_paths_and_survives_success() {
+        let mut tracker = EditFailTracker::new(3, 5, 7);
+        assert_eq!(tracker.total_failures(), 0);
+        tracker.record_failure("a.rs");
+        tracker.record_failure("b.rs");
+        tracker.record_failure("c.rs");
+        assert_eq!(tracker.total_failures(), 3);
+        tracker.record_success("a.rs");
+        assert_eq!(
+            tracker.total_failures(),
+            3,
+            "total_failures must not be reset by per-path success"
+        );
+        tracker.record_failure("a.rs");
+        assert_eq!(tracker.total_failures(), 4);
+    }
+
+    #[test]
+    fn test_should_escalate_for_stagnation_boundary() {
+        // disabled
+        assert!(!should_escalate_for_stagnation(100, 4, 0, 2));
+        // below failures
+        assert!(!should_escalate_for_stagnation(3, 4, 4, 2));
+        // below score
+        assert!(!should_escalate_for_stagnation(4, 1, 4, 2));
+        // exactly at thresholds
+        assert!(should_escalate_for_stagnation(4, 2, 4, 2));
+        // well above
+        assert!(should_escalate_for_stagnation(10, 4, 4, 2));
     }
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -980,6 +980,10 @@ impl App {
             );
         }
 
+        // Issue #332: retrospectively classify repair-turn-only salvage
+        // before pack validation/artifact emission so the counter is durable.
+        self.agent_telemetry.classify_repair_salvage();
+
         // Issue #329: Validate pack expectation gate before writing artifact.
         {
             let result = self.agent_telemetry.validate_pack_expectation();

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -186,6 +186,13 @@ pub struct RuntimeConfig {
     /// Consecutive edit failures before agent.fix_slice escalation (Issue #321).
     /// 0 = disabled.
     pub edit_fixslice_threshold: u32,
+    /// Cumulative edit-failure count that triggers stagnation-driven
+    /// fix_slice escalation when combined with a high stagnation score (Issue #332).
+    /// 0 = disabled (same-path threshold is the only trigger).
+    pub edit_fixslice_stagnation_total_threshold: u32,
+    /// Minimum stagnation score required for stagnation-driven fix_slice
+    /// escalation (Issue #332).
+    pub edit_fixslice_stagnation_score_threshold: u32,
     /// Maximum line count for file.write on existing files (0 = disabled, Issue #156).
     pub safe_write_max_lines: usize,
     /// Deletion ratio threshold for diff warning (0.0-1.0, Issue #156).
@@ -383,6 +390,8 @@ impl EffectiveConfig {
                 edit_reread_threshold: 3,
                 edit_write_fallback_threshold: 5,
                 edit_fixslice_threshold: 7,
+                edit_fixslice_stagnation_total_threshold: 4,
+                edit_fixslice_stagnation_score_threshold: 2,
                 safe_write_max_lines: 500,
                 safe_write_deletion_ratio: 0.5,
                 read_repeat_warn_threshold: 3,
@@ -876,6 +885,26 @@ impl EffectiveConfig {
                     }
                     self.runtime.edit_fixslice_threshold = v;
                 }
+                "edit_fixslice_stagnation_total_threshold"
+                | "ANVIL_EDIT_FIXSLICE_STAGNATION_TOTAL_THRESHOLD" => {
+                    let v: u32 = value
+                        .parse()
+                        .map_err(|_| ConfigError::InvalidNumericValue(value.clone()))?;
+                    if v > 40 {
+                        return Err(ConfigError::InvalidNumericValue(value.clone()));
+                    }
+                    self.runtime.edit_fixslice_stagnation_total_threshold = v;
+                }
+                "edit_fixslice_stagnation_score_threshold"
+                | "ANVIL_EDIT_FIXSLICE_STAGNATION_SCORE_THRESHOLD" => {
+                    let v: u32 = value
+                        .parse()
+                        .map_err(|_| ConfigError::InvalidNumericValue(value.clone()))?;
+                    if !(1..=4).contains(&v) {
+                        return Err(ConfigError::InvalidNumericValue(value.clone()));
+                    }
+                    self.runtime.edit_fixslice_stagnation_score_threshold = v;
+                }
                 "edit_recovery_read_budget" | "ANVIL_EDIT_RECOVERY_READ_BUDGET" => {
                     let v: u32 = value
                         .parse()
@@ -1182,6 +1211,18 @@ impl EffectiveConfig {
                     self.runtime.edit_write_fallback_threshold + 2;
             }
         }
+        // Issue #332: clamp stagnation-escalation thresholds (0 = disabled).
+        if self.runtime.edit_fixslice_stagnation_total_threshold > 0 {
+            self.runtime.edit_fixslice_stagnation_total_threshold = self
+                .runtime
+                .edit_fixslice_stagnation_total_threshold
+                .clamp(1, 40);
+        }
+        // Score threshold is bounded by compute_stagnation_score() range [0, 4].
+        self.runtime.edit_fixslice_stagnation_score_threshold = self
+            .runtime
+            .edit_fixslice_stagnation_score_threshold
+            .clamp(1, 4);
         self.runtime.edit_recovery_read_budget =
             self.runtime.edit_recovery_read_budget.clamp(1, 10);
     }
@@ -1543,6 +1584,14 @@ impl std::fmt::Debug for RuntimeConfig {
                 &self.edit_write_fallback_threshold,
             )
             .field("edit_fixslice_threshold", &self.edit_fixslice_threshold)
+            .field(
+                "edit_fixslice_stagnation_total_threshold",
+                &self.edit_fixslice_stagnation_total_threshold,
+            )
+            .field(
+                "edit_fixslice_stagnation_score_threshold",
+                &self.edit_fixslice_stagnation_score_threshold,
+            )
             .field("safe_write_max_lines", &self.safe_write_max_lines)
             .field("safe_write_deletion_ratio", &self.safe_write_deletion_ratio)
             .field("edit_recovery_read_budget", &self.edit_recovery_read_budget)

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -364,6 +364,22 @@ pub struct AgentTelemetry {
     #[serde(default)]
     pub fixslice_escalation_count: u32,
 
+    /// Fix_slice escalations triggered by consecutive same-path edit failures (Issue #332).
+    #[serde(default)]
+    pub fixslice_escalation_same_path_count: u32,
+
+    /// Fix_slice escalations triggered by stagnation + cross-path edit failures (Issue #332).
+    #[serde(default)]
+    pub fixslice_escalation_stagnation_count: u32,
+
+    /// Retrospective count of repair-turn-only salvage runs (Issue #332).
+    ///
+    /// Set by `classify_repair_salvage()` when a session produced a mutation
+    /// via the pre-exit repair turn but never reached the intended worker path.
+    /// Does NOT flip `worker_observed` — it is a distinct outcome classification.
+    #[serde(default)]
+    pub fixslice_escalation_repair_salvage_count: u32,
+
     /// Number of pre-exit repair turns injected (Issue #325).
     #[serde(default)]
     pub pre_exit_repair_injected_count: u32,
@@ -537,10 +553,46 @@ impl AgentTelemetry {
         self.final_suppressed_with_remaining_targets_count += 1;
     }
 
-    /// Record a fix_slice escalation event (Issue #321).
+    /// Record a same-path fix_slice escalation event (Issue #321, #332).
+    ///
+    /// Triggered when consecutive edit failures on a single path reach the
+    /// `edit_fixslice_threshold`. Bumps both the overall count and the
+    /// same-path counter and flips `worker_observed`.
     pub fn record_fixslice_escalation(&mut self) {
         self.fixslice_escalation_count += 1;
+        self.fixslice_escalation_same_path_count += 1;
         self.worker_observed = true;
+    }
+
+    /// Record a stagnation-triggered fix_slice escalation (Issue #332).
+    ///
+    /// Triggered when the model scatters edit failures across multiple files
+    /// so no same-path threshold is reached, but the session is clearly
+    /// stagnating. Bumps the overall count and the stagnation counter, and
+    /// flips `worker_observed`.
+    pub fn record_fixslice_escalation_stagnation(&mut self) {
+        self.fixslice_escalation_count += 1;
+        self.fixslice_escalation_stagnation_count += 1;
+        self.worker_observed = true;
+    }
+
+    /// Retrospectively classify the session as a repair-turn-only salvage (Issue #332).
+    ///
+    /// Fires at most once per session. A salvage run is one where:
+    /// - the pre-exit repair turn was observed, AND
+    /// - a mutation was observed, AND
+    /// - no worker path was reached.
+    ///
+    /// Does NOT flip `worker_observed`; it only increments the salvage counter
+    /// so pack validation and observability can distinguish a true worker run
+    /// from a late-repair salvage.
+    pub fn classify_repair_salvage(&mut self) {
+        if self.fixslice_escalation_repair_salvage_count > 0 {
+            return;
+        }
+        if self.repair_turn_observed && self.mutation_observed && !self.worker_observed {
+            self.fixslice_escalation_repair_salvage_count = 1;
+        }
     }
 
     /// Threshold: mutations after this turn are considered "late".
@@ -654,6 +706,12 @@ impl AgentTelemetry {
             "repair_turn_observed": self.repair_turn_observed,
             "pack_expectation": self.pack_expectation.map(|e| e.to_string()),
             "expectation_mismatch_reason": self.expectation_mismatch_reason,
+            // Issue #332: distinguishing fix_slice escalation reasons.
+            "fixslice_escalation_count": self.fixslice_escalation_count,
+            "fixslice_escalation_same_path_count": self.fixslice_escalation_same_path_count,
+            "fixslice_escalation_stagnation_count": self.fixslice_escalation_stagnation_count,
+            "fixslice_escalation_repair_salvage_count":
+                self.fixslice_escalation_repair_salvage_count,
         });
 
         let json_bytes = serde_json::to_vec_pretty(&payload)?;

--- a/tests/fixslice_escalation.rs
+++ b/tests/fixslice_escalation.rs
@@ -2,9 +2,13 @@
 //!
 //! Tests that repeated single-file edit failures escalate to
 //! agent.fix_slice via EditFallbackAction::FixSliceEscalation.
+//!
+//! Issue #332 extensions test the broadened escalation trigger that
+//! fires on stagnation + cumulative edit failures across multiple paths,
+//! not only on same-path consecutive failures.
 
 use anvil::app::edit_fail_tracker::{
-    EditFailTracker, EditFallbackAction, determine_fallback_action,
+    EditFailTracker, EditFallbackAction, determine_fallback_action, should_escalate_for_stagnation,
 };
 use anvil::app::stagnation_state::{StagnationState, compute_stagnation_score};
 use anvil::contracts::AgentTelemetry;
@@ -245,4 +249,181 @@ fn test_agent_telemetry_fixslice_default_zero() {
     let json = r#"{"premature_final_count":0,"total_final_requests":0,"plan_registration_count":0,"plan_update_count":0,"sync_from_touched_files_count":0,"completion_kind":null}"#;
     let tel: AgentTelemetry = serde_json::from_str(json).unwrap();
     assert_eq!(tel.fixslice_escalation_count, 0);
+}
+
+// ============================================================
+// Issue #332: broadened escalation (stagnation + cross-path failures)
+// ============================================================
+
+#[test]
+fn test_config_defaults_for_stagnation_escalation_thresholds() {
+    let config = anvil::config::EffectiveConfig::default_for_test().unwrap();
+    assert_eq!(
+        config.runtime.edit_fixslice_stagnation_total_threshold, 4,
+        "default total-failures threshold should be 4"
+    );
+    assert_eq!(
+        config.runtime.edit_fixslice_stagnation_score_threshold, 2,
+        "default stagnation-score threshold should be 2"
+    );
+}
+
+#[test]
+fn test_tracker_total_failures_accumulates_across_paths() {
+    let mut tracker = EditFailTracker::new(3, 5, 7);
+    assert_eq!(tracker.total_failures(), 0);
+
+    tracker.record_failure("a.ts");
+    tracker.record_failure("b.ts");
+    tracker.record_failure("c.ts");
+    assert_eq!(tracker.total_failures(), 3);
+
+    // Success on one path does not decrease the cumulative total.
+    tracker.record_success("a.ts");
+    assert_eq!(tracker.total_failures(), 3);
+
+    tracker.record_failure("a.ts");
+    assert_eq!(tracker.total_failures(), 4);
+}
+
+#[test]
+fn test_should_escalate_for_stagnation_pure_function() {
+    // Disabled threshold: never escalate.
+    assert!(!should_escalate_for_stagnation(10, 4, 0, 2));
+    // Below failure threshold: no escalation.
+    assert!(!should_escalate_for_stagnation(3, 4, 4, 2));
+    // Below stagnation score: no escalation.
+    assert!(!should_escalate_for_stagnation(4, 1, 4, 2));
+    // Both conditions met: escalate.
+    assert!(should_escalate_for_stagnation(4, 2, 4, 2));
+    assert!(should_escalate_for_stagnation(10, 4, 4, 2));
+}
+
+#[test]
+fn test_cross_path_drift_triggers_stagnation_escalation() {
+    // Issue #332: model spreads edits across multiple files and no path
+    // reaches the same-path threshold, but cumulative failures + stagnation
+    // are high enough to escalate.
+    let mut tracker = EditFailTracker::new(3, 5, 7);
+    // 4 failures across 4 different files — no single path hits 3 reread,
+    // so EditFallbackAction never returns FixSliceEscalation.
+    for path in ["a.ts", "b.ts", "c.ts", "d.ts"] {
+        let action = tracker.record_failure(path);
+        assert_eq!(action, EditFallbackAction::Continue);
+    }
+    assert_eq!(tracker.total_failures(), 4);
+
+    // Simulate stagnation score = 2 (mutation drought + workset staleness).
+    let mut stag = StagnationState::new();
+    let workset = vec![0usize];
+    for _ in 0..5 {
+        stag.begin_turn(&workset);
+        stag.end_turn(false);
+    }
+    let score = compute_stagnation_score(&stag);
+    assert!(score >= 2, "expected score >= 2, got {score}");
+
+    // Broadened policy: should fire even though no same-path count >= 7.
+    assert!(should_escalate_for_stagnation(
+        tracker.total_failures(),
+        score as u32,
+        4,
+        2,
+    ));
+}
+
+#[test]
+fn test_telemetry_same_path_counter_bumped_by_legacy_method() {
+    let mut tel = AgentTelemetry::new();
+    tel.record_fixslice_escalation();
+    assert_eq!(tel.fixslice_escalation_count, 1);
+    assert_eq!(tel.fixslice_escalation_same_path_count, 1);
+    assert_eq!(tel.fixslice_escalation_stagnation_count, 0);
+    assert_eq!(tel.fixslice_escalation_repair_salvage_count, 0);
+    assert!(tel.worker_observed);
+}
+
+#[test]
+fn test_telemetry_stagnation_escalation_distinct_from_same_path() {
+    let mut tel = AgentTelemetry::new();
+    tel.record_fixslice_escalation_stagnation();
+    assert_eq!(tel.fixslice_escalation_count, 1);
+    assert_eq!(tel.fixslice_escalation_stagnation_count, 1);
+    assert_eq!(tel.fixslice_escalation_same_path_count, 0);
+    assert!(tel.worker_observed);
+
+    // A subsequent same-path escalation bumps only the same-path counter.
+    tel.record_fixslice_escalation();
+    assert_eq!(tel.fixslice_escalation_count, 2);
+    assert_eq!(tel.fixslice_escalation_same_path_count, 1);
+    assert_eq!(tel.fixslice_escalation_stagnation_count, 1);
+}
+
+#[test]
+fn test_telemetry_repair_salvage_classification_does_not_flip_worker() {
+    // Salvage is a retrospective label — it means repair turn produced
+    // a mutation without ever reaching the worker path.
+    let mut tel = AgentTelemetry::new();
+    tel.record_mutation_turn(3, Some(1.0), "file.edit");
+    tel.record_pre_exit_repair_injected();
+    tel.record_pre_exit_repair_consumed();
+    assert!(!tel.worker_observed);
+
+    tel.classify_repair_salvage();
+    assert_eq!(tel.fixslice_escalation_repair_salvage_count, 1);
+    assert!(
+        !tel.worker_observed,
+        "salvage must not flip worker_observed — it is a distinct classification"
+    );
+    // Salvage classification is idempotent.
+    tel.classify_repair_salvage();
+    assert_eq!(tel.fixslice_escalation_repair_salvage_count, 1);
+}
+
+#[test]
+fn test_telemetry_no_salvage_when_worker_already_observed() {
+    let mut tel = AgentTelemetry::new();
+    tel.record_mutation_turn(3, Some(1.0), "file.edit");
+    tel.record_pre_exit_repair_injected();
+    tel.record_fixslice_escalation_stagnation();
+
+    tel.classify_repair_salvage();
+    assert_eq!(tel.fixslice_escalation_repair_salvage_count, 0);
+}
+
+#[test]
+fn test_telemetry_no_salvage_without_mutation() {
+    let mut tel = AgentTelemetry::new();
+    tel.record_pre_exit_repair_injected();
+    tel.record_pre_exit_repair_consumed();
+
+    tel.classify_repair_salvage();
+    assert_eq!(tel.fixslice_escalation_repair_salvage_count, 0);
+}
+
+#[test]
+fn test_telemetry_serializes_new_counters() {
+    let mut tel = AgentTelemetry::new();
+    tel.record_fixslice_escalation();
+    tel.record_fixslice_escalation_stagnation();
+
+    let json = serde_json::to_string(&tel).unwrap();
+    assert!(json.contains("\"fixslice_escalation_same_path_count\":1"));
+    assert!(json.contains("\"fixslice_escalation_stagnation_count\":1"));
+    assert!(json.contains("\"fixslice_escalation_repair_salvage_count\":0"));
+
+    let round_trip: AgentTelemetry = serde_json::from_str(&json).unwrap();
+    assert_eq!(round_trip.fixslice_escalation_same_path_count, 1);
+    assert_eq!(round_trip.fixslice_escalation_stagnation_count, 1);
+    assert_eq!(round_trip.fixslice_escalation_repair_salvage_count, 0);
+}
+
+#[test]
+fn test_telemetry_new_counters_backward_compat_default_zero() {
+    // Old artifacts missing the new fields should deserialize cleanly.
+    let json = r#"{"premature_final_count":0,"total_final_requests":0,"plan_registration_count":0,"plan_update_count":0,"sync_from_touched_files_count":0,"completion_kind":null}"#;
+    let tel: AgentTelemetry = serde_json::from_str(json).unwrap();
+    assert_eq!(tel.fixslice_escalation_same_path_count, 0);
+    assert_eq!(tel.fixslice_escalation_stagnation_count, 0);
+    assert_eq!(tel.fixslice_escalation_repair_salvage_count, 0);
 }


### PR DESCRIPTION
## Summary
- fix_slice escalation を同一パス連続失敗だけでなく、cross-path drift (stagnation + repeated failed edit attempts) でも発火するように拡張
- 設定可能な stagnation score threshold を追加 (`edit_fixslice_stagnation_score_threshold`)
- テレメトリで escalation 種別を区別 (same-path vs stagnation vs repair salvage)

## Test plan
- [x] cargo test --test fixslice_escalation で新規テスト全パス
- [x] cargo clippy --all-targets 警告0件
- [x] cargo test 全テストパス
- [x] cargo fmt --check 差分なし

Fixes #332

🤖 Generated with [Claude Code](https://claude.com/claude-code)