### PR TITLE
fix(issue-347): add ANVIL_FIXSLICE_MAX_ITERATIONS to env whitelist

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -310,6 +310,55 @@ impl Display for ConfigError {
 
 impl Error for ConfigError {}
 
+/// Environment variable whitelist consumed by [`EffectiveConfig::apply_env_overrides`].
+///
+/// Keys listed here are read from process env and forwarded to
+/// [`EffectiveConfig::apply_map`]. A new tunable that is parsed by `apply_map`
+/// but missing from this whitelist will silently fail to take effect from env
+/// — see Issue #347 for the `ANVIL_FIXSLICE_MAX_ITERATIONS` regression.
+pub const ENV_OVERRIDE_WHITELIST: &[&str] = &[
+    "ANVIL_PROVIDER",
+    "ANVIL_MODEL",
+    "ANVIL_PROVIDER_URL",
+    "ANVIL_SIDECAR_MODEL",
+    "ANVIL_SIDECAR_PROVIDER_URL",
+    "ANVIL_API_KEY",
+    "ANVIL_CONTEXT_WINDOW",
+    "ANVIL_CONTEXT_BUDGET",
+    "ANVIL_MAX_AGENT_ITERATIONS",
+    "ANVIL_MAX_CONSOLE_MESSAGES",
+    "ANVIL_AUTO_COMPACT_THRESHOLD",
+    "ANVIL_TOOL_RESULT_MAX_CHARS",
+    "ANVIL_STREAM",
+    "ANVIL_INTERACTIVE",
+    "ANVIL_APPROVAL_REQUIRED",
+    "ANVIL_FRESH_SESSION",
+    "ANVIL_REASONING_VISIBILITY",
+    "ANVIL_DEBUG",
+    "ANVIL_WEB_SEARCH_PROVIDER",
+    "SERPER_API_KEY",
+    "ANVIL_LOG",
+    "ANVIL_OFFLINE",
+    "ANVIL_TAG_PROTOCOL",
+    "ANVIL_PROMPT_TIER",
+    "ANVIL_SMART_COMPACT_THRESHOLD_RATIO",
+    "ANVIL_SUBAGENT_MAX_ITERATIONS",
+    "ANVIL_SUBAGENT_TIMEOUT",
+    "ANVIL_LOOP_DETECTION_THRESHOLD",
+    "ANVIL_HTTP_TIMEOUT",
+    "ANVIL_CURL_TIMEOUT",
+    "ANVIL_EDIT_STRATEGY",
+    "ANVIL_EDIT_REREAD_THRESHOLD",
+    "ANVIL_EDIT_WRITE_FALLBACK_THRESHOLD",
+    "ANVIL_FIXSLICE_MAX_ITERATIONS",
+    "ANVIL_SAFE_WRITE_MAX_LINES",
+    "ANVIL_SAFE_WRITE_DELETION_RATIO",
+    "ANVIL_UI_LANGUAGE",
+    "ANVIL_MAX_TOOL_CALLS",
+    "ANVIL_GUIDANCE_MODE",
+    "ANVIL_EDIT_RECOVERY_READ_BUDGET",
+];
+
 impl EffectiveConfig {
     pub fn project_instructions(&self) -> Option<&str> {
         self.project_instructions.as_deref()
@@ -502,49 +551,28 @@ impl EffectiveConfig {
 
     fn apply_env_overrides(&mut self) -> Result<(), ConfigError> {
         let mut map = HashMap::new();
-        for key in [
-            "ANVIL_PROVIDER",
-            "ANVIL_MODEL",
-            "ANVIL_PROVIDER_URL",
-            "ANVIL_SIDECAR_MODEL",
-            "ANVIL_SIDECAR_PROVIDER_URL",
-            "ANVIL_API_KEY",
-            "ANVIL_CONTEXT_WINDOW",
-            "ANVIL_CONTEXT_BUDGET",
-            "ANVIL_MAX_AGENT_ITERATIONS",
-            "ANVIL_MAX_CONSOLE_MESSAGES",
-            "ANVIL_AUTO_COMPACT_THRESHOLD",
-            "ANVIL_TOOL_RESULT_MAX_CHARS",
-            "ANVIL_STREAM",
-            "ANVIL_INTERACTIVE",
-            "ANVIL_APPROVAL_REQUIRED",
-            "ANVIL_FRESH_SESSION",
-            "ANVIL_REASONING_VISIBILITY",
-            "ANVIL_DEBUG",
-            "ANVIL_WEB_SEARCH_PROVIDER",
-            "SERPER_API_KEY",
-            "ANVIL_LOG",
-            "ANVIL_OFFLINE",
-            "ANVIL_TAG_PROTOCOL",
-            "ANVIL_PROMPT_TIER",
-            "ANVIL_SMART_COMPACT_THRESHOLD_RATIO",
-            "ANVIL_SUBAGENT_MAX_ITERATIONS",
-            "ANVIL_SUBAGENT_TIMEOUT",
-            "ANVIL_LOOP_DETECTION_THRESHOLD",
-            "ANVIL_HTTP_TIMEOUT",
-            "ANVIL_CURL_TIMEOUT",
-            "ANVIL_EDIT_STRATEGY",
-            "ANVIL_EDIT_REREAD_THRESHOLD",
-            "ANVIL_EDIT_WRITE_FALLBACK_THRESHOLD",
-            "ANVIL_SAFE_WRITE_MAX_LINES",
-            "ANVIL_SAFE_WRITE_DELETION_RATIO",
-            "ANVIL_UI_LANGUAGE",
-            "ANVIL_MAX_TOOL_CALLS",
-            "ANVIL_GUIDANCE_MODE",
-            "ANVIL_EDIT_RECOVERY_READ_BUDGET",
-        ] {
+        for key in ENV_OVERRIDE_WHITELIST {
             if let Ok(value) = std::env::var(key) {
-                map.insert(key.to_string(), value);
+                map.insert((*key).to_string(), value);
+            }
+        }
+        self.apply_map(&map)
+    }
+
+    /// Test-only helper that applies env overrides from a provided map using
+    /// the same [`ENV_OVERRIDE_WHITELIST`] filter as the real
+    /// [`Self::apply_env_overrides`]. Unlike [`Self::apply_overrides_for_test`],
+    /// this goes through the whitelist — so it can catch regressions where a
+    /// new tunable is parsed by `apply_map` but never reaches it because the
+    /// whitelist forgot the key (Issue #347).
+    pub fn apply_env_overrides_from_map_for_test(
+        &mut self,
+        env: &HashMap<String, String>,
+    ) -> Result<(), ConfigError> {
+        let mut map = HashMap::new();
+        for key in ENV_OVERRIDE_WHITELIST {
+            if let Some(value) = env.get(*key) {
+                map.insert((*key).to_string(), value.clone());
             }
         }
         self.apply_map(&map)

--- a/tests/fixslice_worker_contract.rs
+++ b/tests/fixslice_worker_contract.rs
@@ -17,10 +17,12 @@
 //!    `ProposalValidationFailed`, plus the runtime-configurable
 //!    `fixslice_max_iterations` knob that replaces the hard-coded cap.
 
+use std::collections::HashMap;
+
 use anvil::agent::subagent::{
     DEFAULT_FIXSLICE_MAX_ITERATIONS, FixProposalParseOutcome, try_parse_fix_proposal,
 };
-use anvil::config::EffectiveConfig;
+use anvil::config::{ENV_OVERRIDE_WHITELIST, EffectiveConfig};
 use anvil::contracts::{AgentTelemetry, FixSliceFailureReason, FixSliceProposal};
 
 // ---------------------------------------------------------------------------
@@ -327,6 +329,55 @@ fn fixslice_max_iterations_clamped_lower_bound() {
     assert_eq!(
         config.runtime.fixslice_max_iterations, 1,
         "zero must be clamped up to 1 so the worker always gets one shot"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Issue #347: env whitelist must carry ANVIL_FIXSLICE_MAX_ITERATIONS
+// ---------------------------------------------------------------------------
+//
+// Regression: PR #346 added the parse arm for `ANVIL_FIXSLICE_MAX_ITERATIONS`
+// to `apply_map` but forgot the matching entry in `apply_env_overrides`'s
+// whitelist, so process-env values were silently dropped before `apply_map`
+// ever saw them. These tests exercise the whitelist path via
+// `apply_env_overrides_from_map_for_test` — not `apply_overrides_for_test`,
+// which calls `apply_map` directly and bypasses the whitelist.
+
+#[test]
+fn env_whitelist_contains_fixslice_max_iterations() {
+    assert!(
+        ENV_OVERRIDE_WHITELIST.contains(&"ANVIL_FIXSLICE_MAX_ITERATIONS"),
+        "ANVIL_FIXSLICE_MAX_ITERATIONS must be in the env override whitelist \
+         so process env values reach apply_map (Issue #347)"
+    );
+}
+
+#[test]
+fn fixslice_max_iterations_reaches_runtime_via_env_whitelist() {
+    let mut config = EffectiveConfig::default_for_test().expect("config");
+    let mut env = HashMap::new();
+    env.insert("ANVIL_FIXSLICE_MAX_ITERATIONS".to_string(), "8".to_string());
+    config
+        .apply_env_overrides_from_map_for_test(&env)
+        .expect("env override should apply");
+    assert_eq!(
+        config.runtime.fixslice_max_iterations, 8,
+        "ANVIL_FIXSLICE_MAX_ITERATIONS=8 must be reflected in RuntimeConfig"
+    );
+}
+
+#[test]
+fn unknown_env_key_is_ignored_by_whitelist() {
+    let mut config = EffectiveConfig::default_for_test().expect("config");
+    let baseline = config.runtime.fixslice_max_iterations;
+    let mut env = HashMap::new();
+    env.insert("ANVIL_NOT_A_REAL_TUNABLE_KEY".to_string(), "99".to_string());
+    config
+        .apply_env_overrides_from_map_for_test(&env)
+        .expect("unknown keys must be silently ignored");
+    assert_eq!(
+        config.runtime.fixslice_max_iterations, baseline,
+        "unrelated env keys must not mutate runtime state"
     );
 }
 


### PR DESCRIPTION
## Summary
PR #346 (Issue #345) で `fixslice_max_iterations` を tunable にしたが、`apply_env_overrides()` の whitelist に `ANVIL_FIXSLICE_MAX_ITERATIONS` を追加し忘れたため、env 経由で設定しても runtime config に反映されない問題を修正。

### 背景
- Phase 2 phase-bench-loop run `20260411-013137` cycle 4 で `ANVIL_FIXSLICE_MAX_ITERATIONS=8` を渡しても実効 iteration budget は default 3 のまま
- `apply_map()` は parse できるが、`apply_env_overrides()` の whitelist gateway に入っていないため process env から読まれない

### 変更内容
1. `src/config/mod.rs`: whitelist に `"ANVIL_FIXSLICE_MAX_ITERATIONS"` を追加、whitelist 構築を整理して新規 tunable が追加しやすい形に
2. `tests/fixslice_worker_contract.rs`: env → apply_env_overrides → apply_map → effective config の round-trip 回帰テスト追加

### Scope
本 PR は narrow fix に集中。Issue #347 で言及されている以下は別途扱う:
- `apply_map()` と `apply_env_overrides()` の single source of truth 化
- PR #346 周辺の他の env key の spot audit

## Test plan
- [x] cargo clippy --all-targets 警告0件
- [x] cargo test 全テストパス
- [x] cargo fmt --check 差分なし
- [x] fixslice_worker_contract tests の env round-trip 確認

Fixes #347

🤖 Generated with [Claude Code](https://claude.com/claude-code)