### PR TITLE
fix(issue-334): add read-heavy worker escalation and tighten worker-required gate

### DIFF
--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -1038,6 +1038,46 @@ impl App {
                 self.session.push_message(msg);
             }
 
+            // Issue #334: read-heavy drift escalation.
+            //
+            // Issue #332 still requires cumulative edit failures. A session
+            // dominated by reads / audits that never attempts an edit cannot
+            // cross that threshold, so it drifts through repeated reads,
+            // plan repair, and pre-exit repair without reaching the worker
+            // path. Fire escalation here when the stagnation score is high
+            // and no mutation has been observed at all.
+            if !self.agent_telemetry.worker_observed
+                && crate::app::edit_fail_tracker::should_escalate_for_read_heavy_drift(
+                    stagnation_score as u32,
+                    self.agent_telemetry.mutation_observed,
+                    self.stagnation_state.turns_since_last_mutation as u32,
+                    self.config.runtime.edit_fixslice_read_heavy_score_threshold,
+                    self.config
+                        .runtime
+                        .edit_fixslice_read_heavy_drought_threshold,
+                )
+            {
+                tracing::warn!(
+                    score = stagnation_score,
+                    drought = self.stagnation_state.turns_since_last_mutation,
+                    "fixslice_escalation_triggered (read_heavy)"
+                );
+                self.agent_telemetry.record_fixslice_escalation_stagnation();
+                let hint = format!(
+                    "\n\n[Anvil ESCALATION] The session has stagnated on reads / audits \
+                     (score={score}/4, {drought} turns without any mutation). You MUST stop \
+                     reading and call agent.fix_slice on the most relevant target file to \
+                     produce a concrete change. Pick a target_path from the active plan \
+                     and supply a goal describing the mutation you intend to make. Do NOT \
+                     read or search further before calling agent.fix_slice.",
+                    score = stagnation_score,
+                    drought = self.stagnation_state.turns_since_last_mutation,
+                );
+                let msg = SessionMessage::new(MessageRole::Tool, "system", hint)
+                    .with_id(self.next_message_id("tool"));
+                self.session.push_message(msg);
+            }
+
             // Issue #285: staged stagnation recovery.
             let remaining_turns = max_iterations.saturating_sub(iteration + 1);
             let plan_repair_count_before_this_turn =

--- a/src/app/edit_fail_tracker.rs
+++ b/src/app/edit_fail_tracker.rs
@@ -85,6 +85,29 @@ pub fn should_escalate_for_stagnation(
         && stagnation_score >= score_threshold
 }
 
+/// Decide whether to escalate to the worker path due to read-heavy drift
+/// with no mutation observed (Issue #334).
+///
+/// The Issue #332 policy still requires cumulative edit failures. A session
+/// that never attempts an edit cannot cross that threshold, so read-heavy
+/// drift (repeated reads / searches, stagnation score high, zero mutation)
+/// never reaches the worker path. This trigger closes that gap by firing
+/// independently of `total_failures`.
+///
+/// `score_threshold == 0` disables the trigger.
+pub fn should_escalate_for_read_heavy_drift(
+    stagnation_score: u32,
+    mutation_observed: bool,
+    turns_since_last_mutation: u32,
+    score_threshold: u32,
+    drought_threshold: u32,
+) -> bool {
+    score_threshold > 0
+        && !mutation_observed
+        && stagnation_score >= score_threshold
+        && turns_since_last_mutation >= drought_threshold
+}
+
 /// Tracks consecutive file.edit failures per file path.
 /// Used to detect when the LLM is stuck retrying edits on the same file
 /// and should be prompted to try an alternative approach (Issue #158, #321).

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -193,6 +193,14 @@ pub struct RuntimeConfig {
     /// Minimum stagnation score required for stagnation-driven fix_slice
     /// escalation (Issue #332).
     pub edit_fixslice_stagnation_score_threshold: u32,
+    /// Minimum stagnation score required for read-heavy fix_slice
+    /// escalation (Issue #334). Fires independently of cumulative edit
+    /// failures when a session is dominated by reads with no mutation.
+    /// 0 = disabled.
+    pub edit_fixslice_read_heavy_score_threshold: u32,
+    /// Minimum `turns_since_last_mutation` required to treat a session as
+    /// read-heavy drift and escalate to the worker path (Issue #334).
+    pub edit_fixslice_read_heavy_drought_threshold: u32,
     /// Maximum line count for file.write on existing files (0 = disabled, Issue #156).
     pub safe_write_max_lines: usize,
     /// Deletion ratio threshold for diff warning (0.0-1.0, Issue #156).
@@ -392,6 +400,8 @@ impl EffectiveConfig {
                 edit_fixslice_threshold: 7,
                 edit_fixslice_stagnation_total_threshold: 4,
                 edit_fixslice_stagnation_score_threshold: 2,
+                edit_fixslice_read_heavy_score_threshold: 2,
+                edit_fixslice_read_heavy_drought_threshold: 5,
                 safe_write_max_lines: 500,
                 safe_write_deletion_ratio: 0.5,
                 read_repeat_warn_threshold: 3,
@@ -905,6 +915,26 @@ impl EffectiveConfig {
                     }
                     self.runtime.edit_fixslice_stagnation_score_threshold = v;
                 }
+                "edit_fixslice_read_heavy_score_threshold"
+                | "ANVIL_EDIT_FIXSLICE_READ_HEAVY_SCORE_THRESHOLD" => {
+                    let v: u32 = value
+                        .parse()
+                        .map_err(|_| ConfigError::InvalidNumericValue(value.clone()))?;
+                    if v > 4 {
+                        return Err(ConfigError::InvalidNumericValue(value.clone()));
+                    }
+                    self.runtime.edit_fixslice_read_heavy_score_threshold = v;
+                }
+                "edit_fixslice_read_heavy_drought_threshold"
+                | "ANVIL_EDIT_FIXSLICE_READ_HEAVY_DROUGHT_THRESHOLD" => {
+                    let v: u32 = value
+                        .parse()
+                        .map_err(|_| ConfigError::InvalidNumericValue(value.clone()))?;
+                    if !(1..=40).contains(&v) {
+                        return Err(ConfigError::InvalidNumericValue(value.clone()));
+                    }
+                    self.runtime.edit_fixslice_read_heavy_drought_threshold = v;
+                }
                 "edit_recovery_read_budget" | "ANVIL_EDIT_RECOVERY_READ_BUDGET" => {
                     let v: u32 = value
                         .parse()
@@ -1223,6 +1253,18 @@ impl EffectiveConfig {
             .runtime
             .edit_fixslice_stagnation_score_threshold
             .clamp(1, 4);
+        // Issue #334: clamp read-heavy escalation thresholds.
+        // Score: 0 disables; otherwise bounded by score range [1, 4].
+        if self.runtime.edit_fixslice_read_heavy_score_threshold > 0 {
+            self.runtime.edit_fixslice_read_heavy_score_threshold = self
+                .runtime
+                .edit_fixslice_read_heavy_score_threshold
+                .clamp(1, 4);
+        }
+        self.runtime.edit_fixslice_read_heavy_drought_threshold = self
+            .runtime
+            .edit_fixslice_read_heavy_drought_threshold
+            .clamp(1, 40);
         self.runtime.edit_recovery_read_budget =
             self.runtime.edit_recovery_read_budget.clamp(1, 10);
     }
@@ -1591,6 +1633,14 @@ impl std::fmt::Debug for RuntimeConfig {
             .field(
                 "edit_fixslice_stagnation_score_threshold",
                 &self.edit_fixslice_stagnation_score_threshold,
+            )
+            .field(
+                "edit_fixslice_read_heavy_score_threshold",
+                &self.edit_fixslice_read_heavy_score_threshold,
+            )
+            .field(
+                "edit_fixslice_read_heavy_drought_threshold",
+                &self.edit_fixslice_read_heavy_drought_threshold,
             )
             .field("safe_write_max_lines", &self.safe_write_max_lines)
             .field("safe_write_deletion_ratio", &self.safe_write_deletion_ratio)

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -129,8 +129,9 @@ pub enum PackExpectation {
     AuditOnly,
     /// The pack requires at least one real file mutation (`changed_files > 0`).
     RequiresMutation,
-    /// The pack requires observable worker-path evidence: fix_slice escalation,
-    /// pre-exit repair turn, *or* mutation.
+    /// The pack requires observable worker-path evidence: only a fix_slice
+    /// escalation (`worker_observed=true`) satisfies this gate. Repair-turn
+    /// or mutation-only salvage is explicitly rejected (Issue #334).
     RequiresWorkerObservation,
 }
 
@@ -768,11 +769,15 @@ impl AgentTelemetry {
             }
 
             PackExpectation::RequiresWorkerObservation => {
-                if self.worker_observed || self.repair_turn_observed || self.mutation_observed {
+                // Issue #334: repair-turn or mutation-only salvage must NOT
+                // satisfy this gate. Only actual worker-path observation
+                // (fix_slice escalation) counts, so runtime semantics agree
+                // with the strict benchmark runner classification.
+                if self.worker_observed {
                     PackValidationResult::Satisfied
                 } else {
-                    let reason = "pack requires worker observation but no worker path, \
-                                  repair turn, or mutation was observed"
+                    let reason = "pack requires worker path (fix_slice escalation) but \
+                                  worker was not observed"
                         .to_string();
                     self.expectation_mismatch_reason = Some(reason.clone());
                     PackValidationResult::Mismatch {

--- a/tests/pack_validation_gate.rs
+++ b/tests/pack_validation_gate.rs
@@ -147,7 +147,7 @@ fn validate_requires_worker_observation_mismatch_when_nothing_observed() {
             reason,
         } => {
             assert_eq!(*expectation, PackExpectation::RequiresWorkerObservation);
-            assert!(reason.contains("no worker path"), "reason: {reason}");
+            assert!(reason.contains("worker"), "reason: {reason}");
         }
         other => panic!("expected Mismatch, got {other:?}"),
     }
@@ -161,18 +161,59 @@ fn validate_requires_worker_observation_satisfied_by_fixslice() {
     assert_eq!(result, PackValidationResult::Satisfied);
 }
 
+// Issue #334: repair-turn-only and mutation-only sessions must NOT satisfy
+// the worker-observation gate.  Runtime semantics must agree with the
+// benchmark runner's strict classification, otherwise salvage runs mask
+// missing worker-path evidence.
 #[test]
-fn validate_requires_worker_observation_satisfied_by_repair_turn() {
+fn validate_requires_worker_observation_mismatch_when_only_repair_turn() {
     let mut tel = AgentTelemetry::new();
     tel.record_pre_exit_repair_injected();
     let result = tel.validate_against(PackExpectation::RequiresWorkerObservation);
-    assert_eq!(result, PackValidationResult::Satisfied);
+    match &result {
+        PackValidationResult::Mismatch {
+            expectation,
+            reason,
+        } => {
+            assert_eq!(*expectation, PackExpectation::RequiresWorkerObservation);
+            assert!(reason.contains("worker"), "reason: {reason}");
+        }
+        other => panic!("expected Mismatch, got {other:?}"),
+    }
 }
 
 #[test]
-fn validate_requires_worker_observation_satisfied_by_mutation() {
+fn validate_requires_worker_observation_mismatch_when_only_mutation() {
     let mut tel = AgentTelemetry::new();
     tel.record_mutation_turn(2, Some(0.5), "file.write");
+    let result = tel.validate_against(PackExpectation::RequiresWorkerObservation);
+    match &result {
+        PackValidationResult::Mismatch {
+            expectation,
+            reason,
+        } => {
+            assert_eq!(*expectation, PackExpectation::RequiresWorkerObservation);
+            assert!(reason.contains("worker"), "reason: {reason}");
+        }
+        other => panic!("expected Mismatch, got {other:?}"),
+    }
+}
+
+#[test]
+fn validate_requires_worker_observation_mismatch_when_repair_plus_mutation() {
+    // Even repair + mutation together must not satisfy the gate — this is
+    // exactly the salvage pattern the benchmark runner rejects.
+    let mut tel = AgentTelemetry::new();
+    tel.record_pre_exit_repair_injected();
+    tel.record_mutation_turn(4, Some(1.0), "file.edit");
+    let result = tel.validate_against(PackExpectation::RequiresWorkerObservation);
+    assert!(matches!(result, PackValidationResult::Mismatch { .. }));
+}
+
+#[test]
+fn validate_requires_worker_observation_satisfied_only_by_worker_observed() {
+    let mut tel = AgentTelemetry::new();
+    tel.record_fixslice_escalation_stagnation();
     let result = tel.validate_against(PackExpectation::RequiresWorkerObservation);
     assert_eq!(result, PackValidationResult::Satisfied);
 }

--- a/tests/read_heavy_worker_escalation.rs
+++ b/tests/read_heavy_worker_escalation.rs
@@ -1,0 +1,112 @@
+//! Regression tests for Issue #334: read-heavy stagnation must reach the
+//! worker path even when no edit failures accumulate.
+//!
+//! Issue #332 solved the cross-path edit-failure case, but Phase2 drift
+//! manifests as repeated reads / audits with no mutation and almost no
+//! failed edit attempts. The stagnation-driven escalation therefore needs
+//! a second trigger that does not depend on `edit_fail_tracker.total_failures()`.
+
+use anvil::app::edit_fail_tracker::should_escalate_for_read_heavy_drift;
+use anvil::app::stagnation_state::{StagnationState, compute_stagnation_score};
+use anvil::contracts::{AgentTelemetry, PackExpectation, PackValidationResult};
+
+// ---------------------------------------------------------------------------
+// Policy pure function
+// ---------------------------------------------------------------------------
+
+#[test]
+fn read_heavy_escalation_disabled_when_score_threshold_is_zero() {
+    assert!(!should_escalate_for_read_heavy_drift(4, false, 10, 0, 5));
+}
+
+#[test]
+fn read_heavy_escalation_requires_no_mutation_observed() {
+    // Mutation already happened — not a read-heavy session anymore.
+    assert!(!should_escalate_for_read_heavy_drift(4, true, 10, 2, 5));
+}
+
+#[test]
+fn read_heavy_escalation_requires_score_above_threshold() {
+    assert!(!should_escalate_for_read_heavy_drift(1, false, 10, 2, 5));
+}
+
+#[test]
+fn read_heavy_escalation_requires_drought() {
+    assert!(!should_escalate_for_read_heavy_drift(3, false, 4, 2, 5));
+}
+
+#[test]
+fn read_heavy_escalation_fires_on_boundary_conditions() {
+    // Exactly at both thresholds → fire.
+    assert!(should_escalate_for_read_heavy_drift(2, false, 5, 2, 5));
+}
+
+#[test]
+fn read_heavy_escalation_fires_when_score_and_drought_exceed_thresholds() {
+    assert!(should_escalate_for_read_heavy_drift(4, false, 12, 2, 5));
+}
+
+// ---------------------------------------------------------------------------
+// Integrated: stagnation state + policy reproduces the Issue #334 drift
+// ---------------------------------------------------------------------------
+
+#[test]
+fn read_heavy_session_reaches_escalation_without_any_edit_failures() {
+    // Reproduce the Phase2 pattern:
+    //   - repeated read-only turns
+    //   - no mutation observed
+    //   - edit_fail_tracker.total_failures() == 0 (no failed edits)
+    //   - stagnation score climbs
+    //
+    // The existing `should_escalate_for_stagnation` never fires because
+    // it requires `total_failures >= threshold`. The new policy must.
+    let mut state = StagnationState::new();
+    let workset = vec![0usize];
+    for _ in 0..6 {
+        state.begin_turn(&workset);
+        state.end_turn(false);
+    }
+    let score = compute_stagnation_score(&state);
+    assert!(score >= 2, "expected score >= 2, got {score}");
+
+    // mutation_observed == false, turns_since_last_mutation >= drought threshold.
+    assert!(should_escalate_for_read_heavy_drift(
+        score as u32,
+        false,
+        state.turns_since_last_mutation as u32,
+        2,
+        5,
+    ));
+}
+
+// ---------------------------------------------------------------------------
+// Runtime pack-validation gate must only accept worker_observed=true
+// ---------------------------------------------------------------------------
+
+#[test]
+fn runtime_gate_rejects_repair_only_salvage_for_worker_required_pack() {
+    let mut tel = AgentTelemetry::new();
+    tel.record_pre_exit_repair_injected();
+    tel.record_pre_exit_repair_consumed();
+    tel.record_mutation_turn(8, Some(1.5), "file.edit");
+    // Retrospectively classify as salvage — this is the exact A1 log pattern.
+    tel.classify_repair_salvage();
+    assert_eq!(tel.fixslice_escalation_repair_salvage_count, 1);
+    assert!(!tel.worker_observed);
+
+    let result = tel.validate_against(PackExpectation::RequiresWorkerObservation);
+    match result {
+        PackValidationResult::Mismatch { .. } => {}
+        other => panic!("expected Mismatch, got {other:?}"),
+    }
+}
+
+#[test]
+fn runtime_gate_accepts_stagnation_triggered_worker_escalation() {
+    let mut tel = AgentTelemetry::new();
+    tel.record_fixslice_escalation_stagnation();
+    assert!(tel.worker_observed);
+
+    let result = tel.validate_against(PackExpectation::RequiresWorkerObservation);
+    assert_eq!(result, PackValidationResult::Satisfied);
+}


### PR DESCRIPTION
## Summary
Issue #332 (cross-path edit-failure escalation) の次段階修正。read-heavy drift pattern にも対応し、`RequiresWorkerObservation` の満足条件を厳格化。

### 変更内容
1. **read-heavy worker escalation**: edit failure に依存しない escalation を追加
   - stagnation 継続 + no-mutation-drought 時に worker escalation 発火
   - `edit_fixslice_read_heavy_drought_threshold` (default=5) で閾値設定可能
2. **`RequiresWorkerObservation` 厳格化**: `worker_observed=true` のみで satisfy
   - repair-only / mutation-only salvage は satisfy しない
   - runtime gate と benchmark gate の定義が一致
3. **回帰テスト追加**: `tests/read_heavy_worker_escalation.rs` (新規) で read-heavy パターンをカバー

## Test plan
- [x] cargo test --test read_heavy_worker_escalation で新規テスト全パス
- [x] cargo test --test pack_validation_gate で既存テスト全パス
- [x] cargo clippy --all-targets 警告0件
- [x] cargo test 全テストパス
- [x] cargo fmt --check 差分なし

Fixes #334

🤖 Generated with [Claude Code](https://claude.com/claude-code)