### PR TITLE
fix(issue-343): suppress pre-exit repair salvage after fix_slice worker failure

### DIFF
--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -513,9 +513,27 @@ impl App {
         let proposal = match sub_result.fix_proposal {
             Some(p) => p,
             None => {
-                // Worker finished without a valid proposal
-                let reason = sub_result.payload.termination_reason;
-                let summary = format!("fix-slice worker {reason}: no valid proposal produced");
+                // Worker finished without a valid proposal.
+                // Issue #343: classify *why* the worker didn't produce one so
+                // the runtime and telemetry can distinguish max-iterations
+                // exhaustion from ordinary "finished with no proposal" cases.
+                let termination = sub_result.payload.termination_reason;
+                let failure_reason = match termination {
+                    crate::contracts::TerminationReason::MaxIterations => {
+                        crate::contracts::FixSliceFailureReason::MaxIterationsReached
+                    }
+                    _ => crate::contracts::FixSliceFailureReason::NoProposal,
+                };
+                self.agent_telemetry
+                    .record_fixslice_worker_failure(failure_reason);
+                tracing::warn!(
+                    termination = %termination,
+                    failure_reason = %failure_reason,
+                    "fix_slice worker failed to produce proposal"
+                );
+                let summary = format!(
+                    "fix-slice worker {termination}: no valid proposal produced ({failure_reason})"
+                );
                 return vec![build_failed_result_with_text(call, summary)];
             }
         };
@@ -527,6 +545,14 @@ impl App {
             max_lines,
             &self.config.paths.cwd,
         ) {
+            // Issue #343: proposal produced but validation rejected it.
+            self.agent_telemetry.record_fixslice_worker_failure(
+                crate::contracts::FixSliceFailureReason::ProposalValidationFailed,
+            );
+            tracing::warn!(
+                reason = %reason,
+                "fix_slice worker proposal failed validation"
+            );
             let summary = format!("fix-slice validation failed: {reason}");
             return vec![build_failed_result_with_text(call, summary)];
         }
@@ -540,12 +566,23 @@ impl App {
         // and produce a non-empty / non-no-op summary — mirroring the
         // record_mutation_turn guard so the two telemetry flags stay
         // consistent.
-        if rewrite_result.status == ToolExecutionStatus::Completed
+        let rewrite_succeeded = rewrite_result.status == ToolExecutionStatus::Completed
             && !rewrite_result.rolled_back
             && !rewrite_result.summary.is_empty()
-            && !rewrite_result.summary.contains("(no changes)")
-        {
+            && !rewrite_result.summary.contains("(no changes)");
+        if rewrite_succeeded {
             self.agent_telemetry.record_worker_success();
+        } else {
+            // Issue #343: the worker produced a valid proposal but
+            // file.rewrite did not land a real mutation.
+            self.agent_telemetry.record_fixslice_worker_failure(
+                crate::contracts::FixSliceFailureReason::RewriteFailed,
+            );
+            tracing::warn!(
+                rewrite_status = ?rewrite_result.status,
+                rolled_back = rewrite_result.rolled_back,
+                "fix_slice worker rewrite failed or produced no-op"
+            );
         }
 
         // Build agent.fix_slice summary result
@@ -1246,6 +1283,28 @@ impl App {
                     if !self.execution_plan.is_empty()
                         && !self.execution_plan.is_successfully_completed()
                     {
+                        // Issue #343: under a `requires_worker_observation`
+                        // pack, skip the pre-exit repair turn once the worker
+                        // path has already failed. Otherwise the repair turn
+                        // flips `repair_turn_observed`, lets parent-side
+                        // `file.edit` salvage the session, and ends in
+                        // `completion_kind=partial` — exactly the A1 shape
+                        // the benchmark runner rejects.
+                        if self
+                            .agent_telemetry
+                            .should_skip_pre_exit_repair_for_worker_failure()
+                        {
+                            tracing::warn!(
+                                score = stagnation_score,
+                                failure_reason = ?self.agent_telemetry.fixslice_failure_reason,
+                                fixslice_worker_failure_count =
+                                    self.agent_telemetry.fixslice_worker_failure_count,
+                                "worker-required pack + fix_slice failure: \
+                                 skipping pre-exit repair turn (Issue #343)"
+                            );
+                            break;
+                        }
+
                         // Issue #327: record pending count before repair and activate
                         // closure mode to reject unchecked plan expansion.
                         let pending_before = self

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -633,7 +633,16 @@ impl App {
             session_stats: SessionStats::new(),
             last_compact_info: None,
             execution_plan: crate::contracts::ExecutionPlan::default(),
-            agent_telemetry: crate::contracts::AgentTelemetry::new(),
+            agent_telemetry: {
+                // Issue #343: cache the active pack expectation at session
+                // start so the agentic loop can consult it without re-reading
+                // env on every turn. `validate_pack_expectation` still
+                // re-resolves at session end, so this cache is only a
+                // read-side convenience.
+                let mut tel = crate::contracts::AgentTelemetry::new();
+                tel.pack_expectation = crate::contracts::PackExpectation::from_env();
+                tel
+            },
             stagnation_state: stagnation_state::StagnationState::new(),
             forced_mode_active: false,
             tool_recovery_budget: tool_recovery_budget::ToolRecoveryBudget::new(
@@ -983,6 +992,22 @@ impl App {
         // Issue #332: retrospectively classify repair-turn-only salvage
         // before pack validation/artifact emission so the counter is durable.
         self.agent_telemetry.classify_repair_salvage();
+
+        // Issue #343: surface an explicit runtime-summary warning when the
+        // session finished with a recorded fix_slice worker failure but no
+        // corresponding worker success. Makes the A1 shape visible in logs
+        // without waiting for the pack validation gate at the very end.
+        if self.agent_telemetry.has_fixslice_worker_failure()
+            && !self.agent_telemetry.worker_observed
+        {
+            tracing::warn!(
+                fixslice_worker_failure_count = self.agent_telemetry.fixslice_worker_failure_count,
+                fixslice_failure_reason = self.agent_telemetry.fixslice_failure_reason.as_deref(),
+                repair_turn_observed = self.agent_telemetry.repair_turn_observed,
+                mutation_observed = self.agent_telemetry.mutation_observed,
+                "fix_slice worker failed to reach success; session ended without worker observation"
+            );
+        }
 
         // Issue #329: Validate pack expectation gate before writing artifact.
         {

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -113,6 +113,38 @@ pub struct FixSliceProposal {
     pub rationale: String,
 }
 
+/// Why a FixSlice worker invocation failed to reach a successful worker
+/// mutation (Issue #343).
+///
+/// Emitted by `handle_fixslice_result` and recorded on `AgentTelemetry` via
+/// `record_fixslice_worker_failure`. The runtime uses the recorded failure
+/// to decide whether the pre-exit repair turn should still be injected under
+/// a `requires_worker_observation` pack — see
+/// `AgentTelemetry::should_skip_pre_exit_repair_for_worker_failure`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FixSliceFailureReason {
+    /// Worker finished (normal termination) without emitting a proposal.
+    NoProposal,
+    /// Worker emitted a proposal but `validate_fix_proposal` rejected it.
+    ProposalValidationFailed,
+    /// Proposal was valid, but the worker-owned `file.rewrite` did not
+    /// complete cleanly (failed / rolled back / produced a no-op diff).
+    RewriteFailed,
+    /// Worker hit its iteration cap before producing a proposal.
+    MaxIterationsReached,
+}
+
+impl std::fmt::Display for FixSliceFailureReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NoProposal => write!(f, "no_proposal"),
+            Self::ProposalValidationFailed => write!(f, "proposal_validation_failed"),
+            Self::RewriteFailed => write!(f, "rewrite_failed"),
+            Self::MaxIterationsReached => write!(f, "max_iterations_reached"),
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Pack expectation / validation gate (Issue #329)
 // ---------------------------------------------------------------------------
@@ -441,6 +473,23 @@ pub struct AgentTelemetry {
     /// `None` when expectation is satisfied or unset.
     #[serde(default)]
     pub expectation_mismatch_reason: Option<String>,
+
+    /// Number of times a FixSlice worker invocation failed to reach a
+    /// successful worker mutation (Issue #343).
+    ///
+    /// Counts every failure class (`no_proposal`, `proposal_validation_failed`,
+    /// `rewrite_failed`, `max_iterations_reached`). Independent of
+    /// `fixslice_escalation_count`, which tracks request-side escalation
+    /// emission.
+    #[serde(default)]
+    pub fixslice_worker_failure_count: u32,
+
+    /// Most recent FixSlice worker failure reason (Issue #343).
+    ///
+    /// Serialized as the snake_case form of `FixSliceFailureReason`.
+    /// `None` until the first failure is recorded.
+    #[serde(default)]
+    pub fixslice_failure_reason: Option<String>,
 }
 
 impl AgentTelemetry {
@@ -611,6 +660,43 @@ impl AgentTelemetry {
         self.worker_observed = true;
     }
 
+    /// Record a FixSlice worker failure (Issue #343).
+    ///
+    /// Called from `handle_fixslice_result` whenever an invocation of
+    /// `agent.fix_slice` does not reach a successful worker mutation. Bumps
+    /// the running count and stores the latest reason. Does NOT touch
+    /// `worker_observed`: success-side semantics are preserved from Issue #339.
+    pub fn record_fixslice_worker_failure(&mut self, reason: FixSliceFailureReason) {
+        self.fixslice_worker_failure_count += 1;
+        self.fixslice_failure_reason = Some(reason.to_string());
+    }
+
+    /// Whether any FixSlice worker failure has been recorded (Issue #343).
+    pub fn has_fixslice_worker_failure(&self) -> bool {
+        self.fixslice_worker_failure_count > 0
+    }
+
+    /// Whether the pre-exit repair turn should be skipped because the
+    /// worker path has already failed under a `requires_worker_observation`
+    /// pack (Issue #343).
+    ///
+    /// Returns true when all of the following hold:
+    /// - `pack_expectation` is `RequiresWorkerObservation`,
+    /// - at least one FixSlice worker failure has been recorded,
+    /// - `worker_observed` is still false.
+    ///
+    /// The agentic loop uses this to bail out cleanly instead of injecting
+    /// a repair turn that would only flip `repair_turn_observed` and
+    /// degrade `completion_kind` to `partial` without ever satisfying the
+    /// pack expectation.
+    pub fn should_skip_pre_exit_repair_for_worker_failure(&self) -> bool {
+        matches!(
+            self.pack_expectation,
+            Some(PackExpectation::RequiresWorkerObservation)
+        ) && self.has_fixslice_worker_failure()
+            && !self.worker_observed
+    }
+
     /// Retrospectively classify the session as a repair-turn-only salvage (Issue #332).
     ///
     /// Fires at most once per session. A salvage run is one where:
@@ -747,6 +833,9 @@ impl AgentTelemetry {
             "fixslice_escalation_stagnation_count": self.fixslice_escalation_stagnation_count,
             "fixslice_escalation_repair_salvage_count":
                 self.fixslice_escalation_repair_salvage_count,
+            // Issue #343: fix_slice worker failure taxonomy.
+            "fixslice_worker_failure_count": self.fixslice_worker_failure_count,
+            "fixslice_failure_reason": self.fixslice_failure_reason,
         });
 
         let json_bytes = serde_json::to_vec_pretty(&payload)?;

--- a/tests/fixslice_failure_control.rs
+++ b/tests/fixslice_failure_control.rs
@@ -1,0 +1,243 @@
+//! Integration tests for Issue #343: fix_slice failure control.
+//!
+//! Issue #343 covers the failure mode where `agent.fix_slice` is invoked
+//! (request side) but never reaches a successful worker mutation, yet the
+//! parent session continues to drift: `file.edit` lands a mutation later,
+//! the pre-exit repair turn is consumed, and telemetry ends with
+//! `worker_observed=false`, `mutation_observed=true`, `repair_turn_observed=true`.
+//!
+//! Under a `requires_worker_observation` pack expectation, that is a
+//! benchmark failure — the worker never produced observable evidence, but
+//! parent-side salvage kept the loop running and ended in `partial`.
+//!
+//! The fix:
+//! - classifies *why* fix_slice failed (no proposal, validation failure,
+//!   rewrite failure, max iterations),
+//! - exposes a failure counter + last reason on `AgentTelemetry`, and
+//! - provides `should_skip_pre_exit_repair_for_worker_failure()` so the
+//!   agentic loop can bail out cleanly instead of injecting a repair turn
+//!   that would otherwise flip `repair_turn_observed` and degrade
+//!   `completion_kind` to `partial`.
+
+use anvil::contracts::{
+    AgentTelemetry, FixSliceFailureReason, PackExpectation, PackValidationResult,
+};
+
+// ---------------------------------------------------------------------------
+// FixSliceFailureReason
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fixslice_failure_reason_display_roundtrip() {
+    for (variant, expected) in [
+        (FixSliceFailureReason::NoProposal, "no_proposal"),
+        (
+            FixSliceFailureReason::ProposalValidationFailed,
+            "proposal_validation_failed",
+        ),
+        (FixSliceFailureReason::RewriteFailed, "rewrite_failed"),
+        (
+            FixSliceFailureReason::MaxIterationsReached,
+            "max_iterations_reached",
+        ),
+    ] {
+        assert_eq!(variant.to_string(), expected);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// record_fixslice_worker_failure
+// ---------------------------------------------------------------------------
+
+#[test]
+fn record_fixslice_worker_failure_sets_count_and_reason() {
+    let mut tel = AgentTelemetry::new();
+    assert_eq!(tel.fixslice_worker_failure_count, 0);
+    assert!(tel.fixslice_failure_reason.is_none());
+
+    tel.record_fixslice_worker_failure(FixSliceFailureReason::MaxIterationsReached);
+
+    assert_eq!(tel.fixslice_worker_failure_count, 1);
+    assert_eq!(
+        tel.fixslice_failure_reason.as_deref(),
+        Some("max_iterations_reached")
+    );
+    assert!(
+        !tel.worker_observed,
+        "recording a fix_slice failure must NOT flip worker_observed"
+    );
+}
+
+#[test]
+fn record_fixslice_worker_failure_accumulates_count_and_tracks_latest_reason() {
+    let mut tel = AgentTelemetry::new();
+    tel.record_fixslice_worker_failure(FixSliceFailureReason::NoProposal);
+    tel.record_fixslice_worker_failure(FixSliceFailureReason::MaxIterationsReached);
+    tel.record_fixslice_worker_failure(FixSliceFailureReason::ProposalValidationFailed);
+
+    assert_eq!(tel.fixslice_worker_failure_count, 3);
+    assert_eq!(
+        tel.fixslice_failure_reason.as_deref(),
+        Some("proposal_validation_failed"),
+        "latest failure reason should win for observability"
+    );
+}
+
+#[test]
+fn has_fixslice_worker_failure_tracks_any_recorded_failure() {
+    let mut tel = AgentTelemetry::new();
+    assert!(!tel.has_fixslice_worker_failure());
+    tel.record_fixslice_worker_failure(FixSliceFailureReason::RewriteFailed);
+    assert!(tel.has_fixslice_worker_failure());
+}
+
+// ---------------------------------------------------------------------------
+// should_skip_pre_exit_repair_for_worker_failure
+// ---------------------------------------------------------------------------
+
+#[test]
+fn should_skip_repair_true_for_worker_required_after_fixslice_failure() {
+    // The A1 shape from Issue #343:
+    //  - pack expectation = requires_worker_observation
+    //  - fix_slice invoked and failed (e.g. max iterations)
+    //  - worker success never recorded
+    //
+    // Under the fix, the agentic loop must NOT inject a pre-exit repair
+    // turn — the pack cannot be satisfied and the repair turn would only
+    // flip repair_turn_observed and degrade completion_kind.
+    let mut tel = AgentTelemetry::new();
+    tel.pack_expectation = Some(PackExpectation::RequiresWorkerObservation);
+    tel.record_fixslice_escalation();
+    tel.record_fixslice_worker_failure(FixSliceFailureReason::MaxIterationsReached);
+
+    assert!(tel.should_skip_pre_exit_repair_for_worker_failure());
+}
+
+#[test]
+fn should_skip_repair_false_when_worker_success_was_recorded() {
+    let mut tel = AgentTelemetry::new();
+    tel.pack_expectation = Some(PackExpectation::RequiresWorkerObservation);
+    tel.record_fixslice_escalation();
+    tel.record_fixslice_worker_failure(FixSliceFailureReason::RewriteFailed);
+    // A later fix_slice attempt eventually succeeds:
+    tel.record_mutation_turn(6, Some(2.0), "file.rewrite");
+    tel.record_worker_success();
+
+    assert!(!tel.should_skip_pre_exit_repair_for_worker_failure());
+}
+
+#[test]
+fn should_skip_repair_false_without_any_fixslice_failure() {
+    let mut tel = AgentTelemetry::new();
+    tel.pack_expectation = Some(PackExpectation::RequiresWorkerObservation);
+    // Pack is worker-required but fix_slice was never called / never
+    // failed — the existing escape-hatch behavior should remain in effect.
+    assert!(!tel.should_skip_pre_exit_repair_for_worker_failure());
+}
+
+#[test]
+fn should_skip_repair_false_when_pack_expectation_is_unset() {
+    let mut tel = AgentTelemetry::new();
+    tel.record_fixslice_worker_failure(FixSliceFailureReason::NoProposal);
+    assert!(!tel.should_skip_pre_exit_repair_for_worker_failure());
+}
+
+#[test]
+fn should_skip_repair_false_for_requires_mutation_pack() {
+    let mut tel = AgentTelemetry::new();
+    tel.pack_expectation = Some(PackExpectation::RequiresMutation);
+    tel.record_fixslice_worker_failure(FixSliceFailureReason::MaxIterationsReached);
+    // requires_mutation can still be satisfied by a parent-side file.edit
+    // mutation, so the worker-failure skip must not kick in.
+    assert!(!tel.should_skip_pre_exit_repair_for_worker_failure());
+}
+
+#[test]
+fn should_skip_repair_false_for_audit_only_pack() {
+    let mut tel = AgentTelemetry::new();
+    tel.pack_expectation = Some(PackExpectation::AuditOnly);
+    tel.record_fixslice_worker_failure(FixSliceFailureReason::NoProposal);
+    assert!(!tel.should_skip_pre_exit_repair_for_worker_failure());
+}
+
+// ---------------------------------------------------------------------------
+// Interaction with pack validation
+// ---------------------------------------------------------------------------
+
+#[test]
+fn worker_required_gate_still_rejects_after_fixslice_failure_only() {
+    // Parity with Issue #339 semantics: a recorded fix_slice failure on
+    // its own must not accidentally flip worker_observed. The gate must
+    // continue to reject the session.
+    let mut tel = AgentTelemetry::new();
+    tel.record_fixslice_escalation();
+    tel.record_fixslice_worker_failure(FixSliceFailureReason::MaxIterationsReached);
+
+    let result = tel.validate_against(PackExpectation::RequiresWorkerObservation);
+    assert!(matches!(result, PackValidationResult::Mismatch { .. }));
+    assert!(!tel.worker_observed);
+}
+
+// ---------------------------------------------------------------------------
+// Telemetry artifact persistence
+// ---------------------------------------------------------------------------
+
+#[test]
+fn telemetry_artifact_includes_fixslice_failure_fields() {
+    let dir = tempfile::tempdir().unwrap();
+    let session_id = format!("test_fixslice_failure_{}", std::process::id());
+    let dir_str = dir.path().to_str().unwrap();
+
+    let mut tel = AgentTelemetry::new();
+    tel.record_fixslice_escalation();
+    tel.record_fixslice_worker_failure(FixSliceFailureReason::MaxIterationsReached);
+    tel.record_fixslice_worker_failure(FixSliceFailureReason::NoProposal);
+    tel.pack_expectation = Some(PackExpectation::RequiresWorkerObservation);
+
+    tel.write_artifact_to_dir(dir_str, &session_id).unwrap();
+
+    let file_path = dir.path().join(format!("{session_id}_telemetry.json"));
+    let contents = std::fs::read_to_string(&file_path).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&contents).unwrap();
+
+    assert_eq!(json["fixslice_worker_failure_count"], 2);
+    assert_eq!(json["fixslice_failure_reason"], "no_proposal");
+}
+
+#[test]
+fn telemetry_artifact_fixslice_failure_fields_default() {
+    let dir = tempfile::tempdir().unwrap();
+    let session_id = format!("test_fixslice_failure_default_{}", std::process::id());
+    let dir_str = dir.path().to_str().unwrap();
+
+    let tel = AgentTelemetry::new();
+    tel.write_artifact_to_dir(dir_str, &session_id).unwrap();
+
+    let file_path = dir.path().join(format!("{session_id}_telemetry.json"));
+    let contents = std::fs::read_to_string(&file_path).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&contents).unwrap();
+
+    assert_eq!(json["fixslice_worker_failure_count"], 0);
+    assert!(json["fixslice_failure_reason"].is_null());
+}
+
+// ---------------------------------------------------------------------------
+// Salvage classification interaction — the new failure counter is orthogonal
+// to the existing repair-salvage classifier and must not suppress it.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fixslice_failure_does_not_suppress_repair_salvage_classification() {
+    let mut tel = AgentTelemetry::new();
+    tel.record_fixslice_escalation();
+    tel.record_fixslice_worker_failure(FixSliceFailureReason::MaxIterationsReached);
+    tel.record_pre_exit_repair_injected();
+    tel.record_mutation_turn(11, Some(4.0), "file.edit");
+
+    tel.classify_repair_salvage();
+    assert_eq!(
+        tel.fixslice_escalation_repair_salvage_count, 1,
+        "repair-salvage classifier must still fire independently"
+    );
+    assert!(!tel.worker_observed);
+}


### PR DESCRIPTION
## Summary
Phase2 A1 で `agent.fix_slice` が `max iterations reached` 等で worker success boundary に到達できないまま、親エージェントの `file.edit` と pre-exit repair turn が session を引き取ってしまい、`mutation_observed=true` かつ `worker_observed=false` の混成状態で `partial` に落ちる問題を修正。

### 変更内容
1. **fix_slice failure reason 分離**: telemetry に `fixslice_failure_reason` (`no_proposal` / `proposal_validation_failed` / `rewrite_failed` / `max_iterations_reached`) と `fixslice_worker_failure_count` を追加
2. **worker-required mode での repair salvage 抑制**: `RequiresWorkerObservation` pack 下で fix_slice 失敗後は pre-exit repair turn injection を skip
3. **新規回帰テスト (14件)**: `tests/fixslice_failure_control.rs`
   - failure reason classification
   - should_skip_repair gating (worker-required のみ、audit_only/requires_mutation はスキップしない)
   - worker-required gate が fix_slice failure のみでも reject 継続
   - telemetry artifact に新フィールドが persisted

## Test plan
- [x] cargo test --test fixslice_failure_control (14/14 pass)
- [x] cargo clippy --all-targets 警告0件
- [x] cargo test 全テストパス
- [x] cargo fmt --check 差分なし

Fixes #343

🤖 Generated with [Claude Code](https://claude.com/claude-code)