### PR TITLE
fix(issue-353): make fix_slice no-progress detector tunable

### DIFF
--- a/src/agent/subagent.rs
+++ b/src/agent/subagent.rs
@@ -614,14 +614,25 @@ pub struct SubAgentSession<'a, C: ProviderClient> {
     same_target_read_count: u32,
 }
 
-/// Threshold (consecutive iterations) for the same-target `file.read`
-/// oscillation guard inside the FixSlice sub-agent loop (Issue #351).
+/// Default threshold (consecutive iterations) for the same-target
+/// `file.read` oscillation guard inside the FixSlice sub-agent loop
+/// (Issue #351 / Issue #353).
 ///
-/// Two iterations in a row re-reading the exact same target path without
-/// producing a `FixSliceProposal` is the B1 shape from phase-bench cycle
-/// 10: the worker is stuck and will exhaust the iteration budget if
-/// allowed to continue.
-pub const FIXSLICE_REPEATED_READ_THRESHOLD: u32 = 2;
+/// Runtime callers should read
+/// `EffectiveConfig::runtime::fixslice_no_progress_detector` instead —
+/// this constant only pins the default used when nothing else is set.
+///
+/// Issue #353: cycle-11 traces showed the previous default (`2`) killed
+/// legitimate A1/A2 exploration — qwen3.5:122b frequently needs more than
+/// two same-path reads to reach a proposal. Raised to `5` so the guard
+/// still catches the B1 runaway shape but leaves normal exploration
+/// intact. A value of `0` disables the guard entirely.
+pub const DEFAULT_FIXSLICE_REPEATED_READ_THRESHOLD: u32 = 5;
+
+/// Back-compat alias for [`DEFAULT_FIXSLICE_REPEATED_READ_THRESHOLD`]
+/// (Issue #351 / Issue #353). Kept so existing test imports continue to
+/// compile; new code should read the runtime config at the call site.
+pub const FIXSLICE_REPEATED_READ_THRESHOLD: u32 = DEFAULT_FIXSLICE_REPEATED_READ_THRESHOLD;
 
 /// Pure helper for the same-target `file.read` oscillation guard (Issue
 /// #351). Returns `true` when `current_target` matches `last_target` and
@@ -822,6 +833,8 @@ impl<'a, C: ProviderClient> SubAgentSession<'a, C> {
         }
 
         // Issue #351: same-target `file.read` oscillation guard (FixSlice only).
+        // Issue #353: threshold is now configurable via
+        // `runtime.fixslice_no_progress_detector` (0 = disabled).
         //
         // Cycle-10 traces showed FixSlice workers burning the full iteration
         // budget while re-reading the exact same target path without ever
@@ -831,13 +844,15 @@ impl<'a, C: ProviderClient> SubAgentSession<'a, C> {
         // classify the session as pack_gate_invalid instead of waiting for
         // the runner timeout.
         if self.kind == SubAgentKind::FixSlice {
+            let detector_threshold = self.config.runtime.fixslice_no_progress_detector;
             let current_target = first_file_read_target(&structured.tool_calls);
-            let triggered = is_repeated_read_loop(
-                current_target.as_deref(),
-                self.last_file_read_target.as_deref(),
-                self.same_target_read_count,
-                FIXSLICE_REPEATED_READ_THRESHOLD,
-            );
+            let triggered = detector_threshold > 0
+                && is_repeated_read_loop(
+                    current_target.as_deref(),
+                    self.last_file_read_target.as_deref(),
+                    self.same_target_read_count,
+                    detector_threshold,
+                );
             match current_target.as_deref() {
                 Some(path) if self.last_file_read_target.as_deref() == Some(path) => {
                     self.same_target_read_count += 1;

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -207,6 +207,20 @@ pub struct RuntimeConfig {
     /// now configurable so brittle-model workloads can be granted more
     /// attempts to produce a valid `FixSliceProposal`. Clamped to `[1, 10]`.
     pub fixslice_max_iterations: u32,
+    /// Same-target `file.read` oscillation threshold for the FixSlice
+    /// sub-agent no-progress detector (Issue #351 / Issue #353).
+    ///
+    /// `0` disables the guard entirely (B1 runaway workers will be caught
+    /// only by the runner wall-clock timeout). `>=1` sets the number of
+    /// consecutive iterations re-reading the same path that trip the
+    /// abort path. Clamped to `[0, 20]`.
+    ///
+    /// Cycle-11 regression showed the original hard-coded threshold of
+    /// `2` killed legitimate qwen3.5:122b exploration — the new default
+    /// is `5`, with env override `ANVIL_FIXSLICE_NO_PROGRESS_DETECTOR`
+    /// (accepts `on` / `off` / numeric value) and config key
+    /// `fixslice_no_progress_detector`.
+    pub fixslice_no_progress_detector: u32,
     /// Maximum line count for file.write on existing files (0 = disabled, Issue #156).
     pub safe_write_max_lines: usize,
     /// Deletion ratio threshold for diff warning (0.0-1.0, Issue #156).
@@ -351,6 +365,7 @@ pub const ENV_OVERRIDE_WHITELIST: &[&str] = &[
     "ANVIL_EDIT_REREAD_THRESHOLD",
     "ANVIL_EDIT_WRITE_FALLBACK_THRESHOLD",
     "ANVIL_FIXSLICE_MAX_ITERATIONS",
+    "ANVIL_FIXSLICE_NO_PROGRESS_DETECTOR",
     "ANVIL_SAFE_WRITE_MAX_LINES",
     "ANVIL_SAFE_WRITE_DELETION_RATIO",
     "ANVIL_UI_LANGUAGE",
@@ -458,6 +473,8 @@ impl EffectiveConfig {
                 edit_fixslice_read_heavy_score_threshold: 2,
                 edit_fixslice_read_heavy_drought_threshold: 5,
                 fixslice_max_iterations: crate::agent::subagent::DEFAULT_FIXSLICE_MAX_ITERATIONS,
+                fixslice_no_progress_detector:
+                    crate::agent::subagent::DEFAULT_FIXSLICE_REPEATED_READ_THRESHOLD,
                 safe_write_max_lines: 500,
                 safe_write_deletion_ratio: 0.5,
                 read_repeat_warn_threshold: 3,
@@ -979,6 +996,33 @@ impl EffectiveConfig {
                     }
                     self.runtime.fixslice_max_iterations = v;
                 }
+                "fixslice_no_progress_detector" | "ANVIL_FIXSLICE_NO_PROGRESS_DETECTOR" => {
+                    // Issue #353: accept `on` / `off` / numeric threshold.
+                    // `off` (alias: `disabled`, `false`, `0`) fully
+                    // disables the same-target read guard so brittle-model
+                    // workloads are caught only by the runner wall-clock
+                    // timeout. `on` (alias: `default`, `true`) restores the
+                    // default threshold. Any numeric value is used
+                    // directly and clamped later by `validate()`.
+                    let trimmed = value.trim();
+                    let parsed = match trimmed.to_ascii_lowercase().as_str() {
+                        "off" | "disabled" | "false" | "no" => Some(0u32),
+                        "on" | "true" | "yes" | "default" => {
+                            Some(crate::agent::subagent::DEFAULT_FIXSLICE_REPEATED_READ_THRESHOLD)
+                        }
+                        _ => None,
+                    };
+                    let v = match parsed {
+                        Some(v) => v,
+                        None => trimmed
+                            .parse::<u32>()
+                            .map_err(|_| ConfigError::InvalidNumericValue(value.clone()))?,
+                    };
+                    if v > 20 {
+                        return Err(ConfigError::InvalidNumericValue(value.clone()));
+                    }
+                    self.runtime.fixslice_no_progress_detector = v;
+                }
                 "edit_recovery_read_budget" | "ANVIL_EDIT_RECOVERY_READ_BUDGET" => {
                     let v: u32 = value
                         .parse()
@@ -1313,6 +1357,11 @@ impl EffectiveConfig {
             self.runtime.edit_recovery_read_budget.clamp(1, 10);
         // Issue #345: clamp fix_slice worker iteration cap to [1, 10].
         self.runtime.fixslice_max_iterations = self.runtime.fixslice_max_iterations.clamp(1, 10);
+        // Issue #353: clamp fix_slice no-progress detector threshold to
+        // [0, 20] — 0 disables the guard, values above 20 are treated as
+        // a misconfiguration (would exceed the FixSlice iteration cap).
+        self.runtime.fixslice_no_progress_detector =
+            self.runtime.fixslice_no_progress_detector.min(20);
     }
 
     pub fn validate_for_test(&mut self) -> Result<(), ConfigError> {
@@ -1689,6 +1738,10 @@ impl std::fmt::Debug for RuntimeConfig {
                 &self.edit_fixslice_read_heavy_drought_threshold,
             )
             .field("fixslice_max_iterations", &self.fixslice_max_iterations)
+            .field(
+                "fixslice_no_progress_detector",
+                &self.fixslice_no_progress_detector,
+            )
             .field("safe_write_max_lines", &self.safe_write_max_lines)
             .field("safe_write_deletion_ratio", &self.safe_write_deletion_ratio)
             .field("edit_recovery_read_budget", &self.edit_recovery_read_budget)

--- a/tests/fixslice_subagent.rs
+++ b/tests/fixslice_subagent.rs
@@ -1,18 +1,21 @@
 //! Integration tests for the FixSlice sub-agent (Issue #291).
 
 use anvil::agent::subagent::{
-    FIXSLICE_MAX_ITERATIONS, FIXSLICE_REPEATED_READ_THRESHOLD, FIXSLICE_TIMEOUT_SECS,
-    MAX_FIXSLICE_LINES, SubAgentKind, first_file_read_target, is_repeated_read_loop,
+    DEFAULT_FIXSLICE_REPEATED_READ_THRESHOLD, FIXSLICE_MAX_ITERATIONS,
+    FIXSLICE_REPEATED_READ_THRESHOLD, FIXSLICE_TIMEOUT_SECS, MAX_FIXSLICE_LINES, SubAgentKind,
+    first_file_read_target, is_repeated_read_loop,
 };
 use anvil::agent::tag_spec::find_spec;
 use anvil::app::agentic::{
     build_fixslice_user_prompt, build_rewrite_request, validate_fix_proposal,
 };
+use anvil::config::{ENV_OVERRIDE_WHITELIST, EffectiveConfig};
 use anvil::contracts::{FixSliceFailureReason, FixSliceProposal};
 use anvil::tooling::{
     ExecutionClass, ExecutionMode, PermissionClass, ToolCallRequest, ToolInput, ToolKind,
     ToolRegistry, ToolValidationError,
 };
+use std::collections::HashMap;
 
 // ---------------------------------------------------------------------------
 // Task 1.1: FixSliceProposal serde
@@ -608,9 +611,135 @@ fn test_fixslice_tool_kind_mapping() {
 
 #[test]
 fn test_fixslice_repeated_read_threshold_default() {
-    // The default threshold is 2: two consecutive iterations re-reading the
-    // same target path trip the guard.
-    assert_eq!(FIXSLICE_REPEATED_READ_THRESHOLD, 2);
+    // Issue #353: the default threshold is 5 — cycle-11 regressed on the
+    // previous value of 2, which killed legitimate qwen3.5:122b
+    // exploration. The back-compat alias tracks the default.
+    assert_eq!(DEFAULT_FIXSLICE_REPEATED_READ_THRESHOLD, 5);
+    assert_eq!(
+        FIXSLICE_REPEATED_READ_THRESHOLD,
+        DEFAULT_FIXSLICE_REPEATED_READ_THRESHOLD
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Issue #353: no-progress detector tunable — runtime config, env, and file
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_fixslice_no_progress_detector_default_is_raised_threshold() {
+    // Issue #353: the baseline runtime config must ship with the new
+    // raised default so legitimate A1/A2 exploration is not aborted.
+    let config = EffectiveConfig::default_for_test().expect("default config");
+    assert_eq!(
+        config.runtime.fixslice_no_progress_detector,
+        DEFAULT_FIXSLICE_REPEATED_READ_THRESHOLD
+    );
+}
+
+#[test]
+fn test_fixslice_no_progress_detector_allows_five_reads_before_firing() {
+    // Issue #353: with the raised default, five same-path reads in a row
+    // are needed before the guard trips. Four are still fine.
+    let threshold = DEFAULT_FIXSLICE_REPEATED_READ_THRESHOLD;
+    for prior in 0..(threshold - 1) {
+        assert!(
+            !is_repeated_read_loop(Some("src/main.rs"), Some("src/main.rs"), prior, threshold,),
+            "prior={prior} must not trip at default threshold"
+        );
+    }
+    assert!(is_repeated_read_loop(
+        Some("src/main.rs"),
+        Some("src/main.rs"),
+        threshold - 1,
+        threshold,
+    ));
+}
+
+#[test]
+fn test_fixslice_no_progress_detector_env_off_disables_guard() {
+    // Issue #353: `ANVIL_FIXSLICE_NO_PROGRESS_DETECTOR=off` must route to
+    // threshold=0 in RuntimeConfig; the SubAgentSession treats `0` as
+    // "detector disabled" and never aborts on read repetition.
+    let mut config = EffectiveConfig::default_for_test().expect("default config");
+    let file_values: HashMap<String, String> = HashMap::new();
+    let mut env_values: HashMap<String, String> = HashMap::new();
+    env_values.insert(
+        "ANVIL_FIXSLICE_NO_PROGRESS_DETECTOR".to_string(),
+        "off".to_string(),
+    );
+    let cli_values: HashMap<String, String> = HashMap::new();
+    config
+        .apply_overrides_for_test(&file_values, &env_values, &cli_values)
+        .expect("env override applies");
+    assert_eq!(config.runtime.fixslice_no_progress_detector, 0);
+}
+
+#[test]
+fn test_fixslice_no_progress_detector_env_numeric_override() {
+    // Numeric env values are accepted and clamped to [0, 20] by validate.
+    let mut config = EffectiveConfig::default_for_test().expect("default config");
+    let mut env = HashMap::new();
+    env.insert(
+        "ANVIL_FIXSLICE_NO_PROGRESS_DETECTOR".to_string(),
+        "7".to_string(),
+    );
+    config
+        .apply_overrides_for_test(&HashMap::new(), &env, &HashMap::new())
+        .expect("numeric env override applies");
+    assert_eq!(config.runtime.fixslice_no_progress_detector, 7);
+}
+
+#[test]
+fn test_fixslice_no_progress_detector_env_on_restores_default() {
+    let mut config = EffectiveConfig::default_for_test().expect("default config");
+    // Force a non-default state first.
+    config.runtime.fixslice_no_progress_detector = 0;
+    let mut env = HashMap::new();
+    env.insert(
+        "ANVIL_FIXSLICE_NO_PROGRESS_DETECTOR".to_string(),
+        "on".to_string(),
+    );
+    config
+        .apply_overrides_for_test(&HashMap::new(), &env, &HashMap::new())
+        .expect("on override applies");
+    assert_eq!(
+        config.runtime.fixslice_no_progress_detector,
+        DEFAULT_FIXSLICE_REPEATED_READ_THRESHOLD
+    );
+}
+
+#[test]
+fn test_fixslice_no_progress_detector_file_config_key_honored() {
+    // Issue #353: the file-config key must match the env name so users
+    // can set it via `.anvil/config`.
+    let mut config = EffectiveConfig::default_for_test().expect("default config");
+    let mut file = HashMap::new();
+    file.insert("fixslice_no_progress_detector".to_string(), "3".to_string());
+    config
+        .apply_overrides_for_test(&file, &HashMap::new(), &HashMap::new())
+        .expect("file override applies");
+    assert_eq!(config.runtime.fixslice_no_progress_detector, 3);
+}
+
+#[test]
+fn test_fixslice_no_progress_detector_env_whitelisted() {
+    // Issue #347 regression guard: env vars must be in the whitelist, or
+    // `apply_env_overrides()` silently drops them.
+    assert!(
+        ENV_OVERRIDE_WHITELIST.contains(&"ANVIL_FIXSLICE_NO_PROGRESS_DETECTOR"),
+        "ANVIL_FIXSLICE_NO_PROGRESS_DETECTOR must be in the env override \
+         whitelist so it reaches RuntimeConfig via apply_env_overrides"
+    );
+}
+
+#[test]
+fn test_fixslice_no_progress_detector_validate_clamps_upper_bound() {
+    // Values above 20 are clamped (misconfig guard — would exceed the
+    // max FixSlice iteration cap anyway).
+    let mut config = EffectiveConfig::default_for_test().expect("default config");
+    config.runtime.fixslice_no_progress_detector = 999;
+    config.validate_for_test().expect("validate");
+    assert_eq!(config.runtime.fixslice_no_progress_detector, 20);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
PR #352 で導入した subagent no-progress detector が Phase 2 cycle 11 で 3/4 run で発火し、worker_observed が 1/4 → 0/4 に regression。閾値 3 file.read が qwen3.5:122b の exploration pattern に厳しすぎる。cycle 6 では detector 無しで 4/4 worker success が確認されている。

### 変更内容
1. **default 閾値を 3 → 5 に緩和** (src/agent/subagent.rs)
2. **env var `ANVIL_FIXSLICE_NO_PROGRESS_DETECTOR`** 追加 (src/config/mod.rs)
   - `off` で detector 完全 disable
   - 数値 (`5` / `6` 等) で threshold override
3. **config key `fixslice_no_progress_detector`** 追加
4. **回帰テスト** (tests/fixslice_subagent.rs): detector off/threshold override ケースを含む

## Test plan
- [x] cargo test --test fixslice_subagent (48/48 pass, 新規8件含む)
- [x] cargo clippy --all-targets 警告0件
- [x] cargo test 全テストパス
- [x] cargo fmt --check 差分なし

Fixes #353

🤖 Generated with [Claude Code](https://claude.com/claude-code)