### PR TITLE
fix(issue-341): embed target_path and max_lines in FixSlice worker prompt

### DIFF
--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -352,7 +352,8 @@ impl App {
             let kind = SubAgentKind::from_tool_input(&call.input).unwrap();
 
             // Extract prompt, scope, and optional FixSlice parameters.
-            // We pre-compute the FixSlice parent_dir so the borrow lives long enough.
+            // We pre-compute the FixSlice parent_dir and the structured user
+            // prompt so the borrows live long enough for the match below.
             let fixslice_parent_dir: Option<String> = match &call.input {
                 ToolInput::AgentFixSlice { target_path, .. } => {
                     std::path::Path::new(target_path.as_str())
@@ -362,6 +363,17 @@ impl App {
                 }
                 _ => None,
             };
+            // Issue #341: embed target_path and max_lines in the worker's
+            // user prompt so it anchors to the correct file instead of
+            // drifting into unrelated reads.
+            let fixslice_user_prompt: Option<String> = match &call.input {
+                ToolInput::AgentFixSlice {
+                    target_path,
+                    goal,
+                    max_lines,
+                } => Some(build_fixslice_user_prompt(target_path, goal, *max_lines)),
+                _ => None,
+            };
             let (prompt, scope, fixslice_params) = match &call.input {
                 ToolInput::AgentExplore { prompt, scope } => {
                     (prompt.as_str(), scope.as_deref(), None)
@@ -369,12 +381,15 @@ impl App {
                 ToolInput::AgentPlan { prompt, scope } => (prompt.as_str(), scope.as_deref(), None),
                 ToolInput::AgentFixSlice {
                     target_path,
-                    goal,
                     max_lines,
+                    ..
                 } => {
-                    // DR2-010: goal → prompt, target_path parent dir → scope
+                    // DR2-010 + Issue #341: structured prompt (includes
+                    // target_path/max_lines) → prompt, target_path parent dir → scope.
                     (
-                        goal.as_str(),
+                        fixslice_user_prompt
+                            .as_deref()
+                            .expect("fixslice_user_prompt is built for AgentFixSlice"),
                         fixslice_parent_dir.as_deref(),
                         Some((target_path.clone(), *max_lines)),
                     )
@@ -3159,6 +3174,29 @@ pub fn build_rewrite_request(
         tool_call_id: format!("{parent_call_id}_rewrite"),
         extra_field_warnings: Vec::new(),
     }
+}
+
+/// Build the FixSlice sub-agent user prompt from structured parameters.
+///
+/// The worker's correctness depends on knowing exactly which file to edit
+/// and how many lines its proposal may span. Passing only the free-form
+/// `goal` leaves the worker to guess the target file (Issue #341), so we
+/// embed `target_path` and `max_lines` explicitly alongside the goal.
+pub fn build_fixslice_user_prompt(target_path: &str, goal: &str, max_lines: u32) -> String {
+    format!(
+        "FixSlice task — target file is fixed.\n\
+         \n\
+         target_path: {target_path}\n\
+         max_lines: {max_lines}\n\
+         \n\
+         goal:\n{goal}\n\
+         \n\
+         Procedure:\n\
+         1. Read `{target_path}` first with file.read to locate the exact lines to change.\n\
+         2. Return a single JSON proposal inside ANVIL_FINAL whose `target_path` equals `{target_path}` exactly.\n\
+         3. Keep the `end_line - start_line + 1` span within {max_lines} lines.\n\
+         4. Do not explore unrelated files; the edit must stay on the target."
+    )
 }
 
 /// Remove control characters from a string for safe display in summaries.

--- a/tests/fixslice_subagent.rs
+++ b/tests/fixslice_subagent.rs
@@ -4,7 +4,9 @@ use anvil::agent::subagent::{
     FIXSLICE_MAX_ITERATIONS, FIXSLICE_TIMEOUT_SECS, MAX_FIXSLICE_LINES, SubAgentKind,
 };
 use anvil::agent::tag_spec::find_spec;
-use anvil::app::agentic::{build_rewrite_request, validate_fix_proposal};
+use anvil::app::agentic::{
+    build_fixslice_user_prompt, build_rewrite_request, validate_fix_proposal,
+};
 use anvil::contracts::FixSliceProposal;
 use anvil::tooling::{
     ExecutionClass, ExecutionMode, PermissionClass, ToolCallRequest, ToolInput, ToolKind,
@@ -541,6 +543,53 @@ fn test_fixslice_validation_control_char_in_target_path() {
 // ---------------------------------------------------------------------------
 // ToolInput::kind() mapping
 // ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Issue #341: FixSlice worker must receive target_path and max_lines in its
+// user prompt, not only the free-form goal.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_fixslice_user_prompt_contains_target_and_budget() {
+    let prompt = build_fixslice_user_prompt(
+        "src/lib/auto-yes-manager.ts",
+        "remove stale branch and add regression test",
+        80,
+    );
+    assert!(
+        prompt.contains("src/lib/auto-yes-manager.ts"),
+        "prompt must embed the exact target_path: {prompt}"
+    );
+    assert!(
+        prompt.contains("80"),
+        "prompt must embed the max_lines budget: {prompt}"
+    );
+    assert!(
+        prompt.contains("remove stale branch and add regression test"),
+        "prompt must embed the goal verbatim: {prompt}"
+    );
+}
+
+#[test]
+fn test_fixslice_user_prompt_anchors_worker_to_target() {
+    let prompt =
+        build_fixslice_user_prompt("crates/foo/src/bar.rs", "fix panic on empty input", 40);
+    // The worker must be told to read the target first and to match the
+    // target_path in its proposal, otherwise exploration drifts (Issue #341).
+    assert!(
+        prompt.contains("file.read"),
+        "prompt should instruct the worker to read the target first"
+    );
+    assert!(
+        prompt.contains("ANVIL_FINAL"),
+        "prompt should reference the ANVIL_FINAL proposal format"
+    );
+    let target_occurrences = prompt.matches("crates/foo/src/bar.rs").count();
+    assert!(
+        target_occurrences >= 2,
+        "target_path should appear multiple times for redundancy, got {target_occurrences}: {prompt}"
+    );
+}
 
 #[test]
 fn test_fixslice_tool_kind_mapping() {


### PR DESCRIPTION
## Summary
Issue #339 で `worker_observed` semantics は修正されたが、Phase2 retest で FixSlice worker が **target context を受け取らず** target file に収束できない問題を修正。

### 変更内容
- `src/app/agentic.rs`: `ToolInput::AgentFixSlice` ハンドラで subagent user prompt に以下を明示的に埋め込む
  - `target_path` (exact)
  - `max_lines` (bounded budget)
  - `goal`
  - structured instruction block（target file をまず読む、proposal の target_path 一致保証）
- `tests/fixslice_subagent.rs`: subagent 初回 prompt に target_path/max_lines が含まれることを検証する新規テスト追加

## Test plan
- [x] cargo test --test fixslice_subagent 新規テスト全パス
- [x] cargo clippy --all-targets 警告0件
- [x] cargo test 全テストパス
- [x] cargo fmt --check 差分なし

Fixes #341

🤖 Generated with [Claude Code](https://claude.com/claude-code)