### PR TITLE
fix(issue-339): only flip worker_observed after real post-execution worker success

### DIFF
--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -520,6 +520,19 @@ impl App {
         let rewrite_request = build_rewrite_request(&proposal, &call.tool_call_id);
         let rewrite_result = self.execute_single(rewrite_request);
 
+        // Issue #339: flip worker_observed only after a real post-execution
+        // worker mutation. The rewrite must be completed, not rolled back,
+        // and produce a non-empty / non-no-op summary — mirroring the
+        // record_mutation_turn guard so the two telemetry flags stay
+        // consistent.
+        if rewrite_result.status == ToolExecutionStatus::Completed
+            && !rewrite_result.rolled_back
+            && !rewrite_result.summary.is_empty()
+            && !rewrite_result.summary.contains("(no changes)")
+        {
+            self.agent_telemetry.record_worker_success();
+        }
+
         // Build agent.fix_slice summary result
         let rationale = sanitize_for_display(&proposal.rationale);
         let fix_summary = ToolExecutionResult {

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -417,7 +417,15 @@ pub struct AgentTelemetry {
     #[serde(default)]
     pub mutation_observed: bool,
 
-    /// Whether the worker path (fix_slice escalation) was observed.
+    /// Whether the worker path produced a real post-execution mutation
+    /// (Issue #339).
+    ///
+    /// Set to true ONLY after a successful `agent.fix_slice` →
+    /// `file.rewrite` execution whose result survived rollback and no-op
+    /// filtering. Emitting a fix_slice escalation hint does NOT flip this
+    /// flag — escalation-emission is the request side and is tracked by
+    /// `fixslice_escalation_count` / `fixslice_escalation_same_path_count`
+    /// / `fixslice_escalation_stagnation_count`.
     #[serde(default)]
     pub worker_observed: bool,
 
@@ -570,22 +578,36 @@ impl AgentTelemetry {
     ///
     /// Triggered when consecutive edit failures on a single path reach the
     /// `edit_fixslice_threshold`. Bumps both the overall count and the
-    /// same-path counter and flips `worker_observed`.
+    /// same-path counter.
+    ///
+    /// Issue #339: this is a request-side signal (the runtime emitted the
+    /// escalation hint) and MUST NOT flip `worker_observed`. The success-
+    /// side flag is only set by [`record_worker_success`] after a real
+    /// post-execution worker mutation.
     pub fn record_fixslice_escalation(&mut self) {
         self.fixslice_escalation_count += 1;
         self.fixslice_escalation_same_path_count += 1;
-        self.worker_observed = true;
     }
 
     /// Record a stagnation-triggered fix_slice escalation (Issue #332).
     ///
     /// Triggered when the model scatters edit failures across multiple files
     /// so no same-path threshold is reached, but the session is clearly
-    /// stagnating. Bumps the overall count and the stagnation counter, and
-    /// flips `worker_observed`.
+    /// stagnating. Bumps the overall count and the stagnation counter.
+    ///
+    /// Issue #339: request-side only — does NOT flip `worker_observed`.
     pub fn record_fixslice_escalation_stagnation(&mut self) {
         self.fixslice_escalation_count += 1;
         self.fixslice_escalation_stagnation_count += 1;
+    }
+
+    /// Record a real post-execution worker event (Issue #339).
+    ///
+    /// Called only after the agent actually invoked `agent.fix_slice` and
+    /// its resulting `file.rewrite` completed without rollback and with a
+    /// non-empty, non-no-op summary. This is the success-side flag the
+    /// pack validation gate trusts.
+    pub fn record_worker_success(&mut self) {
         self.worker_observed = true;
     }
 

--- a/tests/fixslice_escalation.rs
+++ b/tests/fixslice_escalation.rs
@@ -340,7 +340,12 @@ fn test_telemetry_same_path_counter_bumped_by_legacy_method() {
     assert_eq!(tel.fixslice_escalation_same_path_count, 1);
     assert_eq!(tel.fixslice_escalation_stagnation_count, 0);
     assert_eq!(tel.fixslice_escalation_repair_salvage_count, 0);
-    assert!(tel.worker_observed);
+    // Issue #339: escalation is request-side only and must not flip the
+    // success-side `worker_observed` flag.
+    assert!(
+        !tel.worker_observed,
+        "escalation-emission must not flip worker_observed"
+    );
 }
 
 #[test]
@@ -350,13 +355,15 @@ fn test_telemetry_stagnation_escalation_distinct_from_same_path() {
     assert_eq!(tel.fixslice_escalation_count, 1);
     assert_eq!(tel.fixslice_escalation_stagnation_count, 1);
     assert_eq!(tel.fixslice_escalation_same_path_count, 0);
-    assert!(tel.worker_observed);
+    // Issue #339: stagnation escalation is request-side only.
+    assert!(!tel.worker_observed);
 
     // A subsequent same-path escalation bumps only the same-path counter.
     tel.record_fixslice_escalation();
     assert_eq!(tel.fixslice_escalation_count, 2);
     assert_eq!(tel.fixslice_escalation_same_path_count, 1);
     assert_eq!(tel.fixslice_escalation_stagnation_count, 1);
+    assert!(!tel.worker_observed);
 }
 
 #[test]
@@ -385,7 +392,10 @@ fn test_telemetry_no_salvage_when_worker_already_observed() {
     let mut tel = AgentTelemetry::new();
     tel.record_mutation_turn(3, Some(1.0), "file.edit");
     tel.record_pre_exit_repair_injected();
+    // Issue #339: under the new semantics, salvage suppression requires
+    // real worker success, not merely an escalation request.
     tel.record_fixslice_escalation_stagnation();
+    tel.record_worker_success();
 
     tel.classify_repair_salvage();
     assert_eq!(tel.fixslice_escalation_repair_salvage_count, 0);

--- a/tests/pack_validation_gate.rs
+++ b/tests/pack_validation_gate.rs
@@ -58,11 +58,26 @@ fn mutation_observed_set_by_record_mutation_turn() {
     assert!(tel.mutation_observed);
 }
 
+// Issue #339: escalation is a request-side signal and MUST NOT flip the
+// success-side `worker_observed` flag. Only `record_worker_success()` —
+// called after a real post-execution worker mutation — may set it.
 #[test]
-fn worker_observed_set_by_record_fixslice_escalation() {
+fn worker_observed_not_set_by_record_fixslice_escalation() {
     let mut tel = AgentTelemetry::new();
     assert!(!tel.worker_observed);
     tel.record_fixslice_escalation();
+    assert!(
+        !tel.worker_observed,
+        "escalation-emission must not flip worker_observed"
+    );
+    assert_eq!(tel.fixslice_escalation_count, 1);
+}
+
+#[test]
+fn worker_observed_set_by_record_worker_success() {
+    let mut tel = AgentTelemetry::new();
+    assert!(!tel.worker_observed);
+    tel.record_worker_success();
     assert!(tel.worker_observed);
 }
 
@@ -153,10 +168,26 @@ fn validate_requires_worker_observation_mismatch_when_nothing_observed() {
     }
 }
 
+// Issue #339: escalation alone must NOT satisfy the worker gate.
+// Only a real post-execution worker success does.
 #[test]
-fn validate_requires_worker_observation_satisfied_by_fixslice() {
+fn validate_requires_worker_observation_mismatch_when_only_escalation_emitted() {
     let mut tel = AgentTelemetry::new();
     tel.record_fixslice_escalation();
+    let result = tel.validate_against(PackExpectation::RequiresWorkerObservation);
+    match &result {
+        PackValidationResult::Mismatch { expectation, .. } => {
+            assert_eq!(*expectation, PackExpectation::RequiresWorkerObservation);
+        }
+        other => panic!("expected Mismatch, got {other:?}"),
+    }
+}
+
+#[test]
+fn validate_requires_worker_observation_satisfied_by_worker_success() {
+    let mut tel = AgentTelemetry::new();
+    tel.record_fixslice_escalation();
+    tel.record_worker_success();
     let result = tel.validate_against(PackExpectation::RequiresWorkerObservation);
     assert_eq!(result, PackValidationResult::Satisfied);
 }
@@ -210,10 +241,21 @@ fn validate_requires_worker_observation_mismatch_when_repair_plus_mutation() {
     assert!(matches!(result, PackValidationResult::Mismatch { .. }));
 }
 
+// Issue #339: stagnation-triggered escalation alone must also not satisfy
+// the gate. Worker success telemetry must come from record_worker_success().
 #[test]
-fn validate_requires_worker_observation_satisfied_only_by_worker_observed() {
+fn validate_requires_worker_observation_mismatch_when_only_stagnation_escalation() {
     let mut tel = AgentTelemetry::new();
     tel.record_fixslice_escalation_stagnation();
+    let result = tel.validate_against(PackExpectation::RequiresWorkerObservation);
+    assert!(matches!(result, PackValidationResult::Mismatch { .. }));
+}
+
+#[test]
+fn validate_requires_worker_observation_satisfied_only_by_worker_success() {
+    let mut tel = AgentTelemetry::new();
+    tel.record_fixslice_escalation_stagnation();
+    tel.record_worker_success();
     let result = tel.validate_against(PackExpectation::RequiresWorkerObservation);
     assert_eq!(result, PackValidationResult::Satisfied);
 }
@@ -231,6 +273,7 @@ fn telemetry_artifact_includes_pack_validation_fields() {
     let mut tel = AgentTelemetry::new();
     tel.record_mutation_turn(1, Some(0.3), "file.write");
     tel.record_fixslice_escalation();
+    tel.record_worker_success();
     tel.record_pre_exit_repair_injected();
     tel.pack_expectation = Some(PackExpectation::RequiresWorkerObservation);
 

--- a/tests/read_heavy_worker_escalation.rs
+++ b/tests/read_heavy_worker_escalation.rs
@@ -101,10 +101,23 @@ fn runtime_gate_rejects_repair_only_salvage_for_worker_required_pack() {
     }
 }
 
+// Issue #339: stagnation escalation alone is the request side and must NOT
+// satisfy the gate. The session must also record a real worker success.
 #[test]
-fn runtime_gate_accepts_stagnation_triggered_worker_escalation() {
+fn runtime_gate_rejects_stagnation_escalation_without_worker_success() {
     let mut tel = AgentTelemetry::new();
     tel.record_fixslice_escalation_stagnation();
+    assert!(!tel.worker_observed);
+
+    let result = tel.validate_against(PackExpectation::RequiresWorkerObservation);
+    assert!(matches!(result, PackValidationResult::Mismatch { .. }));
+}
+
+#[test]
+fn runtime_gate_accepts_stagnation_escalation_followed_by_worker_success() {
+    let mut tel = AgentTelemetry::new();
+    tel.record_fixslice_escalation_stagnation();
+    tel.record_worker_success();
     assert!(tel.worker_observed);
 
     let result = tel.validate_against(PackExpectation::RequiresWorkerObservation);

--- a/tests/worker_observed_success_side.rs
+++ b/tests/worker_observed_success_side.rs
@@ -1,0 +1,173 @@
+//! Regression tests for Issue #339: worker_observed must be a success-side
+//! telemetry flag, not a request-side one.
+//!
+//! The exact A1 false-positive shape Issue #339 rejects:
+//!
+//! - runtime emitted a fix_slice escalation hint
+//! - `worker_observed` was flipped to `true` at emission time
+//! - the agent never produced a real mutation
+//! - `mutation_observed` remained `false`
+//! - pack validation returned `Satisfied` for `RequiresWorkerObservation`
+//!
+//! These tests pin the corrected semantics: `worker_observed` only becomes
+//! `true` after `record_worker_success()`, which in runtime is called only
+//! from `handle_fixslice_result` after the worker-owned `file.rewrite`
+//! actually completes without rollback.
+
+use anvil::contracts::{AgentTelemetry, PackExpectation, PackValidationResult};
+
+// ---------------------------------------------------------------------------
+// Negative: escalation-emission must NOT flip worker_observed
+// ---------------------------------------------------------------------------
+
+#[test]
+fn same_path_escalation_alone_does_not_flip_worker_observed() {
+    let mut tel = AgentTelemetry::new();
+    tel.record_fixslice_escalation();
+    assert_eq!(tel.fixslice_escalation_count, 1);
+    assert_eq!(tel.fixslice_escalation_same_path_count, 1);
+    assert!(
+        !tel.worker_observed,
+        "same-path escalation is request-side and must not flip worker_observed"
+    );
+    assert!(!tel.mutation_observed);
+}
+
+#[test]
+fn stagnation_escalation_alone_does_not_flip_worker_observed() {
+    let mut tel = AgentTelemetry::new();
+    tel.record_fixslice_escalation_stagnation();
+    assert_eq!(tel.fixslice_escalation_count, 1);
+    assert_eq!(tel.fixslice_escalation_stagnation_count, 1);
+    assert!(
+        !tel.worker_observed,
+        "stagnation escalation is request-side and must not flip worker_observed"
+    );
+    assert!(!tel.mutation_observed);
+}
+
+#[test]
+fn repeated_escalations_never_flip_worker_observed() {
+    let mut tel = AgentTelemetry::new();
+    for _ in 0..5 {
+        tel.record_fixslice_escalation();
+        tel.record_fixslice_escalation_stagnation();
+    }
+    assert_eq!(tel.fixslice_escalation_count, 10);
+    assert!(!tel.worker_observed);
+}
+
+// ---------------------------------------------------------------------------
+// A1 false-positive shape: must be rejected by the pack validation gate
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a1_false_positive_shape_is_rejected_by_worker_gate() {
+    // Reproduces the exact failure mode captured in Issue #339's A1 run:
+    //   worker_observed=true (pre-fix) + mutation_observed=false + zero-diff
+    //
+    // After the fix, `worker_observed` is false because only escalation
+    // hints were emitted, so the gate correctly reports Mismatch.
+    let mut tel = AgentTelemetry::new();
+    tel.record_fixslice_escalation_stagnation(); // "A1 read-heavy stagnation"
+    assert!(!tel.worker_observed);
+    assert!(!tel.mutation_observed);
+
+    let result = tel.validate_against(PackExpectation::RequiresWorkerObservation);
+    match &result {
+        PackValidationResult::Mismatch { expectation, .. } => {
+            assert_eq!(*expectation, PackExpectation::RequiresWorkerObservation);
+        }
+        other => panic!("expected Mismatch, got {other:?}"),
+    }
+    assert!(tel.expectation_mismatch_reason.is_some());
+}
+
+#[test]
+fn escalation_plus_unrelated_edit_mutation_still_rejected_by_worker_gate() {
+    // Even if the agent later produces a mutation via ordinary `file.edit`
+    // (not the worker path), a worker-required pack must still fail because
+    // no real worker success was recorded.
+    let mut tel = AgentTelemetry::new();
+    tel.record_fixslice_escalation();
+    tel.record_mutation_turn(5, Some(2.0), "file.edit");
+    assert!(tel.mutation_observed);
+    assert!(!tel.worker_observed);
+
+    let result = tel.validate_against(PackExpectation::RequiresWorkerObservation);
+    assert!(matches!(result, PackValidationResult::Mismatch { .. }));
+}
+
+// ---------------------------------------------------------------------------
+// Positive: escalation + real worker success satisfies the gate
+// ---------------------------------------------------------------------------
+
+#[test]
+fn escalation_plus_worker_success_satisfies_worker_gate() {
+    let mut tel = AgentTelemetry::new();
+    // Runtime emits the escalation hint (request side).
+    tel.record_fixslice_escalation();
+    // Agent invokes agent.fix_slice; the resulting file.rewrite completes
+    // without rollback — `handle_fixslice_result` calls both helpers.
+    tel.record_mutation_turn(6, Some(3.0), "file.rewrite");
+    tel.record_worker_success();
+
+    assert!(tel.worker_observed);
+    assert!(tel.mutation_observed);
+    assert_eq!(tel.fixslice_escalation_count, 1);
+
+    let result = tel.validate_against(PackExpectation::RequiresWorkerObservation);
+    assert_eq!(result, PackValidationResult::Satisfied);
+    assert!(tel.expectation_mismatch_reason.is_none());
+}
+
+#[test]
+fn worker_success_without_prior_escalation_also_satisfies_gate() {
+    // The agent may call agent.fix_slice proactively without a preceding
+    // escalation hint. That path should still count as worker observation.
+    let mut tel = AgentTelemetry::new();
+    tel.record_mutation_turn(2, Some(0.8), "file.rewrite");
+    tel.record_worker_success();
+
+    assert!(tel.worker_observed);
+    let result = tel.validate_against(PackExpectation::RequiresWorkerObservation);
+    assert_eq!(result, PackValidationResult::Satisfied);
+}
+
+// ---------------------------------------------------------------------------
+// Salvage classification interaction with the new semantics
+// ---------------------------------------------------------------------------
+
+#[test]
+fn salvage_classification_fires_when_escalation_emitted_but_worker_did_not_succeed() {
+    // Repair-only mutation after escalation: the escalation fired, but the
+    // worker never actually succeeded. The session is a salvage, not a
+    // worker-backed run.
+    let mut tel = AgentTelemetry::new();
+    tel.record_fixslice_escalation();
+    tel.record_pre_exit_repair_injected();
+    tel.record_mutation_turn(7, Some(2.5), "file.edit");
+    assert!(!tel.worker_observed);
+
+    tel.classify_repair_salvage();
+    assert_eq!(tel.fixslice_escalation_repair_salvage_count, 1);
+
+    // And the worker gate still rejects salvage, even with escalation emitted.
+    let result = tel.validate_against(PackExpectation::RequiresWorkerObservation);
+    assert!(matches!(result, PackValidationResult::Mismatch { .. }));
+}
+
+#[test]
+fn salvage_classification_suppressed_by_real_worker_success() {
+    let mut tel = AgentTelemetry::new();
+    tel.record_fixslice_escalation_stagnation();
+    tel.record_pre_exit_repair_injected();
+    tel.record_mutation_turn(8, Some(3.0), "file.rewrite");
+    tel.record_worker_success();
+
+    tel.classify_repair_salvage();
+    assert_eq!(
+        tel.fixslice_escalation_repair_salvage_count, 0,
+        "real worker success must suppress salvage classification"
+    );
+}


### PR DESCRIPTION
## Summary
Issue #334 で `worker_observed` は fix_slice escalation **emission** 時に set されていたが、これは「escalation が要求された」という意味であり、「worker が実際に実行され結果を出した」という意味ではなかった。この inflated semantic により Phase2 A1 が **zero mutation / no changes diff** でも `pack_validation_result=satisfied` を返していた。

### 変更内容
1. **request-side / success-side 分離**: fix_slice escalation emission 時点では `worker_observed` を flip しない
2. **agent.fix_slice 実行後のみ set**: agentic.rs の FixSlice subagent 結果ハンドラで、実際に proposal が返り fix_summary が構築できた時点で set
3. **既存 escalation カウンター**: request-side diagnostic として残るが worker success を含意しない
4. **`RequiresWorkerObservation` validation**: 意味論が success-side になったため runtime と benchmark strict interpretation が一致

### Test plan
- [x] tests/worker_observed_success_side.rs: 新規回帰テスト (9件)
- [x] tests/fixslice_escalation.rs: 既存テスト更新（新意味論対応）
- [x] tests/pack_validation_gate.rs: 既存テスト更新
- [x] tests/read_heavy_worker_escalation.rs: 既存テスト更新
- [x] cargo clippy --all-targets 警告0件
- [x] cargo test 全テストパス
- [x] cargo fmt --check 差分なし

Fixes #339

🤖 Generated with [Claude Code](https://claude.com/claude-code)