### PR TITLE
fix(issue-359): balance fix_slice prompt to prevent proposal-avoidance under path ambiguity

### DIFF
--- a/src/agent/subagent.rs
+++ b/src/agent/subagent.rs
@@ -217,16 +217,22 @@ Correct — request target_path was `src/agent/subagent.rs`:
 {"target_path":"src/agent/subagent.rs","start_line":100,"end_line":101,"replacement_content":"    let x = compute(&ctx);\n","rationale":"Pass ctx to compute to fix overflow"}
 ```
 
-Incorrect — `target_path` dropped the directory (basename drift, do NOT do this):
+Avoid — basename drift (dropped the directory prefix):
 ```ANVIL_FINAL
 {"target_path":"auto-yes-manager.ts","start_line":42,"end_line":44,"replacement_content":"...","rationale":"..."}
 ```
 
-Incorrect — markdown summary under ANVIL_FINAL (do NOT do this):
+Avoid — markdown summary under ANVIL_FINAL:
 ```ANVIL_FINAL
 ## Implementation overview
 I updated the handler so the multiple-choice prompt now returns true on yes...
 ```
+
+## Encouragement
+- Always produce a FixSliceProposal. It is better to submit an imperfect proposal
+  than no proposal — Anvil validates and will ask you to retry if needed.
+- If you are unsure about exact line numbers, make your best attempt.
+- Do not spend iterations reasoning about whether to propose — propose.
 
 "#;
 

--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -3460,7 +3460,17 @@ pub fn build_fixslice_user_prompt(target_path: &str, goal: &str, max_lines: u32)
          1. Read `{target_path}` first with file.read to locate the exact lines to change.\n\
          2. Return a single JSON proposal inside ANVIL_FINAL whose `target_path` equals `{target_path}` exactly.\n\
          3. Keep the `end_line - start_line + 1` span within {max_lines} lines.\n\
-         4. Do not explore unrelated files; the edit must stay on the target."
+         4. Do not explore unrelated files; the edit must stay on the target.\n\
+         \n\
+         IMPORTANT GUIDANCE:\n\
+         - If file.read returns a slightly different path form (e.g., ./src/ vs src/), use \
+         the ORIGINAL target_path `{target_path}` from this prompt in your proposal. \
+         Do not block on resolving path ambiguity.\n\
+         - Partial file context is acceptable. You do not need to read the entire file \
+         before proposing a fix.\n\
+         - It is better to submit an imperfect proposal than to submit no proposal. \
+         Anvil will validate your proposal and retry if needed.\n\
+         - Focus on producing the FixSliceProposal JSON, not on explaining your reasoning."
     )
 }
 

--- a/tests/fixslice_subagent.rs
+++ b/tests/fixslice_subagent.rs
@@ -476,7 +476,7 @@ fn test_fixslice_system_prompt_enforces_contract_issue_357() {
         "prompt must include a positive few-shot example: {prompt}"
     );
     assert!(
-        prompt.contains("Incorrect"),
+        prompt.contains("Avoid"),
         "prompt must include a negative few-shot example: {prompt}"
     );
 
@@ -955,6 +955,75 @@ fn test_first_file_read_target_ignores_non_file_read() {
     assert_eq!(
         first_file_read_target(&calls),
         Some("src/target.rs".to_string())
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Issue #359: balance fix_slice prompt — encouragement guidance + softened
+// negative examples to prevent proposal-avoidance under path ambiguity
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_fixslice_system_prompt_contains_encouragement_issue_359() {
+    use anvil::agent::subagent::{SubAgentPromptOptions, build_subagent_system_prompt};
+
+    let opts = SubAgentPromptOptions {
+        offline: false,
+        ui_language: None,
+    };
+    let prompt = build_subagent_system_prompt(&SubAgentKind::FixSlice, &opts);
+
+    // Encouragement section must exist to counterbalance strict contract.
+    assert!(
+        prompt.contains("imperfect proposal"),
+        "system prompt must encourage submitting imperfect proposals over no proposal: {prompt}"
+    );
+    assert!(
+        prompt.contains("retry"),
+        "system prompt must mention Anvil retry to reduce proposal-avoidance: {prompt}"
+    );
+}
+
+#[test]
+fn test_fixslice_system_prompt_softened_negative_examples_issue_359() {
+    use anvil::agent::subagent::{SubAgentPromptOptions, build_subagent_system_prompt};
+
+    let opts = SubAgentPromptOptions {
+        offline: false,
+        ui_language: None,
+    };
+    let prompt = build_subagent_system_prompt(&SubAgentKind::FixSlice, &opts);
+
+    // Negative examples must use "Avoid" instead of "Incorrect ... do NOT do this".
+    assert!(
+        prompt.contains("Avoid"),
+        "negative examples must use softened label 'Avoid': {prompt}"
+    );
+    assert!(
+        !prompt.contains("do NOT do this"),
+        "prompt must not contain 'do NOT do this' — softened in Issue #359: {prompt}"
+    );
+}
+
+#[test]
+fn test_fixslice_user_prompt_contains_guidance_issue_359() {
+    let prompt =
+        build_fixslice_user_prompt("src/lib/auto-yes-manager.ts", "fix path resolution bug", 80);
+
+    // IMPORTANT GUIDANCE must be present to counterbalance strict contract.
+    assert!(
+        prompt.contains("IMPORTANT GUIDANCE"),
+        "user prompt must contain IMPORTANT GUIDANCE section: {prompt}"
+    );
+    // Path ambiguity guidance — the primary regression trigger.
+    assert!(
+        prompt.contains("path ambiguity"),
+        "user prompt must address path ambiguity: {prompt}"
+    );
+    // Encourage proposal submission.
+    assert!(
+        prompt.contains("imperfect proposal"),
+        "user prompt must encourage imperfect proposals over no proposal: {prompt}"
     );
 }
 


### PR DESCRIPTION
## Summary

Fixes Issue #359 — cycle 14 regression where PR #358's strict prompt caused the fix_slice worker to enter proposal-avoidance behavior under path ambiguity (`./src/` vs `src/`), consuming all iterations on reasoning without ever emitting a FixSliceProposal.

## Changes

- `src/agent/subagent.rs` (+10/-2): Add encouragement guidance block after RULES section:
  - Path ambiguity resolution: use ORIGINAL target_path from request
  - Partial file context is acceptable for proposals
  - Imperfect proposal > no proposal (validator will retry)
  - Soften negative example wording ("Avoid this pattern" vs "This is WRONG")
- `src/app/agentic.rs` (+12/-1): Minor integration adjustment for prompt balance
- `tests/fixslice_subagent.rs` (+71/-1): Regression tests verifying encouragement markers and softened negative examples in the prompt

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets` — 0 warnings
- [x] `cargo test` — all pass (fixslice_subagent suite + worker_observed_success_side 9/9)

Closes #359

🤖 Generated with Claude Code