### PR TITLE
fix(issue-357): enforce FixSliceProposal contract in fix_slice prompt

### DIFF
--- a/src/agent/subagent.rs
+++ b/src/agent/subagent.rs
@@ -161,30 +161,72 @@ You are a Plan sub-agent specializing in implementation planning.
 // FixSlice sub-agent prompts (Issue #291, DR2-007)
 // ---------------------------------------------------------------------------
 
-const FIXSLICE_PROTOCOL_BASE: &str = r#"You are a sub-agent of Anvil, a local coding agent.
+const FIXSLICE_PROTOCOL_BASE: &str = r#"You are a FixSlice sub-agent of Anvil, a local coding agent.
 
-## Tool protocol
-When you need to read files, respond using fenced blocks.
+## Final-message contract (strict — read this first)
+Your FINAL turn MUST contain exactly one ANVIL_FINAL fenced block whose
+body is a single FixSliceProposal JSON object. Any of the following make
+the proposal fail to parse and the whole fix_slice call fail:
+- Markdown summaries, headings (`##`), bullet lists, or prose outside `rationale`.
+- Re-pasting `file.read` tool-call JSON or any `ANVIL_TOOL` block in the final turn.
+- More than one ANVIL_FINAL block, or any text before/after the block.
+- Missing any required field, or extra keys not in the schema below.
 
-After you have analysed the target file, output your fix proposal as JSON inside:
+## FixSliceProposal schema
 ```ANVIL_FINAL
 {
-  "target_path": "relative/path/to/file.rs",
-  "start_line": 10,
-  "end_line": 15,
-  "replacement_content": "replacement lines here\n",
-  "rationale": "Short explanation of the fix"
+  "target_path": "<exact path from the user prompt>",
+  "start_line": <1-based inclusive integer>,
+  "end_line": <1-based inclusive integer>,
+  "replacement_content": "<new lines, \n-terminated>",
+  "rationale": "<short single-line explanation>"
 }
 ```
 
-Rules:
-- All paths must be relative (start with ./ or a directory name).
-- Do not use any other tool syntax.
-- Always include ANVIL_FINAL when you are done.
-- You MUST output ANVIL_FINAL to signal completion.
-- Output valid JSON in ANVIL_FINAL. The JSON must contain target_path, start_line, end_line, and replacement_content.
-- start_line and end_line are 1-based, inclusive.
-- Keep the replacement scope minimal — only the lines that need to change.
+Field rules:
+- `target_path` MUST be byte-for-byte identical to the `target_path` given
+  in the user prompt. Do NOT shorten it to a basename, drop directory
+  prefixes, strip or add `./`, rewrite path separators, or resolve it to a
+  different directory. If the request says `src/lib/auto-yes-manager.ts`,
+  the proposal must say `src/lib/auto-yes-manager.ts` — never
+  `auto-yes-manager.ts`.
+- `start_line` / `end_line` are 1-based and inclusive, and must satisfy
+  `end_line - start_line + 1 <= max_lines` from the user prompt.
+- `replacement_content` must be a non-empty string containing the exact
+  replacement lines (keep the trailing newline if the original slice had one).
+- `rationale` is a short, single-line explanation — never a summary section.
+
+## Tool protocol (exploration turns only)
+While exploring the target you may call file.read via a fenced block:
+```ANVIL_TOOL
+{"id":"call_001","tool":"file.read","path":"./relative/path"}
+```
+`ANVIL_TOOL` blocks are valid ONLY in exploration turns. They must never
+appear in the final turn that emits ANVIL_FINAL. Do not use any other
+tool syntax.
+
+## Few-shot examples
+
+Correct — request target_path was `src/lib/auto-yes-manager.ts`:
+```ANVIL_FINAL
+{"target_path":"src/lib/auto-yes-manager.ts","start_line":42,"end_line":44,"replacement_content":"  if (choice === 'yes') {\n    return true;\n  }\n","rationale":"Return true on explicit yes"}
+```
+
+Correct — request target_path was `src/agent/subagent.rs`:
+```ANVIL_FINAL
+{"target_path":"src/agent/subagent.rs","start_line":100,"end_line":101,"replacement_content":"    let x = compute(&ctx);\n","rationale":"Pass ctx to compute to fix overflow"}
+```
+
+Incorrect — `target_path` dropped the directory (basename drift, do NOT do this):
+```ANVIL_FINAL
+{"target_path":"auto-yes-manager.ts","start_line":42,"end_line":44,"replacement_content":"...","rationale":"..."}
+```
+
+Incorrect — markdown summary under ANVIL_FINAL (do NOT do this):
+```ANVIL_FINAL
+## Implementation overview
+I updated the handler so the multiple-choice prompt now returns true on yes...
+```
 
 "#;
 
@@ -192,9 +234,12 @@ const FIXSLICE_ROLE_PROMPT: &str = r#"## Your role
 You are a FixSlice sub-agent specializing in targeted, local code fixes.
 - Use file.read to read the target file and understand the context.
 - Identify the minimal set of lines that need to change.
-- Produce a FixSliceProposal in ANVIL_FINAL with the exact line range and replacement.
-- Keep the fix within the specified max_lines budget.
+- Produce a FixSliceProposal in ANVIL_FINAL whose `target_path` is
+  byte-for-byte identical to the target path given in the user prompt.
+- Keep `end_line - start_line + 1` within the max_lines budget.
 - You only have read-only access: file.read.
+- Never emit markdown, prose summaries, or copies of tool-call JSON as the
+  final message — the final message is a FixSliceProposal JSON object only.
 "#;
 
 /// Options for sub-agent system prompt generation (Issue #162).

--- a/tests/fixslice_subagent.rs
+++ b/tests/fixslice_subagent.rs
@@ -425,6 +425,73 @@ fn test_fixslice_system_prompt_contents() {
 }
 
 // ---------------------------------------------------------------------------
+// Issue #357: FixSlice system prompt must hard-code the worker contract so
+// B1 (basename drift) and B2 (markdown / tool-call JSON under ANVIL_FINAL)
+// failure modes stop sneaking past the model.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_fixslice_system_prompt_enforces_contract_issue_357() {
+    use anvil::agent::subagent::{SubAgentPromptOptions, build_subagent_system_prompt};
+
+    let opts = SubAgentPromptOptions {
+        offline: false,
+        ui_language: None,
+    };
+    let prompt = build_subagent_system_prompt(&SubAgentKind::FixSlice, &opts);
+
+    // Strict final-message contract stated up front.
+    assert!(
+        prompt.contains("Final-message contract"),
+        "prompt must lead with the final-message contract: {prompt}"
+    );
+    assert!(
+        prompt.contains("exactly one ANVIL_FINAL"),
+        "prompt must forbid more than one ANVIL_FINAL block: {prompt}"
+    );
+
+    // Markdown / tool-call JSON drift must be explicitly forbidden.
+    assert!(
+        prompt.contains("Markdown"),
+        "prompt must forbid Markdown in the final message: {prompt}"
+    );
+    assert!(
+        prompt.contains("ANVIL_TOOL"),
+        "prompt must forbid ANVIL_TOOL re-pastes in the final message: {prompt}"
+    );
+
+    // target_path exact-match requirement — the B1 failure mode.
+    assert!(
+        prompt.contains("byte-for-byte"),
+        "prompt must require byte-for-byte target_path match: {prompt}"
+    );
+    assert!(
+        prompt.contains("basename"),
+        "prompt must call out basename drift: {prompt}"
+    );
+
+    // Few-shot examples — both positive and negative must be present.
+    assert!(
+        prompt.contains("Correct"),
+        "prompt must include a positive few-shot example: {prompt}"
+    );
+    assert!(
+        prompt.contains("Incorrect"),
+        "prompt must include a negative few-shot example: {prompt}"
+    );
+
+    // The cycle-13 B1 drift must appear as an explicit negative example.
+    assert!(
+        prompt.contains(r#""target_path":"src/lib/auto-yes-manager.ts""#),
+        "prompt must include the positive auto-yes-manager example: {prompt}"
+    );
+    assert!(
+        prompt.contains(r#""target_path":"auto-yes-manager.ts""#),
+        "prompt must include the basename-drift negative example: {prompt}"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // Validation via ToolRegistry
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Fixes Issue #357 — cycle 13 Phase 2 B1/B2 prompt contract failures.

- **B1 target_path drift**: worker emitted `\"target_path\": \"auto-yes-manager.ts\"` (basename-only) instead of the request's `src/lib/auto-yes-manager.ts` → `path_mismatch`.
- **B2 (1st)**: worker's final message contained tool-call JSON + natural language, missing the FixSliceProposal JSON; the salvage parser couldn't recover it.
- **B2 (2nd)**: ANVIL_FINAL contained markdown summary instead of FixSliceProposal JSON.

## Changes

- `src/agent/subagent.rs`: Strengthen the fix_slice subagent system prompt with:
  - Strict contract statement at the top (ANVIL_FINAL must contain FixSliceProposal JSON only — no markdown / explanations / tool-call JSON).
  - target_path exact-match requirement (reuse the request's path including directory prefix; basename-only / prefix-drop forbidden).
  - Inline FixSliceProposal schema definition.
  - Few-shot examples (positive 2 + negative 1 markdown summary).
  - Final message rules block.
- `tests/fixslice_subagent.rs` (+67): regression tests verifying that the prompt contains the contract markers, exact-path requirement, schema fields, and few-shot examples.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets` — 0 warnings
- [x] `cargo test` — all pass (worker_observed_success_side 9/9, plus updated fixslice_subagent suite)

Closes #357

🤖 Generated with Claude Code