### PR TITLE
fix(issue-349): add closure-mode reasoning loop guard after fix_slice failure

### DIFF
--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -719,6 +719,8 @@ impl App {
         self.loop_detector.reset();
         // Reset alternating loop detector per-turn (Issue #172)
         self.alternating_loop_detector.reset();
+        // Reset closure-mode reasoning loop guard per top-level turn (Issue #349).
+        self.closure_loop_detector.reset();
         // Reset phase estimator per-turn counters (Issue #159)
         self.phase_estimator.reset();
         // Reset read transition guard per-turn counters (Issue #216)
@@ -1200,6 +1202,9 @@ impl App {
             // Issue #305: match on PlanRegistrationResult for replan support
             match self.try_register_plan(&next_token_buffer) {
                 crate::app::execution_plan::PlanRegistrationResult::Registered => {
+                    // Issue #349: a newly registered plan is a fresh course
+                    // of action — clear any accumulated closure-loop state.
+                    self.closure_loop_detector.reset();
                     let target_files: Vec<String> = self
                         .execution_plan
                         .items
@@ -1212,6 +1217,8 @@ impl App {
                         );
                 }
                 crate::app::execution_plan::PlanRegistrationResult::Replan => {
+                    // Issue #349: replan is also a change of course.
+                    self.closure_loop_detector.reset();
                     // Replan: stagnation_state を差分マージ (Issue #305)
                     let existing = &self.stagnation_state.starved_target_files;
                     let new_targets: Vec<String> = self
@@ -1260,6 +1267,53 @@ impl App {
             if next_structured.anvil_final_detected {
                 anvil_final_seen = true;
                 self.phase_estimator.observe_anvil_final();
+            }
+
+            // Issue #349: closure-mode reasoning loop guard.
+            //
+            // After `agent.fix_slice` has failed at least once without a
+            // subsequent worker success, a zero-tool-call reasoning response
+            // from the parent agent is the shape that historically stalled
+            // phase-bench cycles 8 and 9 until the 600s runner timeout. We
+            // fingerprint such responses and escalate when the same cut
+            // point reappears (exact or paraphrased): Warn → StrongWarn →
+            // Break. Responses with tool calls, worker success, or without
+            // a prior fix_slice failure clear the accumulator — the
+            // detector only stays armed while the closure-loop preconditions
+            // actually hold.
+            let guard_armed = !self.agent_telemetry.worker_observed
+                && self.agent_telemetry.fixslice_worker_failure_count > 0
+                && next_structured.tool_calls.is_empty();
+            if guard_armed {
+                let action = self
+                    .closure_loop_detector
+                    .record_and_check(&next_structured.raw_content);
+                match action {
+                    super::loop_detector::LoopAction::Continue => {}
+                    super::loop_detector::LoopAction::Warn(msg)
+                    | super::loop_detector::LoopAction::StrongWarn(msg) => {
+                        tracing::warn!(
+                            fixslice_worker_failure_count =
+                                self.agent_telemetry.fixslice_worker_failure_count,
+                            "closure_loop_guard: injecting escalation hint"
+                        );
+                        let hint_msg = SessionMessage::new(MessageRole::Tool, "system", msg)
+                            .with_id(self.next_message_id("tool"));
+                        self.session.push_message(hint_msg);
+                    }
+                    super::loop_detector::LoopAction::Break(msg) => {
+                        tracing::warn!(
+                            reason = "closure_loop_guard",
+                            message = %msg,
+                            fixslice_worker_failure_count =
+                                self.agent_telemetry.fixslice_worker_failure_count,
+                            "agentic loop terminated by closure-mode reasoning guard"
+                        );
+                        break;
+                    }
+                }
+            } else {
+                self.closure_loop_detector.reset();
             }
 
             // Issue #325 + Issue #327: if the pre-exit repair turn was injected on

--- a/src/app/closure_loop_detector.rs
+++ b/src/app/closure_loop_detector.rs
@@ -1,0 +1,310 @@
+//! Closure-mode reasoning loop detector (Issue #349).
+//!
+//! After `agent.fix_slice` fails (no successful worker mutation observed),
+//! the parent agent can enter a natural-language "closure" loop: it keeps
+//! producing zero-tool-call reasoning responses that restate the same cut
+//! points (resolveAutoAnswer / truncated file / late-stage closure ...)
+//! until the external runner timeout fires. The existing `LoopDetector`
+//! only fires on repeated tool calls, so it never engages for this shape.
+//!
+//! This detector fingerprints reasoning-only LLM responses seen while the
+//! guard is armed and escalates when a near-duplicate reappears.
+//!
+//! - Guard arming (the caller must verify these before calling):
+//!     1. `worker_observed == false`
+//!     2. `fixslice_worker_failure_count > 0`
+//!     3. The LLM response produced no tool calls
+//!     4. The raw reasoning content is non-trivial (≥ `MIN_SIGNIFICANT_TOKENS`)
+//! - Escalation ladder: `Continue → Warn → StrongWarn → Break`
+//!
+//! A response is fingerprinted as the sorted set of "significant" tokens
+//! (lowercase ASCII-alphanumeric runs of length ≥ `TOKEN_MIN_LEN`). Two
+//! responses match when their Jaccard similarity ≥ `JACCARD_MATCH_THRESHOLD`.
+//! LLM closure loops overwhelmingly recycle the same domain vocabulary
+//! turn after turn — Jaccard survives the connector-word paraphrasing
+//! that exact hashing would miss.
+
+use std::collections::BTreeSet;
+use std::collections::VecDeque;
+
+use super::loop_detector::LoopAction;
+
+/// Minimum number of significant tokens in a response before it is eligible
+/// for fingerprinting. Short acknowledgements ("ok", "done") must not trip
+/// the detector.
+pub const MIN_SIGNIFICANT_TOKENS: usize = 20;
+
+/// Minimum character length of a token to count as "significant". Filters
+/// stopwords and CJK punctuation noise without needing a word list.
+const TOKEN_MIN_LEN: usize = 5;
+
+/// Jaccard similarity threshold (`|A ∩ B| / |A ∪ B|`) at which two
+/// responses are considered near-duplicates. 0.7 is strict enough to
+/// avoid flagging two unrelated discussions that happen to share common
+/// domain words, but loose enough to absorb the connector-word
+/// rewordings observed in cycle 8/9 closure loops.
+const JACCARD_MATCH_THRESHOLD: f64 = 0.7;
+
+/// Recent token sets retained for lookup. Four slots cover the Warn /
+/// StrongWarn / Break ladder plus one headroom entry.
+const HISTORY_CAPACITY: usize = 8;
+
+/// A fingerprinted, reasoning-only LLM response.
+#[derive(Debug, Clone)]
+pub struct Fingerprint {
+    tokens: BTreeSet<String>,
+}
+
+impl Fingerprint {
+    /// Extract significant tokens from `raw_content`.
+    ///
+    /// Returns `None` when the content does not contain enough significant
+    /// tokens to be worth fingerprinting.
+    pub fn from_raw(raw_content: &str) -> Option<Self> {
+        let tokens: BTreeSet<String> = raw_content
+            .split(|c: char| !c.is_ascii_alphanumeric())
+            .filter(|w| w.len() >= TOKEN_MIN_LEN)
+            .map(str::to_ascii_lowercase)
+            .collect();
+        if tokens.len() < MIN_SIGNIFICANT_TOKENS {
+            return None;
+        }
+        Some(Self { tokens })
+    }
+
+    /// Jaccard similarity against `other` in `[0.0, 1.0]`.
+    pub fn jaccard(&self, other: &Self) -> f64 {
+        if self.tokens.is_empty() && other.tokens.is_empty() {
+            return 1.0;
+        }
+        let intersect = self.tokens.intersection(&other.tokens).count() as f64;
+        let union = self.tokens.union(&other.tokens).count() as f64;
+        if union == 0.0 { 0.0 } else { intersect / union }
+    }
+
+    #[cfg(test)]
+    pub fn token_count(&self) -> usize {
+        self.tokens.len()
+    }
+}
+
+/// Detector for closure-mode reasoning loops after `fix_slice` failure.
+#[derive(Debug)]
+pub struct ClosureLoopDetector {
+    history: VecDeque<Fingerprint>,
+    escalation_count: usize,
+}
+
+impl Default for ClosureLoopDetector {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ClosureLoopDetector {
+    pub fn new() -> Self {
+        Self {
+            history: VecDeque::with_capacity(HISTORY_CAPACITY),
+            escalation_count: 0,
+        }
+    }
+
+    /// Reset to a clean state.
+    ///
+    /// Called when the guard is disarmed (worker success observed, a new
+    /// plan registered, or the response carried tool calls again).
+    pub fn reset(&mut self) {
+        self.history.clear();
+        self.escalation_count = 0;
+    }
+
+    /// Observe a reasoning-only LLM response while the guard is armed and
+    /// return the escalation action.
+    ///
+    /// Returns `LoopAction::Continue` if the response is too short to
+    /// fingerprint or if no recent entry is near-duplicate.
+    pub fn record_and_check(&mut self, raw_content: &str) -> LoopAction {
+        let Some(fp) = Fingerprint::from_raw(raw_content) else {
+            return LoopAction::Continue;
+        };
+
+        let near_duplicate = self
+            .history
+            .iter()
+            .any(|prev| prev.jaccard(&fp) >= JACCARD_MATCH_THRESHOLD);
+
+        if self.history.len() >= HISTORY_CAPACITY {
+            self.history.pop_front();
+        }
+        self.history.push_back(fp);
+
+        if !near_duplicate {
+            return LoopAction::Continue;
+        }
+
+        self.escalation_count += 1;
+        match self.escalation_count {
+            1 => LoopAction::Warn(
+                "[Closure Loop Guard] The parent agent is repeating the same closure \
+                 reasoning after a fix_slice worker failure without advancing any tool. \
+                 Decide now: either call agent.fix_slice once more on the troubled target \
+                 or emit ANVIL_FINAL and stop."
+                    .to_string(),
+            ),
+            2 => LoopAction::StrongWarn(
+                "[Closure Loop Guard - WARNING] The parent agent has repeated the same \
+                 closure reasoning multiple times without any tool-advancing output. You \
+                 MUST either issue a concrete tool call now (agent.fix_slice on a specific \
+                 target_path) or terminate with ANVIL_FINAL. Do NOT restate the same \
+                 analysis again."
+                    .to_string(),
+            ),
+            _ => LoopAction::Break(
+                "[Closure Loop Guard - TERMINATED] Agentic loop terminated: closure-mode \
+                 reasoning repeated after fix_slice worker failure with no tool-advancing \
+                 progress."
+                    .to_string(),
+            ),
+        }
+    }
+
+    #[cfg(test)]
+    pub fn escalation_count(&self) -> usize {
+        self.escalation_count
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const CLOSURE_A: &str = "The resolveAutoAnswer helper appears truncated. \
+        Because the worker produced no valid proposal, the fix_slice invocation \
+        failed. The late-stage closure branch should therefore abort instead \
+        of looping. resolveAutoAnswer, truncated, closure, invalid, proposal, \
+        worker, failure, fix_slice, target_path, rewrite, iterations, session.";
+
+    /// Same domain vocabulary, different connector words — the exact cycle
+    /// 8/9 closure-loop shape we need to catch.
+    const CLOSURE_A_REWORDED: &str = "Worker did not produce any valid proposal, \
+        so the fix_slice invocation has failed. The resolveAutoAnswer helper \
+        still appears truncated, therefore the late-stage closure branch \
+        should abort instead of looping further, because continuing reasoning \
+        is unhelpful. Keywords: closure, invalid, proposal, worker, failure, \
+        fix_slice, target_path, rewrite, iterations, session, \
+        resolveAutoAnswer, truncated.";
+
+    const CLOSURE_B: &str = "Different angle now: the ANVIL_PLAN required \
+        additional verification reads against configuration modules. Running \
+        cargo check would reveal compilation blockers. Consider auditing \
+        provider ollama sidecar summarize helpers, exploring retrieval \
+        cache, evaluating telemetry snapshot format, inspecting hooks \
+        engine wiring, scanning tooling shell policy.";
+
+    #[test]
+    fn short_content_is_not_fingerprinted() {
+        assert!(Fingerprint::from_raw("ok").is_none());
+        assert!(Fingerprint::from_raw("Plan done. Looks fine.").is_none());
+    }
+
+    #[test]
+    fn long_content_yields_stable_fingerprint() {
+        let fp1 = Fingerprint::from_raw(CLOSURE_A).expect("fingerprint");
+        let fp2 = Fingerprint::from_raw(CLOSURE_A).expect("fingerprint");
+        assert!((fp1.jaccard(&fp2) - 1.0).abs() < f64::EPSILON);
+        assert!(fp1.token_count() >= MIN_SIGNIFICANT_TOKENS);
+    }
+
+    #[test]
+    fn reworded_paraphrase_is_near_duplicate() {
+        let fp1 = Fingerprint::from_raw(CLOSURE_A).expect("fingerprint");
+        let fp2 = Fingerprint::from_raw(CLOSURE_A_REWORDED).expect("fingerprint");
+        let sim = fp1.jaccard(&fp2);
+        assert!(
+            sim >= JACCARD_MATCH_THRESHOLD,
+            "expected Jaccard ≥ {}, got {}",
+            JACCARD_MATCH_THRESHOLD,
+            sim
+        );
+    }
+
+    #[test]
+    fn unrelated_reasoning_is_below_threshold() {
+        let fp1 = Fingerprint::from_raw(CLOSURE_A).expect("fingerprint");
+        let fp2 = Fingerprint::from_raw(CLOSURE_B).expect("fingerprint");
+        assert!(
+            fp1.jaccard(&fp2) < JACCARD_MATCH_THRESHOLD,
+            "unrelated content should be below threshold; got {}",
+            fp1.jaccard(&fp2)
+        );
+    }
+
+    #[test]
+    fn first_observation_is_continue() {
+        let mut det = ClosureLoopDetector::new();
+        assert_eq!(det.record_and_check(CLOSURE_A), LoopAction::Continue);
+    }
+
+    #[test]
+    fn second_near_duplicate_warns() {
+        let mut det = ClosureLoopDetector::new();
+        det.record_and_check(CLOSURE_A);
+        let action = det.record_and_check(CLOSURE_A_REWORDED);
+        assert!(
+            matches!(action, LoopAction::Warn(_)),
+            "expected Warn, got {:?}",
+            action
+        );
+    }
+
+    #[test]
+    fn escalation_ladder_reaches_break() {
+        let mut det = ClosureLoopDetector::new();
+        assert_eq!(det.record_and_check(CLOSURE_A), LoopAction::Continue);
+        assert!(matches!(
+            det.record_and_check(CLOSURE_A),
+            LoopAction::Warn(_)
+        ));
+        assert!(matches!(
+            det.record_and_check(CLOSURE_A),
+            LoopAction::StrongWarn(_)
+        ));
+        assert!(matches!(
+            det.record_and_check(CLOSURE_A),
+            LoopAction::Break(_)
+        ));
+    }
+
+    #[test]
+    fn novel_reasoning_between_repeats_still_escalates() {
+        let mut det = ClosureLoopDetector::new();
+        det.record_and_check(CLOSURE_A);
+        // Novel cut point interleaves — should NOT clear escalation.
+        assert_eq!(det.record_and_check(CLOSURE_B), LoopAction::Continue);
+        let action = det.record_and_check(CLOSURE_A_REWORDED);
+        assert!(
+            matches!(action, LoopAction::Warn(_)),
+            "expected Warn when A repeats despite B in between, got {:?}",
+            action
+        );
+    }
+
+    #[test]
+    fn short_content_does_not_advance_state() {
+        let mut det = ClosureLoopDetector::new();
+        det.record_and_check(CLOSURE_A);
+        assert_eq!(det.record_and_check("ok"), LoopAction::Continue);
+        assert_eq!(det.escalation_count(), 0);
+    }
+
+    #[test]
+    fn reset_clears_history_and_escalation() {
+        let mut det = ClosureLoopDetector::new();
+        det.record_and_check(CLOSURE_A);
+        det.record_and_check(CLOSURE_A);
+        assert_eq!(det.escalation_count(), 1);
+        det.reset();
+        assert_eq!(det.escalation_count(), 0);
+        assert_eq!(det.record_and_check(CLOSURE_A), LoopAction::Continue);
+    }
+}

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -6,6 +6,7 @@
 pub mod agentic;
 pub mod alternating_loop_detector;
 pub mod cli;
+pub mod closure_loop_detector;
 mod context;
 pub mod edit_fail_tracker;
 pub(crate) mod execution_plan;
@@ -299,6 +300,10 @@ pub struct App {
     /// Whether the session is in pre-exit repair closure mode (Issue #327).
     /// When active, ANVIL_PLAN_UPDATE unchecked items are rejected.
     repair_closure_active: bool,
+    /// Detects closure-mode natural-language reasoning loops that reoccur
+    /// after a `fix_slice` worker failure with no tool-advancing output
+    /// (Issue #349).
+    closure_loop_detector: closure_loop_detector::ClosureLoopDetector,
 }
 
 /// Whether the session loop should continue or exit.
@@ -649,6 +654,7 @@ impl App {
                 edit_recovery_read_budget,
             ),
             repair_closure_active: false,
+            closure_loop_detector: closure_loop_detector::ClosureLoopDetector::new(),
         })
     }
 

--- a/tests/closure_loop_guard.rs
+++ b/tests/closure_loop_guard.rs
@@ -1,0 +1,138 @@
+//! Tests for the closure-mode reasoning loop guard (Issue #349).
+//!
+//! Regression: after `agent.fix_slice` fails, the parent agent sometimes
+//! enters a natural-language closure loop — producing zero-tool-call
+//! reasoning that repeats the same cut points (resolveAutoAnswer /
+//! truncated file / late-stage closure) until the runner kills the
+//! process at 600s. The existing `LoopDetector` only fires on repeated
+//! tool calls and never engages for this shape. `ClosureLoopDetector`
+//! fingerprints reasoning-only responses while the guard is armed and
+//! escalates through `Warn → StrongWarn → Break`.
+
+use anvil::app::closure_loop_detector::{ClosureLoopDetector, Fingerprint};
+use anvil::app::loop_detector::LoopAction;
+
+// The two paraphrases below share the same domain vocabulary (~80%
+// significant-token overlap) but swap connector words. This is the exact
+// cycle 8/9 shape the phase-bench runner exposed: reworded reasoning with
+// the same resolveAutoAnswer / truncated / closure / worker keywords.
+const LOOP_MSG_A: &str = "The resolveAutoAnswer helper appears truncated. \
+    Because the worker produced no valid proposal, the fix_slice invocation \
+    failed. The late-stage closure branch should therefore abort instead \
+    of looping. resolveAutoAnswer, truncated, closure, invalid, proposal, \
+    worker, failure, fix_slice, target_path, rewrite, iterations, session.";
+
+const LOOP_MSG_A_REWORDED: &str = "Worker did not produce any valid proposal, \
+    so the fix_slice invocation has failed. The resolveAutoAnswer helper \
+    still appears truncated, therefore the late-stage closure branch \
+    should abort instead of looping further, because continuing reasoning \
+    is unhelpful. Keywords: closure, invalid, proposal, worker, failure, \
+    fix_slice, target_path, rewrite, iterations, session, \
+    resolveAutoAnswer, truncated.";
+
+const UNRELATED_MSG: &str = "Different angle now: the ANVIL_PLAN required \
+    additional verification reads against configuration modules. Running \
+    cargo check would reveal compilation blockers. Consider auditing \
+    provider ollama sidecar summarize helpers, exploring retrieval \
+    cache, evaluating telemetry snapshot format, inspecting hooks \
+    engine wiring, scanning tooling shell policy.";
+
+#[test]
+fn short_responses_do_not_arm_the_detector() {
+    // A one-line acknowledgement must not be treated as "reasoning" — we
+    // only fingerprint content with enough significant tokens.
+    assert!(Fingerprint::from_raw("Plan is done.").is_none());
+    assert!(Fingerprint::from_raw("ok").is_none());
+
+    let mut det = ClosureLoopDetector::new();
+    for _ in 0..5 {
+        assert_eq!(det.record_and_check("ok"), LoopAction::Continue);
+    }
+}
+
+#[test]
+fn paraphrased_reasoning_is_near_duplicate() {
+    let fp1 = Fingerprint::from_raw(LOOP_MSG_A).expect("fingerprintable");
+    let fp2 = Fingerprint::from_raw(LOOP_MSG_A_REWORDED).expect("fingerprintable");
+    assert!(
+        fp1.jaccard(&fp2) >= 0.7,
+        "reworded paraphrase with the same keyword set should pass the Jaccard threshold; got {}",
+        fp1.jaccard(&fp2)
+    );
+}
+
+#[test]
+fn first_closure_response_is_always_continue() {
+    let mut det = ClosureLoopDetector::new();
+    let action = det.record_and_check(LOOP_MSG_A);
+    assert_eq!(
+        action,
+        LoopAction::Continue,
+        "a single closure response must not escalate"
+    );
+}
+
+#[test]
+fn repeated_closure_reasoning_walks_the_escalation_ladder() {
+    // Reproduces the Issue #349 cycle: the parent agent keeps producing
+    // the same verbose reasoning without any tool-advancing output. Each
+    // repeat should climb one rung: Warn → StrongWarn → Break.
+    let mut det = ClosureLoopDetector::new();
+    assert_eq!(det.record_and_check(LOOP_MSG_A), LoopAction::Continue);
+    assert!(
+        matches!(det.record_and_check(LOOP_MSG_A), LoopAction::Warn(_)),
+        "second identical reasoning turn must Warn"
+    );
+    assert!(
+        matches!(
+            det.record_and_check(LOOP_MSG_A_REWORDED),
+            LoopAction::StrongWarn(_)
+        ),
+        "third reasoning turn (even reworded) must StrongWarn"
+    );
+    assert!(
+        matches!(det.record_and_check(LOOP_MSG_A), LoopAction::Break(_)),
+        "fourth reasoning turn must terminate the loop"
+    );
+}
+
+#[test]
+fn unrelated_reasoning_does_not_match_prior_fingerprint() {
+    let mut det = ClosureLoopDetector::new();
+    det.record_and_check(LOOP_MSG_A);
+    assert_eq!(
+        det.record_and_check(UNRELATED_MSG),
+        LoopAction::Continue,
+        "a genuinely different cut point must not trip the guard"
+    );
+}
+
+#[test]
+fn unrelated_interleaving_does_not_break_escalation() {
+    // cycle 6 mixed different reasoning cuts between turns and still
+    // completed successfully. The guard must not reset escalation just
+    // because one novel response interleaves — only a worker success or
+    // an explicit reset should clear state.
+    let mut det = ClosureLoopDetector::new();
+    det.record_and_check(LOOP_MSG_A);
+    assert_eq!(det.record_and_check(UNRELATED_MSG), LoopAction::Continue);
+    let action = det.record_and_check(LOOP_MSG_A_REWORDED);
+    assert!(
+        matches!(action, LoopAction::Warn(_)),
+        "LOOP_MSG_A repeating after an interleaved UNRELATED_MSG must still Warn, got {:?}",
+        action
+    );
+}
+
+#[test]
+fn reset_clears_history_between_armed_phases() {
+    let mut det = ClosureLoopDetector::new();
+    det.record_and_check(LOOP_MSG_A);
+    det.record_and_check(LOOP_MSG_A);
+    det.reset();
+    assert_eq!(
+        det.record_and_check(LOOP_MSG_A),
+        LoopAction::Continue,
+        "after reset, a previously-seen fingerprint must look fresh again"
+    );
+}


### PR DESCRIPTION
## Summary
Phase2 cycle 8/9 で `fix_slice` 失敗後、parent agent が closure mode で自然言語 reasoning を無限反復し、tool-advancing output を止めたまま `600s` timeout まで抜け出せない問題を修正。

### 変更内容
1. **ClosureLoopDetector** 新規モジュール (`src/app/closure_loop_detector.rs`): paraphrase を検出する fingerprint ベースの near-duplicate detector (Jaccard similarity)
2. **Parent agent integration** (`src/app/agentic.rs`): `worker_observed=false` かつ fix_slice failure 後の closure mode で parent メッセージが近似重複した場合、段階的にエスカレーションして早期終了
3. **escalation ladder**: continue → warn → abort の段階的対応で cycle 6 型の有効 run は regression しない
4. **reset on replan**: replan 時に detector を reset して有効な reasoning が次の cycle に持ち越されないようにする

### Test plan
- [x] tests/closure_loop_guard.rs: 新規統合テスト 7件
  - first_closure_response_is_always_continue (初回は常に continue)
  - short_responses_do_not_arm_the_detector (短い応答では発火しない)
  - paraphrased_reasoning_is_near_duplicate (paraphrase 検出)
  - unrelated_reasoning_does_not_match_prior_fingerprint (無関係は match しない)
  - reset_clears_history_between_armed_phases (reset 動作)
  - repeated_closure_reasoning_walks_the_escalation_ladder (段階的エスカレーション)
  - unrelated_interleaving_does_not_break_escalation (無関係挟み込みで escalation が壊れない)
- [x] cargo clippy --all-targets 警告0件
- [x] cargo test 全テストパス
- [x] cargo fmt --check 差分なし

Fixes #349

🤖 Generated with [Claude Code](https://claude.com/claude-code)