### PR TITLE
Phase 2 fix_slice stabilization: Issues #290-#359

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,8 +147,8 @@ src/
 ├── spinner.rs           # スピナーUI（並列詳細進捗表示・start_parallel_detailed・format_detailed_progress）
 ├── state/mod.rs         # 状態マシン
 ├── tooling/
-│   ├── mod.rs           # ツール実行・検証・CheckpointStack（undo用チェックポイント管理）・EditFallbackStage・file.edit詳細ログ
-│   ├── diff.rs          # 差分プレビュー生成（file.write/file.edit承認時）
+│   ├── mod.rs           # ツール実行・検証・CheckpointStack（undo用チェックポイント管理）・EditFallbackStage・file.edit詳細ログ・file.rewrite（行番号範囲ベースのブロック全置換）
+│   ├── diff.rs          # 差分プレビュー生成（file.write/file.edit/file.rewrite承認時）
 │   ├── file_cache.rs    # ファイル読み取りキャッシュ（FileReadCache: LRUエビクション・sandbox境界検証）
 │   ├── progress.rs      # 並列実行進捗型（ToolProgressStatus・ToolProgressEntry）
 │   └── shell_policy.rs  # ShellPolicy分類（ReadOnly/BuildTest/General）・offline用ネットワークコマンド検出

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,7 +101,7 @@ src/
 ├── agent/
 │   ├── mod.rs           # エージェントループ・プロトコル
 │   ├── model_classifier.rs # モデル分類・ToolProtocolMode判定
-│   ├── subagent.rs      # サブエージェント実行ループ（Explore/Plan、構造化payload・JSON ANVIL_FINAL対応）
+│   ├── subagent.rs      # サブエージェント実行ループ（Explore/Plan/FixSlice、構造化payload・JSON ANVIL_FINAL対応・FixSliceProposalパース）
 │   ├── tag_parser.rs    # タグベースツール呼び出しパーサー（多層プロトコル対応）
 │   └── tag_spec.rs      # ツールタグ仕様テーブル（TOOL_TAG_SPECS）
 ├── app/
@@ -125,7 +125,7 @@ src/
 │   └── mock.rs          # テスト用モック
 ├── config/mod.rs        # 設定管理
 ├── contracts/
-│   ├── mod.rs           # 共通型定義（TerminationReason, Finding, SubAgentPayload含む）
+│   ├── mod.rs           # 共通型定義（TerminationReason, Finding, SubAgentPayload, FixSliceProposal含む）
 │   └── tokens.rs        # トークン推定（CJK対応ヒューリスティック・モデル実測値ベースEMA補正）
 ├── extensions/
 │   ├── mod.rs           # スラッシュコマンド・拡張
@@ -175,6 +175,7 @@ tests/
 ├── followup_replan.rs   # follow-up ANVIL_PLAN replan テスト（Issue #305）
 ├── prose_retire_fallback.rs # prose-only確認のplan retire変換テスト（Issue #307）
 ├── shell_inspection_drift.rs # shell.exec inspection drift テスト（Issue #309）
+├── fixslice_subagent.rs # FixSliceサブエージェント統合テスト（Issue #291）
 └── walk_system.rs       # ディレクトリウォーカーテスト
 ```
 

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -728,6 +728,14 @@ const TOOL_DESC_FILE_EDIT: &str = concat!(
     "\n",
 );
 
+const TOOL_DESC_FILE_REWRITE: &str = concat!(
+    "3b. file.rewrite — replace a line range with new content (use file.read first to confirm line numbers):\n",
+    "```ANVIL_TOOL\n",
+    "{\"id\":\"call_010\",\"tool\":\"file.rewrite\",\"path\":\"./relative/path\",\"start_line\":10,\"end_line\":15,\"content\":\"replacement lines here\"}\n",
+    "```\n",
+    "\n",
+);
+
 const TOOL_DESC_FILE_SEARCH: &str = concat!(
     "4. file.search — search for files by name or content (respects .gitignore):\n",
     "```ANVIL_TOOL\n",
@@ -848,7 +856,7 @@ const PROMPT_TOOL_RULES: &str = concat!(
     "- When the user's request requires file changes (implement, fix, create, modify, etc.), \
        you must complete the actual file modifications using file.write/file.edit, \
        not just output a plan or description.\n",
-    "- For large existing files, file.write may be blocked. Use file.edit or file.edit_anchor for targeted modifications instead of rewriting entire files.\n",
+    "- For large existing files, file.write may be blocked. Use file.edit, file.edit_anchor, or file.rewrite for targeted modifications instead of rewriting entire files.\n",
     "- Start exploration with file.read on \".\" to list the project root before reading specific files.\n",
     "- Do not assume files like README.md exist — verify first.\n",
     "- For dev servers and watch processes (npm run dev, cargo watch, etc.), use background execution with '&' so the command returns immediately.\n",
@@ -988,6 +996,7 @@ fn build_json_protocol_prompt(
     prompt.push_str(TOOL_DESC_FILE_READ);
     prompt.push_str(TOOL_DESC_FILE_WRITE);
     prompt.push_str(TOOL_DESC_FILE_EDIT);
+    prompt.push_str(TOOL_DESC_FILE_REWRITE);
     prompt.push_str(TOOL_DESC_FILE_SEARCH);
     prompt.push_str(TOOL_DESC_SHELL_EXEC);
     prompt.push_str(TOOL_DESC_WEB_FETCH);
@@ -1111,6 +1120,7 @@ fn tool_protocol_system_prompt_compact(
     prompt.push_str(TOOL_DESC_FILE_READ);
     prompt.push_str(TOOL_DESC_FILE_WRITE);
     prompt.push_str(TOOL_DESC_FILE_EDIT);
+    prompt.push_str(TOOL_DESC_FILE_REWRITE);
     prompt.push_str(TOOL_DESC_FILE_SEARCH);
     prompt.push_str(TOOL_DESC_SHELL_EXEC);
     prompt.push_str(TOOL_DESC_WEB_FETCH);
@@ -1152,10 +1162,11 @@ fn tool_protocol_system_prompt_tiny() -> String {
     prompt.push_str("You are Anvil, a coding agent.\n\n");
     prompt.push_str("Use ANVIL_TOOL blocks for tool calls. Available tools:\n\n");
 
-    // Only core 4 tools + shell
+    // Only core 4 tools + shell + rewrite
     prompt.push_str(TOOL_DESC_FILE_READ);
     prompt.push_str(TOOL_DESC_FILE_WRITE);
     prompt.push_str(TOOL_DESC_FILE_EDIT);
+    prompt.push_str(TOOL_DESC_FILE_REWRITE);
     prompt.push_str(TOOL_DESC_SHELL_EXEC);
 
     prompt.push_str(concat!(

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -789,6 +789,16 @@ const TOOL_DESC_AGENT_PLAN: &str = concat!(
     "\n",
 );
 
+const TOOL_DESC_AGENT_FIX_SLICE: &str = concat!(
+    "10. agent.fix_slice — launch a microtask sub-agent to propose a targeted fix for a specific file:\n",
+    "```ANVIL_TOOL\n",
+    "{\"id\":\"call_010\",\"tool\":\"agent.fix_slice\",\"target_path\":\"./src/main.rs\",\"goal\":\"Fix the compilation error in function foo\",\"max_lines\":50}\n",
+    "```\n",
+    "The sub-agent reads the target file, proposes a minimal line-range replacement, and the parent applies it via file.rewrite.\n",
+    "Use this for small, focused fixes where you know the target file and the nature of the problem.\n",
+    "\n",
+);
+
 /// Data-driven definition of optional tools: (tool_name, tool_description, catalog_one_liner).
 /// Note: web.fetch and web.search were moved to basic tools (always included)
 /// because LLMs cannot discover them without prompt descriptions. See Issue #114.
@@ -802,6 +812,11 @@ const OPTIONAL_TOOLS: &[(&str, &str, &str)] = &[
         "agent.plan",
         TOOL_DESC_AGENT_PLAN,
         "agent.plan: launch a read-only sub-agent to create an implementation plan",
+    ),
+    (
+        "agent.fix_slice",
+        TOOL_DESC_AGENT_FIX_SLICE,
+        "agent.fix_slice: launch a microtask sub-agent to propose a targeted fix for a file",
     ),
 ];
 

--- a/src/agent/subagent.rs
+++ b/src/agent/subagent.rs
@@ -299,6 +299,12 @@ pub enum FixProposalParseFailure {
     /// distinct from `EmptyFinal` because it reflects loop exhaustion rather
     /// than a blank model output.
     NoFinal,
+    /// The sub-agent hit the same-target `file.read` oscillation guard and
+    /// aborted early (Issue #351, B1 shape). The worker kept re-reading the
+    /// same target path without producing a proposal; the runtime aborts
+    /// before the iteration budget is exhausted so the parent can classify
+    /// the session as pack_gate_invalid.
+    RepeatedReadLoop,
 }
 
 /// Outcome of `try_parse_fix_proposal` (Issue #345).
@@ -599,6 +605,51 @@ pub struct SubAgentSession<'a, C: ProviderClient> {
     iterations_used: u32,
     /// Model/context_window overrides from the parent App (Issue #77).
     overrides: SubAgentOverrides,
+    /// Most recent `file.read` target path observed in a FixSlice iteration
+    /// (Issue #351). Used together with `same_target_read_count` to detect
+    /// same-path read oscillation inside the sub-agent loop.
+    last_file_read_target: Option<String>,
+    /// Number of consecutive FixSlice iterations whose primary `file.read`
+    /// call targeted `last_file_read_target` (Issue #351).
+    same_target_read_count: u32,
+}
+
+/// Threshold (consecutive iterations) for the same-target `file.read`
+/// oscillation guard inside the FixSlice sub-agent loop (Issue #351).
+///
+/// Two iterations in a row re-reading the exact same target path without
+/// producing a `FixSliceProposal` is the B1 shape from phase-bench cycle
+/// 10: the worker is stuck and will exhaust the iteration budget if
+/// allowed to continue.
+pub const FIXSLICE_REPEATED_READ_THRESHOLD: u32 = 2;
+
+/// Pure helper for the same-target `file.read` oscillation guard (Issue
+/// #351). Returns `true` when `current_target` matches `last_target` and
+/// the resulting consecutive count reaches `threshold`.
+///
+/// Exposed as a pure function so the guard can be unit-tested without
+/// standing up a provider / tool-executor stack.
+pub fn is_repeated_read_loop(
+    current_target: Option<&str>,
+    last_target: Option<&str>,
+    prior_consecutive_count: u32,
+    threshold: u32,
+) -> bool {
+    match (current_target, last_target) {
+        (Some(c), Some(l)) if c == l => prior_consecutive_count + 1 >= threshold,
+        _ => false,
+    }
+}
+
+/// Return the first `file.read` target path from a slice of tool calls, if
+/// any (Issue #351). The FixSlice sub-agent is limited to `file.read`, so
+/// "first match" is the simplest stable fingerprint for the iteration's
+/// dominant target.
+pub fn first_file_read_target(tool_calls: &[ToolCallRequest]) -> Option<String> {
+    tool_calls.iter().find_map(|call| match &call.input {
+        ToolInput::FileRead { path } => Some(path.clone()),
+        _ => None,
+    })
 }
 
 impl<'a, C: ProviderClient> SubAgentSession<'a, C> {
@@ -645,6 +696,8 @@ impl<'a, C: ProviderClient> SubAgentSession<'a, C> {
             scope_path: scope.to_path_buf(),
             iterations_used: 0,
             overrides,
+            last_file_read_target: None,
+            same_target_read_count: 0,
         }
     }
 
@@ -766,6 +819,63 @@ impl<'a, C: ProviderClient> SubAgentSession<'a, C> {
                 fix_proposal: None,
                 fix_proposal_failure: None,
             })));
+        }
+
+        // Issue #351: same-target `file.read` oscillation guard (FixSlice only).
+        //
+        // Cycle-10 traces showed FixSlice workers burning the full iteration
+        // budget while re-reading the exact same target path without ever
+        // producing a proposal. Detect that shape here, before the executor
+        // runs another round of IO against the same file, and abort with a
+        // dedicated `RepeatedReadLoop` classification so the parent can
+        // classify the session as pack_gate_invalid instead of waiting for
+        // the runner timeout.
+        if self.kind == SubAgentKind::FixSlice {
+            let current_target = first_file_read_target(&structured.tool_calls);
+            let triggered = is_repeated_read_loop(
+                current_target.as_deref(),
+                self.last_file_read_target.as_deref(),
+                self.same_target_read_count,
+                FIXSLICE_REPEATED_READ_THRESHOLD,
+            );
+            match current_target.as_deref() {
+                Some(path) if self.last_file_read_target.as_deref() == Some(path) => {
+                    self.same_target_read_count += 1;
+                }
+                Some(path) => {
+                    self.last_file_read_target = Some(path.to_string());
+                    self.same_target_read_count = 1;
+                }
+                None => {
+                    self.last_file_read_target = None;
+                    self.same_target_read_count = 0;
+                }
+            }
+            if triggered {
+                let tokens = crate::contracts::tokens::estimate_tokens(
+                    &token_buffer,
+                    crate::contracts::tokens::ContentKind::Text,
+                );
+                let target = self.last_file_read_target.clone().unwrap_or_default();
+                eprintln!(
+                    "[subagent:fix_slice] repeated-read loop detected (path={target}); \
+                     aborting after {} iteration(s)",
+                    self.iterations_used
+                );
+                let summary = format!(
+                    "fix-slice worker aborted: repeated-read loop on target '{target}' \
+                     after {} iteration(s)",
+                    self.iterations_used
+                );
+                let payload = SubAgentPayload::fallback(summary, TerminationReason::LoopDetected);
+                return Ok(TurnOutcome::Finished(Box::new(SubAgentResult {
+                    payload,
+                    estimated_tokens: tokens,
+                    iterations_used: self.iterations_used,
+                    fix_proposal: None,
+                    fix_proposal_failure: Some(FixProposalParseFailure::RepeatedReadLoop),
+                })));
+            }
         }
 
         // Validate and execute tool calls

--- a/src/agent/subagent.rs
+++ b/src/agent/subagent.rs
@@ -30,8 +30,17 @@ use std::time::{Duration, Instant};
 // FixSlice budget constants (Issue #291, DR1-004: code-level const)
 // ---------------------------------------------------------------------------
 
-/// Maximum iterations for a FixSlice sub-agent run.
-pub const FIXSLICE_MAX_ITERATIONS: u32 = 3;
+/// Default value for the runtime `fixslice_max_iterations` knob (Issue #345).
+///
+/// Since Issue #345 the iteration cap is configurable. This const is kept so
+/// tests and config defaults can reference the historical value in a single
+/// place. Runtime callers should read
+/// `EffectiveConfig::runtime::fixslice_max_iterations` instead.
+pub const DEFAULT_FIXSLICE_MAX_ITERATIONS: u32 = 3;
+/// Back-compat alias for `DEFAULT_FIXSLICE_MAX_ITERATIONS` (Issue #291 /
+/// Issue #345). Kept so external callers that imported the old name continue
+/// to compile; prefer the runtime config at the call site.
+pub const FIXSLICE_MAX_ITERATIONS: u32 = DEFAULT_FIXSLICE_MAX_ITERATIONS;
 /// Wall-clock timeout (seconds) for a FixSlice sub-agent run.
 pub const FIXSLICE_TIMEOUT_SECS: u64 = 60;
 /// Maximum allowed value for `max_lines` in agent.fix_slice input.
@@ -269,6 +278,109 @@ impl SubAgentKind {
     }
 }
 
+/// Why a FixSlice sub-agent finished without a usable `FixSliceProposal`
+/// (Issue #345).
+///
+/// Surfaces the parse outcome to `handle_fixslice_result` so it can record a
+/// granular `FixSliceFailureReason` instead of lumping everything into
+/// `NoProposal`. `None` on `SubAgentResult::fix_proposal_failure` means the
+/// worker either produced a usable proposal (possibly salvaged) or the result
+/// came from a non-FixSlice kind where this field is irrelevant.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FixProposalParseFailure {
+    /// Final response was empty (or whitespace-only) after trimming.
+    EmptyFinal,
+    /// Final response was non-empty but could not be parsed into a
+    /// `FixSliceProposal`, even after the salvage pass that extracts the
+    /// first embedded JSON object.
+    ParseFailed,
+    /// Worker terminated without emitting a final response of its own — the
+    /// result was built from a partial/max-iterations exit path. Treated as
+    /// distinct from `EmptyFinal` because it reflects loop exhaustion rather
+    /// than a blank model output.
+    NoFinal,
+}
+
+/// Outcome of `try_parse_fix_proposal` (Issue #345).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FixProposalParseOutcome {
+    /// The full `final_response` parsed as strict JSON.
+    Parsed(FixSliceProposal),
+    /// The first balanced `{...}` substring parsed as JSON after the strict
+    /// parse failed.
+    Salvaged(FixSliceProposal),
+    /// `final_response` was blank after trimming.
+    EmptyFinal,
+    /// `final_response` was non-empty but no JSON object could be extracted.
+    ParseFailed,
+}
+
+/// Extract a `FixSliceProposal` from a worker's final response (Issue #345).
+///
+/// Tries a strict parse first, then falls back to extracting the first
+/// balanced `{...}` substring from the text. The depth scanner tracks JSON
+/// string state so braces inside string literals (e.g. Rust code in
+/// `replacement_content`) don't throw off the bracket count.
+pub fn try_parse_fix_proposal(final_response: &str) -> FixProposalParseOutcome {
+    let trimmed = final_response.trim();
+    if trimmed.is_empty() {
+        return FixProposalParseOutcome::EmptyFinal;
+    }
+    if let Ok(parsed) = serde_json::from_str::<FixSliceProposal>(trimmed) {
+        return FixProposalParseOutcome::Parsed(parsed);
+    }
+    if let Some(slice) = extract_first_json_object(trimmed)
+        && let Ok(parsed) = serde_json::from_str::<FixSliceProposal>(slice)
+    {
+        return FixProposalParseOutcome::Salvaged(parsed);
+    }
+    FixProposalParseOutcome::ParseFailed
+}
+
+/// Return the first balanced `{...}` substring from `text`, respecting JSON
+/// string state so braces inside string literals don't unbalance the scan.
+fn extract_first_json_object(text: &str) -> Option<&str> {
+    let bytes = text.as_bytes();
+    let mut start: Option<usize> = None;
+    let mut depth: i32 = 0;
+    let mut in_string = false;
+    let mut escape = false;
+    for (i, &b) in bytes.iter().enumerate() {
+        if in_string {
+            if escape {
+                escape = false;
+            } else if b == b'\\' {
+                escape = true;
+            } else if b == b'"' {
+                in_string = false;
+            }
+            continue;
+        }
+        match b {
+            b'"' => {
+                in_string = true;
+            }
+            b'{' => {
+                if start.is_none() {
+                    start = Some(i);
+                }
+                depth += 1;
+            }
+            b'}' => {
+                if depth > 0 {
+                    depth -= 1;
+                    if depth == 0 {
+                        let s = start?;
+                        return Some(&text[s..=i]);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
 /// Result returned by a successful sub-agent run.
 // TODO(DR1-001): When a 4th sub-agent kind is added, refactor SubAgentResult
 // into an enum to avoid accumulating Option fields.
@@ -281,6 +393,13 @@ pub struct SubAgentResult {
     pub iterations_used: u32,
     /// FixSlice proposal extracted from ANVIL_FINAL (Issue #291).
     pub fix_proposal: Option<FixSliceProposal>,
+    /// Why `fix_proposal` is `None` for FixSlice runs (Issue #345).
+    ///
+    /// `None` when the result produced a usable proposal or the run was not
+    /// a FixSlice sub-agent. Populated by `run_turn` / `build_partial_result`
+    /// for the FixSlice kind so `handle_fixslice_result` can pick a precise
+    /// `FixSliceFailureReason` classification.
+    pub fix_proposal_failure: Option<FixProposalParseFailure>,
 }
 
 impl SubAgentResult {
@@ -594,14 +713,31 @@ impl<'a, C: ProviderClient> SubAgentSession<'a, C> {
                 crate::contracts::tokens::ContentKind::Text,
             );
 
-            // FixSlice: parse ANVIL_FINAL as FixSliceProposal (Issue #291, DR1-007)
+            // FixSlice: parse ANVIL_FINAL as FixSliceProposal.
+            // Issue #291, DR1-007: strict JSON parse.
+            // Issue #345: fall back to a salvage pass and report the parse
+            // outcome so the parent can classify `no_proposal` sub-classes.
             if self.kind == SubAgentKind::FixSlice {
-                let fix_proposal =
-                    serde_json::from_str::<FixSliceProposal>(&structured.final_response).ok();
-                let payload = SubAgentPayload::fallback(
-                    if fix_proposal.is_some() {
-                        "fix-slice proposal parsed successfully".to_string()
-                    } else {
+                let outcome = try_parse_fix_proposal(&structured.final_response);
+                let (fix_proposal, fix_proposal_failure, summary) = match outcome {
+                    FixProposalParseOutcome::Parsed(p) => (
+                        Some(p),
+                        None,
+                        "fix-slice proposal parsed successfully".to_string(),
+                    ),
+                    FixProposalParseOutcome::Salvaged(p) => (
+                        Some(p),
+                        None,
+                        "fix-slice proposal salvaged from embedded JSON".to_string(),
+                    ),
+                    FixProposalParseOutcome::EmptyFinal => (
+                        None,
+                        Some(FixProposalParseFailure::EmptyFinal),
+                        "fix-slice proposal missing: empty final response".to_string(),
+                    ),
+                    FixProposalParseOutcome::ParseFailed => (
+                        None,
+                        Some(FixProposalParseFailure::ParseFailed),
                         format!(
                             "fix-slice proposal parse failed: {}",
                             &structured
@@ -609,15 +745,16 @@ impl<'a, C: ProviderClient> SubAgentSession<'a, C> {
                                 .chars()
                                 .take(200)
                                 .collect::<String>()
-                        )
-                    },
-                    TerminationReason::Completed,
-                );
+                        ),
+                    ),
+                };
+                let payload = SubAgentPayload::fallback(summary, TerminationReason::Completed);
                 return Ok(TurnOutcome::Finished(Box::new(SubAgentResult {
                     payload,
                     estimated_tokens: tokens,
                     iterations_used: self.iterations_used,
                     fix_proposal,
+                    fix_proposal_failure,
                 })));
             }
 
@@ -627,6 +764,7 @@ impl<'a, C: ProviderClient> SubAgentSession<'a, C> {
                 estimated_tokens: tokens,
                 iterations_used: self.iterations_used,
                 fix_proposal: None,
+                fix_proposal_failure: None,
             })));
         }
 
@@ -728,8 +866,9 @@ impl<'a, C: ProviderClient> SubAgentSession<'a, C> {
         eprintln!("[subagent:{kind_label}] Starting...");
         let start = Instant::now();
         let (max_iterations, timeout) = if self.kind == SubAgentKind::FixSlice {
+            // Issue #345: runtime-configurable iteration cap.
             (
-                FIXSLICE_MAX_ITERATIONS,
+                self.config.runtime.fixslice_max_iterations,
                 Duration::from_secs(FIXSLICE_TIMEOUT_SECS),
             )
         } else {
@@ -785,6 +924,26 @@ impl<'a, C: ProviderClient> SubAgentSession<'a, C> {
             .map(|m| m.content.clone())
             .unwrap_or_default();
 
+        // Issue #345: attempt to salvage a proposal from the last assistant
+        // message even on a partial exit path. Timeout / max-iterations paths
+        // sometimes have a valid-looking ANVIL_FINAL in the last turn that
+        // the strict main path never got to parse.
+        let (fix_proposal, fix_proposal_failure) = if self.kind == SubAgentKind::FixSlice {
+            match try_parse_fix_proposal(&raw_summary) {
+                FixProposalParseOutcome::Parsed(p) | FixProposalParseOutcome::Salvaged(p) => {
+                    (Some(p), None)
+                }
+                FixProposalParseOutcome::EmptyFinal => {
+                    (None, Some(FixProposalParseFailure::NoFinal))
+                }
+                FixProposalParseOutcome::ParseFailed => {
+                    (None, Some(FixProposalParseFailure::ParseFailed))
+                }
+            }
+        } else {
+            (None, None)
+        };
+
         SubAgentResult {
             payload: SubAgentPayload {
                 found_files: vec![],
@@ -796,7 +955,8 @@ impl<'a, C: ProviderClient> SubAgentSession<'a, C> {
             },
             estimated_tokens: 0,
             iterations_used: iterations,
-            fix_proposal: None,
+            fix_proposal,
+            fix_proposal_failure,
         }
     }
 }

--- a/src/agent/subagent.rs
+++ b/src/agent/subagent.rs
@@ -161,30 +161,72 @@ You are a Plan sub-agent specializing in implementation planning.
 // FixSlice sub-agent prompts (Issue #291, DR2-007)
 // ---------------------------------------------------------------------------
 
-const FIXSLICE_PROTOCOL_BASE: &str = r#"You are a sub-agent of Anvil, a local coding agent.
+const FIXSLICE_PROTOCOL_BASE: &str = r#"You are a FixSlice sub-agent of Anvil, a local coding agent.
 
-## Tool protocol
-When you need to read files, respond using fenced blocks.
+## Final-message contract (strict — read this first)
+Your FINAL turn MUST contain exactly one ANVIL_FINAL fenced block whose
+body is a single FixSliceProposal JSON object. Any of the following make
+the proposal fail to parse and the whole fix_slice call fail:
+- Markdown summaries, headings (`##`), bullet lists, or prose outside `rationale`.
+- Re-pasting `file.read` tool-call JSON or any `ANVIL_TOOL` block in the final turn.
+- More than one ANVIL_FINAL block, or any text before/after the block.
+- Missing any required field, or extra keys not in the schema below.
 
-After you have analysed the target file, output your fix proposal as JSON inside:
+## FixSliceProposal schema
 ```ANVIL_FINAL
 {
-  "target_path": "relative/path/to/file.rs",
-  "start_line": 10,
-  "end_line": 15,
-  "replacement_content": "replacement lines here\n",
-  "rationale": "Short explanation of the fix"
+  "target_path": "<exact path from the user prompt>",
+  "start_line": <1-based inclusive integer>,
+  "end_line": <1-based inclusive integer>,
+  "replacement_content": "<new lines, \n-terminated>",
+  "rationale": "<short single-line explanation>"
 }
 ```
 
-Rules:
-- All paths must be relative (start with ./ or a directory name).
-- Do not use any other tool syntax.
-- Always include ANVIL_FINAL when you are done.
-- You MUST output ANVIL_FINAL to signal completion.
-- Output valid JSON in ANVIL_FINAL. The JSON must contain target_path, start_line, end_line, and replacement_content.
-- start_line and end_line are 1-based, inclusive.
-- Keep the replacement scope minimal — only the lines that need to change.
+Field rules:
+- `target_path` MUST be byte-for-byte identical to the `target_path` given
+  in the user prompt. Do NOT shorten it to a basename, drop directory
+  prefixes, strip or add `./`, rewrite path separators, or resolve it to a
+  different directory. If the request says `src/lib/auto-yes-manager.ts`,
+  the proposal must say `src/lib/auto-yes-manager.ts` — never
+  `auto-yes-manager.ts`.
+- `start_line` / `end_line` are 1-based and inclusive, and must satisfy
+  `end_line - start_line + 1 <= max_lines` from the user prompt.
+- `replacement_content` must be a non-empty string containing the exact
+  replacement lines (keep the trailing newline if the original slice had one).
+- `rationale` is a short, single-line explanation — never a summary section.
+
+## Tool protocol (exploration turns only)
+While exploring the target you may call file.read via a fenced block:
+```ANVIL_TOOL
+{"id":"call_001","tool":"file.read","path":"./relative/path"}
+```
+`ANVIL_TOOL` blocks are valid ONLY in exploration turns. They must never
+appear in the final turn that emits ANVIL_FINAL. Do not use any other
+tool syntax.
+
+## Few-shot examples
+
+Correct — request target_path was `src/lib/auto-yes-manager.ts`:
+```ANVIL_FINAL
+{"target_path":"src/lib/auto-yes-manager.ts","start_line":42,"end_line":44,"replacement_content":"  if (choice === 'yes') {\n    return true;\n  }\n","rationale":"Return true on explicit yes"}
+```
+
+Correct — request target_path was `src/agent/subagent.rs`:
+```ANVIL_FINAL
+{"target_path":"src/agent/subagent.rs","start_line":100,"end_line":101,"replacement_content":"    let x = compute(&ctx);\n","rationale":"Pass ctx to compute to fix overflow"}
+```
+
+Incorrect — `target_path` dropped the directory (basename drift, do NOT do this):
+```ANVIL_FINAL
+{"target_path":"auto-yes-manager.ts","start_line":42,"end_line":44,"replacement_content":"...","rationale":"..."}
+```
+
+Incorrect — markdown summary under ANVIL_FINAL (do NOT do this):
+```ANVIL_FINAL
+## Implementation overview
+I updated the handler so the multiple-choice prompt now returns true on yes...
+```
 
 "#;
 
@@ -192,9 +234,12 @@ const FIXSLICE_ROLE_PROMPT: &str = r#"## Your role
 You are a FixSlice sub-agent specializing in targeted, local code fixes.
 - Use file.read to read the target file and understand the context.
 - Identify the minimal set of lines that need to change.
-- Produce a FixSliceProposal in ANVIL_FINAL with the exact line range and replacement.
-- Keep the fix within the specified max_lines budget.
+- Produce a FixSliceProposal in ANVIL_FINAL whose `target_path` is
+  byte-for-byte identical to the target path given in the user prompt.
+- Keep `end_line - start_line + 1` within the max_lines budget.
 - You only have read-only access: file.read.
+- Never emit markdown, prose summaries, or copies of tool-call JSON as the
+  final message — the final message is a FixSliceProposal JSON object only.
 "#;
 
 /// Options for sub-agent system prompt generation (Issue #162).

--- a/src/agent/subagent.rs
+++ b/src/agent/subagent.rs
@@ -5,7 +5,7 @@
 
 use crate::app::policy::{OFFLINE_BLOCK_PAYLOAD, check_offline_blocked};
 use crate::config::EffectiveConfig;
-use crate::contracts::{Finding, SubAgentPayload, TerminationReason};
+use crate::contracts::{Finding, FixSliceProposal, SubAgentPayload, TerminationReason};
 use crate::provider::{ProviderClient, ProviderEvent, ProviderTurnError};
 use crate::session::{MessageRole, SessionMessage, SessionRecord};
 use crate::tooling::{
@@ -25,6 +25,17 @@ use std::time::{Duration, Instant};
 // ---------------------------------------------------------------------------
 // Sub-agent system prompt constants
 // ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// FixSlice budget constants (Issue #291, DR1-004: code-level const)
+// ---------------------------------------------------------------------------
+
+/// Maximum iterations for a FixSlice sub-agent run.
+pub const FIXSLICE_MAX_ITERATIONS: u32 = 3;
+/// Wall-clock timeout (seconds) for a FixSlice sub-agent run.
+pub const FIXSLICE_TIMEOUT_SECS: u64 = 60;
+/// Maximum allowed value for `max_lines` in agent.fix_slice input.
+pub const MAX_FIXSLICE_LINES: u32 = 200;
 
 const SUBAGENT_PROTOCOL_BASE: &str = r#"You are a sub-agent of Anvil, a local coding agent.
 
@@ -137,6 +148,46 @@ You are a Plan sub-agent specializing in implementation planning.
 - Note: Offline mode is active. Web access is unavailable.
 "#;
 
+// ---------------------------------------------------------------------------
+// FixSlice sub-agent prompts (Issue #291, DR2-007)
+// ---------------------------------------------------------------------------
+
+const FIXSLICE_PROTOCOL_BASE: &str = r#"You are a sub-agent of Anvil, a local coding agent.
+
+## Tool protocol
+When you need to read files, respond using fenced blocks.
+
+After you have analysed the target file, output your fix proposal as JSON inside:
+```ANVIL_FINAL
+{
+  "target_path": "relative/path/to/file.rs",
+  "start_line": 10,
+  "end_line": 15,
+  "replacement_content": "replacement lines here\n",
+  "rationale": "Short explanation of the fix"
+}
+```
+
+Rules:
+- All paths must be relative (start with ./ or a directory name).
+- Do not use any other tool syntax.
+- Always include ANVIL_FINAL when you are done.
+- You MUST output ANVIL_FINAL to signal completion.
+- Output valid JSON in ANVIL_FINAL. The JSON must contain target_path, start_line, end_line, and replacement_content.
+- start_line and end_line are 1-based, inclusive.
+- Keep the replacement scope minimal — only the lines that need to change.
+
+"#;
+
+const FIXSLICE_ROLE_PROMPT: &str = r#"## Your role
+You are a FixSlice sub-agent specializing in targeted, local code fixes.
+- Use file.read to read the target file and understand the context.
+- Identify the minimal set of lines that need to change.
+- Produce a FixSliceProposal in ANVIL_FINAL with the exact line range and replacement.
+- Keep the fix within the specified max_lines budget.
+- You only have read-only access: file.read.
+"#;
+
 /// Options for sub-agent system prompt generation (Issue #162).
 pub struct SubAgentPromptOptions<'a> {
     pub offline: bool,
@@ -153,10 +204,11 @@ pub fn build_subagent_system_prompt(
 ) -> String {
     use crate::config::{effective_ui_language_code, language_constraint_prompt};
 
+    // FixSlice uses its own protocol base; Explore/Plan share SUBAGENT_PROTOCOL_BASE.
     let mut prompt = String::new();
-    prompt.push_str(SUBAGENT_PROTOCOL_BASE);
     match kind {
         SubAgentKind::Explore => {
+            prompt.push_str(SUBAGENT_PROTOCOL_BASE);
             prompt.push_str(TOOL_DESC_FILE_READ);
             prompt.push_str(TOOL_DESC_FILE_SEARCH);
             prompt.push_str(TOOL_DESC_GIT_STATUS);
@@ -165,6 +217,7 @@ pub fn build_subagent_system_prompt(
             prompt.push_str(EXPLORE_ROLE_PROMPT);
         }
         SubAgentKind::Plan => {
+            prompt.push_str(SUBAGENT_PROTOCOL_BASE);
             prompt.push_str(TOOL_DESC_FILE_READ);
             prompt.push_str(TOOL_DESC_FILE_SEARCH);
             if !opts.offline {
@@ -176,6 +229,11 @@ pub fn build_subagent_system_prompt(
             } else {
                 PLAN_ROLE_PROMPT
             });
+        }
+        SubAgentKind::FixSlice => {
+            prompt.push_str(FIXSLICE_PROTOCOL_BASE);
+            prompt.push_str(TOOL_DESC_FILE_READ);
+            prompt.push_str(FIXSLICE_ROLE_PROMPT);
         }
     }
 
@@ -190,11 +248,13 @@ pub fn build_subagent_system_prompt(
 // Public types
 // ---------------------------------------------------------------------------
 
-/// Sub-agent kind (Explore or Plan).
+/// Sub-agent kind (Explore, Plan, or FixSlice).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SubAgentKind {
     Explore,
     Plan,
+    /// Microtask fix-slice worker (Issue #291).
+    FixSlice,
 }
 
 impl SubAgentKind {
@@ -203,12 +263,15 @@ impl SubAgentKind {
         match input {
             ToolInput::AgentExplore { .. } => Some(SubAgentKind::Explore),
             ToolInput::AgentPlan { .. } => Some(SubAgentKind::Plan),
+            ToolInput::AgentFixSlice { .. } => Some(SubAgentKind::FixSlice),
             _ => None,
         }
     }
 }
 
 /// Result returned by a successful sub-agent run.
+// TODO(DR1-001): When a 4th sub-agent kind is added, refactor SubAgentResult
+// into an enum to avoid accumulating Option fields.
 pub struct SubAgentResult {
     /// 構造化ペイロード
     pub payload: SubAgentPayload,
@@ -216,6 +279,8 @@ pub struct SubAgentResult {
     pub estimated_tokens: usize,
     /// 使用したイテレーション数
     pub iterations_used: u32,
+    /// FixSlice proposal extracted from ANVIL_FINAL (Issue #291).
+    pub fix_proposal: Option<FixSliceProposal>,
 }
 
 impl SubAgentResult {
@@ -302,7 +367,7 @@ impl SubAgentError {
 /// Outcome of a single sub-agent turn.
 enum TurnOutcome {
     /// The sub-agent produced a final answer.
-    Finished(SubAgentResult),
+    Finished(Box<SubAgentResult>),
     /// The sub-agent wants to continue (tool calls were executed).
     Continue,
 }
@@ -440,6 +505,7 @@ impl<'a, C: ProviderClient> SubAgentSession<'a, C> {
         match kind {
             SubAgentKind::Explore => registry.register_explore_tools(),
             SubAgentKind::Plan => registry.register_plan_tools(),
+            SubAgentKind::FixSlice => registry.register_fixslice_tools(),
         }
 
         // 3. Dedicated system prompt
@@ -527,12 +593,41 @@ impl<'a, C: ProviderClient> SubAgentSession<'a, C> {
                 &token_buffer,
                 crate::contracts::tokens::ContentKind::Text,
             );
+
+            // FixSlice: parse ANVIL_FINAL as FixSliceProposal (Issue #291, DR1-007)
+            if self.kind == SubAgentKind::FixSlice {
+                let fix_proposal =
+                    serde_json::from_str::<FixSliceProposal>(&structured.final_response).ok();
+                let payload = SubAgentPayload::fallback(
+                    if fix_proposal.is_some() {
+                        "fix-slice proposal parsed successfully".to_string()
+                    } else {
+                        format!(
+                            "fix-slice proposal parse failed: {}",
+                            &structured
+                                .final_response
+                                .chars()
+                                .take(200)
+                                .collect::<String>()
+                        )
+                    },
+                    TerminationReason::Completed,
+                );
+                return Ok(TurnOutcome::Finished(Box::new(SubAgentResult {
+                    payload,
+                    estimated_tokens: tokens,
+                    iterations_used: self.iterations_used,
+                    fix_proposal,
+                })));
+            }
+
             let payload = parse_final_response_to_payload(&structured.final_response);
-            return Ok(TurnOutcome::Finished(SubAgentResult {
+            return Ok(TurnOutcome::Finished(Box::new(SubAgentResult {
                 payload,
                 estimated_tokens: tokens,
                 iterations_used: self.iterations_used,
-            }));
+                fix_proposal: None,
+            })));
         }
 
         // Validate and execute tool calls
@@ -628,11 +723,21 @@ impl<'a, C: ProviderClient> SubAgentSession<'a, C> {
         let kind_label = match self.kind {
             SubAgentKind::Explore => "explore",
             SubAgentKind::Plan => "plan",
+            SubAgentKind::FixSlice => "fix_slice",
         };
         eprintln!("[subagent:{kind_label}] Starting...");
         let start = Instant::now();
-        let max_iterations = self.config.runtime.subagent_max_iterations;
-        let timeout = Duration::from_secs(self.config.runtime.subagent_timeout_secs);
+        let (max_iterations, timeout) = if self.kind == SubAgentKind::FixSlice {
+            (
+                FIXSLICE_MAX_ITERATIONS,
+                Duration::from_secs(FIXSLICE_TIMEOUT_SECS),
+            )
+        } else {
+            (
+                self.config.runtime.subagent_max_iterations,
+                Duration::from_secs(self.config.runtime.subagent_timeout_secs),
+            )
+        };
 
         for iteration in 0..max_iterations {
             // Wall-clock timeout -> partial result with Ok
@@ -657,7 +762,7 @@ impl<'a, C: ProviderClient> SubAgentSession<'a, C> {
             );
 
             match self.run_turn()? {
-                TurnOutcome::Finished(result) => return Ok(result),
+                TurnOutcome::Finished(result) => return Ok(*result),
                 TurnOutcome::Continue => continue,
             }
         }
@@ -691,6 +796,7 @@ impl<'a, C: ProviderClient> SubAgentSession<'a, C> {
             },
             estimated_tokens: 0,
             iterations_used: iterations,
+            fix_proposal: None,
         }
     }
 }

--- a/src/agent/subagent.rs
+++ b/src/agent/subagent.rs
@@ -217,16 +217,22 @@ Correct — request target_path was `src/agent/subagent.rs`:
 {"target_path":"src/agent/subagent.rs","start_line":100,"end_line":101,"replacement_content":"    let x = compute(&ctx);\n","rationale":"Pass ctx to compute to fix overflow"}
 ```
 
-Incorrect — `target_path` dropped the directory (basename drift, do NOT do this):
+Avoid — basename drift (dropped the directory prefix):
 ```ANVIL_FINAL
 {"target_path":"auto-yes-manager.ts","start_line":42,"end_line":44,"replacement_content":"...","rationale":"..."}
 ```
 
-Incorrect — markdown summary under ANVIL_FINAL (do NOT do this):
+Avoid — markdown summary under ANVIL_FINAL:
 ```ANVIL_FINAL
 ## Implementation overview
 I updated the handler so the multiple-choice prompt now returns true on yes...
 ```
+
+## Encouragement
+- Always produce a FixSliceProposal. It is better to submit an imperfect proposal
+  than no proposal — Anvil validates and will ask you to retry if needed.
+- If you are unsure about exact line numbers, make your best attempt.
+- Do not spend iterations reasoning about whether to propose — propose.
 
 "#;
 

--- a/src/agent/subagent.rs
+++ b/src/agent/subagent.rs
@@ -614,14 +614,25 @@ pub struct SubAgentSession<'a, C: ProviderClient> {
     same_target_read_count: u32,
 }
 
-/// Threshold (consecutive iterations) for the same-target `file.read`
-/// oscillation guard inside the FixSlice sub-agent loop (Issue #351).
+/// Default threshold (consecutive iterations) for the same-target
+/// `file.read` oscillation guard inside the FixSlice sub-agent loop
+/// (Issue #351 / Issue #353).
 ///
-/// Two iterations in a row re-reading the exact same target path without
-/// producing a `FixSliceProposal` is the B1 shape from phase-bench cycle
-/// 10: the worker is stuck and will exhaust the iteration budget if
-/// allowed to continue.
-pub const FIXSLICE_REPEATED_READ_THRESHOLD: u32 = 2;
+/// Runtime callers should read
+/// `EffectiveConfig::runtime::fixslice_no_progress_detector` instead —
+/// this constant only pins the default used when nothing else is set.
+///
+/// Issue #353: cycle-11 traces showed the previous default (`2`) killed
+/// legitimate A1/A2 exploration — qwen3.5:122b frequently needs more than
+/// two same-path reads to reach a proposal. Raised to `5` so the guard
+/// still catches the B1 runaway shape but leaves normal exploration
+/// intact. A value of `0` disables the guard entirely.
+pub const DEFAULT_FIXSLICE_REPEATED_READ_THRESHOLD: u32 = 5;
+
+/// Back-compat alias for [`DEFAULT_FIXSLICE_REPEATED_READ_THRESHOLD`]
+/// (Issue #351 / Issue #353). Kept so existing test imports continue to
+/// compile; new code should read the runtime config at the call site.
+pub const FIXSLICE_REPEATED_READ_THRESHOLD: u32 = DEFAULT_FIXSLICE_REPEATED_READ_THRESHOLD;
 
 /// Pure helper for the same-target `file.read` oscillation guard (Issue
 /// #351). Returns `true` when `current_target` matches `last_target` and
@@ -822,6 +833,8 @@ impl<'a, C: ProviderClient> SubAgentSession<'a, C> {
         }
 
         // Issue #351: same-target `file.read` oscillation guard (FixSlice only).
+        // Issue #353: threshold is now configurable via
+        // `runtime.fixslice_no_progress_detector` (0 = disabled).
         //
         // Cycle-10 traces showed FixSlice workers burning the full iteration
         // budget while re-reading the exact same target path without ever
@@ -831,13 +844,15 @@ impl<'a, C: ProviderClient> SubAgentSession<'a, C> {
         // classify the session as pack_gate_invalid instead of waiting for
         // the runner timeout.
         if self.kind == SubAgentKind::FixSlice {
+            let detector_threshold = self.config.runtime.fixslice_no_progress_detector;
             let current_target = first_file_read_target(&structured.tool_calls);
-            let triggered = is_repeated_read_loop(
-                current_target.as_deref(),
-                self.last_file_read_target.as_deref(),
-                self.same_target_read_count,
-                FIXSLICE_REPEATED_READ_THRESHOLD,
-            );
+            let triggered = detector_threshold > 0
+                && is_repeated_read_loop(
+                    current_target.as_deref(),
+                    self.last_file_read_target.as_deref(),
+                    self.same_target_read_count,
+                    detector_threshold,
+                );
             match current_target.as_deref() {
                 Some(path) if self.last_file_read_target.as_deref() == Some(path) => {
                     self.same_target_read_count += 1;

--- a/src/agent/tag_parser.rs
+++ b/src/agent/tag_parser.rs
@@ -286,6 +286,20 @@ fn build_tool_input(
                 .ok_or_else(|| "missing prompt element for agent.plan".to_string())?,
             scope: get_attr("scope"),
         },
+        "agent.fix_slice" => {
+            let target_path = get_attr("target_path")
+                .ok_or_else(|| "missing target_path attribute for agent.fix_slice".to_string())?;
+            let goal = get_child("goal")
+                .ok_or_else(|| "missing goal element for agent.fix_slice".to_string())?;
+            let max_lines: u32 = get_attr("max_lines")
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(50);
+            ToolInput::AgentFixSlice {
+                target_path,
+                goal,
+                max_lines,
+            }
+        }
         "file.rewrite" => {
             let path = get_attr("path")
                 .ok_or_else(|| "missing path attribute for file.rewrite".to_string())?;

--- a/src/agent/tag_parser.rs
+++ b/src/agent/tag_parser.rs
@@ -286,6 +286,25 @@ fn build_tool_input(
                 .ok_or_else(|| "missing prompt element for agent.plan".to_string())?,
             scope: get_attr("scope"),
         },
+        "file.rewrite" => {
+            let path = get_attr("path")
+                .ok_or_else(|| "missing path attribute for file.rewrite".to_string())?;
+            let start_line: u32 = get_attr("start_line")
+                .ok_or_else(|| "missing start_line attribute for file.rewrite".to_string())?
+                .parse()
+                .map_err(|_| "invalid start_line value for file.rewrite".to_string())?;
+            let end_line: u32 = get_attr("end_line")
+                .ok_or_else(|| "missing end_line attribute for file.rewrite".to_string())?
+                .parse()
+                .map_err(|_| "invalid end_line value for file.rewrite".to_string())?;
+            let content = get_child("content").unwrap_or_default();
+            ToolInput::FileRewrite {
+                path,
+                start_line,
+                end_line,
+                content,
+            }
+        }
         _ => return Err(format!("unsupported tool in tag format: {tool_name}")),
     };
 

--- a/src/agent/tag_spec.rs
+++ b/src/agent/tag_spec.rs
@@ -83,6 +83,12 @@ pub const TOOL_TAG_SPECS: &[ToolTagSpec] = &[
         child_elements: &["content"],
         example: r#"<tool name="file.rewrite" path="./src/main.rs" start_line="10" end_line="15"><content>replacement lines here</content></tool>"#,
     },
+    ToolTagSpec {
+        name: "agent.fix_slice",
+        attributes: &["target_path", "max_lines"],
+        child_elements: &["goal"],
+        example: r#"<tool name="agent.fix_slice" target_path="./src/main.rs" max_lines="50"><goal>Fix the compilation error in function foo</goal></tool>"#,
+    },
 ];
 
 /// ツール名からスペックを検索

--- a/src/agent/tag_spec.rs
+++ b/src/agent/tag_spec.rs
@@ -77,6 +77,12 @@ pub const TOOL_TAG_SPECS: &[ToolTagSpec] = &[
         child_elements: &["prompt"],
         example: r#"<tool name="agent.plan" scope="..."><prompt>...</prompt></tool> (for exploration only, use ANVIL_PLAN for implementation plans)"#,
     },
+    ToolTagSpec {
+        name: "file.rewrite",
+        attributes: &["path", "start_line", "end_line"],
+        child_elements: &["content"],
+        example: r#"<tool name="file.rewrite" path="./src/main.rs" start_line="10" end_line="15"><content>replacement lines here</content></tool>"#,
+    },
 ];
 
 /// ツール名からスペックを検索

--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -673,6 +673,10 @@ impl App {
         let mut noplan_suppression_count: u8 = 0;
         // Issue #303: pre-mutation plan barrier.
         let mut mutation_barrier = super::mutation_barrier::MutationBarrier::new();
+        // Issue #325: track whether a pre-exit repair turn was injected.
+        // When true, the next iteration processes the repair turn's LLM response
+        // before terminating the loop.
+        let mut pre_exit_repair_injected = false;
 
         for iteration in 0..max_iterations {
             let iteration_started = std::time::Instant::now();
@@ -1079,6 +1083,15 @@ impl App {
                 self.phase_estimator.observe_anvil_final();
             }
 
+            // Issue #325: if the pre-exit repair turn was injected on the previous
+            // iteration, the LLM has now consumed it and responded. Terminate the
+            // loop — the repair turn has had its chance.
+            if pre_exit_repair_injected {
+                self.agent_telemetry.record_pre_exit_repair_consumed();
+                tracing::info!("pre-exit repair turn consumed; terminating loop");
+                break;
+            }
+
             // Plan repair request.
             if crate::app::stagnation_state::should_request_plan_repair(
                 &self.stagnation_state,
@@ -1099,8 +1112,10 @@ impl App {
                     plan_repair_count_before_this_turn,
                     remaining_turns,
                 ) {
-                    // Issue #309: inject structured repair turn before termination.
-                    // Give the agent one last chance to close remaining items.
+                    // Issue #325: inject structured repair turn and continue for one
+                    // more LLM turn so the model actually sees the repair message.
+                    // Previously (Issue #309) the message was injected then immediately
+                    // discarded by the same-branch `break`.
                     if !self.execution_plan.is_empty()
                         && !self.execution_plan.is_successfully_completed()
                     {
@@ -1108,7 +1123,13 @@ impl App {
                         let msg = SessionMessage::new(MessageRole::Tool, "system", repair_msg)
                             .with_id(self.next_message_id("tool"));
                         self.session.push_message(msg);
-                        tracing::info!("pre-exit repair turn injected before escape hatch");
+                        self.agent_telemetry.record_pre_exit_repair_injected();
+                        tracing::info!(
+                            "pre-exit repair turn injected; continuing for one more LLM turn"
+                        );
+                        pre_exit_repair_injected = true;
+                        current = next_structured;
+                        continue;
                     }
                     tracing::warn!(
                         score = stagnation_score,

--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -520,6 +520,19 @@ impl App {
         let rewrite_request = build_rewrite_request(&proposal, &call.tool_call_id);
         let rewrite_result = self.execute_single(rewrite_request);
 
+        // Issue #339: flip worker_observed only after a real post-execution
+        // worker mutation. The rewrite must be completed, not rolled back,
+        // and produce a non-empty / non-no-op summary — mirroring the
+        // record_mutation_turn guard so the two telemetry flags stay
+        // consistent.
+        if rewrite_result.status == ToolExecutionStatus::Completed
+            && !rewrite_result.rolled_back
+            && !rewrite_result.summary.is_empty()
+            && !rewrite_result.summary.contains("(no changes)")
+        {
+            self.agent_telemetry.record_worker_success();
+        }
+
         // Build agent.fix_slice summary result
         let rationale = sanitize_for_display(&proposal.rationale);
         let fix_summary = ToolExecutionResult {

--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -785,6 +785,11 @@ impl App {
         let mut noplan_suppression_count: u8 = 0;
         // Issue #303: pre-mutation plan barrier.
         let mut mutation_barrier = super::mutation_barrier::MutationBarrier::new();
+        // Issue #355: post-escalation fix_slice routing barrier. Suspends
+        // parent-side mutation tools once `agent.fix_slice` escalation has
+        // fired under a `requires_worker_observation` pack and the worker
+        // path has not yet been invoked.
+        let mut escalation_barrier = super::escalation_barrier::EscalationBarrier::new();
         // Issue #325: track whether a pre-exit repair turn was injected.
         // When true, the next iteration processes the repair turn's LLM response
         // before terminating the loop.
@@ -847,8 +852,11 @@ impl App {
             // live streaming output on stderr (Issue #1).
 
             // Execute normal tool calls and record results WITH payload
-            let (results, loop_action, recovery_read_count) =
-                self.execute_structured_tool_calls(&current_normal, &mut mutation_barrier)?;
+            let (results, loop_action, recovery_read_count) = self.execute_structured_tool_calls(
+                &current_normal,
+                &mut mutation_barrier,
+                &mut escalation_barrier,
+            )?;
             total_tool_count += results.len();
 
             // Update plan item status from tool results; capture telemetry.
@@ -962,6 +970,25 @@ impl App {
 
             // Check shutdown flag before LLM call
             if self.is_shutdown_requested() {
+                break;
+            }
+
+            // Issue #355: Post-success early exit under a worker-required pack.
+            // Once `agent.fix_slice` has produced a real worker mutation the
+            // pack expectation is already satisfied; continuing would only
+            // burn LLM turns and eventually the 600s runner timeout without
+            // adding observable evidence. Break cleanly so the session
+            // terminates as `session_completed`.
+            if self
+                .agent_telemetry
+                .should_early_exit_after_worker_success()
+            {
+                self.agent_telemetry.record_worker_required_early_exit();
+                tracing::info!(
+                    worker_observed = self.agent_telemetry.worker_observed,
+                    pack_expectation = ?self.agent_telemetry.pack_expectation,
+                    "worker-required pack satisfied; terminating session early (Issue #355)"
+                );
                 break;
             }
 
@@ -1882,6 +1909,7 @@ impl App {
         &mut self,
         structured: &StructuredAssistantResponse,
         mutation_barrier: &mut super::mutation_barrier::MutationBarrier,
+        escalation_barrier: &mut super::escalation_barrier::EscalationBarrier,
     ) -> Result<
         (
             Vec<ToolExecutionResult>,
@@ -1975,6 +2003,30 @@ impl App {
         failed_results.extend(barrier_result.blocked_results);
         if barrier_result.blocked_count > 0 {
             self.agent_telemetry.record_mutation_barrier_block();
+        }
+
+        // Phase 1.85: Post-escalation fix_slice routing barrier (Issue #355).
+        // Once fix_slice escalation has fired under a `requires_worker_observation`
+        // pack and `agent.fix_slice` has not yet been invoked, parent-side
+        // mutation tools (file.edit / file.write / file.edit_anchor) are
+        // suspended so the LLM is forced onto the worker path.
+        let force_fixslice = self.agent_telemetry.should_force_fixslice_routing();
+        let escalation_result =
+            escalation_barrier.check_and_filter(validated_requests, force_fixslice);
+        let validated_requests = escalation_result.passed_requests;
+        let escalation_blocked = escalation_result.blocked_count;
+        failed_results.extend(escalation_result.blocked_results);
+        if escalation_blocked > 0 {
+            for _ in 0..escalation_blocked {
+                self.agent_telemetry.record_escalation_barrier_block();
+            }
+            tracing::warn!(
+                blocked = escalation_blocked,
+                fixslice_escalation_count = self.agent_telemetry.fixslice_escalation_count,
+                fixslice_worker_invocation_count =
+                    self.agent_telemetry.fixslice_worker_invocation_count,
+                "escalation_barrier: blocked parent-side mutation(s); forcing agent.fix_slice"
+            );
         }
 
         // Loop detection: record each validated tool call and check for repetition (Issue #145, #172)

--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -719,6 +719,8 @@ impl App {
         self.loop_detector.reset();
         // Reset alternating loop detector per-turn (Issue #172)
         self.alternating_loop_detector.reset();
+        // Reset closure-mode reasoning loop guard per top-level turn (Issue #349).
+        self.closure_loop_detector.reset();
         // Reset phase estimator per-turn counters (Issue #159)
         self.phase_estimator.reset();
         // Reset read transition guard per-turn counters (Issue #216)
@@ -1200,6 +1202,9 @@ impl App {
             // Issue #305: match on PlanRegistrationResult for replan support
             match self.try_register_plan(&next_token_buffer) {
                 crate::app::execution_plan::PlanRegistrationResult::Registered => {
+                    // Issue #349: a newly registered plan is a fresh course
+                    // of action — clear any accumulated closure-loop state.
+                    self.closure_loop_detector.reset();
                     let target_files: Vec<String> = self
                         .execution_plan
                         .items
@@ -1212,6 +1217,8 @@ impl App {
                         );
                 }
                 crate::app::execution_plan::PlanRegistrationResult::Replan => {
+                    // Issue #349: replan is also a change of course.
+                    self.closure_loop_detector.reset();
                     // Replan: stagnation_state を差分マージ (Issue #305)
                     let existing = &self.stagnation_state.starved_target_files;
                     let new_targets: Vec<String> = self
@@ -1260,6 +1267,53 @@ impl App {
             if next_structured.anvil_final_detected {
                 anvil_final_seen = true;
                 self.phase_estimator.observe_anvil_final();
+            }
+
+            // Issue #349: closure-mode reasoning loop guard.
+            //
+            // After `agent.fix_slice` has failed at least once without a
+            // subsequent worker success, a zero-tool-call reasoning response
+            // from the parent agent is the shape that historically stalled
+            // phase-bench cycles 8 and 9 until the 600s runner timeout. We
+            // fingerprint such responses and escalate when the same cut
+            // point reappears (exact or paraphrased): Warn → StrongWarn →
+            // Break. Responses with tool calls, worker success, or without
+            // a prior fix_slice failure clear the accumulator — the
+            // detector only stays armed while the closure-loop preconditions
+            // actually hold.
+            let guard_armed = !self.agent_telemetry.worker_observed
+                && self.agent_telemetry.fixslice_worker_failure_count > 0
+                && next_structured.tool_calls.is_empty();
+            if guard_armed {
+                let action = self
+                    .closure_loop_detector
+                    .record_and_check(&next_structured.raw_content);
+                match action {
+                    super::loop_detector::LoopAction::Continue => {}
+                    super::loop_detector::LoopAction::Warn(msg)
+                    | super::loop_detector::LoopAction::StrongWarn(msg) => {
+                        tracing::warn!(
+                            fixslice_worker_failure_count =
+                                self.agent_telemetry.fixslice_worker_failure_count,
+                            "closure_loop_guard: injecting escalation hint"
+                        );
+                        let hint_msg = SessionMessage::new(MessageRole::Tool, "system", msg)
+                            .with_id(self.next_message_id("tool"));
+                        self.session.push_message(hint_msg);
+                    }
+                    super::loop_detector::LoopAction::Break(msg) => {
+                        tracing::warn!(
+                            reason = "closure_loop_guard",
+                            message = %msg,
+                            fixslice_worker_failure_count =
+                                self.agent_telemetry.fixslice_worker_failure_count,
+                            "agentic loop terminated by closure-mode reasoning guard"
+                        );
+                        break;
+                    }
+                }
+            } else {
+                self.closure_loop_detector.reset();
             }
 
             // Issue #325 + Issue #327: if the pre-exit repair turn was injected on

--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -90,7 +90,12 @@ pub fn summarize_tool_names(names: &[String]) -> String {
 }
 
 /// Mutation tool names used for the successful-mutation check (Issue #285).
-const MUTATION_TOOL_NAMES: &[&str] = &["file.write", "file.edit", "file.edit_anchor"];
+const MUTATION_TOOL_NAMES: &[&str] = &[
+    "file.write",
+    "file.edit",
+    "file.edit_anchor",
+    "file.rewrite",
+];
 
 /// Check whether the tool results contain at least one successful mutation
 /// (file.write / file.edit / file.edit_anchor with Completed status,
@@ -1609,7 +1614,10 @@ impl App {
             tool_kind_map.get(tool_call_id).is_some_and(|kind| {
                 matches!(
                     kind,
-                    ToolKind::FileWrite | ToolKind::FileEdit | ToolKind::FileEditAnchor
+                    ToolKind::FileWrite
+                        | ToolKind::FileEdit
+                        | ToolKind::FileEditAnchor
+                        | ToolKind::FileRewrite
                 )
             })
         };
@@ -1879,7 +1887,7 @@ impl App {
         // Working memory: track touched files (file-mutating tools only) (Issue #130, #157)
         let is_file_tool = matches!(
             result.tool_name.as_str(),
-            "file.write" | "file.edit" | "file.edit_anchor"
+            "file.write" | "file.edit" | "file.edit_anchor" | "file.rewrite"
         );
         if is_file_tool
             && result.status == ToolExecutionStatus::Completed
@@ -1916,7 +1924,9 @@ impl App {
         let mut edit_hint: Option<String> = None;
         let is_barrier_blocked = result.summary.starts_with("[plan_barrier]");
         if !is_barrier_blocked
-            && (result.tool_name == "file.edit" || result.tool_name == "file.edit_anchor")
+            && (result.tool_name == "file.edit"
+                || result.tool_name == "file.edit_anchor"
+                || result.tool_name == "file.rewrite")
         {
             if result.status == ToolExecutionStatus::Failed {
                 if let Some(raw_path) = extract_edit_path_from_summary(&result.summary) {
@@ -2150,7 +2160,7 @@ impl App {
     /// Track consecutive file.write failures and repeated successful writes,
     /// returning a hint if either threshold is reached.
     fn update_write_trackers(&mut self, result: &ToolExecutionResult) -> Option<String> {
-        if result.tool_name != "file.write" {
+        if result.tool_name != "file.write" && result.tool_name != "file.rewrite" {
             return None;
         }
         if result.status == ToolExecutionStatus::Failed {
@@ -2490,6 +2500,14 @@ pub(crate) fn infer_plan_from_structured_response(
             crate::tooling::ToolInput::FileEditAnchor { path, .. } => {
                 format!("edit (anchor) {path}")
             }
+            crate::tooling::ToolInput::FileRewrite {
+                path,
+                start_line,
+                end_line,
+                ..
+            } => {
+                format!("rewrite {path} (lines {start_line}-{end_line})")
+            }
         };
         plan.push(item);
     }
@@ -2664,6 +2682,14 @@ fn tool_call_approval_summary(call: &crate::tooling::ToolCallRequest) -> String 
         }
         crate::tooling::ToolInput::FileEdit { path, .. } => {
             format!("{}: {path}", call.tool_name)
+        }
+        crate::tooling::ToolInput::FileRewrite {
+            path,
+            start_line,
+            end_line,
+            ..
+        } => {
+            format!("file.rewrite: {path} (lines {start_line}-{end_line})")
         }
         crate::tooling::ToolInput::WebFetch { url } => {
             format!("{}: {url}", call.tool_name)

--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -1083,12 +1083,33 @@ impl App {
                 self.phase_estimator.observe_anvil_final();
             }
 
-            // Issue #325: if the pre-exit repair turn was injected on the previous
-            // iteration, the LLM has now consumed it and responded. Terminate the
-            // loop — the repair turn has had its chance.
+            // Issue #325 + Issue #327: if the pre-exit repair turn was injected on
+            // the previous iteration, the LLM has now consumed it and responded.
+            // Decide termination based on the resulting plan state, not just the
+            // fact that one repair response was consumed.
             if pre_exit_repair_injected {
                 self.agent_telemetry.record_pre_exit_repair_consumed();
-                tracing::info!("pre-exit repair turn consumed; terminating loop");
+                let pending_after = self
+                    .execution_plan
+                    .items
+                    .iter()
+                    .filter(|i| !i.is_finished())
+                    .count() as u32;
+                self.agent_telemetry
+                    .record_repair_turn_pending_after(pending_after);
+
+                if self.execution_plan.is_cleanly_finished() {
+                    tracing::info!(
+                        pending_after,
+                        "pre-exit repair turn consumed; plan cleanly finished"
+                    );
+                } else {
+                    tracing::info!(
+                        pending_after,
+                        "pre-exit repair turn consumed; plan still incomplete, \
+                         terminating (unchecked expansion was rejected)"
+                    );
+                }
                 break;
             }
 
@@ -1119,12 +1140,25 @@ impl App {
                     if !self.execution_plan.is_empty()
                         && !self.execution_plan.is_successfully_completed()
                     {
+                        // Issue #327: record pending count before repair and activate
+                        // closure mode to reject unchecked plan expansion.
+                        let pending_before = self
+                            .execution_plan
+                            .items
+                            .iter()
+                            .filter(|i| !i.is_finished())
+                            .count() as u32;
+                        self.agent_telemetry
+                            .record_repair_turn_pending_before(pending_before);
+                        self.repair_closure_active = true;
+
                         let repair_msg = self.build_pre_exit_repair_message();
                         let msg = SessionMessage::new(MessageRole::Tool, "system", repair_msg)
                             .with_id(self.next_message_id("tool"));
                         self.session.push_message(msg);
                         self.agent_telemetry.record_pre_exit_repair_injected();
                         tracing::info!(
+                            pending_before,
                             "pre-exit repair turn injected; continuing for one more LLM turn"
                         );
                         pre_exit_repair_injected = true;

--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -1006,65 +1006,11 @@ impl App {
                 self.agent_telemetry.record_forced_workset_transition();
             }
 
-            // Plan repair request.
-            if crate::app::stagnation_state::should_request_plan_repair(
-                &self.stagnation_state,
-                plan_repair_count_before_this_turn,
-                remaining_turns,
-            ) {
-                let msg_text = crate::app::stagnation_state::build_plan_repair_message(
-                    &self.stagnation_state.starved_target_files,
-                );
-                let msg = SessionMessage::new(MessageRole::Tool, "system", msg_text)
-                    .with_id(self.next_message_id("tool"));
-                self.session.push_message(msg);
-                self.agent_telemetry.record_plan_repair_request();
-            } else {
-                // Escape hatch: plan repair was already attempted but stagnation persists.
-                if crate::app::stagnation_state::should_allow_escape_hatch(
-                    &self.stagnation_state,
-                    plan_repair_count_before_this_turn,
-                    remaining_turns,
-                ) {
-                    // Issue #309: inject structured repair turn before termination.
-                    // Give the agent one last chance to close remaining items.
-                    if !self.execution_plan.is_empty()
-                        && !self.execution_plan.is_successfully_completed()
-                    {
-                        let repair_msg = self.build_pre_exit_repair_message();
-                        let msg = SessionMessage::new(MessageRole::Tool, "system", repair_msg)
-                            .with_id(self.next_message_id("tool"));
-                        self.session.push_message(msg);
-                        tracing::info!("pre-exit repair turn injected before escape hatch");
-                    }
-                    tracing::warn!(
-                        score = stagnation_score,
-                        "stagnation escape hatch: terminating loop"
-                    );
-                    break;
-                }
-            }
-
-            // Update prev_forced_mode_active at turn end.
-            prev_forced_mode_active = self.forced_mode_active;
-
-            log_turn_summary(&TurnSummary {
-                turn: self.session_stats.total_turns,
-                max_turns: max_iterations as u32,
-                elapsed: iteration_started.elapsed(),
-                tokens_used: used_tokens,
-                token_budget,
-                tool_calls: turn_tool_count,
-                tool_names: &turn_tool_names,
-                files_modified: turn_files_modified,
-                compact_info: self.last_compact_info.as_ref(),
-                phase: self.phase_estimator.current_phase(),
-                mutations_this_turn: Some(turn_mutations),
-                items_advanced_this_turn: Some(turn_items_advanced),
-            });
-            // Reset last_compact_info after it's been consumed by the turn summary
-            self.last_compact_info = None;
-
+            // Issue #323: Process ANVIL_PLAN / ANVIL_PLAN_UPDATE / ANVIL_FINAL from
+            // the current response BEFORE evaluating escape hatch. Without this,
+            // a late zero-tool-call response containing a corrective ANVIL_PLAN_UPDATE
+            // with checked [x] items gets dropped when the escape hatch breaks the loop.
+            //
             // Issue #249: Detect ANVIL_PLAN / ANVIL_PLAN_UPDATE from follow-up responses.
             // Scan the raw token buffer since ANVIL_PLAN may be outside the ANVIL_FINAL block.
             // Issue #287: re-initialize stagnation_state on plan registration
@@ -1132,6 +1078,65 @@ impl App {
                 anvil_final_seen = true;
                 self.phase_estimator.observe_anvil_final();
             }
+
+            // Plan repair request.
+            if crate::app::stagnation_state::should_request_plan_repair(
+                &self.stagnation_state,
+                plan_repair_count_before_this_turn,
+                remaining_turns,
+            ) {
+                let msg_text = crate::app::stagnation_state::build_plan_repair_message(
+                    &self.stagnation_state.starved_target_files,
+                );
+                let msg = SessionMessage::new(MessageRole::Tool, "system", msg_text)
+                    .with_id(self.next_message_id("tool"));
+                self.session.push_message(msg);
+                self.agent_telemetry.record_plan_repair_request();
+            } else {
+                // Escape hatch: plan repair was already attempted but stagnation persists.
+                if crate::app::stagnation_state::should_allow_escape_hatch(
+                    &self.stagnation_state,
+                    plan_repair_count_before_this_turn,
+                    remaining_turns,
+                ) {
+                    // Issue #309: inject structured repair turn before termination.
+                    // Give the agent one last chance to close remaining items.
+                    if !self.execution_plan.is_empty()
+                        && !self.execution_plan.is_successfully_completed()
+                    {
+                        let repair_msg = self.build_pre_exit_repair_message();
+                        let msg = SessionMessage::new(MessageRole::Tool, "system", repair_msg)
+                            .with_id(self.next_message_id("tool"));
+                        self.session.push_message(msg);
+                        tracing::info!("pre-exit repair turn injected before escape hatch");
+                    }
+                    tracing::warn!(
+                        score = stagnation_score,
+                        "stagnation escape hatch: terminating loop"
+                    );
+                    break;
+                }
+            }
+
+            // Update prev_forced_mode_active at turn end.
+            prev_forced_mode_active = self.forced_mode_active;
+
+            log_turn_summary(&TurnSummary {
+                turn: self.session_stats.total_turns,
+                max_turns: max_iterations as u32,
+                elapsed: iteration_started.elapsed(),
+                tokens_used: used_tokens,
+                token_budget,
+                tool_calls: turn_tool_count,
+                tool_names: &turn_tool_names,
+                files_modified: turn_files_modified,
+                compact_info: self.last_compact_info.as_ref(),
+                phase: self.phase_estimator.current_phase(),
+                mutations_this_turn: Some(turn_mutations),
+                items_advanced_this_turn: Some(turn_items_advanced),
+            });
+            // Reset last_compact_info after it's been consumed by the turn summary
+            self.last_compact_info = None;
 
             if next_structured.tool_calls.is_empty() {
                 if awaiting_guidance_followup {

--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -470,6 +470,13 @@ impl App {
 
             // FixSlice: validate proposal and apply via file.rewrite (Issue #291)
             if let Some((ref original_target_path, max_lines)) = fixslice_params {
+                // Issue #345: record the invocation *before* handing off to
+                // `handle_fixslice_result` so telemetry reflects every
+                // attempted call, even ones where the worker errors out
+                // before reaching a proposal. This is the signal the session
+                // wrap-up uses to distinguish A1 (escalation, no invocation)
+                // from sessions where the worker ran and failed concretely.
+                self.agent_telemetry.record_fixslice_worker_invocation();
                 match result {
                     Ok(sub_result) => {
                         let fix_results = self.handle_fixslice_result(
@@ -517,10 +524,17 @@ impl App {
                 // Issue #343: classify *why* the worker didn't produce one so
                 // the runtime and telemetry can distinguish max-iterations
                 // exhaustion from ordinary "finished with no proposal" cases.
+                // Issue #345: the subagent now reports a concrete parse
+                // failure detail (empty final vs parse failure vs no final
+                // on a partial exit). We combine that with the termination
+                // reason to pick the precise classification.
                 let termination = sub_result.payload.termination_reason;
-                let failure_reason = match termination {
-                    crate::contracts::TerminationReason::MaxIterations => {
+                let failure_reason = match (termination, sub_result.fix_proposal_failure) {
+                    (crate::contracts::TerminationReason::MaxIterations, _) => {
                         crate::contracts::FixSliceFailureReason::MaxIterationsReached
+                    }
+                    (_, Some(crate::agent::subagent::FixProposalParseFailure::ParseFailed)) => {
+                        crate::contracts::FixSliceFailureReason::ProposalParseFailed
                     }
                     _ => crate::contracts::FixSliceFailureReason::NoProposal,
                 };
@@ -537,6 +551,28 @@ impl App {
                 return vec![build_failed_result_with_text(call, summary)];
             }
         };
+
+        // Issue #345: detect path mismatch as its own failure class before
+        // falling into the generic validator. This is the single most
+        // actionable subclass of the B1 shape — the worker is active but
+        // drifted off the target file — and splitting it out lets telemetry
+        // steer recovery (e.g. re-grounding prompts) instead of hiding it
+        // under `proposal_validation_failed`.
+        if proposal.target_path != original_target_path {
+            self.agent_telemetry.record_fixslice_worker_failure(
+                crate::contracts::FixSliceFailureReason::PathMismatch,
+            );
+            tracing::warn!(
+                proposed = %proposal.target_path,
+                expected = %original_target_path,
+                "fix_slice worker proposal path mismatch"
+            );
+            let summary = format!(
+                "fix-slice validation failed: target_path mismatch: proposal '{}' != original '{}'",
+                proposal.target_path, original_target_path
+            );
+            return vec![build_failed_result_with_text(call, summary)];
+        }
 
         // Validate the proposal
         if let Err(reason) = validate_fix_proposal(

--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -1000,6 +1000,44 @@ impl App {
                 );
             }
 
+            // Issue #332: broadened fix_slice escalation.
+            //
+            // The original same-path escalation in EditFailTracker only fires
+            // when one path accumulates `edit_fixslice_threshold` consecutive
+            // failures. In the real drift pattern the model spreads failures
+            // across multiple files, so that threshold is never reached and
+            // the worker path is never observed. Trigger escalation here when
+            // cumulative failures + stagnation score cross the configured
+            // stagnation thresholds and fix_slice has not already escalated.
+            if !self.agent_telemetry.worker_observed
+                && crate::app::edit_fail_tracker::should_escalate_for_stagnation(
+                    self.edit_fail_tracker.total_failures(),
+                    stagnation_score as u32,
+                    self.config.runtime.edit_fixslice_stagnation_total_threshold,
+                    self.config.runtime.edit_fixslice_stagnation_score_threshold,
+                )
+            {
+                tracing::warn!(
+                    score = stagnation_score,
+                    total_failures = self.edit_fail_tracker.total_failures(),
+                    "fixslice_escalation_triggered (stagnation)"
+                );
+                self.agent_telemetry.record_fixslice_escalation_stagnation();
+                let hint = format!(
+                    "\n\n[Anvil ESCALATION] {n} file.edit failures have occurred across \
+                     multiple files and the session has stagnated (score={score}/4). \
+                     You MUST use agent.fix_slice to repair the most troubled file. \
+                     Call agent.fix_slice with target_path pointing at the file you have been \
+                     trying to modify, and a goal describing the intended change. Do NOT \
+                     retry file.edit on the same paths — use agent.fix_slice now.",
+                    n = self.edit_fail_tracker.total_failures(),
+                    score = stagnation_score,
+                );
+                let msg = SessionMessage::new(MessageRole::Tool, "system", hint)
+                    .with_id(self.next_message_id("tool"));
+                self.session.push_message(msg);
+            }
+
             // Issue #285: staged stagnation recovery.
             let remaining_turns = max_iterations.saturating_sub(iteration + 1);
             let plan_repair_count_before_this_turn =

--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -530,6 +530,13 @@ impl App {
                 // reason to pick the precise classification.
                 let termination = sub_result.payload.termination_reason;
                 let failure_reason = match (termination, sub_result.fix_proposal_failure) {
+                    // Issue #351: subagent-side same-target read oscillation
+                    // guard — classify before the MaxIterations branch so
+                    // the more specific failure class wins.
+                    (
+                        _,
+                        Some(crate::agent::subagent::FixProposalParseFailure::RepeatedReadLoop),
+                    ) => crate::contracts::FixSliceFailureReason::RepeatedReadLoop,
                     (crate::contracts::TerminationReason::MaxIterations, _) => {
                         crate::contracts::FixSliceFailureReason::MaxIterationsReached
                     }
@@ -721,6 +728,8 @@ impl App {
         self.alternating_loop_detector.reset();
         // Reset closure-mode reasoning loop guard per top-level turn (Issue #349).
         self.closure_loop_detector.reset();
+        // Reset post-failure tool-active thrash guard per top-level turn (Issue #351).
+        self.post_failure_thrash_detector.reset();
         // Reset phase estimator per-turn counters (Issue #159)
         self.phase_estimator.reset();
         // Reset read transition guard per-turn counters (Issue #216)
@@ -1205,6 +1214,10 @@ impl App {
                     // Issue #349: a newly registered plan is a fresh course
                     // of action — clear any accumulated closure-loop state.
                     self.closure_loop_detector.reset();
+                    // Issue #351: same rationale for the post-failure thrash
+                    // counter — a freshly registered plan is real progress,
+                    // regardless of prior worker failures.
+                    self.post_failure_thrash_detector.reset();
                     let target_files: Vec<String> = self
                         .execution_plan
                         .items
@@ -1219,6 +1232,8 @@ impl App {
                 crate::app::execution_plan::PlanRegistrationResult::Replan => {
                     // Issue #349: replan is also a change of course.
                     self.closure_loop_detector.reset();
+                    // Issue #351: replan clears the thrash counter too.
+                    self.post_failure_thrash_detector.reset();
                     // Replan: stagnation_state を差分マージ (Issue #305)
                     let existing = &self.stagnation_state.starved_target_files;
                     let new_targets: Vec<String> = self
@@ -1314,6 +1329,55 @@ impl App {
                 }
             } else {
                 self.closure_loop_detector.reset();
+            }
+
+            // Issue #351: parent-side post-failure tool-active thrash guard.
+            //
+            // The closure_loop_detector above only fires on zero-tool-call
+            // reasoning responses. The complementary B2 shape from cycle 10
+            // is a tool-active thrash: the parent keeps calling file.read /
+            // file.search / shell.exec after a fix_slice worker failure but
+            // the execution plan never advances, so the runner times out at
+            // 600s. Track consecutive no-progress turns here and escalate
+            // through the Warn → StrongWarn → Break ladder.
+            let thrash_armed = !self.agent_telemetry.worker_observed
+                && self.agent_telemetry.fixslice_worker_failure_count > 0;
+            if thrash_armed {
+                let had_tool_calls = !results.is_empty();
+                let plan_advanced = turn_items_advanced > 0 || turn_mutations > 0;
+                let action = self
+                    .post_failure_thrash_detector
+                    .record_turn(had_tool_calls, plan_advanced);
+                match action {
+                    super::loop_detector::LoopAction::Continue => {}
+                    super::loop_detector::LoopAction::Warn(msg)
+                    | super::loop_detector::LoopAction::StrongWarn(msg) => {
+                        tracing::warn!(
+                            no_progress_turns =
+                                self.post_failure_thrash_detector.no_progress_turns(),
+                            fixslice_worker_failure_count =
+                                self.agent_telemetry.fixslice_worker_failure_count,
+                            "post_failure_thrash_guard: injecting escalation hint"
+                        );
+                        let hint_msg = SessionMessage::new(MessageRole::Tool, "system", msg)
+                            .with_id(self.next_message_id("tool"));
+                        self.session.push_message(hint_msg);
+                    }
+                    super::loop_detector::LoopAction::Break(msg) => {
+                        tracing::warn!(
+                            reason = "post_failure_thrash_guard",
+                            message = %msg,
+                            no_progress_turns =
+                                self.post_failure_thrash_detector.no_progress_turns(),
+                            fixslice_worker_failure_count =
+                                self.agent_telemetry.fixslice_worker_failure_count,
+                            "agentic loop terminated by post-failure thrash guard"
+                        );
+                        break;
+                    }
+                }
+            } else {
+                self.post_failure_thrash_detector.reset();
             }
 
             // Issue #325 + Issue #327: if the pre-exit repair turn was injected on

--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -513,9 +513,27 @@ impl App {
         let proposal = match sub_result.fix_proposal {
             Some(p) => p,
             None => {
-                // Worker finished without a valid proposal
-                let reason = sub_result.payload.termination_reason;
-                let summary = format!("fix-slice worker {reason}: no valid proposal produced");
+                // Worker finished without a valid proposal.
+                // Issue #343: classify *why* the worker didn't produce one so
+                // the runtime and telemetry can distinguish max-iterations
+                // exhaustion from ordinary "finished with no proposal" cases.
+                let termination = sub_result.payload.termination_reason;
+                let failure_reason = match termination {
+                    crate::contracts::TerminationReason::MaxIterations => {
+                        crate::contracts::FixSliceFailureReason::MaxIterationsReached
+                    }
+                    _ => crate::contracts::FixSliceFailureReason::NoProposal,
+                };
+                self.agent_telemetry
+                    .record_fixslice_worker_failure(failure_reason);
+                tracing::warn!(
+                    termination = %termination,
+                    failure_reason = %failure_reason,
+                    "fix_slice worker failed to produce proposal"
+                );
+                let summary = format!(
+                    "fix-slice worker {termination}: no valid proposal produced ({failure_reason})"
+                );
                 return vec![build_failed_result_with_text(call, summary)];
             }
         };
@@ -527,6 +545,14 @@ impl App {
             max_lines,
             &self.config.paths.cwd,
         ) {
+            // Issue #343: proposal produced but validation rejected it.
+            self.agent_telemetry.record_fixslice_worker_failure(
+                crate::contracts::FixSliceFailureReason::ProposalValidationFailed,
+            );
+            tracing::warn!(
+                reason = %reason,
+                "fix_slice worker proposal failed validation"
+            );
             let summary = format!("fix-slice validation failed: {reason}");
             return vec![build_failed_result_with_text(call, summary)];
         }
@@ -540,12 +566,23 @@ impl App {
         // and produce a non-empty / non-no-op summary — mirroring the
         // record_mutation_turn guard so the two telemetry flags stay
         // consistent.
-        if rewrite_result.status == ToolExecutionStatus::Completed
+        let rewrite_succeeded = rewrite_result.status == ToolExecutionStatus::Completed
             && !rewrite_result.rolled_back
             && !rewrite_result.summary.is_empty()
-            && !rewrite_result.summary.contains("(no changes)")
-        {
+            && !rewrite_result.summary.contains("(no changes)");
+        if rewrite_succeeded {
             self.agent_telemetry.record_worker_success();
+        } else {
+            // Issue #343: the worker produced a valid proposal but
+            // file.rewrite did not land a real mutation.
+            self.agent_telemetry.record_fixslice_worker_failure(
+                crate::contracts::FixSliceFailureReason::RewriteFailed,
+            );
+            tracing::warn!(
+                rewrite_status = ?rewrite_result.status,
+                rolled_back = rewrite_result.rolled_back,
+                "fix_slice worker rewrite failed or produced no-op"
+            );
         }
 
         // Build agent.fix_slice summary result
@@ -1246,6 +1283,28 @@ impl App {
                     if !self.execution_plan.is_empty()
                         && !self.execution_plan.is_successfully_completed()
                     {
+                        // Issue #343: under a `requires_worker_observation`
+                        // pack, skip the pre-exit repair turn once the worker
+                        // path has already failed. Otherwise the repair turn
+                        // flips `repair_turn_observed`, lets parent-side
+                        // `file.edit` salvage the session, and ends in
+                        // `completion_kind=partial` — exactly the A1 shape
+                        // the benchmark runner rejects.
+                        if self
+                            .agent_telemetry
+                            .should_skip_pre_exit_repair_for_worker_failure()
+                        {
+                            tracing::warn!(
+                                score = stagnation_score,
+                                failure_reason = ?self.agent_telemetry.fixslice_failure_reason,
+                                fixslice_worker_failure_count =
+                                    self.agent_telemetry.fixslice_worker_failure_count,
+                                "worker-required pack + fix_slice failure: \
+                                 skipping pre-exit repair turn (Issue #343)"
+                            );
+                            break;
+                        }
+
                         // Issue #327: record pending count before repair and activate
                         // closure mode to reject unchecked plan expansion.
                         let pending_before = self

--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -3460,7 +3460,17 @@ pub fn build_fixslice_user_prompt(target_path: &str, goal: &str, max_lines: u32)
          1. Read `{target_path}` first with file.read to locate the exact lines to change.\n\
          2. Return a single JSON proposal inside ANVIL_FINAL whose `target_path` equals `{target_path}` exactly.\n\
          3. Keep the `end_line - start_line + 1` span within {max_lines} lines.\n\
-         4. Do not explore unrelated files; the edit must stay on the target."
+         4. Do not explore unrelated files; the edit must stay on the target.\n\
+         \n\
+         IMPORTANT GUIDANCE:\n\
+         - If file.read returns a slightly different path form (e.g., ./src/ vs src/), use \
+         the ORIGINAL target_path `{target_path}` from this prompt in your proposal. \
+         Do not block on resolving path ambiguity.\n\
+         - Partial file context is acceptable. You do not need to read the entire file \
+         before proposing a fix.\n\
+         - It is better to submit an imperfect proposal than to submit no proposal. \
+         Anvil will validate your proposal and retry if needed.\n\
+         - Focus on producing the FixSliceProposal JSON, not on explaining your reasoning."
     )
 }
 

--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -1038,6 +1038,46 @@ impl App {
                 self.session.push_message(msg);
             }
 
+            // Issue #334: read-heavy drift escalation.
+            //
+            // Issue #332 still requires cumulative edit failures. A session
+            // dominated by reads / audits that never attempts an edit cannot
+            // cross that threshold, so it drifts through repeated reads,
+            // plan repair, and pre-exit repair without reaching the worker
+            // path. Fire escalation here when the stagnation score is high
+            // and no mutation has been observed at all.
+            if !self.agent_telemetry.worker_observed
+                && crate::app::edit_fail_tracker::should_escalate_for_read_heavy_drift(
+                    stagnation_score as u32,
+                    self.agent_telemetry.mutation_observed,
+                    self.stagnation_state.turns_since_last_mutation as u32,
+                    self.config.runtime.edit_fixslice_read_heavy_score_threshold,
+                    self.config
+                        .runtime
+                        .edit_fixslice_read_heavy_drought_threshold,
+                )
+            {
+                tracing::warn!(
+                    score = stagnation_score,
+                    drought = self.stagnation_state.turns_since_last_mutation,
+                    "fixslice_escalation_triggered (read_heavy)"
+                );
+                self.agent_telemetry.record_fixslice_escalation_stagnation();
+                let hint = format!(
+                    "\n\n[Anvil ESCALATION] The session has stagnated on reads / audits \
+                     (score={score}/4, {drought} turns without any mutation). You MUST stop \
+                     reading and call agent.fix_slice on the most relevant target file to \
+                     produce a concrete change. Pick a target_path from the active plan \
+                     and supply a goal describing the mutation you intend to make. Do NOT \
+                     read or search further before calling agent.fix_slice.",
+                    score = stagnation_score,
+                    drought = self.stagnation_state.turns_since_last_mutation,
+                );
+                let msg = SessionMessage::new(MessageRole::Tool, "system", hint)
+                    .with_id(self.next_message_id("tool"));
+                self.session.push_message(msg);
+            }
+
             // Issue #285: staged stagnation recovery.
             let remaining_turns = max_iterations.saturating_sub(iteration + 1);
             let plan_repair_count_before_this_turn =

--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -2160,6 +2160,23 @@ impl App {
                                 ));
                             }
                         }
+                        crate::app::edit_fail_tracker::EditFallbackAction::FixSliceEscalation => {
+                            tracing::warn!(
+                                tool = "file.edit",
+                                path = %path,
+                                count = count,
+                                "fixslice_escalation_triggered"
+                            );
+                            self.agent_telemetry.record_fixslice_escalation();
+                            edit_hint = Some(format!(
+                                "\n\n[Anvil ESCALATION] file.edit has failed {count} consecutive \
+                                 times for '{path}'. You MUST use agent.fix_slice to repair this \
+                                 file. Call agent.fix_slice with target_path=\"{path}\" and a goal \
+                                 describing what needs to be changed. The fix_slice worker will \
+                                 read the file, produce a bounded replacement, and apply it. \
+                                 Do NOT retry file.edit on this path — use agent.fix_slice now."
+                            ));
+                        }
                     }
                 }
             } else if result.status == ToolExecutionStatus::Completed {

--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -352,7 +352,8 @@ impl App {
             let kind = SubAgentKind::from_tool_input(&call.input).unwrap();
 
             // Extract prompt, scope, and optional FixSlice parameters.
-            // We pre-compute the FixSlice parent_dir so the borrow lives long enough.
+            // We pre-compute the FixSlice parent_dir and the structured user
+            // prompt so the borrows live long enough for the match below.
             let fixslice_parent_dir: Option<String> = match &call.input {
                 ToolInput::AgentFixSlice { target_path, .. } => {
                     std::path::Path::new(target_path.as_str())
@@ -362,6 +363,17 @@ impl App {
                 }
                 _ => None,
             };
+            // Issue #341: embed target_path and max_lines in the worker's
+            // user prompt so it anchors to the correct file instead of
+            // drifting into unrelated reads.
+            let fixslice_user_prompt: Option<String> = match &call.input {
+                ToolInput::AgentFixSlice {
+                    target_path,
+                    goal,
+                    max_lines,
+                } => Some(build_fixslice_user_prompt(target_path, goal, *max_lines)),
+                _ => None,
+            };
             let (prompt, scope, fixslice_params) = match &call.input {
                 ToolInput::AgentExplore { prompt, scope } => {
                     (prompt.as_str(), scope.as_deref(), None)
@@ -369,12 +381,15 @@ impl App {
                 ToolInput::AgentPlan { prompt, scope } => (prompt.as_str(), scope.as_deref(), None),
                 ToolInput::AgentFixSlice {
                     target_path,
-                    goal,
                     max_lines,
+                    ..
                 } => {
-                    // DR2-010: goal → prompt, target_path parent dir → scope
+                    // DR2-010 + Issue #341: structured prompt (includes
+                    // target_path/max_lines) → prompt, target_path parent dir → scope.
                     (
-                        goal.as_str(),
+                        fixslice_user_prompt
+                            .as_deref()
+                            .expect("fixslice_user_prompt is built for AgentFixSlice"),
                         fixslice_parent_dir.as_deref(),
                         Some((target_path.clone(), *max_lines)),
                     )
@@ -3159,6 +3174,29 @@ pub fn build_rewrite_request(
         tool_call_id: format!("{parent_call_id}_rewrite"),
         extra_field_warnings: Vec::new(),
     }
+}
+
+/// Build the FixSlice sub-agent user prompt from structured parameters.
+///
+/// The worker's correctness depends on knowing exactly which file to edit
+/// and how many lines its proposal may span. Passing only the free-form
+/// `goal` leaves the worker to guess the target file (Issue #341), so we
+/// embed `target_path` and `max_lines` explicitly alongside the goal.
+pub fn build_fixslice_user_prompt(target_path: &str, goal: &str, max_lines: u32) -> String {
+    format!(
+        "FixSlice task — target file is fixed.\n\
+         \n\
+         target_path: {target_path}\n\
+         max_lines: {max_lines}\n\
+         \n\
+         goal:\n{goal}\n\
+         \n\
+         Procedure:\n\
+         1. Read `{target_path}` first with file.read to locate the exact lines to change.\n\
+         2. Return a single JSON proposal inside ANVIL_FINAL whose `target_path` equals `{target_path}` exactly.\n\
+         3. Keep the `end_line - start_line + 1` span within {max_lines} lines.\n\
+         4. Do not explore unrelated files; the edit must stay on the target."
+    )
 }
 
 /// Remove control characters from a string for safe display in summaries.

--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -350,9 +350,35 @@ impl App {
             }
 
             let kind = SubAgentKind::from_tool_input(&call.input).unwrap();
-            let (prompt, scope) = match &call.input {
-                ToolInput::AgentExplore { prompt, scope } => (prompt.as_str(), scope.as_deref()),
-                ToolInput::AgentPlan { prompt, scope } => (prompt.as_str(), scope.as_deref()),
+
+            // Extract prompt, scope, and optional FixSlice parameters.
+            // We pre-compute the FixSlice parent_dir so the borrow lives long enough.
+            let fixslice_parent_dir: Option<String> = match &call.input {
+                ToolInput::AgentFixSlice { target_path, .. } => {
+                    std::path::Path::new(target_path.as_str())
+                        .parent()
+                        .map(|p| p.to_string_lossy().to_string())
+                        .filter(|s| !s.is_empty())
+                }
+                _ => None,
+            };
+            let (prompt, scope, fixslice_params) = match &call.input {
+                ToolInput::AgentExplore { prompt, scope } => {
+                    (prompt.as_str(), scope.as_deref(), None)
+                }
+                ToolInput::AgentPlan { prompt, scope } => (prompt.as_str(), scope.as_deref(), None),
+                ToolInput::AgentFixSlice {
+                    target_path,
+                    goal,
+                    max_lines,
+                } => {
+                    // DR2-010: goal → prompt, target_path parent dir → scope
+                    (
+                        goal.as_str(),
+                        fixslice_parent_dir.as_deref(),
+                        Some((target_path.clone(), *max_lines)),
+                    )
+                }
                 _ => unreachable!(),
             };
 
@@ -387,6 +413,31 @@ impl App {
                 self.config.paths.cwd.clone()
             };
 
+            // CB-002: FixSlice is PermissionClass::Confirm, so require approval
+            // before launching the sub-agent. Explore/Plan are Safe and skip this.
+            if kind == SubAgentKind::FixSlice && self.config.mode.approval_required {
+                let spec = self.tools.get("agent.fix_slice");
+                let effective_perm = spec
+                    .map(|s| effective_permission_class(&call.input, s))
+                    .unwrap_or(PermissionClass::Confirm);
+                let tool_kind = spec.map(|s| s.kind).unwrap_or(ToolKind::AgentFixSlice);
+                let trusted = is_trusted(
+                    &call.tool_name,
+                    tool_kind,
+                    effective_perm,
+                    self.trust_all,
+                    &self.trusted_tools,
+                );
+                if !trusted {
+                    let summary = tool_call_approval_summary(call);
+                    let approved = prompt_inline_approval(&summary, None);
+                    if !approved {
+                        agent_results.push(build_failed_result(call, "denied by user".to_string()));
+                        continue;
+                    }
+                }
+            }
+
             let overrides = SubAgentOverrides {
                 model: self.active_model.clone(),
                 context_window: self.active_context_window,
@@ -401,13 +452,99 @@ impl App {
                 overrides,
             );
             let result = session.run();
-            agent_results.push(match result {
-                Ok(r) => r.into_tool_execution_result(call),
-                Err(e) => e.into_tool_execution_result(call),
-            });
+
+            // FixSlice: validate proposal and apply via file.rewrite (Issue #291)
+            if let Some((ref original_target_path, max_lines)) = fixslice_params {
+                match result {
+                    Ok(sub_result) => {
+                        let fix_results = self.handle_fixslice_result(
+                            sub_result,
+                            call,
+                            original_target_path,
+                            max_lines,
+                        );
+                        agent_results.extend(fix_results);
+                    }
+                    Err(e) => {
+                        agent_results.push(e.into_tool_execution_result(call));
+                    }
+                }
+            } else {
+                agent_results.push(match result {
+                    Ok(r) => r.into_tool_execution_result(call),
+                    Err(e) => e.into_tool_execution_result(call),
+                });
+            }
         }
 
         (agent_results, normal_calls)
+    }
+
+    // -----------------------------------------------------------------------
+    // FixSlice result handling (Issue #291)
+    // -----------------------------------------------------------------------
+
+    /// Handle a FixSlice sub-agent result: validate proposal, apply via
+    /// file.rewrite, and return result(s).
+    ///
+    /// Returns up to 2 results: file.rewrite result (if applied) + agent.fix_slice summary.
+    fn handle_fixslice_result(
+        &mut self,
+        sub_result: crate::agent::subagent::SubAgentResult,
+        call: &ToolCallRequest,
+        original_target_path: &str,
+        max_lines: u32,
+    ) -> Vec<ToolExecutionResult> {
+        let proposal = match sub_result.fix_proposal {
+            Some(p) => p,
+            None => {
+                // Worker finished without a valid proposal
+                let reason = sub_result.payload.termination_reason;
+                let summary = format!("fix-slice worker {reason}: no valid proposal produced");
+                return vec![build_failed_result_with_text(call, summary)];
+            }
+        };
+
+        // Validate the proposal
+        if let Err(reason) = validate_fix_proposal(
+            &proposal,
+            original_target_path,
+            max_lines,
+            &self.config.paths.cwd,
+        ) {
+            let summary = format!("fix-slice validation failed: {reason}");
+            return vec![build_failed_result_with_text(call, summary)];
+        }
+
+        // Build file.rewrite execution request and actually execute it (CB-001).
+        let rewrite_request = build_rewrite_request(&proposal, &call.tool_call_id);
+        let rewrite_result = self.execute_single(rewrite_request);
+
+        // Build agent.fix_slice summary result
+        let rationale = sanitize_for_display(&proposal.rationale);
+        let fix_summary = ToolExecutionResult {
+            tool_call_id: call.tool_call_id.clone(),
+            tool_name: call.tool_name.clone(),
+            status: ToolExecutionStatus::Completed,
+            summary: format!("fix-slice applied: {rationale}"),
+            payload: ToolExecutionPayload::Text(
+                serde_json::json!({
+                    "target_path": proposal.target_path,
+                    "start_line": proposal.start_line,
+                    "end_line": proposal.end_line,
+                    "rationale": rationale,
+                })
+                .to_string(),
+            ),
+            artifacts: Vec::new(),
+            elapsed_ms: 0,
+            diff_summary: None,
+            edit_detail: None,
+            rolled_back: false,
+        };
+
+        // DR3-001: file.rewrite first, then agent.fix_slice summary
+        vec![rewrite_result, fix_summary]
     }
 
     /// Check if the ANVIL_FINAL guard should activate.
@@ -2508,6 +2645,12 @@ pub(crate) fn infer_plan_from_structured_response(
             } => {
                 format!("rewrite {path} (lines {start_line}-{end_line})")
             }
+            crate::tooling::ToolInput::AgentFixSlice {
+                target_path, goal, ..
+            } => {
+                let truncated = truncate_chars(goal, 50);
+                format!("fix_slice: {target_path} — {truncated}")
+            }
         };
         plan.push(item);
     }
@@ -2671,6 +2814,25 @@ fn build_failed_result(
     }
 }
 
+/// Build a failed [`ToolExecutionResult`] with the summary echoed as text payload.
+fn build_failed_result_with_text(
+    call: &crate::tooling::ToolCallRequest,
+    summary: String,
+) -> ToolExecutionResult {
+    ToolExecutionResult {
+        tool_call_id: call.tool_call_id.clone(),
+        tool_name: call.tool_name.clone(),
+        status: crate::tooling::ToolExecutionStatus::Failed,
+        summary: summary.clone(),
+        payload: crate::tooling::ToolExecutionPayload::Text(summary),
+        artifacts: Vec::new(),
+        elapsed_ms: 0,
+        diff_summary: None,
+        edit_detail: None,
+        rolled_back: false,
+    }
+}
+
 /// Produce a human-readable summary of a tool call for the approval prompt.
 fn tool_call_approval_summary(call: &crate::tooling::ToolCallRequest) -> String {
     match &call.input {
@@ -2719,6 +2881,12 @@ fn tool_call_approval_summary(call: &crate::tooling::ToolCallRequest) -> String 
             let truncated = truncate_chars(prompt, 100);
             format!("agent.plan [scope: {scope_info}]: {truncated}")
         }
+        crate::tooling::ToolInput::AgentFixSlice {
+            target_path, goal, ..
+        } => {
+            let truncated = truncate_chars(goal, 100);
+            format!("agent.fix_slice [target: {target_path}]: {truncated}")
+        }
         _ => call.tool_name.clone(),
     }
 }
@@ -2739,6 +2907,97 @@ fn prompt_inline_approval(summary: &str, diff_preview: Option<&str>) -> bool {
     } else {
         false
     }
+}
+
+// ---------------------------------------------------------------------------
+// FixSlice helpers (Issue #291)
+// ---------------------------------------------------------------------------
+
+/// Validate a FixSlice proposal from the sub-agent.
+///
+/// Checks:
+/// - `target_path` matches the parent-specified path
+/// - `replacement_content` is non-empty
+/// - Line range fits within `max_lines`
+/// - `target_path` resolves within the sandbox
+/// - No control characters in `target_path`
+pub fn validate_fix_proposal(
+    proposal: &crate::contracts::FixSliceProposal,
+    original_target_path: &str,
+    max_lines: u32,
+    sandbox_root: &std::path::Path,
+) -> Result<(), String> {
+    // Control character check
+    if proposal.target_path.chars().any(|c| c.is_control()) {
+        return Err("target_path contains control characters".to_string());
+    }
+
+    // Path match check
+    if proposal.target_path != original_target_path {
+        return Err(format!(
+            "target_path mismatch: proposal '{}' != original '{}'",
+            proposal.target_path, original_target_path
+        ));
+    }
+
+    // Sandbox check
+    if resolve_sandbox_path(sandbox_root, &proposal.target_path).is_err() {
+        return Err(format!(
+            "target_path sandbox violation: {}",
+            proposal.target_path
+        ));
+    }
+
+    // Non-empty replacement
+    if proposal.replacement_content.is_empty() {
+        return Err("replacement_content must not be empty".to_string());
+    }
+
+    // Line range within max_lines
+    let span = proposal.end_line.saturating_sub(proposal.start_line) + 1;
+    if span > max_lines {
+        return Err(format!(
+            "line range ({} lines) exceeds max_lines ({})",
+            span, max_lines
+        ));
+    }
+
+    Ok(())
+}
+
+/// Build a `ToolExecutionRequest` for applying a FixSlice proposal via file.rewrite.
+pub fn build_rewrite_request(
+    proposal: &crate::contracts::FixSliceProposal,
+    parent_call_id: &str,
+) -> ToolExecutionRequest {
+    use crate::tooling::{ExecutionClass, PlanModePolicy, RollbackPolicy, ToolSpec};
+    ToolExecutionRequest {
+        spec: ToolSpec {
+            version: 1,
+            name: "file.rewrite".to_string(),
+            kind: ToolKind::FileRewrite,
+            execution_class: ExecutionClass::Mutating,
+            permission_class: PermissionClass::Confirm,
+            execution_mode: ExecutionMode::SequentialOnly,
+            plan_mode: PlanModePolicy::Allowed,
+            rollback_policy: RollbackPolicy::CheckpointBeforeWrite,
+        },
+        input: ToolInput::FileRewrite {
+            path: proposal.target_path.clone(),
+            start_line: proposal.start_line,
+            end_line: proposal.end_line,
+            content: proposal.replacement_content.clone(),
+        },
+        tool_call_id: format!("{parent_call_id}_rewrite"),
+        extra_field_warnings: Vec::new(),
+    }
+}
+
+/// Remove control characters from a string for safe display in summaries.
+fn sanitize_for_display(s: &str) -> String {
+    s.chars()
+        .filter(|c| !c.is_control() || *c == '\n')
+        .collect()
 }
 
 /// Truncate a string to at most `max_chars` Unicode characters, appending

--- a/src/app/closure_loop_detector.rs
+++ b/src/app/closure_loop_detector.rs
@@ -1,0 +1,310 @@
+//! Closure-mode reasoning loop detector (Issue #349).
+//!
+//! After `agent.fix_slice` fails (no successful worker mutation observed),
+//! the parent agent can enter a natural-language "closure" loop: it keeps
+//! producing zero-tool-call reasoning responses that restate the same cut
+//! points (resolveAutoAnswer / truncated file / late-stage closure ...)
+//! until the external runner timeout fires. The existing `LoopDetector`
+//! only fires on repeated tool calls, so it never engages for this shape.
+//!
+//! This detector fingerprints reasoning-only LLM responses seen while the
+//! guard is armed and escalates when a near-duplicate reappears.
+//!
+//! - Guard arming (the caller must verify these before calling):
+//!     1. `worker_observed == false`
+//!     2. `fixslice_worker_failure_count > 0`
+//!     3. The LLM response produced no tool calls
+//!     4. The raw reasoning content is non-trivial (≥ `MIN_SIGNIFICANT_TOKENS`)
+//! - Escalation ladder: `Continue → Warn → StrongWarn → Break`
+//!
+//! A response is fingerprinted as the sorted set of "significant" tokens
+//! (lowercase ASCII-alphanumeric runs of length ≥ `TOKEN_MIN_LEN`). Two
+//! responses match when their Jaccard similarity ≥ `JACCARD_MATCH_THRESHOLD`.
+//! LLM closure loops overwhelmingly recycle the same domain vocabulary
+//! turn after turn — Jaccard survives the connector-word paraphrasing
+//! that exact hashing would miss.
+
+use std::collections::BTreeSet;
+use std::collections::VecDeque;
+
+use super::loop_detector::LoopAction;
+
+/// Minimum number of significant tokens in a response before it is eligible
+/// for fingerprinting. Short acknowledgements ("ok", "done") must not trip
+/// the detector.
+pub const MIN_SIGNIFICANT_TOKENS: usize = 20;
+
+/// Minimum character length of a token to count as "significant". Filters
+/// stopwords and CJK punctuation noise without needing a word list.
+const TOKEN_MIN_LEN: usize = 5;
+
+/// Jaccard similarity threshold (`|A ∩ B| / |A ∪ B|`) at which two
+/// responses are considered near-duplicates. 0.7 is strict enough to
+/// avoid flagging two unrelated discussions that happen to share common
+/// domain words, but loose enough to absorb the connector-word
+/// rewordings observed in cycle 8/9 closure loops.
+const JACCARD_MATCH_THRESHOLD: f64 = 0.7;
+
+/// Recent token sets retained for lookup. Four slots cover the Warn /
+/// StrongWarn / Break ladder plus one headroom entry.
+const HISTORY_CAPACITY: usize = 8;
+
+/// A fingerprinted, reasoning-only LLM response.
+#[derive(Debug, Clone)]
+pub struct Fingerprint {
+    tokens: BTreeSet<String>,
+}
+
+impl Fingerprint {
+    /// Extract significant tokens from `raw_content`.
+    ///
+    /// Returns `None` when the content does not contain enough significant
+    /// tokens to be worth fingerprinting.
+    pub fn from_raw(raw_content: &str) -> Option<Self> {
+        let tokens: BTreeSet<String> = raw_content
+            .split(|c: char| !c.is_ascii_alphanumeric())
+            .filter(|w| w.len() >= TOKEN_MIN_LEN)
+            .map(str::to_ascii_lowercase)
+            .collect();
+        if tokens.len() < MIN_SIGNIFICANT_TOKENS {
+            return None;
+        }
+        Some(Self { tokens })
+    }
+
+    /// Jaccard similarity against `other` in `[0.0, 1.0]`.
+    pub fn jaccard(&self, other: &Self) -> f64 {
+        if self.tokens.is_empty() && other.tokens.is_empty() {
+            return 1.0;
+        }
+        let intersect = self.tokens.intersection(&other.tokens).count() as f64;
+        let union = self.tokens.union(&other.tokens).count() as f64;
+        if union == 0.0 { 0.0 } else { intersect / union }
+    }
+
+    #[cfg(test)]
+    pub fn token_count(&self) -> usize {
+        self.tokens.len()
+    }
+}
+
+/// Detector for closure-mode reasoning loops after `fix_slice` failure.
+#[derive(Debug)]
+pub struct ClosureLoopDetector {
+    history: VecDeque<Fingerprint>,
+    escalation_count: usize,
+}
+
+impl Default for ClosureLoopDetector {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ClosureLoopDetector {
+    pub fn new() -> Self {
+        Self {
+            history: VecDeque::with_capacity(HISTORY_CAPACITY),
+            escalation_count: 0,
+        }
+    }
+
+    /// Reset to a clean state.
+    ///
+    /// Called when the guard is disarmed (worker success observed, a new
+    /// plan registered, or the response carried tool calls again).
+    pub fn reset(&mut self) {
+        self.history.clear();
+        self.escalation_count = 0;
+    }
+
+    /// Observe a reasoning-only LLM response while the guard is armed and
+    /// return the escalation action.
+    ///
+    /// Returns `LoopAction::Continue` if the response is too short to
+    /// fingerprint or if no recent entry is near-duplicate.
+    pub fn record_and_check(&mut self, raw_content: &str) -> LoopAction {
+        let Some(fp) = Fingerprint::from_raw(raw_content) else {
+            return LoopAction::Continue;
+        };
+
+        let near_duplicate = self
+            .history
+            .iter()
+            .any(|prev| prev.jaccard(&fp) >= JACCARD_MATCH_THRESHOLD);
+
+        if self.history.len() >= HISTORY_CAPACITY {
+            self.history.pop_front();
+        }
+        self.history.push_back(fp);
+
+        if !near_duplicate {
+            return LoopAction::Continue;
+        }
+
+        self.escalation_count += 1;
+        match self.escalation_count {
+            1 => LoopAction::Warn(
+                "[Closure Loop Guard] The parent agent is repeating the same closure \
+                 reasoning after a fix_slice worker failure without advancing any tool. \
+                 Decide now: either call agent.fix_slice once more on the troubled target \
+                 or emit ANVIL_FINAL and stop."
+                    .to_string(),
+            ),
+            2 => LoopAction::StrongWarn(
+                "[Closure Loop Guard - WARNING] The parent agent has repeated the same \
+                 closure reasoning multiple times without any tool-advancing output. You \
+                 MUST either issue a concrete tool call now (agent.fix_slice on a specific \
+                 target_path) or terminate with ANVIL_FINAL. Do NOT restate the same \
+                 analysis again."
+                    .to_string(),
+            ),
+            _ => LoopAction::Break(
+                "[Closure Loop Guard - TERMINATED] Agentic loop terminated: closure-mode \
+                 reasoning repeated after fix_slice worker failure with no tool-advancing \
+                 progress."
+                    .to_string(),
+            ),
+        }
+    }
+
+    #[cfg(test)]
+    pub fn escalation_count(&self) -> usize {
+        self.escalation_count
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const CLOSURE_A: &str = "The resolveAutoAnswer helper appears truncated. \
+        Because the worker produced no valid proposal, the fix_slice invocation \
+        failed. The late-stage closure branch should therefore abort instead \
+        of looping. resolveAutoAnswer, truncated, closure, invalid, proposal, \
+        worker, failure, fix_slice, target_path, rewrite, iterations, session.";
+
+    /// Same domain vocabulary, different connector words — the exact cycle
+    /// 8/9 closure-loop shape we need to catch.
+    const CLOSURE_A_REWORDED: &str = "Worker did not produce any valid proposal, \
+        so the fix_slice invocation has failed. The resolveAutoAnswer helper \
+        still appears truncated, therefore the late-stage closure branch \
+        should abort instead of looping further, because continuing reasoning \
+        is unhelpful. Keywords: closure, invalid, proposal, worker, failure, \
+        fix_slice, target_path, rewrite, iterations, session, \
+        resolveAutoAnswer, truncated.";
+
+    const CLOSURE_B: &str = "Different angle now: the ANVIL_PLAN required \
+        additional verification reads against configuration modules. Running \
+        cargo check would reveal compilation blockers. Consider auditing \
+        provider ollama sidecar summarize helpers, exploring retrieval \
+        cache, evaluating telemetry snapshot format, inspecting hooks \
+        engine wiring, scanning tooling shell policy.";
+
+    #[test]
+    fn short_content_is_not_fingerprinted() {
+        assert!(Fingerprint::from_raw("ok").is_none());
+        assert!(Fingerprint::from_raw("Plan done. Looks fine.").is_none());
+    }
+
+    #[test]
+    fn long_content_yields_stable_fingerprint() {
+        let fp1 = Fingerprint::from_raw(CLOSURE_A).expect("fingerprint");
+        let fp2 = Fingerprint::from_raw(CLOSURE_A).expect("fingerprint");
+        assert!((fp1.jaccard(&fp2) - 1.0).abs() < f64::EPSILON);
+        assert!(fp1.token_count() >= MIN_SIGNIFICANT_TOKENS);
+    }
+
+    #[test]
+    fn reworded_paraphrase_is_near_duplicate() {
+        let fp1 = Fingerprint::from_raw(CLOSURE_A).expect("fingerprint");
+        let fp2 = Fingerprint::from_raw(CLOSURE_A_REWORDED).expect("fingerprint");
+        let sim = fp1.jaccard(&fp2);
+        assert!(
+            sim >= JACCARD_MATCH_THRESHOLD,
+            "expected Jaccard ≥ {}, got {}",
+            JACCARD_MATCH_THRESHOLD,
+            sim
+        );
+    }
+
+    #[test]
+    fn unrelated_reasoning_is_below_threshold() {
+        let fp1 = Fingerprint::from_raw(CLOSURE_A).expect("fingerprint");
+        let fp2 = Fingerprint::from_raw(CLOSURE_B).expect("fingerprint");
+        assert!(
+            fp1.jaccard(&fp2) < JACCARD_MATCH_THRESHOLD,
+            "unrelated content should be below threshold; got {}",
+            fp1.jaccard(&fp2)
+        );
+    }
+
+    #[test]
+    fn first_observation_is_continue() {
+        let mut det = ClosureLoopDetector::new();
+        assert_eq!(det.record_and_check(CLOSURE_A), LoopAction::Continue);
+    }
+
+    #[test]
+    fn second_near_duplicate_warns() {
+        let mut det = ClosureLoopDetector::new();
+        det.record_and_check(CLOSURE_A);
+        let action = det.record_and_check(CLOSURE_A_REWORDED);
+        assert!(
+            matches!(action, LoopAction::Warn(_)),
+            "expected Warn, got {:?}",
+            action
+        );
+    }
+
+    #[test]
+    fn escalation_ladder_reaches_break() {
+        let mut det = ClosureLoopDetector::new();
+        assert_eq!(det.record_and_check(CLOSURE_A), LoopAction::Continue);
+        assert!(matches!(
+            det.record_and_check(CLOSURE_A),
+            LoopAction::Warn(_)
+        ));
+        assert!(matches!(
+            det.record_and_check(CLOSURE_A),
+            LoopAction::StrongWarn(_)
+        ));
+        assert!(matches!(
+            det.record_and_check(CLOSURE_A),
+            LoopAction::Break(_)
+        ));
+    }
+
+    #[test]
+    fn novel_reasoning_between_repeats_still_escalates() {
+        let mut det = ClosureLoopDetector::new();
+        det.record_and_check(CLOSURE_A);
+        // Novel cut point interleaves — should NOT clear escalation.
+        assert_eq!(det.record_and_check(CLOSURE_B), LoopAction::Continue);
+        let action = det.record_and_check(CLOSURE_A_REWORDED);
+        assert!(
+            matches!(action, LoopAction::Warn(_)),
+            "expected Warn when A repeats despite B in between, got {:?}",
+            action
+        );
+    }
+
+    #[test]
+    fn short_content_does_not_advance_state() {
+        let mut det = ClosureLoopDetector::new();
+        det.record_and_check(CLOSURE_A);
+        assert_eq!(det.record_and_check("ok"), LoopAction::Continue);
+        assert_eq!(det.escalation_count(), 0);
+    }
+
+    #[test]
+    fn reset_clears_history_and_escalation() {
+        let mut det = ClosureLoopDetector::new();
+        det.record_and_check(CLOSURE_A);
+        det.record_and_check(CLOSURE_A);
+        assert_eq!(det.escalation_count(), 1);
+        det.reset();
+        assert_eq!(det.escalation_count(), 0);
+        assert_eq!(det.record_and_check(CLOSURE_A), LoopAction::Continue);
+    }
+}

--- a/src/app/edit_fail_tracker.rs
+++ b/src/app/edit_fail_tracker.rs
@@ -66,6 +66,25 @@ pub fn determine_fallback_action(
     }
 }
 
+/// Decide whether to escalate to the worker path based on cumulative failures
+/// and stagnation score (Issue #332).
+///
+/// This is the broadened escalation policy: fires when the model spreads
+/// edit failures across multiple paths so no single path reaches
+/// `edit_fixslice_threshold`, but the session is clearly stagnating.
+///
+/// `failures_threshold == 0` disables the trigger.
+pub fn should_escalate_for_stagnation(
+    total_failures: u32,
+    stagnation_score: u32,
+    failures_threshold: u32,
+    score_threshold: u32,
+) -> bool {
+    failures_threshold > 0
+        && total_failures >= failures_threshold
+        && stagnation_score >= score_threshold
+}
+
 /// Tracks consecutive file.edit failures per file path.
 /// Used to detect when the LLM is stuck retrying edits on the same file
 /// and should be prompted to try an alternative approach (Issue #158, #321).
@@ -76,6 +95,13 @@ pub struct EditFailTracker {
     /// Threshold for escalating to agent.fix_slice (Issue #321).
     /// 0 = disabled.
     fixslice_threshold: u32,
+    /// Cumulative failure count across all paths (Issue #332).
+    ///
+    /// Not reset on `record_success`, because the broadened stagnation
+    /// escalation uses it to detect the drift pattern where the model
+    /// scatters failures across multiple files and no single path accumulates
+    /// enough to hit `fixslice_threshold`.
+    total_failures: u32,
 }
 
 impl EditFailTracker {
@@ -89,6 +115,7 @@ impl EditFailTracker {
             reread_threshold,
             write_fallback_threshold,
             fixslice_threshold,
+            total_failures: 0,
         }
     }
 
@@ -100,6 +127,7 @@ impl EditFailTracker {
             .entry(path.to_string())
             .or_insert(0);
         *count += 1;
+        self.total_failures = self.total_failures.saturating_add(1);
         determine_fallback_action(
             *count,
             self.reread_threshold,
@@ -116,6 +144,11 @@ impl EditFailTracker {
     /// Get the current failure count for a path.
     pub fn failure_count(&self, path: &str) -> u32 {
         self.consecutive_failures.get(path).copied().unwrap_or(0)
+    }
+
+    /// Cumulative failure count across all paths in this session (Issue #332).
+    pub fn total_failures(&self) -> u32 {
+        self.total_failures
     }
 }
 
@@ -361,5 +394,39 @@ mod tests {
         tracker.record_success("a.rs");
         assert_eq!(tracker.failure_count("a.rs"), 0);
         assert_eq!(tracker.record_failure("a.rs"), EditFallbackAction::Continue);
+    }
+
+    // --- Issue #332: cumulative total_failures & stagnation helper ---
+
+    #[test]
+    fn test_total_failures_accumulates_across_paths_and_survives_success() {
+        let mut tracker = EditFailTracker::new(3, 5, 7);
+        assert_eq!(tracker.total_failures(), 0);
+        tracker.record_failure("a.rs");
+        tracker.record_failure("b.rs");
+        tracker.record_failure("c.rs");
+        assert_eq!(tracker.total_failures(), 3);
+        tracker.record_success("a.rs");
+        assert_eq!(
+            tracker.total_failures(),
+            3,
+            "total_failures must not be reset by per-path success"
+        );
+        tracker.record_failure("a.rs");
+        assert_eq!(tracker.total_failures(), 4);
+    }
+
+    #[test]
+    fn test_should_escalate_for_stagnation_boundary() {
+        // disabled
+        assert!(!should_escalate_for_stagnation(100, 4, 0, 2));
+        // below failures
+        assert!(!should_escalate_for_stagnation(3, 4, 4, 2));
+        // below score
+        assert!(!should_escalate_for_stagnation(4, 1, 4, 2));
+        // exactly at thresholds
+        assert!(should_escalate_for_stagnation(4, 2, 4, 2));
+        // well above
+        assert!(should_escalate_for_stagnation(10, 4, 4, 2));
     }
 }

--- a/src/app/edit_fail_tracker.rs
+++ b/src/app/edit_fail_tracker.rs
@@ -33,7 +33,7 @@ impl FromStr for EditStrategy {
     }
 }
 
-/// Recommended action after a file.edit failure (Issue #158).
+/// Recommended action after a file.edit failure (Issue #158, #321).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum EditFallbackAction {
     /// Normal continuation (failure count < reread_threshold).
@@ -42,17 +42,22 @@ pub enum EditFallbackAction {
     ReRead,
     /// Recommend switching to file.write.
     WriteFallback,
+    /// Escalate to agent.fix_slice for bounded single-file repair (Issue #321).
+    FixSliceEscalation,
 }
 
 /// Determine the fallback action based on failure count and thresholds.
 ///
 /// Separated from `EditFailTracker` to maintain SRP (counter vs policy).
-pub(crate) fn determine_fallback_action(
+pub fn determine_fallback_action(
     count: u32,
     reread_threshold: u32,
     write_fallback_threshold: u32,
+    fixslice_threshold: u32,
 ) -> EditFallbackAction {
-    if count >= write_fallback_threshold {
+    if fixslice_threshold > 0 && count >= fixslice_threshold {
+        EditFallbackAction::FixSliceEscalation
+    } else if count >= write_fallback_threshold {
         EditFallbackAction::WriteFallback
     } else if count >= reread_threshold {
         EditFallbackAction::ReRead
@@ -63,40 +68,53 @@ pub(crate) fn determine_fallback_action(
 
 /// Tracks consecutive file.edit failures per file path.
 /// Used to detect when the LLM is stuck retrying edits on the same file
-/// and should be prompted to try an alternative approach (Issue #158).
-pub(crate) struct EditFailTracker {
+/// and should be prompted to try an alternative approach (Issue #158, #321).
+pub struct EditFailTracker {
     consecutive_failures: HashMap<String, u32>,
     reread_threshold: u32,
     write_fallback_threshold: u32,
+    /// Threshold for escalating to agent.fix_slice (Issue #321).
+    /// 0 = disabled.
+    fixslice_threshold: u32,
 }
 
 impl EditFailTracker {
-    pub(crate) fn new(reread_threshold: u32, write_fallback_threshold: u32) -> Self {
+    pub fn new(
+        reread_threshold: u32,
+        write_fallback_threshold: u32,
+        fixslice_threshold: u32,
+    ) -> Self {
         Self {
             consecutive_failures: HashMap::new(),
             reread_threshold,
             write_fallback_threshold,
+            fixslice_threshold,
         }
     }
 
     /// Record a file.edit failure for the given path.
     /// Returns the recommended fallback action based on the cumulative failure count.
-    pub(crate) fn record_failure(&mut self, path: &str) -> EditFallbackAction {
+    pub fn record_failure(&mut self, path: &str) -> EditFallbackAction {
         let count = self
             .consecutive_failures
             .entry(path.to_string())
             .or_insert(0);
         *count += 1;
-        determine_fallback_action(*count, self.reread_threshold, self.write_fallback_threshold)
+        determine_fallback_action(
+            *count,
+            self.reread_threshold,
+            self.write_fallback_threshold,
+            self.fixslice_threshold,
+        )
     }
 
     /// Record a successful file.edit, resetting the failure count for that path.
-    pub(crate) fn record_success(&mut self, path: &str) {
+    pub fn record_success(&mut self, path: &str) {
         self.consecutive_failures.remove(path);
     }
 
     /// Get the current failure count for a path.
-    pub(crate) fn failure_count(&self, path: &str) -> u32 {
+    pub fn failure_count(&self, path: &str) -> u32 {
         self.consecutive_failures.get(path).copied().unwrap_or(0)
     }
 }
@@ -143,38 +161,59 @@ mod tests {
 
     #[test]
     fn test_determine_fallback_action() {
-        // N=3, M=5
+        // N=3, M=5, fixslice=0 (disabled)
         assert_eq!(
-            determine_fallback_action(0, 3, 5),
+            determine_fallback_action(0, 3, 5, 0),
             EditFallbackAction::Continue
         );
         assert_eq!(
-            determine_fallback_action(1, 3, 5),
+            determine_fallback_action(1, 3, 5, 0),
             EditFallbackAction::Continue
         );
         assert_eq!(
-            determine_fallback_action(2, 3, 5),
+            determine_fallback_action(2, 3, 5, 0),
             EditFallbackAction::Continue
         );
         assert_eq!(
-            determine_fallback_action(3, 3, 5),
+            determine_fallback_action(3, 3, 5, 0),
             EditFallbackAction::ReRead
         );
         assert_eq!(
-            determine_fallback_action(4, 3, 5),
+            determine_fallback_action(4, 3, 5, 0),
             EditFallbackAction::ReRead
         );
         assert_eq!(
-            determine_fallback_action(5, 3, 5),
+            determine_fallback_action(5, 3, 5, 0),
             EditFallbackAction::WriteFallback
         );
         assert_eq!(
-            determine_fallback_action(6, 3, 5),
+            determine_fallback_action(6, 3, 5, 0),
             EditFallbackAction::WriteFallback
         );
         assert_eq!(
-            determine_fallback_action(100, 3, 5),
+            determine_fallback_action(100, 3, 5, 0),
             EditFallbackAction::WriteFallback
+        );
+    }
+
+    #[test]
+    fn test_determine_fallback_action_fixslice_escalation() {
+        // N=3, M=5, fixslice=7
+        assert_eq!(
+            determine_fallback_action(5, 3, 5, 7),
+            EditFallbackAction::WriteFallback
+        );
+        assert_eq!(
+            determine_fallback_action(6, 3, 5, 7),
+            EditFallbackAction::WriteFallback
+        );
+        assert_eq!(
+            determine_fallback_action(7, 3, 5, 7),
+            EditFallbackAction::FixSliceEscalation
+        );
+        assert_eq!(
+            determine_fallback_action(10, 3, 5, 7),
+            EditFallbackAction::FixSliceEscalation
         );
     }
 
@@ -182,7 +221,7 @@ mod tests {
 
     #[test]
     fn test_tracker_basic_flow() {
-        let mut tracker = EditFailTracker::new(3, 5);
+        let mut tracker = EditFailTracker::new(3, 5, 0);
 
         // 1st and 2nd failure: Continue
         assert_eq!(
@@ -208,7 +247,7 @@ mod tests {
 
     #[test]
     fn test_tracker_success_resets() {
-        let mut tracker = EditFailTracker::new(3, 5);
+        let mut tracker = EditFailTracker::new(3, 5, 0);
 
         tracker.record_failure("foo.rs");
         tracker.record_failure("foo.rs");
@@ -224,7 +263,7 @@ mod tests {
 
     #[test]
     fn test_tracker_independent_paths() {
-        let mut tracker = EditFailTracker::new(3, 5);
+        let mut tracker = EditFailTracker::new(3, 5, 0);
 
         tracker.record_failure("foo.rs");
         assert_eq!(
@@ -245,7 +284,7 @@ mod tests {
 
     #[test]
     fn test_tracker_custom_thresholds() {
-        let mut tracker = EditFailTracker::new(2, 4);
+        let mut tracker = EditFailTracker::new(2, 4, 0);
         assert_eq!(tracker.record_failure("a.rs"), EditFallbackAction::Continue); // 1st
         assert_eq!(tracker.record_failure("a.rs"), EditFallbackAction::ReRead); // 2nd = reread
         assert_eq!(tracker.record_failure("a.rs"), EditFallbackAction::ReRead); // 3rd
@@ -257,11 +296,11 @@ mod tests {
 
     #[test]
     fn test_tracker_write_fallback_persists() {
-        let mut tracker = EditFailTracker::new(3, 5);
+        let mut tracker = EditFailTracker::new(3, 5, 0);
         for _ in 0..5 {
             tracker.record_failure("a.rs");
         }
-        // Beyond threshold, still WriteFallback
+        // Beyond threshold, still WriteFallback (fixslice disabled)
         assert_eq!(
             tracker.record_failure("a.rs"),
             EditFallbackAction::WriteFallback
@@ -271,5 +310,56 @@ mod tests {
             EditFallbackAction::WriteFallback
         );
         assert_eq!(tracker.failure_count("a.rs"), 7);
+    }
+
+    // --- FixSlice escalation tests (Issue #321) ---
+
+    #[test]
+    fn test_tracker_fixslice_escalation() {
+        // reread=3, write_fallback=5, fixslice=7
+        let mut tracker = EditFailTracker::new(3, 5, 7);
+
+        // 1-2: Continue
+        assert_eq!(tracker.record_failure("a.rs"), EditFallbackAction::Continue);
+        assert_eq!(tracker.record_failure("a.rs"), EditFallbackAction::Continue);
+        // 3-4: ReRead
+        assert_eq!(tracker.record_failure("a.rs"), EditFallbackAction::ReRead);
+        assert_eq!(tracker.record_failure("a.rs"), EditFallbackAction::ReRead);
+        // 5-6: WriteFallback
+        assert_eq!(
+            tracker.record_failure("a.rs"),
+            EditFallbackAction::WriteFallback
+        );
+        assert_eq!(
+            tracker.record_failure("a.rs"),
+            EditFallbackAction::WriteFallback
+        );
+        // 7+: FixSliceEscalation
+        assert_eq!(
+            tracker.record_failure("a.rs"),
+            EditFallbackAction::FixSliceEscalation
+        );
+        assert_eq!(tracker.failure_count("a.rs"), 7);
+        // Persists beyond threshold
+        assert_eq!(
+            tracker.record_failure("a.rs"),
+            EditFallbackAction::FixSliceEscalation
+        );
+    }
+
+    #[test]
+    fn test_tracker_fixslice_escalation_resets_on_success() {
+        let mut tracker = EditFailTracker::new(3, 5, 7);
+        for _ in 0..7 {
+            tracker.record_failure("a.rs");
+        }
+        assert_eq!(
+            tracker.record_failure("a.rs"),
+            EditFallbackAction::FixSliceEscalation
+        );
+
+        tracker.record_success("a.rs");
+        assert_eq!(tracker.failure_count("a.rs"), 0);
+        assert_eq!(tracker.record_failure("a.rs"), EditFallbackAction::Continue);
     }
 }

--- a/src/app/edit_fail_tracker.rs
+++ b/src/app/edit_fail_tracker.rs
@@ -85,6 +85,29 @@ pub fn should_escalate_for_stagnation(
         && stagnation_score >= score_threshold
 }
 
+/// Decide whether to escalate to the worker path due to read-heavy drift
+/// with no mutation observed (Issue #334).
+///
+/// The Issue #332 policy still requires cumulative edit failures. A session
+/// that never attempts an edit cannot cross that threshold, so read-heavy
+/// drift (repeated reads / searches, stagnation score high, zero mutation)
+/// never reaches the worker path. This trigger closes that gap by firing
+/// independently of `total_failures`.
+///
+/// `score_threshold == 0` disables the trigger.
+pub fn should_escalate_for_read_heavy_drift(
+    stagnation_score: u32,
+    mutation_observed: bool,
+    turns_since_last_mutation: u32,
+    score_threshold: u32,
+    drought_threshold: u32,
+) -> bool {
+    score_threshold > 0
+        && !mutation_observed
+        && stagnation_score >= score_threshold
+        && turns_since_last_mutation >= drought_threshold
+}
+
 /// Tracks consecutive file.edit failures per file path.
 /// Used to detect when the LLM is stuck retrying edits on the same file
 /// and should be prompted to try an alternative approach (Issue #158, #321).

--- a/src/app/escalation_barrier.rs
+++ b/src/app/escalation_barrier.rs
@@ -1,0 +1,108 @@
+//! Post-escalation fix_slice routing barrier (Issue #355, Bug 1).
+//!
+//! When a `requires_worker_observation` pack has flagged fix_slice
+//! escalation but the LLM still emits parent-side mutation tools
+//! (`file.edit`, `file.write`, `file.edit_anchor`) without actually
+//! invoking `agent.fix_slice`, this barrier blocks those mutations and
+//! forces the LLM onto the worker path. Bounded by
+//! [`MAX_ESCALATION_BARRIER_BLOCKS`] so a model that refuses to comply
+//! still releases after a small number of attempts and lets the existing
+//! `finalize_fixslice_outcome` classification fire.
+
+use crate::tooling::{
+    ToolExecutionPayload, ToolExecutionRequest, ToolExecutionResult, ToolExecutionStatus,
+};
+
+/// Maximum times the barrier will fire per session before auto-releasing.
+pub const MAX_ESCALATION_BARRIER_BLOCKS: u8 = 3;
+
+/// Message returned to the LLM when a parent-side mutation tool is
+/// blocked by the barrier.
+pub const ESCALATION_BARRIER_MESSAGE: &str = "fix_slice escalation is active for this worker-required pack. \
+     You MUST call agent.fix_slice on the most relevant target file \
+     instead of file.edit / file.write / file.edit_anchor. Parent-side \
+     mutation tools are temporarily suspended until agent.fix_slice has \
+     been invoked. Emit a single agent.fix_slice call with target_path \
+     and goal describing the intended change.";
+
+const BLOCKED_TOOLS: &[&str] = &["file.write", "file.edit", "file.edit_anchor"];
+
+/// Per-session state: tracks how many times the barrier has fired.
+#[derive(Default)]
+pub struct EscalationBarrier {
+    block_count: u8,
+}
+
+/// Result of a barrier check-and-filter.
+pub struct EscalationBarrierResult {
+    /// Requests that passed the barrier (non-mutation, or barrier inactive).
+    pub passed_requests: Vec<(usize, ToolExecutionRequest)>,
+    /// Results for blocked mutation tools.
+    pub blocked_results: Vec<(usize, ToolExecutionResult)>,
+    /// Number of mutations blocked in this batch.
+    pub blocked_count: usize,
+}
+
+impl EscalationBarrier {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Check a batch of validated requests. When `armed` is true and the
+    /// per-session cap has not been reached, parent-side mutation tools are
+    /// moved into `blocked_results`. Non-mutation tools always pass.
+    pub fn check_and_filter(
+        &mut self,
+        validated_requests: Vec<(usize, ToolExecutionRequest)>,
+        armed: bool,
+    ) -> EscalationBarrierResult {
+        if !armed || self.block_count >= MAX_ESCALATION_BARRIER_BLOCKS {
+            return EscalationBarrierResult {
+                passed_requests: validated_requests,
+                blocked_results: Vec::new(),
+                blocked_count: 0,
+            };
+        }
+
+        let has_target = validated_requests
+            .iter()
+            .any(|(_, r)| BLOCKED_TOOLS.contains(&r.spec.name.as_str()));
+        if !has_target {
+            return EscalationBarrierResult {
+                passed_requests: validated_requests,
+                blocked_results: Vec::new(),
+                blocked_count: 0,
+            };
+        }
+
+        self.block_count += 1;
+        let mut passed = Vec::new();
+        let mut blocked = Vec::new();
+        for (idx, request) in validated_requests {
+            if BLOCKED_TOOLS.contains(&request.spec.name.as_str()) {
+                let result = ToolExecutionResult {
+                    tool_call_id: request.tool_call_id.clone(),
+                    tool_name: request.spec.name.clone(),
+                    status: ToolExecutionStatus::Blocked,
+                    summary: format!("[fixslice_escalation_barrier] {ESCALATION_BARRIER_MESSAGE}"),
+                    payload: ToolExecutionPayload::None,
+                    artifacts: Vec::new(),
+                    elapsed_ms: 0,
+                    diff_summary: None,
+                    edit_detail: None,
+                    rolled_back: false,
+                };
+                blocked.push((idx, result));
+            } else {
+                passed.push((idx, request));
+            }
+        }
+
+        let blocked_count = blocked.len();
+        EscalationBarrierResult {
+            passed_requests: passed,
+            blocked_results: blocked,
+            blocked_count,
+        }
+    }
+}

--- a/src/app/execution_plan.rs
+++ b/src/app/execution_plan.rs
@@ -166,7 +166,7 @@ impl App {
                 .record_repair_turn_items_retired(retire_count);
         }
 
-        let new_items = filter_unchecked_items(all_items, &checked_indices);
+        let mut new_items = filter_unchecked_items(all_items, &checked_indices);
         if new_items.is_empty() {
             if had_retire {
                 tracing::info!("plan update pipeline: all items checked → retired");
@@ -186,6 +186,65 @@ impl App {
                 rejected_items = rejected,
                 "plan update pipeline: rejected unchecked items during repair closure mode"
             );
+            if had_retire {
+                self.agent_telemetry.record_plan_update();
+            }
+            return had_retire;
+        }
+
+        // Issue #336: late-stage closure guard.
+        //
+        // When `remaining==1 && finished>=1`, the late-stage closure hint is
+        // already asking the agent to close or retire the last item.  Before
+        // evaluating overlap, reconcile the plan against already-touched
+        // files so a last item whose target was already mutated flips to Done
+        // naturally — otherwise we'd reject legitimate updates that simply
+        // lagged the underlying file state.
+        //
+        // If closure mode is still active after reconciliation, any incoming
+        // unchecked item whose target files overlap the single remaining
+        // item's target files is rejected outright.  This stops the
+        // supersede→dedup→append churn that kept "refreshing" the last item
+        // indefinitely in Phase2 Issue334 follow-up runs.
+        let touched_snapshot = self.session.working_memory.touched_files.clone();
+        let finished_before_sync = self.execution_plan.finished_count();
+        self.execution_plan
+            .sync_from_touched_files(&touched_snapshot);
+        if self.execution_plan.finished_count() > finished_before_sync {
+            self.agent_telemetry.record_sync_from_touched_files();
+        }
+        if self
+            .execution_plan
+            .build_late_stage_closure_hint()
+            .is_some()
+            && let Some(remaining_targets) = self
+                .execution_plan
+                .next_actionable_index()
+                .and_then(|i| self.execution_plan.items.get(i))
+                .map(|item| item.target_files.clone())
+            && !remaining_targets.is_empty()
+        {
+            let initial_len = new_items.len();
+            new_items.retain(|new_item| {
+                !remaining_targets.iter().any(|rt| {
+                    new_item
+                        .target_files
+                        .iter()
+                        .any(|nt| crate::contracts::ExecutionPlan::path_matches(rt, nt))
+                })
+            });
+            let rejected = (initial_len - new_items.len()) as u32;
+            if rejected > 0 {
+                self.agent_telemetry
+                    .record_late_stage_closure_items_rejected(rejected);
+                tracing::warn!(
+                    rejected_items = rejected,
+                    "plan update pipeline: rejected unchecked items overlapping single remaining target during late-stage closure mode (Issue #336)"
+                );
+            }
+        }
+
+        if new_items.is_empty() {
             if had_retire {
                 self.agent_telemetry.record_plan_update();
             }
@@ -839,5 +898,136 @@ mod tests {
         assert!(updated);
         assert_eq!(app.execution_plan.items.len(), 2);
         assert_eq!(app.agent_telemetry.plan_update_count, 1);
+    }
+
+    // --- Issue #336: late-stage closure guard tests ---
+
+    /// Regression: when remaining==1 with finished>=1, a follow-up
+    /// ANVIL_PLAN_UPDATE that only restates the single remaining target must
+    /// be rejected rather than creating an endless supersede→append churn.
+    #[test]
+    fn late_stage_closure_rejects_same_target_replan() {
+        let mut app = build_test_app();
+        let content1 = "```ANVIL_PLAN\n- [ ] src/a.rs: item A\n- [ ] src/b.rs: item B\n```";
+        app.try_register_plan(content1);
+        // Simulate item A completed via mutation.
+        app.execution_plan.mark_done(0);
+        assert_eq!(app.execution_plan.finished_count(), 1);
+
+        // Follow-up restating item B's file with a "refined" description.
+        let update = "```ANVIL_PLAN_UPDATE\n- [ ] src/b.rs: refined item B\n```";
+        let updated = app.try_update_plan(update);
+
+        // No new item appended, existing item B stays actionable.
+        assert_eq!(
+            app.execution_plan.items.len(),
+            2,
+            "closure guard must not append a refreshed last item"
+        );
+        let b_item = &app.execution_plan.items[1];
+        assert!(
+            !b_item.is_finished(),
+            "existing remaining item must not be superseded by closure guard"
+        );
+        // Pipeline reports no meaningful change (nothing retired, nothing appended).
+        assert!(!updated);
+        assert_eq!(
+            app.agent_telemetry.late_stage_closure_items_rejected, 1,
+            "telemetry must count the rejected closure-mode item"
+        );
+        assert_eq!(app.agent_telemetry.plan_update_count, 0);
+    }
+
+    /// Closure guard must allow follow-up items targeting genuinely different
+    /// files, so the agent can still pivot to new work when remaining==1.
+    #[test]
+    fn late_stage_closure_allows_different_target_replan() {
+        let mut app = build_test_app();
+        let content1 = "```ANVIL_PLAN\n- [ ] src/a.rs: A\n- [ ] src/b.rs: B\n```";
+        app.try_register_plan(content1);
+        app.execution_plan.mark_done(0);
+
+        let update = "```ANVIL_PLAN_UPDATE\n- [ ] src/c.rs: genuinely new task\n```";
+        let updated = app.try_update_plan(update);
+
+        assert!(updated);
+        assert_eq!(app.execution_plan.items.len(), 3);
+        assert_eq!(app.agent_telemetry.late_stage_closure_items_rejected, 0);
+    }
+
+    /// Closure guard must not fire when remaining > 1: normal replan
+    /// supersede/dedup semantics must keep working for mid-plan churn.
+    #[test]
+    fn late_stage_closure_inactive_when_multiple_remaining() {
+        let mut app = build_test_app();
+        let content1 =
+            "```ANVIL_PLAN\n- [ ] src/a.rs: A\n- [ ] src/b.rs: B\n- [ ] src/c.rs: C\n```";
+        app.try_register_plan(content1);
+        app.execution_plan.mark_done(0);
+        // remaining == 2 → closure guard inactive.
+
+        let update = "```ANVIL_PLAN_UPDATE\n- [ ] src/b.rs: refined B\n```";
+        let updated = app.try_update_plan(update);
+
+        assert!(updated);
+        assert_eq!(app.agent_telemetry.late_stage_closure_items_rejected, 0);
+    }
+
+    /// The closure path must reconcile the plan against already-touched files
+    /// before rejecting: if the remaining target was already mutated, sync
+    /// should close the plan instead of indefinitely gating on an update.
+    #[test]
+    fn late_stage_closure_reconciles_touched_files_first() {
+        let mut app = build_test_app();
+        let content1 = "```ANVIL_PLAN\n- [ ] src/a.rs: A\n- [ ] src/b.rs: B\n```";
+        app.try_register_plan(content1);
+        app.execution_plan.mark_done(0);
+        // External evidence: src/b.rs was already touched.
+        app.session
+            .working_memory
+            .touched_files
+            .push("src/b.rs".into());
+
+        let update = "```ANVIL_PLAN_UPDATE\n- [ ] src/b.rs: refined B\n```";
+        let _ = app.try_update_plan(update);
+
+        assert!(
+            app.execution_plan.all_finished(),
+            "sync_from_touched_files should have closed the last item before guard"
+        );
+        // No rejection recorded — the guard condition no longer holds post-sync.
+        assert_eq!(app.agent_telemetry.late_stage_closure_items_rejected, 0);
+    }
+
+    /// Partial-overlap update: the portion targeting the single remaining item
+    /// is rejected, while unrelated new items are still appended.
+    #[test]
+    fn late_stage_closure_partial_overlap_rejects_only_overlapping() {
+        let mut app = build_test_app();
+        let content1 = "```ANVIL_PLAN\n- [ ] src/a.rs: A\n- [ ] src/b.rs: B\n```";
+        app.try_register_plan(content1);
+        app.execution_plan.mark_done(0);
+
+        let update =
+            "```ANVIL_PLAN_UPDATE\n- [ ] src/b.rs: refined B\n- [ ] src/d.rs: new work\n```";
+        let updated = app.try_update_plan(update);
+
+        assert!(updated);
+        // Original B stays, d.rs appended, refined B rejected.
+        assert_eq!(app.execution_plan.items.len(), 3);
+        assert_eq!(app.agent_telemetry.late_stage_closure_items_rejected, 1);
+        let has_d = app
+            .execution_plan
+            .items
+            .iter()
+            .any(|i| i.target_files.iter().any(|f| f == "src/d.rs"));
+        assert!(has_d, "non-overlapping item must still be appended");
+        let b_item = app
+            .execution_plan
+            .items
+            .iter()
+            .find(|i| i.target_files.iter().any(|f| f == "src/b.rs"))
+            .unwrap();
+        assert!(!b_item.is_finished());
     }
 }

--- a/src/app/execution_plan.rs
+++ b/src/app/execution_plan.rs
@@ -126,6 +126,7 @@ impl App {
         // --- checked-first retire (Issue #301 + Issue #315) ---
         let checked_indices = detect_checked_lines(block);
         let mut had_retire = false;
+        let mut retire_count: u32 = 0;
         if !checked_indices.is_empty() {
             let mut all_retired: Vec<String> = Vec::new();
             let mut no_path_descriptions: Vec<String> = Vec::new();
@@ -148,20 +149,44 @@ impl App {
                 );
                 if count > 0 {
                     had_retire = true;
+                    retire_count += count as u32;
                     self.stagnation_state.record_plan_item_completion();
                 }
             }
             if !all_retired.is_empty() {
                 had_retire = true;
+                retire_count += all_retired.len() as u32;
                 self.stagnation_state.retire_target_files(&all_retired);
                 self.stagnation_state.record_plan_item_completion();
             }
+        }
+        // Issue #327: record retired item count during repair closure mode.
+        if self.repair_closure_active && retire_count > 0 {
+            self.agent_telemetry
+                .record_repair_turn_items_retired(retire_count);
         }
 
         let new_items = filter_unchecked_items(all_items, &checked_indices);
         if new_items.is_empty() {
             if had_retire {
                 tracing::info!("plan update pipeline: all items checked → retired");
+                self.agent_telemetry.record_plan_update();
+            }
+            return had_retire;
+        }
+
+        // Issue #327: During repair closure mode, reject unchecked items instead
+        // of appending them. The repair turn is for closing remaining work, not
+        // expanding it.
+        if self.repair_closure_active {
+            let rejected = new_items.len() as u32;
+            self.agent_telemetry
+                .record_repair_turn_items_rejected(rejected);
+            tracing::warn!(
+                rejected_items = rejected,
+                "plan update pipeline: rejected unchecked items during repair closure mode"
+            );
+            if had_retire {
                 self.agent_telemetry.record_plan_update();
             }
             return had_retire;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -296,6 +296,9 @@ pub struct App {
     forced_mode_active: bool,
     /// Recovery read budget for file.edit failure recovery (Issue #299).
     tool_recovery_budget: tool_recovery_budget::ToolRecoveryBudget,
+    /// Whether the session is in pre-exit repair closure mode (Issue #327).
+    /// When active, ANVIL_PLAN_UPDATE unchecked items are rejected.
+    repair_closure_active: bool,
 }
 
 /// Whether the session loop should continue or exit.
@@ -636,6 +639,7 @@ impl App {
             tool_recovery_budget: tool_recovery_budget::ToolRecoveryBudget::new(
                 edit_recovery_read_budget,
             ),
+            repair_closure_active: false,
         })
     }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -503,6 +503,7 @@ impl App {
         // Register sub-agent tools separately (design decision #6, DR1-008)
         tools.register_agent_explore();
         tools.register_agent_plan();
+        tools.register_agent_fix_slice();
         if let Some(ref manager) = mcp_manager {
             let mcp_tools = manager.get_tools();
             for (server_name, tool_list) in &mcp_tools {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -9,6 +9,7 @@ pub mod cli;
 pub mod closure_loop_detector;
 mod context;
 pub mod edit_fail_tracker;
+pub mod escalation_barrier;
 pub(crate) mod execution_plan;
 pub mod loop_detector;
 pub mod mock;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -919,7 +919,7 @@ impl App {
     ///
     /// Should be called once when the session actually ends (interactive exit
     /// or non-interactive completion), not per-turn.
-    pub(crate) fn log_session_summary(&self) {
+    pub(crate) fn log_session_summary(&mut self) {
         let session_elapsed = self
             .session_stats
             .session_start
@@ -978,6 +978,35 @@ impl App {
                 pre_exit_repair_consumed_count = tel.pre_exit_repair_consumed_count,
                 "agent telemetry"
             );
+        }
+
+        // Issue #329: Validate pack expectation gate before writing artifact.
+        {
+            let result = self.agent_telemetry.validate_pack_expectation();
+            match &result {
+                crate::contracts::PackValidationResult::NoExpectation => {}
+                crate::contracts::PackValidationResult::Satisfied => {
+                    tracing::info!(
+                        pack_expectation = %self.agent_telemetry.pack_expectation
+                            .map(|e| e.to_string())
+                            .unwrap_or_default(),
+                        "pack validation gate: satisfied"
+                    );
+                }
+                crate::contracts::PackValidationResult::Mismatch {
+                    expectation,
+                    reason,
+                } => {
+                    tracing::warn!(
+                        pack_expectation = %expectation,
+                        reason = %reason,
+                        mutation_observed = self.agent_telemetry.mutation_observed,
+                        worker_observed = self.agent_telemetry.worker_observed,
+                        repair_turn_observed = self.agent_telemetry.repair_turn_observed,
+                        "pack validation gate: expectation mismatch"
+                    );
+                }
+            }
         }
 
         // Issue #271: Write telemetry artifact (opt-in via ANVIL_TELEMETRY_DIR).

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -65,7 +65,12 @@ pub use render::{cli_prompt, render_help_frame, slash_commands};
 /// Mutation tools tracked for telemetry purposes.
 /// Note: shell.exec is intentionally excluded — see Issue #273 for rationale
 /// (first_mutation_event_* fields are runtime_lower_bound, not strict post-hoc values).
-pub(crate) const MUTATION_TOOLS: &[&str] = &["file.write", "file.edit", "file.edit_anchor"];
+pub(crate) const MUTATION_TOOLS: &[&str] = &[
+    "file.write",
+    "file.edit",
+    "file.edit_anchor",
+    "file.rewrite",
+];
 
 /// Detect project languages from the project root directory.
 ///
@@ -2350,7 +2355,8 @@ impl App {
         let rel_path = match &request.input {
             ToolInput::FileWrite { path, .. }
             | ToolInput::FileEdit { path, .. }
-            | ToolInput::FileEditAnchor { path, .. } => path,
+            | ToolInput::FileEditAnchor { path, .. }
+            | ToolInput::FileRewrite { path, .. } => path,
             _ => return None,
         };
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -16,6 +16,7 @@ pub mod mutation_barrier;
 pub mod phase_estimator;
 pub mod plan;
 pub mod policy;
+pub mod post_failure_thrash_detector;
 pub(crate) mod read_repeat_tracker;
 pub mod read_transition_guard;
 pub mod render;
@@ -304,6 +305,10 @@ pub struct App {
     /// after a `fix_slice` worker failure with no tool-advancing output
     /// (Issue #349).
     closure_loop_detector: closure_loop_detector::ClosureLoopDetector,
+    /// Detects tool-active thrash loops after a `fix_slice` worker failure
+    /// where the parent keeps calling tools but the execution plan never
+    /// advances (Issue #351).
+    post_failure_thrash_detector: post_failure_thrash_detector::PostFailureThrashDetector,
 }
 
 /// Whether the session loop should continue or exit.
@@ -655,6 +660,8 @@ impl App {
             ),
             repair_closure_active: false,
             closure_loop_detector: closure_loop_detector::ClosureLoopDetector::new(),
+            post_failure_thrash_detector:
+                post_failure_thrash_detector::PostFailureThrashDetector::default(),
         })
     }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -980,6 +980,10 @@ impl App {
             );
         }
 
+        // Issue #332: retrospectively classify repair-turn-only salvage
+        // before pack validation/artifact emission so the counter is durable.
+        self.agent_telemetry.classify_repair_salvage();
+
         // Issue #329: Validate pack expectation gate before writing artifact.
         {
             let result = self.agent_telemetry.validate_pack_expectation();

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -989,6 +989,13 @@ impl App {
             );
         }
 
+        // Issue #345: classify the A1 shape (escalation fired but the worker
+        // was never invoked) before the salvage / pack-validation steps so
+        // they see a consistent failure record. Runs unconditionally — the
+        // hook is a no-op when no escalation fired or when the worker was
+        // actually invoked.
+        self.agent_telemetry.finalize_fixslice_outcome();
+
         // Issue #332: retrospectively classify repair-turn-only salvage
         // before pack validation/artifact emission so the counter is durable.
         self.agent_telemetry.classify_repair_salvage();

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -7,7 +7,7 @@ pub mod agentic;
 pub mod alternating_loop_detector;
 pub mod cli;
 mod context;
-pub(crate) mod edit_fail_tracker;
+pub mod edit_fail_tracker;
 pub(crate) mod execution_plan;
 pub mod loop_detector;
 pub mod mock;
@@ -573,6 +573,7 @@ impl App {
         let read_transition_reinject_interval = config.runtime.read_transition_reinject_interval;
         let edit_reread_threshold = config.runtime.edit_reread_threshold;
         let edit_write_fallback_threshold = config.runtime.edit_write_fallback_threshold;
+        let edit_fixslice_threshold = config.runtime.edit_fixslice_threshold;
         let read_repeat_warn = config.runtime.read_repeat_warn_threshold;
         let read_repeat_strong_warn = config.runtime.read_repeat_strong_warn_threshold;
         let edit_recovery_read_budget = config.runtime.edit_recovery_read_budget;
@@ -608,6 +609,7 @@ impl App {
             edit_fail_tracker: edit_fail_tracker::EditFailTracker::new(
                 edit_reread_threshold,
                 edit_write_fallback_threshold,
+                edit_fixslice_threshold,
             ),
             phase_estimator: phase_estimator::PhaseEstimator::new(
                 phase_explore,
@@ -967,6 +969,7 @@ impl App {
                 no_op_mutation_count = tel.no_op_mutation_count,
                 rolled_back_mutation_count = tel.rolled_back_mutation_count,
                 initial_plan_miss_count = tel.initial_plan_miss_count,
+                fixslice_escalation_count = tel.fixslice_escalation_count,
                 "agent telemetry"
             );
         }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -6,6 +6,7 @@
 pub mod agentic;
 pub mod alternating_loop_detector;
 pub mod cli;
+pub mod closure_loop_detector;
 mod context;
 pub mod edit_fail_tracker;
 pub(crate) mod execution_plan;
@@ -299,6 +300,10 @@ pub struct App {
     /// Whether the session is in pre-exit repair closure mode (Issue #327).
     /// When active, ANVIL_PLAN_UPDATE unchecked items are rejected.
     repair_closure_active: bool,
+    /// Detects closure-mode natural-language reasoning loops that reoccur
+    /// after a `fix_slice` worker failure with no tool-advancing output
+    /// (Issue #349).
+    closure_loop_detector: closure_loop_detector::ClosureLoopDetector,
 }
 
 /// Whether the session loop should continue or exit.
@@ -649,6 +654,7 @@ impl App {
                 edit_recovery_read_budget,
             ),
             repair_closure_active: false,
+            closure_loop_detector: closure_loop_detector::ClosureLoopDetector::new(),
         })
     }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -633,7 +633,16 @@ impl App {
             session_stats: SessionStats::new(),
             last_compact_info: None,
             execution_plan: crate::contracts::ExecutionPlan::default(),
-            agent_telemetry: crate::contracts::AgentTelemetry::new(),
+            agent_telemetry: {
+                // Issue #343: cache the active pack expectation at session
+                // start so the agentic loop can consult it without re-reading
+                // env on every turn. `validate_pack_expectation` still
+                // re-resolves at session end, so this cache is only a
+                // read-side convenience.
+                let mut tel = crate::contracts::AgentTelemetry::new();
+                tel.pack_expectation = crate::contracts::PackExpectation::from_env();
+                tel
+            },
             stagnation_state: stagnation_state::StagnationState::new(),
             forced_mode_active: false,
             tool_recovery_budget: tool_recovery_budget::ToolRecoveryBudget::new(
@@ -983,6 +992,22 @@ impl App {
         // Issue #332: retrospectively classify repair-turn-only salvage
         // before pack validation/artifact emission so the counter is durable.
         self.agent_telemetry.classify_repair_salvage();
+
+        // Issue #343: surface an explicit runtime-summary warning when the
+        // session finished with a recorded fix_slice worker failure but no
+        // corresponding worker success. Makes the A1 shape visible in logs
+        // without waiting for the pack validation gate at the very end.
+        if self.agent_telemetry.has_fixslice_worker_failure()
+            && !self.agent_telemetry.worker_observed
+        {
+            tracing::warn!(
+                fixslice_worker_failure_count = self.agent_telemetry.fixslice_worker_failure_count,
+                fixslice_failure_reason = self.agent_telemetry.fixslice_failure_reason.as_deref(),
+                repair_turn_observed = self.agent_telemetry.repair_turn_observed,
+                mutation_observed = self.agent_telemetry.mutation_observed,
+                "fix_slice worker failed to reach success; session ended without worker observation"
+            );
+        }
 
         // Issue #329: Validate pack expectation gate before writing artifact.
         {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -970,6 +970,8 @@ impl App {
                 rolled_back_mutation_count = tel.rolled_back_mutation_count,
                 initial_plan_miss_count = tel.initial_plan_miss_count,
                 fixslice_escalation_count = tel.fixslice_escalation_count,
+                pre_exit_repair_injected_count = tel.pre_exit_repair_injected_count,
+                pre_exit_repair_consumed_count = tel.pre_exit_repair_consumed_count,
                 "agent telemetry"
             );
         }

--- a/src/app/phase_estimator.rs
+++ b/src/app/phase_estimator.rs
@@ -7,7 +7,12 @@
 /// Read-category tool names.
 const READ_TOOLS: &[&str] = &["file.read", "file.search", "web.fetch"];
 /// Write-category tool names.
-const WRITE_TOOLS: &[&str] = &["file.edit", "file.edit_anchor", "file.write"];
+const WRITE_TOOLS: &[&str] = &[
+    "file.edit",
+    "file.edit_anchor",
+    "file.rewrite",
+    "file.write",
+];
 
 /// Action recommended by the phase estimator.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/app/post_failure_thrash_detector.rs
+++ b/src/app/post_failure_thrash_detector.rs
@@ -1,0 +1,229 @@
+//! Post-failure tool-active thrash detector (Issue #351).
+//!
+//! After `agent.fix_slice` has failed at least once without a subsequent
+//! worker success, the parent agent can enter a tool-active thrash loop:
+//! it keeps calling tools (`file.read` / `file.search` / `shell.exec`) but
+//! the execution plan never advances and no mutation lands. This shape is
+//! outside PR #350's closure loop detector (which only fires on zero-
+//! tool-call reasoning responses) and not caught by the generic
+//! `LoopDetector` (which requires identical tool calls in a tight window).
+//!
+//! This detector counts consecutive turns while the guard is armed in
+//! which (a) at least one tool was executed and (b) no execution plan
+//! items were advanced and no mutation was recorded. When the count
+//! reaches the configured thresholds, it escalates via the
+//! `LoopAction` ladder: `Continue → Warn → StrongWarn → Break`.
+//!
+//! - Guard arming (the caller must verify these before calling):
+//!     1. `worker_observed == false`
+//!     2. `fixslice_worker_failure_count > 0`
+//! - The detector is reset at the start of each top-level turn, when the
+//!   guard disarms, and whenever a plan is (re-)registered.
+
+use super::loop_detector::LoopAction;
+
+/// Default number of consecutive no-progress turns before a Warn fires.
+pub const DEFAULT_WARN_THRESHOLD: u32 = 3;
+/// Default number of consecutive no-progress turns before a StrongWarn fires.
+pub const DEFAULT_STRONG_WARN_THRESHOLD: u32 = 4;
+/// Default number of consecutive no-progress turns before the detector
+/// breaks the agentic loop.
+pub const DEFAULT_BREAK_THRESHOLD: u32 = 5;
+
+/// Detector for parent-side post-failure tool-active thrash.
+#[derive(Debug)]
+pub struct PostFailureThrashDetector {
+    no_progress_turns: u32,
+    warn_threshold: u32,
+    strong_warn_threshold: u32,
+    break_threshold: u32,
+    escalation_count: u32,
+}
+
+impl Default for PostFailureThrashDetector {
+    fn default() -> Self {
+        Self::new(
+            DEFAULT_WARN_THRESHOLD,
+            DEFAULT_STRONG_WARN_THRESHOLD,
+            DEFAULT_BREAK_THRESHOLD,
+        )
+    }
+}
+
+impl PostFailureThrashDetector {
+    pub fn new(warn_threshold: u32, strong_warn_threshold: u32, break_threshold: u32) -> Self {
+        Self {
+            no_progress_turns: 0,
+            warn_threshold,
+            strong_warn_threshold,
+            break_threshold,
+            escalation_count: 0,
+        }
+    }
+
+    /// Reset to a clean state.
+    ///
+    /// Called when the guard disarms (worker success observed, plan
+    /// (re-)registered, or the turn made progress), and at the start of
+    /// each top-level turn.
+    pub fn reset(&mut self) {
+        self.no_progress_turns = 0;
+        self.escalation_count = 0;
+    }
+
+    /// Number of consecutive no-progress turns observed while armed.
+    pub fn no_progress_turns(&self) -> u32 {
+        self.no_progress_turns
+    }
+
+    /// Record a turn while the guard is armed and return the escalation
+    /// action.
+    ///
+    /// `had_tool_calls` is true when the turn executed at least one tool
+    /// call; `plan_advanced` is true when the turn advanced at least one
+    /// plan item or recorded at least one mutation. Any turn that lacks
+    /// tool calls or made progress resets the counter — this detector
+    /// targets the tool-active-but-stuck shape specifically.
+    pub fn record_turn(&mut self, had_tool_calls: bool, plan_advanced: bool) -> LoopAction {
+        if plan_advanced || !had_tool_calls {
+            self.no_progress_turns = 0;
+            self.escalation_count = 0;
+            return LoopAction::Continue;
+        }
+
+        self.no_progress_turns += 1;
+
+        if self.no_progress_turns >= self.break_threshold {
+            self.escalation_count += 1;
+            return LoopAction::Break(
+                "[Post-Failure Thrash Guard - TERMINATED] Agentic loop terminated: \
+                 parent agent has been issuing tool calls with zero plan advancement \
+                 after fix_slice worker failure. Classifying as post-failure thrash."
+                    .to_string(),
+            );
+        }
+        if self.no_progress_turns >= self.strong_warn_threshold {
+            self.escalation_count += 1;
+            return LoopAction::StrongWarn(
+                "[Post-Failure Thrash Guard - WARNING] Tool calls are continuing but \
+                 the execution plan has not advanced after a fix_slice worker failure. \
+                 You MUST either re-invoke agent.fix_slice on the troubled target or \
+                 emit ANVIL_FINAL and terminate. Do NOT keep reading / searching."
+                    .to_string(),
+            );
+        }
+        if self.no_progress_turns >= self.warn_threshold {
+            self.escalation_count += 1;
+            return LoopAction::Warn(
+                "[Post-Failure Thrash Guard] The parent agent keeps calling tools after \
+                 a fix_slice worker failure without advancing the execution plan. \
+                 Decide now: either re-invoke agent.fix_slice with a specific target, \
+                 or emit ANVIL_FINAL."
+                    .to_string(),
+            );
+        }
+
+        LoopAction::Continue
+    }
+
+    #[cfg(test)]
+    pub fn escalation_count(&self) -> u32 {
+        self.escalation_count
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn new_default() -> PostFailureThrashDetector {
+        PostFailureThrashDetector::default()
+    }
+
+    #[test]
+    fn progress_resets_counter() {
+        let mut det = new_default();
+        assert_eq!(det.record_turn(true, false), LoopAction::Continue);
+        assert_eq!(det.no_progress_turns(), 1);
+        assert_eq!(det.record_turn(true, true), LoopAction::Continue);
+        assert_eq!(det.no_progress_turns(), 0);
+    }
+
+    #[test]
+    fn tool_inactive_turn_resets_counter() {
+        let mut det = new_default();
+        assert_eq!(det.record_turn(true, false), LoopAction::Continue);
+        assert_eq!(det.record_turn(true, false), LoopAction::Continue);
+        // Zero-tool-call turn: closure_loop_detector territory, not ours.
+        assert_eq!(det.record_turn(false, false), LoopAction::Continue);
+        assert_eq!(det.no_progress_turns(), 0);
+    }
+
+    #[test]
+    fn warn_at_warn_threshold() {
+        let mut det = new_default();
+        for _ in 0..(DEFAULT_WARN_THRESHOLD - 1) {
+            assert_eq!(det.record_turn(true, false), LoopAction::Continue);
+        }
+        let action = det.record_turn(true, false);
+        assert!(
+            matches!(action, LoopAction::Warn(_)),
+            "expected Warn at turn {DEFAULT_WARN_THRESHOLD}, got {action:?}"
+        );
+    }
+
+    #[test]
+    fn strong_warn_at_strong_warn_threshold() {
+        let mut det = new_default();
+        for _ in 0..(DEFAULT_STRONG_WARN_THRESHOLD - 1) {
+            det.record_turn(true, false);
+        }
+        let action = det.record_turn(true, false);
+        assert!(
+            matches!(action, LoopAction::StrongWarn(_)),
+            "expected StrongWarn at turn {DEFAULT_STRONG_WARN_THRESHOLD}, got {action:?}"
+        );
+    }
+
+    #[test]
+    fn break_at_break_threshold() {
+        let mut det = new_default();
+        for _ in 0..(DEFAULT_BREAK_THRESHOLD - 1) {
+            det.record_turn(true, false);
+        }
+        let action = det.record_turn(true, false);
+        assert!(
+            matches!(action, LoopAction::Break(_)),
+            "expected Break at turn {DEFAULT_BREAK_THRESHOLD}, got {action:?}"
+        );
+    }
+
+    #[test]
+    fn reset_clears_state() {
+        let mut det = new_default();
+        for _ in 0..DEFAULT_WARN_THRESHOLD {
+            det.record_turn(true, false);
+        }
+        assert!(det.escalation_count() > 0);
+        det.reset();
+        assert_eq!(det.no_progress_turns(), 0);
+        assert_eq!(det.escalation_count(), 0);
+        assert_eq!(det.record_turn(true, false), LoopAction::Continue);
+    }
+
+    #[test]
+    fn progress_turn_after_warn_clears_escalation() {
+        let mut det = new_default();
+        for _ in 0..DEFAULT_WARN_THRESHOLD {
+            det.record_turn(true, false);
+        }
+        // A turn that finally advanced the plan resets escalation.
+        assert_eq!(det.record_turn(true, true), LoopAction::Continue);
+        assert_eq!(det.no_progress_turns(), 0);
+        // Future drift still works from a clean slate.
+        for _ in 0..(DEFAULT_WARN_THRESHOLD - 1) {
+            assert_eq!(det.record_turn(true, false), LoopAction::Continue);
+        }
+        assert!(matches!(det.record_turn(true, false), LoopAction::Warn(_)));
+    }
+}

--- a/src/app/read_transition_guard.rs
+++ b/src/app/read_transition_guard.rs
@@ -82,7 +82,7 @@ impl ReadTransitionGuard {
             "file.search" | "web.fetch" => {
                 self.consecutive_exploration_calls += 1;
             }
-            "file.edit" | "file.edit_anchor" | "file.write" => {
+            "file.edit" | "file.edit_anchor" | "file.rewrite" | "file.write" => {
                 self.reset();
                 return ReadTransitionAction::Continue;
             }
@@ -119,7 +119,7 @@ impl ReadTransitionGuard {
         ReadTransitionAction::Inject(format!(
             "[System] You have already spent {} consecutive tool calls exploring \
              (including {} file.read calls). You have enough context. \
-             Start implementing now using file.edit, file.edit_anchor, or file.write. \
+             Start implementing now using file.edit, file.edit_anchor, file.rewrite, or file.write. \
              Do NOT call file.read or use shell.exec with grep/sed/cat to read files. \
              Proceed to implementation immediately.",
             self.consecutive_exploration_calls, self.consecutive_file_reads

--- a/src/config/custom_tools.rs
+++ b/src/config/custom_tools.rs
@@ -19,6 +19,7 @@ const BUILTIN_TOOL_NAMES: &[&str] = &[
     "web.search",
     "agent.explore",
     "agent.plan",
+    "agent.fix_slice",
     "git.status",
     "git.diff",
     "git.log",

--- a/src/config/custom_tools.rs
+++ b/src/config/custom_tools.rs
@@ -12,6 +12,7 @@ const BUILTIN_TOOL_NAMES: &[&str] = &[
     "file.write",
     "file.edit",
     "file.edit_anchor",
+    "file.rewrite",
     "file.search",
     "shell.exec",
     "web.fetch",

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -201,6 +201,12 @@ pub struct RuntimeConfig {
     /// Minimum `turns_since_last_mutation` required to treat a session as
     /// read-heavy drift and escalate to the worker path (Issue #334).
     pub edit_fixslice_read_heavy_drought_threshold: u32,
+    /// Maximum iterations allowed inside a FixSlice sub-agent run (Issue #345).
+    ///
+    /// Previously hard-coded to 3 at `crate::agent::subagent::FIXSLICE_MAX_ITERATIONS`;
+    /// now configurable so brittle-model workloads can be granted more
+    /// attempts to produce a valid `FixSliceProposal`. Clamped to `[1, 10]`.
+    pub fixslice_max_iterations: u32,
     /// Maximum line count for file.write on existing files (0 = disabled, Issue #156).
     pub safe_write_max_lines: usize,
     /// Deletion ratio threshold for diff warning (0.0-1.0, Issue #156).
@@ -402,6 +408,7 @@ impl EffectiveConfig {
                 edit_fixslice_stagnation_score_threshold: 2,
                 edit_fixslice_read_heavy_score_threshold: 2,
                 edit_fixslice_read_heavy_drought_threshold: 5,
+                fixslice_max_iterations: crate::agent::subagent::DEFAULT_FIXSLICE_MAX_ITERATIONS,
                 safe_write_max_lines: 500,
                 safe_write_deletion_ratio: 0.5,
                 read_repeat_warn_threshold: 3,
@@ -935,6 +942,15 @@ impl EffectiveConfig {
                     }
                     self.runtime.edit_fixslice_read_heavy_drought_threshold = v;
                 }
+                "fixslice_max_iterations" | "ANVIL_FIXSLICE_MAX_ITERATIONS" => {
+                    let v: u32 = value
+                        .parse()
+                        .map_err(|_| ConfigError::InvalidNumericValue(value.clone()))?;
+                    if !(1..=10).contains(&v) {
+                        return Err(ConfigError::InvalidNumericValue(value.clone()));
+                    }
+                    self.runtime.fixslice_max_iterations = v;
+                }
                 "edit_recovery_read_budget" | "ANVIL_EDIT_RECOVERY_READ_BUDGET" => {
                     let v: u32 = value
                         .parse()
@@ -1267,6 +1283,8 @@ impl EffectiveConfig {
             .clamp(1, 40);
         self.runtime.edit_recovery_read_budget =
             self.runtime.edit_recovery_read_budget.clamp(1, 10);
+        // Issue #345: clamp fix_slice worker iteration cap to [1, 10].
+        self.runtime.fixslice_max_iterations = self.runtime.fixslice_max_iterations.clamp(1, 10);
     }
 
     pub fn validate_for_test(&mut self) -> Result<(), ConfigError> {
@@ -1642,6 +1660,7 @@ impl std::fmt::Debug for RuntimeConfig {
                 "edit_fixslice_read_heavy_drought_threshold",
                 &self.edit_fixslice_read_heavy_drought_threshold,
             )
+            .field("fixslice_max_iterations", &self.fixslice_max_iterations)
             .field("safe_write_max_lines", &self.safe_write_max_lines)
             .field("safe_write_deletion_ratio", &self.safe_write_deletion_ratio)
             .field("edit_recovery_read_budget", &self.edit_recovery_read_budget)

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -183,6 +183,9 @@ pub struct RuntimeConfig {
     pub edit_reread_threshold: u32,
     /// Consecutive edit failures before write fallback hint (Issue #158).
     pub edit_write_fallback_threshold: u32,
+    /// Consecutive edit failures before agent.fix_slice escalation (Issue #321).
+    /// 0 = disabled.
+    pub edit_fixslice_threshold: u32,
     /// Maximum line count for file.write on existing files (0 = disabled, Issue #156).
     pub safe_write_max_lines: usize,
     /// Deletion ratio threshold for diff warning (0.0-1.0, Issue #156).
@@ -379,6 +382,7 @@ impl EffectiveConfig {
                 edit_strategy: crate::app::edit_fail_tracker::EditStrategy::EditFirst,
                 edit_reread_threshold: 3,
                 edit_write_fallback_threshold: 5,
+                edit_fixslice_threshold: 7,
                 safe_write_max_lines: 500,
                 safe_write_deletion_ratio: 0.5,
                 read_repeat_warn_threshold: 3,
@@ -863,6 +867,15 @@ impl EffectiveConfig {
                     }
                     self.runtime.edit_write_fallback_threshold = v;
                 }
+                "edit_fixslice_threshold" | "ANVIL_EDIT_FIXSLICE_THRESHOLD" => {
+                    let v: u32 = value
+                        .parse()
+                        .map_err(|_| ConfigError::InvalidNumericValue(value.clone()))?;
+                    if v > 20 {
+                        return Err(ConfigError::InvalidNumericValue(value.clone()));
+                    }
+                    self.runtime.edit_fixslice_threshold = v;
+                }
                 "edit_recovery_read_budget" | "ANVIL_EDIT_RECOVERY_READ_BUDGET" => {
                     let v: u32 = value
                         .parse()
@@ -1159,6 +1172,15 @@ impl EffectiveConfig {
         // Ensure write_fallback > reread
         if self.runtime.edit_write_fallback_threshold <= self.runtime.edit_reread_threshold {
             self.runtime.edit_write_fallback_threshold = self.runtime.edit_reread_threshold + 2;
+        }
+        // Issue #321: clamp fixslice threshold (0 = disabled, otherwise must be > write_fallback)
+        if self.runtime.edit_fixslice_threshold > 0 {
+            self.runtime.edit_fixslice_threshold =
+                self.runtime.edit_fixslice_threshold.clamp(1, 20);
+            if self.runtime.edit_fixslice_threshold <= self.runtime.edit_write_fallback_threshold {
+                self.runtime.edit_fixslice_threshold =
+                    self.runtime.edit_write_fallback_threshold + 2;
+            }
         }
         self.runtime.edit_recovery_read_budget =
             self.runtime.edit_recovery_read_budget.clamp(1, 10);
@@ -1520,6 +1542,7 @@ impl std::fmt::Debug for RuntimeConfig {
                 "edit_write_fallback_threshold",
                 &self.edit_write_fallback_threshold,
             )
+            .field("edit_fixslice_threshold", &self.edit_fixslice_threshold)
             .field("safe_write_max_lines", &self.safe_write_max_lines)
             .field("safe_write_deletion_ratio", &self.safe_write_deletion_ratio)
             .field("edit_recovery_read_budget", &self.edit_recovery_read_budget)

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -186,6 +186,13 @@ pub struct RuntimeConfig {
     /// Consecutive edit failures before agent.fix_slice escalation (Issue #321).
     /// 0 = disabled.
     pub edit_fixslice_threshold: u32,
+    /// Cumulative edit-failure count that triggers stagnation-driven
+    /// fix_slice escalation when combined with a high stagnation score (Issue #332).
+    /// 0 = disabled (same-path threshold is the only trigger).
+    pub edit_fixslice_stagnation_total_threshold: u32,
+    /// Minimum stagnation score required for stagnation-driven fix_slice
+    /// escalation (Issue #332).
+    pub edit_fixslice_stagnation_score_threshold: u32,
     /// Maximum line count for file.write on existing files (0 = disabled, Issue #156).
     pub safe_write_max_lines: usize,
     /// Deletion ratio threshold for diff warning (0.0-1.0, Issue #156).
@@ -383,6 +390,8 @@ impl EffectiveConfig {
                 edit_reread_threshold: 3,
                 edit_write_fallback_threshold: 5,
                 edit_fixslice_threshold: 7,
+                edit_fixslice_stagnation_total_threshold: 4,
+                edit_fixslice_stagnation_score_threshold: 2,
                 safe_write_max_lines: 500,
                 safe_write_deletion_ratio: 0.5,
                 read_repeat_warn_threshold: 3,
@@ -876,6 +885,26 @@ impl EffectiveConfig {
                     }
                     self.runtime.edit_fixslice_threshold = v;
                 }
+                "edit_fixslice_stagnation_total_threshold"
+                | "ANVIL_EDIT_FIXSLICE_STAGNATION_TOTAL_THRESHOLD" => {
+                    let v: u32 = value
+                        .parse()
+                        .map_err(|_| ConfigError::InvalidNumericValue(value.clone()))?;
+                    if v > 40 {
+                        return Err(ConfigError::InvalidNumericValue(value.clone()));
+                    }
+                    self.runtime.edit_fixslice_stagnation_total_threshold = v;
+                }
+                "edit_fixslice_stagnation_score_threshold"
+                | "ANVIL_EDIT_FIXSLICE_STAGNATION_SCORE_THRESHOLD" => {
+                    let v: u32 = value
+                        .parse()
+                        .map_err(|_| ConfigError::InvalidNumericValue(value.clone()))?;
+                    if !(1..=4).contains(&v) {
+                        return Err(ConfigError::InvalidNumericValue(value.clone()));
+                    }
+                    self.runtime.edit_fixslice_stagnation_score_threshold = v;
+                }
                 "edit_recovery_read_budget" | "ANVIL_EDIT_RECOVERY_READ_BUDGET" => {
                     let v: u32 = value
                         .parse()
@@ -1182,6 +1211,18 @@ impl EffectiveConfig {
                     self.runtime.edit_write_fallback_threshold + 2;
             }
         }
+        // Issue #332: clamp stagnation-escalation thresholds (0 = disabled).
+        if self.runtime.edit_fixslice_stagnation_total_threshold > 0 {
+            self.runtime.edit_fixslice_stagnation_total_threshold = self
+                .runtime
+                .edit_fixslice_stagnation_total_threshold
+                .clamp(1, 40);
+        }
+        // Score threshold is bounded by compute_stagnation_score() range [0, 4].
+        self.runtime.edit_fixslice_stagnation_score_threshold = self
+            .runtime
+            .edit_fixslice_stagnation_score_threshold
+            .clamp(1, 4);
         self.runtime.edit_recovery_read_budget =
             self.runtime.edit_recovery_read_budget.clamp(1, 10);
     }
@@ -1543,6 +1584,14 @@ impl std::fmt::Debug for RuntimeConfig {
                 &self.edit_write_fallback_threshold,
             )
             .field("edit_fixslice_threshold", &self.edit_fixslice_threshold)
+            .field(
+                "edit_fixslice_stagnation_total_threshold",
+                &self.edit_fixslice_stagnation_total_threshold,
+            )
+            .field(
+                "edit_fixslice_stagnation_score_threshold",
+                &self.edit_fixslice_stagnation_score_threshold,
+            )
             .field("safe_write_max_lines", &self.safe_write_max_lines)
             .field("safe_write_deletion_ratio", &self.safe_write_deletion_ratio)
             .field("edit_recovery_read_budget", &self.edit_recovery_read_budget)

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -310,6 +310,55 @@ impl Display for ConfigError {
 
 impl Error for ConfigError {}
 
+/// Environment variable whitelist consumed by [`EffectiveConfig::apply_env_overrides`].
+///
+/// Keys listed here are read from process env and forwarded to
+/// [`EffectiveConfig::apply_map`]. A new tunable that is parsed by `apply_map`
+/// but missing from this whitelist will silently fail to take effect from env
+/// — see Issue #347 for the `ANVIL_FIXSLICE_MAX_ITERATIONS` regression.
+pub const ENV_OVERRIDE_WHITELIST: &[&str] = &[
+    "ANVIL_PROVIDER",
+    "ANVIL_MODEL",
+    "ANVIL_PROVIDER_URL",
+    "ANVIL_SIDECAR_MODEL",
+    "ANVIL_SIDECAR_PROVIDER_URL",
+    "ANVIL_API_KEY",
+    "ANVIL_CONTEXT_WINDOW",
+    "ANVIL_CONTEXT_BUDGET",
+    "ANVIL_MAX_AGENT_ITERATIONS",
+    "ANVIL_MAX_CONSOLE_MESSAGES",
+    "ANVIL_AUTO_COMPACT_THRESHOLD",
+    "ANVIL_TOOL_RESULT_MAX_CHARS",
+    "ANVIL_STREAM",
+    "ANVIL_INTERACTIVE",
+    "ANVIL_APPROVAL_REQUIRED",
+    "ANVIL_FRESH_SESSION",
+    "ANVIL_REASONING_VISIBILITY",
+    "ANVIL_DEBUG",
+    "ANVIL_WEB_SEARCH_PROVIDER",
+    "SERPER_API_KEY",
+    "ANVIL_LOG",
+    "ANVIL_OFFLINE",
+    "ANVIL_TAG_PROTOCOL",
+    "ANVIL_PROMPT_TIER",
+    "ANVIL_SMART_COMPACT_THRESHOLD_RATIO",
+    "ANVIL_SUBAGENT_MAX_ITERATIONS",
+    "ANVIL_SUBAGENT_TIMEOUT",
+    "ANVIL_LOOP_DETECTION_THRESHOLD",
+    "ANVIL_HTTP_TIMEOUT",
+    "ANVIL_CURL_TIMEOUT",
+    "ANVIL_EDIT_STRATEGY",
+    "ANVIL_EDIT_REREAD_THRESHOLD",
+    "ANVIL_EDIT_WRITE_FALLBACK_THRESHOLD",
+    "ANVIL_FIXSLICE_MAX_ITERATIONS",
+    "ANVIL_SAFE_WRITE_MAX_LINES",
+    "ANVIL_SAFE_WRITE_DELETION_RATIO",
+    "ANVIL_UI_LANGUAGE",
+    "ANVIL_MAX_TOOL_CALLS",
+    "ANVIL_GUIDANCE_MODE",
+    "ANVIL_EDIT_RECOVERY_READ_BUDGET",
+];
+
 impl EffectiveConfig {
     pub fn project_instructions(&self) -> Option<&str> {
         self.project_instructions.as_deref()
@@ -502,49 +551,28 @@ impl EffectiveConfig {
 
     fn apply_env_overrides(&mut self) -> Result<(), ConfigError> {
         let mut map = HashMap::new();
-        for key in [
-            "ANVIL_PROVIDER",
-            "ANVIL_MODEL",
-            "ANVIL_PROVIDER_URL",
-            "ANVIL_SIDECAR_MODEL",
-            "ANVIL_SIDECAR_PROVIDER_URL",
-            "ANVIL_API_KEY",
-            "ANVIL_CONTEXT_WINDOW",
-            "ANVIL_CONTEXT_BUDGET",
-            "ANVIL_MAX_AGENT_ITERATIONS",
-            "ANVIL_MAX_CONSOLE_MESSAGES",
-            "ANVIL_AUTO_COMPACT_THRESHOLD",
-            "ANVIL_TOOL_RESULT_MAX_CHARS",
-            "ANVIL_STREAM",
-            "ANVIL_INTERACTIVE",
-            "ANVIL_APPROVAL_REQUIRED",
-            "ANVIL_FRESH_SESSION",
-            "ANVIL_REASONING_VISIBILITY",
-            "ANVIL_DEBUG",
-            "ANVIL_WEB_SEARCH_PROVIDER",
-            "SERPER_API_KEY",
-            "ANVIL_LOG",
-            "ANVIL_OFFLINE",
-            "ANVIL_TAG_PROTOCOL",
-            "ANVIL_PROMPT_TIER",
-            "ANVIL_SMART_COMPACT_THRESHOLD_RATIO",
-            "ANVIL_SUBAGENT_MAX_ITERATIONS",
-            "ANVIL_SUBAGENT_TIMEOUT",
-            "ANVIL_LOOP_DETECTION_THRESHOLD",
-            "ANVIL_HTTP_TIMEOUT",
-            "ANVIL_CURL_TIMEOUT",
-            "ANVIL_EDIT_STRATEGY",
-            "ANVIL_EDIT_REREAD_THRESHOLD",
-            "ANVIL_EDIT_WRITE_FALLBACK_THRESHOLD",
-            "ANVIL_SAFE_WRITE_MAX_LINES",
-            "ANVIL_SAFE_WRITE_DELETION_RATIO",
-            "ANVIL_UI_LANGUAGE",
-            "ANVIL_MAX_TOOL_CALLS",
-            "ANVIL_GUIDANCE_MODE",
-            "ANVIL_EDIT_RECOVERY_READ_BUDGET",
-        ] {
+        for key in ENV_OVERRIDE_WHITELIST {
             if let Ok(value) = std::env::var(key) {
-                map.insert(key.to_string(), value);
+                map.insert((*key).to_string(), value);
+            }
+        }
+        self.apply_map(&map)
+    }
+
+    /// Test-only helper that applies env overrides from a provided map using
+    /// the same [`ENV_OVERRIDE_WHITELIST`] filter as the real
+    /// [`Self::apply_env_overrides`]. Unlike [`Self::apply_overrides_for_test`],
+    /// this goes through the whitelist — so it can catch regressions where a
+    /// new tunable is parsed by `apply_map` but never reaches it because the
+    /// whitelist forgot the key (Issue #347).
+    pub fn apply_env_overrides_from_map_for_test(
+        &mut self,
+        env: &HashMap<String, String>,
+    ) -> Result<(), ConfigError> {
+        let mut map = HashMap::new();
+        for key in ENV_OVERRIDE_WHITELIST {
+            if let Some(value) = env.get(*key) {
+                map.insert((*key).to_string(), value.clone());
             }
         }
         self.apply_map(&map)

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -193,6 +193,14 @@ pub struct RuntimeConfig {
     /// Minimum stagnation score required for stagnation-driven fix_slice
     /// escalation (Issue #332).
     pub edit_fixslice_stagnation_score_threshold: u32,
+    /// Minimum stagnation score required for read-heavy fix_slice
+    /// escalation (Issue #334). Fires independently of cumulative edit
+    /// failures when a session is dominated by reads with no mutation.
+    /// 0 = disabled.
+    pub edit_fixslice_read_heavy_score_threshold: u32,
+    /// Minimum `turns_since_last_mutation` required to treat a session as
+    /// read-heavy drift and escalate to the worker path (Issue #334).
+    pub edit_fixslice_read_heavy_drought_threshold: u32,
     /// Maximum line count for file.write on existing files (0 = disabled, Issue #156).
     pub safe_write_max_lines: usize,
     /// Deletion ratio threshold for diff warning (0.0-1.0, Issue #156).
@@ -392,6 +400,8 @@ impl EffectiveConfig {
                 edit_fixslice_threshold: 7,
                 edit_fixslice_stagnation_total_threshold: 4,
                 edit_fixslice_stagnation_score_threshold: 2,
+                edit_fixslice_read_heavy_score_threshold: 2,
+                edit_fixslice_read_heavy_drought_threshold: 5,
                 safe_write_max_lines: 500,
                 safe_write_deletion_ratio: 0.5,
                 read_repeat_warn_threshold: 3,
@@ -905,6 +915,26 @@ impl EffectiveConfig {
                     }
                     self.runtime.edit_fixslice_stagnation_score_threshold = v;
                 }
+                "edit_fixslice_read_heavy_score_threshold"
+                | "ANVIL_EDIT_FIXSLICE_READ_HEAVY_SCORE_THRESHOLD" => {
+                    let v: u32 = value
+                        .parse()
+                        .map_err(|_| ConfigError::InvalidNumericValue(value.clone()))?;
+                    if v > 4 {
+                        return Err(ConfigError::InvalidNumericValue(value.clone()));
+                    }
+                    self.runtime.edit_fixslice_read_heavy_score_threshold = v;
+                }
+                "edit_fixslice_read_heavy_drought_threshold"
+                | "ANVIL_EDIT_FIXSLICE_READ_HEAVY_DROUGHT_THRESHOLD" => {
+                    let v: u32 = value
+                        .parse()
+                        .map_err(|_| ConfigError::InvalidNumericValue(value.clone()))?;
+                    if !(1..=40).contains(&v) {
+                        return Err(ConfigError::InvalidNumericValue(value.clone()));
+                    }
+                    self.runtime.edit_fixslice_read_heavy_drought_threshold = v;
+                }
                 "edit_recovery_read_budget" | "ANVIL_EDIT_RECOVERY_READ_BUDGET" => {
                     let v: u32 = value
                         .parse()
@@ -1223,6 +1253,18 @@ impl EffectiveConfig {
             .runtime
             .edit_fixslice_stagnation_score_threshold
             .clamp(1, 4);
+        // Issue #334: clamp read-heavy escalation thresholds.
+        // Score: 0 disables; otherwise bounded by score range [1, 4].
+        if self.runtime.edit_fixslice_read_heavy_score_threshold > 0 {
+            self.runtime.edit_fixslice_read_heavy_score_threshold = self
+                .runtime
+                .edit_fixslice_read_heavy_score_threshold
+                .clamp(1, 4);
+        }
+        self.runtime.edit_fixslice_read_heavy_drought_threshold = self
+            .runtime
+            .edit_fixslice_read_heavy_drought_threshold
+            .clamp(1, 40);
         self.runtime.edit_recovery_read_budget =
             self.runtime.edit_recovery_read_budget.clamp(1, 10);
     }
@@ -1591,6 +1633,14 @@ impl std::fmt::Debug for RuntimeConfig {
             .field(
                 "edit_fixslice_stagnation_score_threshold",
                 &self.edit_fixslice_stagnation_score_threshold,
+            )
+            .field(
+                "edit_fixslice_read_heavy_score_threshold",
+                &self.edit_fixslice_read_heavy_score_threshold,
+            )
+            .field(
+                "edit_fixslice_read_heavy_drought_threshold",
+                &self.edit_fixslice_read_heavy_drought_threshold,
             )
             .field("safe_write_max_lines", &self.safe_write_max_lines)
             .field("safe_write_deletion_ratio", &self.safe_write_deletion_ratio)

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -207,6 +207,20 @@ pub struct RuntimeConfig {
     /// now configurable so brittle-model workloads can be granted more
     /// attempts to produce a valid `FixSliceProposal`. Clamped to `[1, 10]`.
     pub fixslice_max_iterations: u32,
+    /// Same-target `file.read` oscillation threshold for the FixSlice
+    /// sub-agent no-progress detector (Issue #351 / Issue #353).
+    ///
+    /// `0` disables the guard entirely (B1 runaway workers will be caught
+    /// only by the runner wall-clock timeout). `>=1` sets the number of
+    /// consecutive iterations re-reading the same path that trip the
+    /// abort path. Clamped to `[0, 20]`.
+    ///
+    /// Cycle-11 regression showed the original hard-coded threshold of
+    /// `2` killed legitimate qwen3.5:122b exploration — the new default
+    /// is `5`, with env override `ANVIL_FIXSLICE_NO_PROGRESS_DETECTOR`
+    /// (accepts `on` / `off` / numeric value) and config key
+    /// `fixslice_no_progress_detector`.
+    pub fixslice_no_progress_detector: u32,
     /// Maximum line count for file.write on existing files (0 = disabled, Issue #156).
     pub safe_write_max_lines: usize,
     /// Deletion ratio threshold for diff warning (0.0-1.0, Issue #156).
@@ -351,6 +365,7 @@ pub const ENV_OVERRIDE_WHITELIST: &[&str] = &[
     "ANVIL_EDIT_REREAD_THRESHOLD",
     "ANVIL_EDIT_WRITE_FALLBACK_THRESHOLD",
     "ANVIL_FIXSLICE_MAX_ITERATIONS",
+    "ANVIL_FIXSLICE_NO_PROGRESS_DETECTOR",
     "ANVIL_SAFE_WRITE_MAX_LINES",
     "ANVIL_SAFE_WRITE_DELETION_RATIO",
     "ANVIL_UI_LANGUAGE",
@@ -458,6 +473,8 @@ impl EffectiveConfig {
                 edit_fixslice_read_heavy_score_threshold: 2,
                 edit_fixslice_read_heavy_drought_threshold: 5,
                 fixslice_max_iterations: crate::agent::subagent::DEFAULT_FIXSLICE_MAX_ITERATIONS,
+                fixslice_no_progress_detector:
+                    crate::agent::subagent::DEFAULT_FIXSLICE_REPEATED_READ_THRESHOLD,
                 safe_write_max_lines: 500,
                 safe_write_deletion_ratio: 0.5,
                 read_repeat_warn_threshold: 3,
@@ -979,6 +996,33 @@ impl EffectiveConfig {
                     }
                     self.runtime.fixslice_max_iterations = v;
                 }
+                "fixslice_no_progress_detector" | "ANVIL_FIXSLICE_NO_PROGRESS_DETECTOR" => {
+                    // Issue #353: accept `on` / `off` / numeric threshold.
+                    // `off` (alias: `disabled`, `false`, `0`) fully
+                    // disables the same-target read guard so brittle-model
+                    // workloads are caught only by the runner wall-clock
+                    // timeout. `on` (alias: `default`, `true`) restores the
+                    // default threshold. Any numeric value is used
+                    // directly and clamped later by `validate()`.
+                    let trimmed = value.trim();
+                    let parsed = match trimmed.to_ascii_lowercase().as_str() {
+                        "off" | "disabled" | "false" | "no" => Some(0u32),
+                        "on" | "true" | "yes" | "default" => {
+                            Some(crate::agent::subagent::DEFAULT_FIXSLICE_REPEATED_READ_THRESHOLD)
+                        }
+                        _ => None,
+                    };
+                    let v = match parsed {
+                        Some(v) => v,
+                        None => trimmed
+                            .parse::<u32>()
+                            .map_err(|_| ConfigError::InvalidNumericValue(value.clone()))?,
+                    };
+                    if v > 20 {
+                        return Err(ConfigError::InvalidNumericValue(value.clone()));
+                    }
+                    self.runtime.fixslice_no_progress_detector = v;
+                }
                 "edit_recovery_read_budget" | "ANVIL_EDIT_RECOVERY_READ_BUDGET" => {
                     let v: u32 = value
                         .parse()
@@ -1313,6 +1357,11 @@ impl EffectiveConfig {
             self.runtime.edit_recovery_read_budget.clamp(1, 10);
         // Issue #345: clamp fix_slice worker iteration cap to [1, 10].
         self.runtime.fixslice_max_iterations = self.runtime.fixslice_max_iterations.clamp(1, 10);
+        // Issue #353: clamp fix_slice no-progress detector threshold to
+        // [0, 20] — 0 disables the guard, values above 20 are treated as
+        // a misconfiguration (would exceed the FixSlice iteration cap).
+        self.runtime.fixslice_no_progress_detector =
+            self.runtime.fixslice_no_progress_detector.min(20);
     }
 
     pub fn validate_for_test(&mut self) -> Result<(), ConfigError> {
@@ -1689,6 +1738,10 @@ impl std::fmt::Debug for RuntimeConfig {
                 &self.edit_fixslice_read_heavy_drought_threshold,
             )
             .field("fixslice_max_iterations", &self.fixslice_max_iterations)
+            .field(
+                "fixslice_no_progress_detector",
+                &self.fixslice_no_progress_detector,
+            )
             .field("safe_write_max_lines", &self.safe_write_max_lines)
             .field("safe_write_deletion_ratio", &self.safe_write_deletion_ratio)
             .field("edit_recovery_read_budget", &self.edit_recovery_read_budget)

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -417,7 +417,15 @@ pub struct AgentTelemetry {
     #[serde(default)]
     pub mutation_observed: bool,
 
-    /// Whether the worker path (fix_slice escalation) was observed.
+    /// Whether the worker path produced a real post-execution mutation
+    /// (Issue #339).
+    ///
+    /// Set to true ONLY after a successful `agent.fix_slice` →
+    /// `file.rewrite` execution whose result survived rollback and no-op
+    /// filtering. Emitting a fix_slice escalation hint does NOT flip this
+    /// flag — escalation-emission is the request side and is tracked by
+    /// `fixslice_escalation_count` / `fixslice_escalation_same_path_count`
+    /// / `fixslice_escalation_stagnation_count`.
     #[serde(default)]
     pub worker_observed: bool,
 
@@ -570,22 +578,36 @@ impl AgentTelemetry {
     ///
     /// Triggered when consecutive edit failures on a single path reach the
     /// `edit_fixslice_threshold`. Bumps both the overall count and the
-    /// same-path counter and flips `worker_observed`.
+    /// same-path counter.
+    ///
+    /// Issue #339: this is a request-side signal (the runtime emitted the
+    /// escalation hint) and MUST NOT flip `worker_observed`. The success-
+    /// side flag is only set by [`record_worker_success`] after a real
+    /// post-execution worker mutation.
     pub fn record_fixslice_escalation(&mut self) {
         self.fixslice_escalation_count += 1;
         self.fixslice_escalation_same_path_count += 1;
-        self.worker_observed = true;
     }
 
     /// Record a stagnation-triggered fix_slice escalation (Issue #332).
     ///
     /// Triggered when the model scatters edit failures across multiple files
     /// so no same-path threshold is reached, but the session is clearly
-    /// stagnating. Bumps the overall count and the stagnation counter, and
-    /// flips `worker_observed`.
+    /// stagnating. Bumps the overall count and the stagnation counter.
+    ///
+    /// Issue #339: request-side only — does NOT flip `worker_observed`.
     pub fn record_fixslice_escalation_stagnation(&mut self) {
         self.fixslice_escalation_count += 1;
         self.fixslice_escalation_stagnation_count += 1;
+    }
+
+    /// Record a real post-execution worker event (Issue #339).
+    ///
+    /// Called only after the agent actually invoked `agent.fix_slice` and
+    /// its resulting `file.rewrite` completed without rollback and with a
+    /// non-empty, non-no-op summary. This is the success-side flag the
+    /// pack validation gate trusts.
+    pub fn record_worker_success(&mut self) {
         self.worker_observed = true;
     }
 

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -278,6 +278,10 @@ pub struct AgentTelemetry {
     /// None if no mutation occurred during the session.
     #[serde(default)]
     pub first_mutation_event_tool: Option<String>,
+
+    /// Number of times fix_slice escalation was triggered (Issue #321).
+    #[serde(default)]
+    pub fixslice_escalation_count: u32,
 }
 
 impl AgentTelemetry {
@@ -371,6 +375,11 @@ impl AgentTelemetry {
     /// Record an ANVIL_FINAL suppression with remaining core targets.
     pub fn record_final_suppressed_with_remaining_targets(&mut self) {
         self.final_suppressed_with_remaining_targets_count += 1;
+    }
+
+    /// Record a fix_slice escalation event (Issue #321).
+    pub fn record_fixslice_escalation(&mut self) {
+        self.fixslice_escalation_count += 1;
     }
 
     /// Threshold: mutations after this turn are considered "late".

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -114,33 +114,54 @@ pub struct FixSliceProposal {
 }
 
 /// Why a FixSlice worker invocation failed to reach a successful worker
-/// mutation (Issue #343).
+/// mutation (Issue #343, extended in Issue #345).
 ///
-/// Emitted by `handle_fixslice_result` and recorded on `AgentTelemetry` via
-/// `record_fixslice_worker_failure`. The runtime uses the recorded failure
+/// Emitted by `handle_fixslice_result` (per-invocation) and by
+/// `AgentTelemetry::finalize_fixslice_outcome` (session wrap-up) and recorded
+/// via `record_fixslice_worker_failure`. The runtime uses the recorded failure
 /// to decide whether the pre-exit repair turn should still be injected under
 /// a `requires_worker_observation` pack — see
 /// `AgentTelemetry::should_skip_pre_exit_repair_for_worker_failure`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FixSliceFailureReason {
-    /// Worker finished (normal termination) without emitting a proposal.
+    /// Worker finished (normal termination) with a blank / tool-only final
+    /// response. Narrow sense after Issue #345 — parse failures and path
+    /// mismatches now get their own variants.
     NoProposal,
-    /// Worker emitted a proposal but `validate_fix_proposal` rejected it.
+    /// Worker produced a non-empty final response but it could not be parsed
+    /// into a `FixSliceProposal`, even after the salvage pass that extracts
+    /// embedded JSON (Issue #345).
+    ProposalParseFailed,
+    /// Worker returned a parseable proposal but its `target_path` did not
+    /// match the original target (Issue #345). Previously lumped into
+    /// `ProposalValidationFailed`; split out because it is the most actionable
+    /// subclass of the B1 shape.
+    PathMismatch,
+    /// Worker emitted a proposal but `validate_fix_proposal` rejected it for
+    /// a reason other than path mismatch (sandbox, control chars, empty
+    /// replacement, line range).
     ProposalValidationFailed,
     /// Proposal was valid, but the worker-owned `file.rewrite` did not
     /// complete cleanly (failed / rolled back / produced a no-op diff).
     RewriteFailed,
     /// Worker hit its iteration cap before producing a proposal.
     MaxIterationsReached,
+    /// An escalation hint fired, but `agent.fix_slice` was never invoked by
+    /// the LLM during the session (Issue #345, A1 shape). Recorded only at
+    /// session wrap-up via `finalize_fixslice_outcome`.
+    EscalatedNotInvoked,
 }
 
 impl std::fmt::Display for FixSliceFailureReason {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::NoProposal => write!(f, "no_proposal"),
+            Self::ProposalParseFailed => write!(f, "proposal_parse_failed"),
+            Self::PathMismatch => write!(f, "path_mismatch"),
             Self::ProposalValidationFailed => write!(f, "proposal_validation_failed"),
             Self::RewriteFailed => write!(f, "rewrite_failed"),
             Self::MaxIterationsReached => write!(f, "max_iterations_reached"),
+            Self::EscalatedNotInvoked => write!(f, "escalated_not_invoked"),
         }
     }
 }
@@ -490,6 +511,18 @@ pub struct AgentTelemetry {
     /// `None` until the first failure is recorded.
     #[serde(default)]
     pub fixslice_failure_reason: Option<String>,
+
+    /// Number of times `agent.fix_slice` was actually invoked during the
+    /// session (Issue #345).
+    ///
+    /// Incremented before `handle_fixslice_result` runs, so the counter
+    /// reflects every invocation attempt regardless of whether the worker
+    /// reached a successful mutation. Used by `finalize_fixslice_outcome` to
+    /// distinguish the A1 shape (`fixslice_escalation_count > 0` but
+    /// `fixslice_worker_invocation_count == 0`) from a session where the
+    /// worker was invoked and failed for a concrete reason.
+    #[serde(default)]
+    pub fixslice_worker_invocation_count: u32,
 }
 
 impl AgentTelemetry {
@@ -671,6 +704,41 @@ impl AgentTelemetry {
         self.fixslice_failure_reason = Some(reason.to_string());
     }
 
+    /// Record an `agent.fix_slice` invocation attempt (Issue #345).
+    ///
+    /// Called from the agentic loop before `handle_fixslice_result` runs so
+    /// the counter reflects every attempted invocation, even ones that fail
+    /// before producing a proposal.
+    pub fn record_fixslice_worker_invocation(&mut self) {
+        self.fixslice_worker_invocation_count += 1;
+    }
+
+    /// Classify the session's FixSlice outcome at wrap-up time (Issue #345).
+    ///
+    /// When one or more escalations fired but `agent.fix_slice` was never
+    /// actually invoked and no worker success was recorded, the session is
+    /// the A1 shape from Issue #345: the LLM ignored the escalation hint and
+    /// the parent's own `file.edit` landed the mutation. This records an
+    /// `EscalatedNotInvoked` failure so telemetry and the pre-exit repair
+    /// guard can distinguish it from sessions that never escalated.
+    ///
+    /// Idempotent: calling this more than once will not double-record the
+    /// failure. Safe to invoke from multiple loop exit branches.
+    pub fn finalize_fixslice_outcome(&mut self) {
+        if self.fixslice_escalation_count == 0
+            || self.fixslice_worker_invocation_count > 0
+            || self.worker_observed
+        {
+            return;
+        }
+        if self.fixslice_failure_reason.as_deref()
+            == Some(&FixSliceFailureReason::EscalatedNotInvoked.to_string())
+        {
+            return;
+        }
+        self.record_fixslice_worker_failure(FixSliceFailureReason::EscalatedNotInvoked);
+    }
+
     /// Whether any FixSlice worker failure has been recorded (Issue #343).
     pub fn has_fixslice_worker_failure(&self) -> bool {
         self.fixslice_worker_failure_count > 0
@@ -836,6 +904,8 @@ impl AgentTelemetry {
             // Issue #343: fix_slice worker failure taxonomy.
             "fixslice_worker_failure_count": self.fixslice_worker_failure_count,
             "fixslice_failure_reason": self.fixslice_failure_reason,
+            // Issue #345: fix_slice worker invocation tracking.
+            "fixslice_worker_invocation_count": self.fixslice_worker_invocation_count,
         });
 
         let json_bytes = serde_json::to_vec_pretty(&payload)?;

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -531,6 +531,21 @@ pub struct AgentTelemetry {
     /// worker was invoked and failed for a concrete reason.
     #[serde(default)]
     pub fixslice_worker_invocation_count: u32,
+
+    /// Number of times the post-escalation fix_slice routing barrier
+    /// blocked a parent-side mutation tool (Issue #355). Incremented every
+    /// time `EscalationBarrier` filters out a `file.edit` / `file.write` /
+    /// `file.edit_anchor` call because the pack is worker-required and
+    /// `agent.fix_slice` has not yet been invoked after an escalation.
+    #[serde(default)]
+    pub escalation_barrier_block_count: u32,
+
+    /// Number of times the worker-required early exit fired (Issue #355).
+    /// A positive value means the session terminated cleanly after
+    /// `pack_validation_result=satisfied` + `worker_observed=true`, without
+    /// waiting for the 600s runner timeout.
+    #[serde(default)]
+    pub worker_required_early_exit_count: u32,
 }
 
 impl AgentTelemetry {
@@ -773,6 +788,53 @@ impl AgentTelemetry {
             && !self.worker_observed
     }
 
+    /// Whether parent-side mutation tools should be suspended until
+    /// `agent.fix_slice` is invoked (Issue #355, Bug 1).
+    ///
+    /// Returns true iff all of the following hold:
+    /// - `pack_expectation` is `RequiresWorkerObservation`,
+    /// - at least one fix_slice escalation has been recorded,
+    /// - `agent.fix_slice` has not yet been invoked (`fixslice_worker_invocation_count == 0`),
+    /// - no worker success has been recorded.
+    ///
+    /// Pack-scoped on purpose: under other pack expectations parent-side
+    /// mutations are legitimate, so the barrier stays inactive.
+    pub fn should_force_fixslice_routing(&self) -> bool {
+        matches!(
+            self.pack_expectation,
+            Some(PackExpectation::RequiresWorkerObservation)
+        ) && self.fixslice_escalation_count > 0
+            && self.fixslice_worker_invocation_count == 0
+            && !self.worker_observed
+    }
+
+    /// Whether the session should terminate early because the pack
+    /// expectation has already been satisfied by worker-path evidence
+    /// (Issue #355, Bug 2).
+    ///
+    /// Returns true iff `pack_expectation == RequiresWorkerObservation`
+    /// and `worker_observed == true`. The agentic loop consults this just
+    /// before the follow-up LLM call and breaks when it flips true, which
+    /// keeps worker-satisfied sessions from burning the 600s runner
+    /// timeout.
+    pub fn should_early_exit_after_worker_success(&self) -> bool {
+        matches!(
+            self.pack_expectation,
+            Some(PackExpectation::RequiresWorkerObservation)
+        ) && self.worker_observed
+    }
+
+    /// Record that the post-escalation fix_slice routing barrier blocked a
+    /// parent-side mutation (Issue #355).
+    pub fn record_escalation_barrier_block(&mut self) {
+        self.escalation_barrier_block_count += 1;
+    }
+
+    /// Record that the worker-required early exit fired (Issue #355).
+    pub fn record_worker_required_early_exit(&mut self) {
+        self.worker_required_early_exit_count += 1;
+    }
+
     /// Retrospectively classify the session as a repair-turn-only salvage (Issue #332).
     ///
     /// Fires at most once per session. A salvage run is one where:
@@ -914,6 +976,9 @@ impl AgentTelemetry {
             "fixslice_failure_reason": self.fixslice_failure_reason,
             // Issue #345: fix_slice worker invocation tracking.
             "fixslice_worker_invocation_count": self.fixslice_worker_invocation_count,
+            // Issue #355: escalation routing barrier + early-exit counters.
+            "escalation_barrier_block_count": self.escalation_barrier_block_count,
+            "worker_required_early_exit_count": self.worker_required_early_exit_count,
         });
 
         let json_bytes = serde_json::to_vec_pretty(&payload)?;

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -282,6 +282,14 @@ pub struct AgentTelemetry {
     /// Number of times fix_slice escalation was triggered (Issue #321).
     #[serde(default)]
     pub fixslice_escalation_count: u32,
+
+    /// Number of pre-exit repair turns injected (Issue #325).
+    #[serde(default)]
+    pub pre_exit_repair_injected_count: u32,
+
+    /// Number of pre-exit repair turns actually consumed by the LLM (Issue #325).
+    #[serde(default)]
+    pub pre_exit_repair_consumed_count: u32,
 }
 
 impl AgentTelemetry {
@@ -351,6 +359,16 @@ impl AgentTelemetry {
     /// Record an ANVIL_PLAN block observed (visible to external telemetry).
     pub fn record_anvil_plan_visible(&mut self) {
         self.anvil_plan_visible_count += 1;
+    }
+
+    /// Record a pre-exit repair turn injection (Issue #325).
+    pub fn record_pre_exit_repair_injected(&mut self) {
+        self.pre_exit_repair_injected_count += 1;
+    }
+
+    /// Record a pre-exit repair turn consumed by LLM (Issue #325).
+    pub fn record_pre_exit_repair_consumed(&mut self) {
+        self.pre_exit_repair_consumed_count += 1;
     }
 
     /// Record a pre-mutation barrier block (Issue #303).

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -290,6 +290,22 @@ pub struct AgentTelemetry {
     /// Number of pre-exit repair turns actually consumed by the LLM (Issue #325).
     #[serde(default)]
     pub pre_exit_repair_consumed_count: u32,
+
+    /// Number of unchecked plan items rejected during repair closure mode (Issue #327).
+    #[serde(default)]
+    pub repair_turn_items_rejected: u32,
+
+    /// Number of plan items retired during repair turn (Issue #327).
+    #[serde(default)]
+    pub repair_turn_items_retired: u32,
+
+    /// Number of pending plan items before repair turn (Issue #327).
+    #[serde(default)]
+    pub repair_turn_pending_before: Option<u32>,
+
+    /// Number of pending plan items after repair turn (Issue #327).
+    #[serde(default)]
+    pub repair_turn_pending_after: Option<u32>,
 }
 
 impl AgentTelemetry {
@@ -369,6 +385,26 @@ impl AgentTelemetry {
     /// Record a pre-exit repair turn consumed by LLM (Issue #325).
     pub fn record_pre_exit_repair_consumed(&mut self) {
         self.pre_exit_repair_consumed_count += 1;
+    }
+
+    /// Record unchecked items rejected during repair closure mode (Issue #327).
+    pub fn record_repair_turn_items_rejected(&mut self, count: u32) {
+        self.repair_turn_items_rejected += count;
+    }
+
+    /// Record items retired during repair turn (Issue #327).
+    pub fn record_repair_turn_items_retired(&mut self, count: u32) {
+        self.repair_turn_items_retired += count;
+    }
+
+    /// Snapshot pending item count before repair turn (Issue #327).
+    pub fn record_repair_turn_pending_before(&mut self, count: u32) {
+        self.repair_turn_pending_before = Some(count);
+    }
+
+    /// Snapshot pending item count after repair turn (Issue #327).
+    pub fn record_repair_turn_pending_after(&mut self, count: u32) {
+        self.repair_turn_pending_after = Some(count);
     }
 
     /// Record a pre-mutation barrier block (Issue #303).

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -364,6 +364,22 @@ pub struct AgentTelemetry {
     #[serde(default)]
     pub fixslice_escalation_count: u32,
 
+    /// Fix_slice escalations triggered by consecutive same-path edit failures (Issue #332).
+    #[serde(default)]
+    pub fixslice_escalation_same_path_count: u32,
+
+    /// Fix_slice escalations triggered by stagnation + cross-path edit failures (Issue #332).
+    #[serde(default)]
+    pub fixslice_escalation_stagnation_count: u32,
+
+    /// Retrospective count of repair-turn-only salvage runs (Issue #332).
+    ///
+    /// Set by `classify_repair_salvage()` when a session produced a mutation
+    /// via the pre-exit repair turn but never reached the intended worker path.
+    /// Does NOT flip `worker_observed` — it is a distinct outcome classification.
+    #[serde(default)]
+    pub fixslice_escalation_repair_salvage_count: u32,
+
     /// Number of pre-exit repair turns injected (Issue #325).
     #[serde(default)]
     pub pre_exit_repair_injected_count: u32,
@@ -537,10 +553,46 @@ impl AgentTelemetry {
         self.final_suppressed_with_remaining_targets_count += 1;
     }
 
-    /// Record a fix_slice escalation event (Issue #321).
+    /// Record a same-path fix_slice escalation event (Issue #321, #332).
+    ///
+    /// Triggered when consecutive edit failures on a single path reach the
+    /// `edit_fixslice_threshold`. Bumps both the overall count and the
+    /// same-path counter and flips `worker_observed`.
     pub fn record_fixslice_escalation(&mut self) {
         self.fixslice_escalation_count += 1;
+        self.fixslice_escalation_same_path_count += 1;
         self.worker_observed = true;
+    }
+
+    /// Record a stagnation-triggered fix_slice escalation (Issue #332).
+    ///
+    /// Triggered when the model scatters edit failures across multiple files
+    /// so no same-path threshold is reached, but the session is clearly
+    /// stagnating. Bumps the overall count and the stagnation counter, and
+    /// flips `worker_observed`.
+    pub fn record_fixslice_escalation_stagnation(&mut self) {
+        self.fixslice_escalation_count += 1;
+        self.fixslice_escalation_stagnation_count += 1;
+        self.worker_observed = true;
+    }
+
+    /// Retrospectively classify the session as a repair-turn-only salvage (Issue #332).
+    ///
+    /// Fires at most once per session. A salvage run is one where:
+    /// - the pre-exit repair turn was observed, AND
+    /// - a mutation was observed, AND
+    /// - no worker path was reached.
+    ///
+    /// Does NOT flip `worker_observed`; it only increments the salvage counter
+    /// so pack validation and observability can distinguish a true worker run
+    /// from a late-repair salvage.
+    pub fn classify_repair_salvage(&mut self) {
+        if self.fixslice_escalation_repair_salvage_count > 0 {
+            return;
+        }
+        if self.repair_turn_observed && self.mutation_observed && !self.worker_observed {
+            self.fixslice_escalation_repair_salvage_count = 1;
+        }
     }
 
     /// Threshold: mutations after this turn are considered "late".
@@ -654,6 +706,12 @@ impl AgentTelemetry {
             "repair_turn_observed": self.repair_turn_observed,
             "pack_expectation": self.pack_expectation.map(|e| e.to_string()),
             "expectation_mismatch_reason": self.expectation_mismatch_reason,
+            // Issue #332: distinguishing fix_slice escalation reasons.
+            "fixslice_escalation_count": self.fixslice_escalation_count,
+            "fixslice_escalation_same_path_count": self.fixslice_escalation_same_path_count,
+            "fixslice_escalation_stagnation_count": self.fixslice_escalation_stagnation_count,
+            "fixslice_escalation_repair_salvage_count":
+                self.fixslice_escalation_repair_salvage_count,
         });
 
         let json_bytes = serde_json::to_vec_pretty(&payload)?;

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -150,6 +150,13 @@ pub enum FixSliceFailureReason {
     /// the LLM during the session (Issue #345, A1 shape). Recorded only at
     /// session wrap-up via `finalize_fixslice_outcome`.
     EscalatedNotInvoked,
+    /// The FixSlice sub-agent aborted early because it kept issuing
+    /// `file.read` calls against the same target path without producing a
+    /// proposal (Issue #351, B1 shape). The subagent's `run_turn` loop
+    /// detects same-path read oscillation and terminates with this class
+    /// so the parent can classify the session as pack_gate_invalid
+    /// instead of letting it burn through the remaining iteration budget.
+    RepeatedReadLoop,
 }
 
 impl std::fmt::Display for FixSliceFailureReason {
@@ -162,6 +169,7 @@ impl std::fmt::Display for FixSliceFailureReason {
             Self::RewriteFailed => write!(f, "rewrite_failed"),
             Self::MaxIterationsReached => write!(f, "max_iterations_reached"),
             Self::EscalatedNotInvoked => write!(f, "escalated_not_invoked"),
+            Self::RepeatedReadLoop => write!(f, "repeated_read_loop"),
         }
     }
 }

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -393,6 +393,13 @@ pub struct AgentTelemetry {
     #[serde(default)]
     pub repair_turn_items_rejected: u32,
 
+    /// Number of unchecked plan items rejected by the late-stage closure guard
+    /// (Issue #336).  Counts follow-up `ANVIL_PLAN` / `ANVIL_PLAN_UPDATE` items
+    /// that targeted the single remaining plan item while late-stage closure
+    /// mode was active, preventing endless supersede→append churn.
+    #[serde(default)]
+    pub late_stage_closure_items_rejected: u32,
+
     /// Number of plan items retired during repair turn (Issue #327).
     #[serde(default)]
     pub repair_turn_items_retired: u32,
@@ -512,6 +519,11 @@ impl AgentTelemetry {
     /// Record unchecked items rejected during repair closure mode (Issue #327).
     pub fn record_repair_turn_items_rejected(&mut self, count: u32) {
         self.repair_turn_items_rejected += count;
+    }
+
+    /// Record unchecked items rejected by the late-stage closure guard (Issue #336).
+    pub fn record_late_stage_closure_items_rejected(&mut self, count: u32) {
+        self.late_stage_closure_items_rejected += count;
     }
 
     /// Record items retired during repair turn (Issue #327).

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -91,6 +91,29 @@ impl SubAgentPayload {
 }
 
 // ---------------------------------------------------------------------------
+// FixSlice proposal (Issue #291)
+// ---------------------------------------------------------------------------
+
+/// A structured proposal returned by the FixSlice sub-agent.
+///
+/// The sub-agent produces this as its ANVIL_FINAL output; the parent validates
+/// and applies it via the normal `file.rewrite` execution path.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FixSliceProposal {
+    /// Target file path (relative, must match the parent-specified path).
+    pub target_path: String,
+    /// First line of the replacement range (1-based, inclusive).
+    pub start_line: u32,
+    /// Last line of the replacement range (1-based, inclusive).
+    pub end_line: u32,
+    /// The replacement content for the specified line range.
+    pub replacement_content: String,
+    /// Human-readable rationale for the change.
+    #[serde(default)]
+    pub rationale: String,
+}
+
+// ---------------------------------------------------------------------------
 // Completion taxonomy (Issue #255: AgentPhase integration)
 // ---------------------------------------------------------------------------
 

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -113,6 +113,38 @@ pub struct FixSliceProposal {
     pub rationale: String,
 }
 
+/// Why a FixSlice worker invocation failed to reach a successful worker
+/// mutation (Issue #343).
+///
+/// Emitted by `handle_fixslice_result` and recorded on `AgentTelemetry` via
+/// `record_fixslice_worker_failure`. The runtime uses the recorded failure
+/// to decide whether the pre-exit repair turn should still be injected under
+/// a `requires_worker_observation` pack — see
+/// `AgentTelemetry::should_skip_pre_exit_repair_for_worker_failure`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FixSliceFailureReason {
+    /// Worker finished (normal termination) without emitting a proposal.
+    NoProposal,
+    /// Worker emitted a proposal but `validate_fix_proposal` rejected it.
+    ProposalValidationFailed,
+    /// Proposal was valid, but the worker-owned `file.rewrite` did not
+    /// complete cleanly (failed / rolled back / produced a no-op diff).
+    RewriteFailed,
+    /// Worker hit its iteration cap before producing a proposal.
+    MaxIterationsReached,
+}
+
+impl std::fmt::Display for FixSliceFailureReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NoProposal => write!(f, "no_proposal"),
+            Self::ProposalValidationFailed => write!(f, "proposal_validation_failed"),
+            Self::RewriteFailed => write!(f, "rewrite_failed"),
+            Self::MaxIterationsReached => write!(f, "max_iterations_reached"),
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Pack expectation / validation gate (Issue #329)
 // ---------------------------------------------------------------------------
@@ -441,6 +473,23 @@ pub struct AgentTelemetry {
     /// `None` when expectation is satisfied or unset.
     #[serde(default)]
     pub expectation_mismatch_reason: Option<String>,
+
+    /// Number of times a FixSlice worker invocation failed to reach a
+    /// successful worker mutation (Issue #343).
+    ///
+    /// Counts every failure class (`no_proposal`, `proposal_validation_failed`,
+    /// `rewrite_failed`, `max_iterations_reached`). Independent of
+    /// `fixslice_escalation_count`, which tracks request-side escalation
+    /// emission.
+    #[serde(default)]
+    pub fixslice_worker_failure_count: u32,
+
+    /// Most recent FixSlice worker failure reason (Issue #343).
+    ///
+    /// Serialized as the snake_case form of `FixSliceFailureReason`.
+    /// `None` until the first failure is recorded.
+    #[serde(default)]
+    pub fixslice_failure_reason: Option<String>,
 }
 
 impl AgentTelemetry {
@@ -611,6 +660,43 @@ impl AgentTelemetry {
         self.worker_observed = true;
     }
 
+    /// Record a FixSlice worker failure (Issue #343).
+    ///
+    /// Called from `handle_fixslice_result` whenever an invocation of
+    /// `agent.fix_slice` does not reach a successful worker mutation. Bumps
+    /// the running count and stores the latest reason. Does NOT touch
+    /// `worker_observed`: success-side semantics are preserved from Issue #339.
+    pub fn record_fixslice_worker_failure(&mut self, reason: FixSliceFailureReason) {
+        self.fixslice_worker_failure_count += 1;
+        self.fixslice_failure_reason = Some(reason.to_string());
+    }
+
+    /// Whether any FixSlice worker failure has been recorded (Issue #343).
+    pub fn has_fixslice_worker_failure(&self) -> bool {
+        self.fixslice_worker_failure_count > 0
+    }
+
+    /// Whether the pre-exit repair turn should be skipped because the
+    /// worker path has already failed under a `requires_worker_observation`
+    /// pack (Issue #343).
+    ///
+    /// Returns true when all of the following hold:
+    /// - `pack_expectation` is `RequiresWorkerObservation`,
+    /// - at least one FixSlice worker failure has been recorded,
+    /// - `worker_observed` is still false.
+    ///
+    /// The agentic loop uses this to bail out cleanly instead of injecting
+    /// a repair turn that would only flip `repair_turn_observed` and
+    /// degrade `completion_kind` to `partial` without ever satisfying the
+    /// pack expectation.
+    pub fn should_skip_pre_exit_repair_for_worker_failure(&self) -> bool {
+        matches!(
+            self.pack_expectation,
+            Some(PackExpectation::RequiresWorkerObservation)
+        ) && self.has_fixslice_worker_failure()
+            && !self.worker_observed
+    }
+
     /// Retrospectively classify the session as a repair-turn-only salvage (Issue #332).
     ///
     /// Fires at most once per session. A salvage run is one where:
@@ -747,6 +833,9 @@ impl AgentTelemetry {
             "fixslice_escalation_stagnation_count": self.fixslice_escalation_stagnation_count,
             "fixslice_escalation_repair_salvage_count":
                 self.fixslice_escalation_repair_salvage_count,
+            // Issue #343: fix_slice worker failure taxonomy.
+            "fixslice_worker_failure_count": self.fixslice_worker_failure_count,
+            "fixslice_failure_reason": self.fixslice_failure_reason,
         });
 
         let json_bytes = serde_json::to_vec_pretty(&payload)?;

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -114,6 +114,87 @@ pub struct FixSliceProposal {
 }
 
 // ---------------------------------------------------------------------------
+// Pack expectation / validation gate (Issue #329)
+// ---------------------------------------------------------------------------
+
+/// Declares what a benchmark pack expects from the session.
+///
+/// Read from `$ANVIL_PACK_EXPECTATION` at session start.
+/// When unset the harness applies no pack-level gate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PackExpectation {
+    /// The prompt is a follow-up audit; a no-op / zero-mutation completion is
+    /// a valid success path.
+    AuditOnly,
+    /// The pack requires at least one real file mutation (`changed_files > 0`).
+    RequiresMutation,
+    /// The pack requires observable worker-path evidence: fix_slice escalation,
+    /// pre-exit repair turn, *or* mutation.
+    RequiresWorkerObservation,
+}
+
+impl PackExpectation {
+    /// Parse from the raw env-var value.  Returns `None` for unknown strings.
+    pub fn from_env_str(s: &str) -> Option<Self> {
+        match s {
+            "audit_only" => Some(Self::AuditOnly),
+            "requires_mutation" => Some(Self::RequiresMutation),
+            "requires_worker_observation" => Some(Self::RequiresWorkerObservation),
+            _ => None,
+        }
+    }
+
+    /// Read from `$ANVIL_PACK_EXPECTATION`.  Returns `None` when unset or empty.
+    pub fn from_env() -> Option<Self> {
+        let raw = std::env::var("ANVIL_PACK_EXPECTATION").ok()?;
+        if raw.is_empty() {
+            return None;
+        }
+        Self::from_env_str(&raw)
+    }
+}
+
+impl std::fmt::Display for PackExpectation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::AuditOnly => write!(f, "audit_only"),
+            Self::RequiresMutation => write!(f, "requires_mutation"),
+            Self::RequiresWorkerObservation => write!(f, "requires_worker_observation"),
+        }
+    }
+}
+
+/// Result of validating telemetry against a pack expectation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PackValidationResult {
+    /// No pack expectation was set — nothing to validate.
+    NoExpectation,
+    /// Telemetry satisfies the expectation.
+    Satisfied,
+    /// Telemetry does NOT satisfy the expectation.
+    Mismatch {
+        expectation: PackExpectation,
+        reason: String,
+    },
+}
+
+impl std::fmt::Display for PackValidationResult {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NoExpectation => write!(f, "no_expectation"),
+            Self::Satisfied => write!(f, "satisfied"),
+            Self::Mismatch {
+                expectation,
+                reason,
+            } => {
+                write!(f, "mismatch({expectation}): {reason}")
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Completion taxonomy (Issue #255: AgentPhase integration)
 // ---------------------------------------------------------------------------
 
@@ -306,6 +387,28 @@ pub struct AgentTelemetry {
     /// Number of pending plan items after repair turn (Issue #327).
     #[serde(default)]
     pub repair_turn_pending_after: Option<u32>,
+
+    // ---- Pack validation gate (Issue #329) ----
+    /// Whether at least one mutation (file change) was observed during the session.
+    #[serde(default)]
+    pub mutation_observed: bool,
+
+    /// Whether the worker path (fix_slice escalation) was observed.
+    #[serde(default)]
+    pub worker_observed: bool,
+
+    /// Whether a pre-exit repair turn was observed.
+    #[serde(default)]
+    pub repair_turn_observed: bool,
+
+    /// Pack expectation that was active for this session (from `$ANVIL_PACK_EXPECTATION`).
+    #[serde(default)]
+    pub pack_expectation: Option<PackExpectation>,
+
+    /// Mismatch reason when the session did not satisfy the pack expectation.
+    /// `None` when expectation is satisfied or unset.
+    #[serde(default)]
+    pub expectation_mismatch_reason: Option<String>,
 }
 
 impl AgentTelemetry {
@@ -380,11 +483,13 @@ impl AgentTelemetry {
     /// Record a pre-exit repair turn injection (Issue #325).
     pub fn record_pre_exit_repair_injected(&mut self) {
         self.pre_exit_repair_injected_count += 1;
+        self.repair_turn_observed = true;
     }
 
     /// Record a pre-exit repair turn consumed by LLM (Issue #325).
     pub fn record_pre_exit_repair_consumed(&mut self) {
         self.pre_exit_repair_consumed_count += 1;
+        self.repair_turn_observed = true;
     }
 
     /// Record unchecked items rejected during repair closure mode (Issue #327).
@@ -419,6 +524,7 @@ impl AgentTelemetry {
     /// (i.e. from `crate::app::MUTATION_TOOLS`) to avoid storing arbitrary strings.
     pub fn record_mutation_turn(&mut self, turn: u32, elapsed_s: Option<f64>, tool_name: &str) {
         self.last_mutation_turn = turn;
+        self.mutation_observed = true;
         if self.first_mutation_event_turn.is_none() {
             self.first_mutation_event_turn = Some(turn);
             self.first_mutation_event_elapsed_s = elapsed_s;
@@ -434,6 +540,7 @@ impl AgentTelemetry {
     /// Record a fix_slice escalation event (Issue #321).
     pub fn record_fixslice_escalation(&mut self) {
         self.fixslice_escalation_count += 1;
+        self.worker_observed = true;
     }
 
     /// Threshold: mutations after this turn are considered "late".
@@ -541,6 +648,12 @@ impl AgentTelemetry {
             "first_mutation_event_elapsed_s": self.first_mutation_event_elapsed_s,
             "first_mutation_event_tool": self.first_mutation_event_tool,
             "first_mutation_event_semantic_basis": "runtime_lower_bound",
+            // Issue #329: pack validation gate observability fields
+            "mutation_observed": self.mutation_observed,
+            "worker_observed": self.worker_observed,
+            "repair_turn_observed": self.repair_turn_observed,
+            "pack_expectation": self.pack_expectation.map(|e| e.to_string()),
+            "expectation_mismatch_reason": self.expectation_mismatch_reason,
         });
 
         let json_bytes = serde_json::to_vec_pretty(&payload)?;
@@ -556,6 +669,61 @@ impl AgentTelemetry {
         file.write_all(&json_bytes)?;
 
         Ok(())
+    }
+
+    /// Validate telemetry against the active pack expectation (Issue #329).
+    ///
+    /// Reads `$ANVIL_PACK_EXPECTATION` from the environment.
+    /// Call this after `completion_kind` is set.  Updates `pack_expectation`
+    /// and `expectation_mismatch_reason` fields.
+    pub fn validate_pack_expectation(&mut self) -> PackValidationResult {
+        let expectation = match PackExpectation::from_env() {
+            Some(exp) => exp,
+            None => return PackValidationResult::NoExpectation,
+        };
+        self.validate_against(expectation)
+    }
+
+    /// Validate telemetry against the given expectation (Issue #329).
+    ///
+    /// This is the testable core; `validate_pack_expectation` is the
+    /// env-reading convenience wrapper.
+    pub fn validate_against(&mut self, expectation: PackExpectation) -> PackValidationResult {
+        self.pack_expectation = Some(expectation);
+
+        match expectation {
+            PackExpectation::AuditOnly => PackValidationResult::Satisfied,
+
+            PackExpectation::RequiresMutation => {
+                if self.mutation_observed {
+                    PackValidationResult::Satisfied
+                } else {
+                    let reason =
+                        "pack requires mutation but session completed with zero file changes"
+                            .to_string();
+                    self.expectation_mismatch_reason = Some(reason.clone());
+                    PackValidationResult::Mismatch {
+                        expectation,
+                        reason,
+                    }
+                }
+            }
+
+            PackExpectation::RequiresWorkerObservation => {
+                if self.worker_observed || self.repair_turn_observed || self.mutation_observed {
+                    PackValidationResult::Satisfied
+                } else {
+                    let reason = "pack requires worker observation but no worker path, \
+                                  repair turn, or mutation was observed"
+                        .to_string();
+                    self.expectation_mismatch_reason = Some(reason.clone());
+                    PackValidationResult::Mismatch {
+                        expectation,
+                        reason,
+                    }
+                }
+            }
+        }
     }
 
     /// Premature Final Request Rate: ratio of suppressed finals to total finals.

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -129,8 +129,9 @@ pub enum PackExpectation {
     AuditOnly,
     /// The pack requires at least one real file mutation (`changed_files > 0`).
     RequiresMutation,
-    /// The pack requires observable worker-path evidence: fix_slice escalation,
-    /// pre-exit repair turn, *or* mutation.
+    /// The pack requires observable worker-path evidence: only a fix_slice
+    /// escalation (`worker_observed=true`) satisfies this gate. Repair-turn
+    /// or mutation-only salvage is explicitly rejected (Issue #334).
     RequiresWorkerObservation,
 }
 
@@ -768,11 +769,15 @@ impl AgentTelemetry {
             }
 
             PackExpectation::RequiresWorkerObservation => {
-                if self.worker_observed || self.repair_turn_observed || self.mutation_observed {
+                // Issue #334: repair-turn or mutation-only salvage must NOT
+                // satisfy this gate. Only actual worker-path observation
+                // (fix_slice escalation) counts, so runtime semantics agree
+                // with the strict benchmark runner classification.
+                if self.worker_observed {
                     PackValidationResult::Satisfied
                 } else {
-                    let reason = "pack requires worker observation but no worker path, \
-                                  repair turn, or mutation was observed"
+                    let reason = "pack requires worker path (fix_slice escalation) but \
+                                  worker was not observed"
                         .to_string();
                     self.expectation_mismatch_reason = Some(reason.clone());
                     PackValidationResult::Mismatch {

--- a/src/provider/openai.rs
+++ b/src/provider/openai.rs
@@ -220,6 +220,7 @@ fn normalize_openai_tool_name(name: &str) -> String {
         "file_edit" => "file.edit".to_string(),
         "file_search" => "file.search".to_string(),
         "file_edit_anchor" => "file.edit_anchor".to_string(),
+        "file_rewrite" => "file.rewrite".to_string(),
         "shell_exec" => "shell.exec".to_string(),
         "web_fetch" => "web.fetch".to_string(),
         "web_search" => "web.search".to_string(),

--- a/src/provider/openai.rs
+++ b/src/provider/openai.rs
@@ -226,6 +226,7 @@ fn normalize_openai_tool_name(name: &str) -> String {
         "web_search" => "web.search".to_string(),
         "agent_explore" => "agent.explore".to_string(),
         "agent_plan" => "agent.plan".to_string(),
+        "agent_fix_slice" => "agent.fix_slice".to_string(),
         "git_status" => "git.status".to_string(),
         "git_diff" => "git.diff".to_string(),
         "git_log" => "git.log".to_string(),

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -1417,7 +1417,9 @@ pub fn extract_session_notes(messages: &[SessionMessage]) -> Vec<SessionNote> {
         }
 
         let kind = match msg.author.as_str() {
-            "file.edit" | "file.write" => Some(NoteKind::FileEdit),
+            "file.edit" | "file.edit_anchor" | "file.rewrite" | "file.write" => {
+                Some(NoteKind::FileEdit)
+            }
             "file.read" => Some(NoteKind::FileRead),
             "shell.exec" => Some(NoteKind::ShellExec),
             _ => None,

--- a/src/tooling/diff.rs
+++ b/src/tooling/diff.rs
@@ -74,7 +74,9 @@ pub fn generate_diff_preview(
         // MCP tools do not have diff previews
         ToolInput::Mcp { .. } => None,
         // Agent tools do not have diff previews
-        ToolInput::AgentExplore { .. } | ToolInput::AgentPlan { .. } => None,
+        ToolInput::AgentExplore { .. }
+        | ToolInput::AgentPlan { .. }
+        | ToolInput::AgentFixSlice { .. } => None,
         _ => None,
     }
 }

--- a/src/tooling/diff.rs
+++ b/src/tooling/diff.rs
@@ -65,6 +65,12 @@ pub fn generate_diff_preview(
         ToolInput::FileEditAnchor { params, .. } => {
             generate_file_edit_diff(&params.old_content, &params.new_content)
         }
+        ToolInput::FileRewrite {
+            path,
+            start_line,
+            end_line,
+            content,
+        } => generate_file_rewrite_diff(workspace_root, path, *start_line, *end_line, content),
         // MCP tools do not have diff previews
         ToolInput::Mcp { .. } => None,
         // Agent tools do not have diff previews
@@ -149,6 +155,65 @@ fn generate_file_write_diff(
         Some(original_line_count),
         options.deletion_ratio_threshold,
     ))
+}
+
+/// Generate a diff preview for `file.rewrite` (line range replacement).
+fn generate_file_rewrite_diff(
+    workspace_root: &Path,
+    path: &str,
+    start_line: u32,
+    end_line: u32,
+    content: &str,
+) -> Option<String> {
+    // Guard: content size
+    if content.len() > MAX_NEW_CONTENT_SIZE {
+        return None;
+    }
+
+    let resolved = match resolve_sandbox_path(workspace_root, path) {
+        Ok(p) => p,
+        Err(_) => return None,
+    };
+
+    // Check file size
+    match std::fs::metadata(&resolved) {
+        Ok(meta) => {
+            if meta.len() > MAX_FILE_SIZE {
+                return Some(format!(
+                    "(file too large for diff preview: {} bytes)",
+                    meta.len()
+                ));
+            }
+        }
+        Err(_) => return None,
+    }
+
+    let existing_bytes = match std::fs::read(&resolved) {
+        Ok(bytes) => bytes,
+        Err(_) => return None,
+    };
+
+    if is_binary_content(&existing_bytes) {
+        return Some("(binary file - diff not available)".to_string());
+    }
+
+    let existing_content = match String::from_utf8(existing_bytes) {
+        Ok(s) => s,
+        Err(_) => return None,
+    };
+
+    let lines: Vec<&str> = existing_content.lines().collect();
+    let total = lines.len() as u32;
+
+    if start_line < 1 || end_line < start_line || end_line > total {
+        return None;
+    }
+
+    let start_idx = (start_line - 1) as usize;
+    let end_idx = end_line as usize;
+    let old_text = lines[start_idx..end_idx].join("\n");
+
+    generate_file_edit_diff(&old_text, content)
 }
 
 /// Generate a diff preview for `file.edit` (old_string -> new_string).

--- a/src/tooling/mod.rs
+++ b/src/tooling/mod.rs
@@ -94,6 +94,7 @@ pub enum ToolKind {
     FileWrite,
     FileEdit,
     FileEditAnchor,
+    FileRewrite,
     FileSearch,
     ShellExec,
     WebFetch,
@@ -182,6 +183,12 @@ pub enum ToolInput {
         path: String,
         params: AnchorEditParams,
     },
+    FileRewrite {
+        path: String,
+        start_line: u32,
+        end_line: u32,
+        content: String,
+    },
 }
 
 impl ToolInput {
@@ -201,6 +208,7 @@ impl ToolInput {
             Self::GitDiff { .. } => ToolKind::GitDiff,
             Self::GitLog { .. } => ToolKind::GitLog,
             Self::FileEditAnchor { .. } => ToolKind::FileEditAnchor,
+            Self::FileRewrite { .. } => ToolKind::FileRewrite,
         }
     }
 
@@ -379,6 +387,38 @@ impl ToolInput {
                     },
                 })
             }
+            "file.rewrite" => {
+                let path = value
+                    .get("path")
+                    .and_then(serde_json::Value::as_str)
+                    .map(String::from)
+                    .ok_or_else(|| "missing path in file.rewrite tool block".to_string())?;
+                let start_line_u64 = value
+                    .get("start_line")
+                    .and_then(serde_json::Value::as_u64)
+                    .ok_or_else(|| "missing start_line in file.rewrite tool block".to_string())?;
+                let start_line = u32::try_from(start_line_u64).map_err(|_| {
+                    format!("start_line value {start_line_u64} exceeds u32 range in file.rewrite")
+                })?;
+                let end_line_u64 = value
+                    .get("end_line")
+                    .and_then(serde_json::Value::as_u64)
+                    .ok_or_else(|| "missing end_line in file.rewrite tool block".to_string())?;
+                let end_line = u32::try_from(end_line_u64).map_err(|_| {
+                    format!("end_line value {end_line_u64} exceeds u32 range in file.rewrite")
+                })?;
+                let content = value
+                    .get("content")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or_default()
+                    .to_string();
+                Ok(ToolInput::FileRewrite {
+                    path,
+                    start_line,
+                    end_line,
+                    content,
+                })
+            }
             other => {
                 // mcp__<server>__<tool> pattern detection
                 if let Some((server, tool)) = parse_mcp_tool_name(other) {
@@ -472,6 +512,18 @@ impl ToolInput {
                         old_content,
                         new_content,
                     },
+                })
+            }
+            "file.rewrite" => {
+                let path = extract_simple(block, "path")?;
+                let start_line = extract_simple(block, "start_line")?.parse::<u32>().ok()?;
+                let end_line = extract_simple(block, "end_line")?.parse::<u32>().ok()?;
+                let content = extract_trailing(block, "content").unwrap_or_default();
+                Some(ToolInput::FileRewrite {
+                    path,
+                    start_line,
+                    end_line,
+                    content,
                 })
             }
             _ => None,
@@ -780,6 +832,19 @@ impl ToolRegistry {
         });
     }
 
+    pub fn register_file_rewrite(&mut self) {
+        self.register(ToolSpec {
+            version: 1,
+            name: "file.rewrite".to_string(),
+            kind: ToolKind::FileRewrite,
+            execution_class: ExecutionClass::Mutating,
+            permission_class: PermissionClass::Confirm,
+            execution_mode: ExecutionMode::SequentialOnly,
+            plan_mode: PlanModePolicy::AllowedWithScope,
+            rollback_policy: RollbackPolicy::CheckpointBeforeWrite,
+        });
+    }
+
     pub fn register_file_search(&mut self) {
         self.register(ToolSpec {
             version: 1,
@@ -919,6 +984,7 @@ impl ToolRegistry {
         self.register_file_write();
         self.register_file_edit();
         self.register_file_edit_anchor();
+        self.register_file_rewrite();
         self.register_file_search();
         self.register_shell_exec();
         self.register_web_fetch();
@@ -1367,6 +1433,12 @@ impl LocalToolExecutor {
                 ref path,
                 ref params,
             } => self.execute_file_edit_anchor(&request, path, params, started),
+            ToolInput::FileRewrite {
+                ref path,
+                start_line,
+                end_line,
+                ref content,
+            } => self.execute_file_rewrite(&request, path, start_line, end_line, content, started),
             ToolInput::Mcp { .. } => unreachable!("MCP tools are dispatched in agentic.rs"),
             ToolInput::AgentExplore { .. } | ToolInput::AgentPlan { .. } => {
                 unreachable!("agent tools are dispatched in agentic.rs")
@@ -1715,6 +1787,95 @@ impl LocalToolExecutor {
                 "anchor: old_content matched {n} locations in {path}, need unique match"
             ))),
         }
+    }
+
+    /// Execute `file.rewrite`: replace a line range with new content.
+    fn execute_file_rewrite(
+        &self,
+        request: &ToolExecutionRequest,
+        path: &str,
+        start_line: u32,
+        end_line: u32,
+        content: &str,
+        started: Instant,
+    ) -> Result<ToolExecutionResult, ToolRuntimeError> {
+        let resolved = self.resolve_path(path)?;
+        let file_content = fs::read_to_string(&resolved).map_err(|err| {
+            ToolRuntimeError::Io(format!(
+                "file.rewrite failed to read {}: {err}",
+                resolved.display()
+            ))
+        })?;
+
+        let lines: Vec<&str> = file_content.lines().collect();
+        let total = lines.len() as u32;
+
+        // Validate range: 1 <= start_line <= end_line <= total_lines
+        if start_line < 1 || end_line < start_line || end_line > total {
+            let nearby = if is_sensitive_file(path) {
+                String::new()
+            } else {
+                extract_nearby_context(&lines, start_line, end_line, total)
+            };
+            return Err(ToolRuntimeError::Io(format!(
+                "file.rewrite: invalid line range {start_line}-{end_line} \
+                 (file has {total} lines). {nearby}"
+            )));
+        }
+
+        // Extract old block (0-indexed)
+        let start_idx = (start_line - 1) as usize;
+        let end_idx = end_line as usize; // exclusive
+        let old_block: Vec<&str> = lines[start_idx..end_idx].to_vec();
+        let old_text = old_block.join("\n");
+
+        // No-op check: compare old block with replacement content
+        let new_text = content.trim_end_matches('\n');
+        if old_text == new_text {
+            return Err(ToolRuntimeError::Io(format!(
+                "file.rewrite: replacement content is identical to existing \
+                 lines {start_line}-{end_line} in {path}. No changes to apply."
+            )));
+        }
+
+        // Build new file content: before + replacement + after
+        let before = &lines[..start_idx];
+        let after = &lines[end_idx..];
+        let replacement_lines: Vec<&str> = if content.is_empty() {
+            Vec::new()
+        } else {
+            content.lines().collect()
+        };
+
+        let mut new_lines: Vec<&str> =
+            Vec::with_capacity(before.len() + replacement_lines.len() + after.len());
+        new_lines.extend_from_slice(before);
+        new_lines.extend_from_slice(&replacement_lines);
+        new_lines.extend_from_slice(after);
+
+        let mut new_content = new_lines.join("\n");
+        // Preserve trailing newline if original had one, but only if content remains
+        if file_content.ends_with('\n') && !new_content.is_empty() {
+            new_content.push('\n');
+        }
+
+        fs::write(&resolved, &new_content).map_err(|err| {
+            ToolRuntimeError::Io(format!(
+                "file.rewrite failed to write {}: {err}",
+                resolved.display()
+            ))
+        })?;
+        self.invalidate_cache(&resolved);
+
+        let diff = diff::generate_file_edit_diff(&old_text, new_text);
+        Ok(build_completed_result_with_diff(
+            request,
+            path.to_string(),
+            Self::build_edit_diff_payload(&old_text, new_text),
+            vec![resolved.display().to_string()],
+            started,
+            diff,
+        ))
     }
 
     /// Try file.edit with 3-level fallback: strict → trailing-ws → anchor.
@@ -2613,6 +2774,23 @@ fn log_file_edit_detail(result: &ToolExecutionResult) {
     }
 }
 
+/// Extract nearby context lines for file.rewrite range errors.
+///
+/// Shows up to 5 lines around the target range boundary for LLM recovery.
+fn extract_nearby_context(lines: &[&str], start_line: u32, _end_line: u32, total: u32) -> String {
+    if lines.is_empty() {
+        return String::new();
+    }
+    let center = (start_line.min(total).max(1) - 1) as usize;
+    let ctx_start = center.saturating_sub(5);
+    let ctx_end = (center + 6).min(lines.len());
+    let mut ctx = String::from("Nearby lines:\n");
+    for (i, line) in lines.iter().enumerate().take(ctx_end).skip(ctx_start) {
+        ctx.push_str(&format!("{:>4}: {}\n", i + 1, line));
+    }
+    ctx
+}
+
 /// Build a [`ToolExecutionResult`] with `Completed` status.
 ///
 /// Centralises the boilerplate shared by every successful execution path.
@@ -2820,6 +2998,34 @@ fn validate_required_fields(input: &ToolInput) -> Result<(), ToolValidationError
                     "old_content".to_string(),
                 ));
             }
+        }
+        ToolInput::FileRewrite {
+            path,
+            start_line,
+            end_line,
+            ..
+        } => {
+            if path.trim().is_empty() {
+                return Err(ToolValidationError::MissingRequiredField(
+                    "path".to_string(),
+                ));
+            }
+            if *start_line < 1 {
+                return Err(ToolValidationError::InvalidFieldValue {
+                    field: "start_line".to_string(),
+                    reason: "start_line must be >= 1".to_string(),
+                });
+            }
+            if *end_line < *start_line {
+                return Err(ToolValidationError::InvalidFieldValue {
+                    field: "end_line".to_string(),
+                    reason: format!(
+                        "end_line ({}) must be >= start_line ({})",
+                        end_line, start_line
+                    ),
+                });
+            }
+            // content: empty is OK (line deletion use case)
         }
         // [D3-001] MCP tool input validation is handled by the MCP server side
         ToolInput::Mcp { .. } => {}

--- a/src/tooling/mod.rs
+++ b/src/tooling/mod.rs
@@ -102,6 +102,7 @@ pub enum ToolKind {
     Mcp,
     AgentExplore,
     AgentPlan,
+    AgentFixSlice,
     GitStatus,
     GitDiff,
     GitLog,
@@ -189,6 +190,12 @@ pub enum ToolInput {
         end_line: u32,
         content: String,
     },
+    /// Microtask fix-slice sub-agent (Issue #291).
+    AgentFixSlice {
+        target_path: String,
+        goal: String,
+        max_lines: u32,
+    },
 }
 
 impl ToolInput {
@@ -209,6 +216,7 @@ impl ToolInput {
             Self::GitLog { .. } => ToolKind::GitLog,
             Self::FileEditAnchor { .. } => ToolKind::FileEditAnchor,
             Self::FileRewrite { .. } => ToolKind::FileRewrite,
+            Self::AgentFixSlice { .. } => ToolKind::AgentFixSlice,
         }
     }
 
@@ -387,6 +395,31 @@ impl ToolInput {
                     },
                 })
             }
+            "agent.fix_slice" => {
+                let target_path = value
+                    .get("target_path")
+                    .and_then(serde_json::Value::as_str)
+                    .map(String::from)
+                    .ok_or_else(|| {
+                        "missing target_path in agent.fix_slice tool block".to_string()
+                    })?;
+                let goal = value
+                    .get("goal")
+                    .and_then(serde_json::Value::as_str)
+                    .map(String::from)
+                    .ok_or_else(|| "missing goal in agent.fix_slice tool block".to_string())?;
+                let max_lines = match value.get("max_lines").and_then(serde_json::Value::as_u64) {
+                    Some(v) => u32::try_from(v).map_err(|_| {
+                        format!("max_lines value {v} exceeds u32 range in agent.fix_slice")
+                    })?,
+                    None => 50,
+                };
+                Ok(ToolInput::AgentFixSlice {
+                    target_path,
+                    goal,
+                    max_lines,
+                })
+            }
             "file.rewrite" => {
                 let path = value
                     .get("path")
@@ -492,6 +525,18 @@ impl ToolInput {
                 prompt: extract_simple(block, "prompt")?,
                 scope: extract_simple(block, "scope"),
             }),
+            "agent.fix_slice" => {
+                let target_path = extract_simple(block, "target_path")?;
+                let goal = extract_simple(block, "goal")?;
+                let max_lines = extract_simple(block, "max_lines")
+                    .and_then(|v| v.parse::<u32>().ok())
+                    .unwrap_or(50);
+                Some(ToolInput::AgentFixSlice {
+                    target_path,
+                    goal,
+                    max_lines,
+                })
+            }
             "git.status" => Some(ToolInput::GitStatus {}),
             "git.diff" => Some(ToolInput::GitDiff {
                 path: extract_simple(block, "path"),
@@ -979,6 +1024,25 @@ impl ToolRegistry {
         self.register_git_status();
     }
 
+    /// Register the agent.fix_slice tool (Issue #291).
+    pub fn register_agent_fix_slice(&mut self) {
+        self.register(ToolSpec {
+            version: 1,
+            name: "agent.fix_slice".to_string(),
+            kind: ToolKind::AgentFixSlice,
+            execution_class: ExecutionClass::Mutating,
+            permission_class: PermissionClass::Confirm,
+            execution_mode: ExecutionMode::SequentialOnly,
+            plan_mode: PlanModePolicy::Allowed,
+            rollback_policy: RollbackPolicy::None,
+        });
+    }
+
+    /// Register the subset of tools available to the FixSlice sub-agent (Issue #291).
+    pub fn register_fixslice_tools(&mut self) {
+        self.register_file_read();
+    }
+
     pub fn register_standard_tools(&mut self) {
         self.register_file_read();
         self.register_file_write();
@@ -1440,7 +1504,9 @@ impl LocalToolExecutor {
                 ref content,
             } => self.execute_file_rewrite(&request, path, start_line, end_line, content, started),
             ToolInput::Mcp { .. } => unreachable!("MCP tools are dispatched in agentic.rs"),
-            ToolInput::AgentExplore { .. } | ToolInput::AgentPlan { .. } => {
+            ToolInput::AgentExplore { .. }
+            | ToolInput::AgentPlan { .. }
+            | ToolInput::AgentFixSlice { .. } => {
                 unreachable!("agent tools are dispatched in agentic.rs")
             }
         };
@@ -2983,6 +3049,48 @@ fn validate_required_fields(input: &ToolInput) -> Result<(), ToolValidationError
                         "prompt length {} exceeds maximum of {} characters",
                         prompt.len(),
                         MAX_PROMPT_LENGTH
+                    ),
+                });
+            }
+        }
+        ToolInput::AgentFixSlice {
+            target_path,
+            goal,
+            max_lines,
+        } => {
+            if target_path.trim().is_empty() {
+                return Err(ToolValidationError::MissingRequiredField(
+                    "target_path".to_string(),
+                ));
+            }
+            if target_path.chars().any(|c| c.is_control()) {
+                return Err(ToolValidationError::InvalidFieldValue {
+                    field: "target_path".to_string(),
+                    reason: "target_path must not contain control characters".to_string(),
+                });
+            }
+            if goal.trim().is_empty() {
+                return Err(ToolValidationError::MissingRequiredField(
+                    "goal".to_string(),
+                ));
+            }
+            const MAX_GOAL_LENGTH: usize = 10000;
+            if goal.len() > MAX_GOAL_LENGTH {
+                return Err(ToolValidationError::InvalidFieldValue {
+                    field: "goal".to_string(),
+                    reason: format!(
+                        "goal length {} exceeds maximum of {} characters",
+                        goal.len(),
+                        MAX_GOAL_LENGTH
+                    ),
+                });
+            }
+            if *max_lines < 1 || *max_lines > crate::agent::subagent::MAX_FIXSLICE_LINES {
+                return Err(ToolValidationError::InvalidFieldValue {
+                    field: "max_lines".to_string(),
+                    reason: format!(
+                        "max_lines must be between 1 and {}",
+                        crate::agent::subagent::MAX_FIXSLICE_LINES
                     ),
                 });
             }

--- a/tests/closure_loop_guard.rs
+++ b/tests/closure_loop_guard.rs
@@ -1,0 +1,138 @@
+//! Tests for the closure-mode reasoning loop guard (Issue #349).
+//!
+//! Regression: after `agent.fix_slice` fails, the parent agent sometimes
+//! enters a natural-language closure loop — producing zero-tool-call
+//! reasoning that repeats the same cut points (resolveAutoAnswer /
+//! truncated file / late-stage closure) until the runner kills the
+//! process at 600s. The existing `LoopDetector` only fires on repeated
+//! tool calls and never engages for this shape. `ClosureLoopDetector`
+//! fingerprints reasoning-only responses while the guard is armed and
+//! escalates through `Warn → StrongWarn → Break`.
+
+use anvil::app::closure_loop_detector::{ClosureLoopDetector, Fingerprint};
+use anvil::app::loop_detector::LoopAction;
+
+// The two paraphrases below share the same domain vocabulary (~80%
+// significant-token overlap) but swap connector words. This is the exact
+// cycle 8/9 shape the phase-bench runner exposed: reworded reasoning with
+// the same resolveAutoAnswer / truncated / closure / worker keywords.
+const LOOP_MSG_A: &str = "The resolveAutoAnswer helper appears truncated. \
+    Because the worker produced no valid proposal, the fix_slice invocation \
+    failed. The late-stage closure branch should therefore abort instead \
+    of looping. resolveAutoAnswer, truncated, closure, invalid, proposal, \
+    worker, failure, fix_slice, target_path, rewrite, iterations, session.";
+
+const LOOP_MSG_A_REWORDED: &str = "Worker did not produce any valid proposal, \
+    so the fix_slice invocation has failed. The resolveAutoAnswer helper \
+    still appears truncated, therefore the late-stage closure branch \
+    should abort instead of looping further, because continuing reasoning \
+    is unhelpful. Keywords: closure, invalid, proposal, worker, failure, \
+    fix_slice, target_path, rewrite, iterations, session, \
+    resolveAutoAnswer, truncated.";
+
+const UNRELATED_MSG: &str = "Different angle now: the ANVIL_PLAN required \
+    additional verification reads against configuration modules. Running \
+    cargo check would reveal compilation blockers. Consider auditing \
+    provider ollama sidecar summarize helpers, exploring retrieval \
+    cache, evaluating telemetry snapshot format, inspecting hooks \
+    engine wiring, scanning tooling shell policy.";
+
+#[test]
+fn short_responses_do_not_arm_the_detector() {
+    // A one-line acknowledgement must not be treated as "reasoning" — we
+    // only fingerprint content with enough significant tokens.
+    assert!(Fingerprint::from_raw("Plan is done.").is_none());
+    assert!(Fingerprint::from_raw("ok").is_none());
+
+    let mut det = ClosureLoopDetector::new();
+    for _ in 0..5 {
+        assert_eq!(det.record_and_check("ok"), LoopAction::Continue);
+    }
+}
+
+#[test]
+fn paraphrased_reasoning_is_near_duplicate() {
+    let fp1 = Fingerprint::from_raw(LOOP_MSG_A).expect("fingerprintable");
+    let fp2 = Fingerprint::from_raw(LOOP_MSG_A_REWORDED).expect("fingerprintable");
+    assert!(
+        fp1.jaccard(&fp2) >= 0.7,
+        "reworded paraphrase with the same keyword set should pass the Jaccard threshold; got {}",
+        fp1.jaccard(&fp2)
+    );
+}
+
+#[test]
+fn first_closure_response_is_always_continue() {
+    let mut det = ClosureLoopDetector::new();
+    let action = det.record_and_check(LOOP_MSG_A);
+    assert_eq!(
+        action,
+        LoopAction::Continue,
+        "a single closure response must not escalate"
+    );
+}
+
+#[test]
+fn repeated_closure_reasoning_walks_the_escalation_ladder() {
+    // Reproduces the Issue #349 cycle: the parent agent keeps producing
+    // the same verbose reasoning without any tool-advancing output. Each
+    // repeat should climb one rung: Warn → StrongWarn → Break.
+    let mut det = ClosureLoopDetector::new();
+    assert_eq!(det.record_and_check(LOOP_MSG_A), LoopAction::Continue);
+    assert!(
+        matches!(det.record_and_check(LOOP_MSG_A), LoopAction::Warn(_)),
+        "second identical reasoning turn must Warn"
+    );
+    assert!(
+        matches!(
+            det.record_and_check(LOOP_MSG_A_REWORDED),
+            LoopAction::StrongWarn(_)
+        ),
+        "third reasoning turn (even reworded) must StrongWarn"
+    );
+    assert!(
+        matches!(det.record_and_check(LOOP_MSG_A), LoopAction::Break(_)),
+        "fourth reasoning turn must terminate the loop"
+    );
+}
+
+#[test]
+fn unrelated_reasoning_does_not_match_prior_fingerprint() {
+    let mut det = ClosureLoopDetector::new();
+    det.record_and_check(LOOP_MSG_A);
+    assert_eq!(
+        det.record_and_check(UNRELATED_MSG),
+        LoopAction::Continue,
+        "a genuinely different cut point must not trip the guard"
+    );
+}
+
+#[test]
+fn unrelated_interleaving_does_not_break_escalation() {
+    // cycle 6 mixed different reasoning cuts between turns and still
+    // completed successfully. The guard must not reset escalation just
+    // because one novel response interleaves — only a worker success or
+    // an explicit reset should clear state.
+    let mut det = ClosureLoopDetector::new();
+    det.record_and_check(LOOP_MSG_A);
+    assert_eq!(det.record_and_check(UNRELATED_MSG), LoopAction::Continue);
+    let action = det.record_and_check(LOOP_MSG_A_REWORDED);
+    assert!(
+        matches!(action, LoopAction::Warn(_)),
+        "LOOP_MSG_A repeating after an interleaved UNRELATED_MSG must still Warn, got {:?}",
+        action
+    );
+}
+
+#[test]
+fn reset_clears_history_between_armed_phases() {
+    let mut det = ClosureLoopDetector::new();
+    det.record_and_check(LOOP_MSG_A);
+    det.record_and_check(LOOP_MSG_A);
+    det.reset();
+    assert_eq!(
+        det.record_and_check(LOOP_MSG_A),
+        LoopAction::Continue,
+        "after reset, a previously-seen fingerprint must look fresh again"
+    );
+}

--- a/tests/escalation_routing_control.rs
+++ b/tests/escalation_routing_control.rs
@@ -1,0 +1,342 @@
+//! Integration tests for Issue #355: escalation routing + post-success early-exit.
+//!
+//! Two runtime bugs are fixed:
+//!
+//! 1. `escalated_not_invoked` — under a `requires_worker_observation` pack,
+//!    once fix_slice escalation has fired the parent must actually call
+//!    `agent.fix_slice`. Parent-side mutation tools (`file.edit`,
+//!    `file.write`, `file.edit_anchor`) must be suspended until the worker
+//!    path has been invoked.
+//!
+//! 2. post-success continuation timeout — once `worker_observed=true` under
+//!    a worker-required pack, the session must exit cleanly on the next
+//!    loop boundary instead of burning turns (or the 600s runner timeout).
+
+use anvil::app::escalation_barrier::{
+    ESCALATION_BARRIER_MESSAGE, EscalationBarrier, MAX_ESCALATION_BARRIER_BLOCKS,
+};
+use anvil::contracts::{AgentTelemetry, PackExpectation};
+use anvil::tooling::{
+    ExecutionClass, ExecutionMode, PermissionClass, PlanModePolicy, RollbackPolicy,
+    ToolExecutionRequest, ToolExecutionStatus, ToolInput, ToolKind, ToolSpec,
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn make_request(name: &str, kind: ToolKind, input: ToolInput) -> (usize, ToolExecutionRequest) {
+    (
+        0,
+        ToolExecutionRequest {
+            tool_call_id: format!("call_{name}"),
+            spec: ToolSpec {
+                version: 1,
+                name: name.to_string(),
+                kind,
+                execution_class: ExecutionClass::Mutating,
+                permission_class: PermissionClass::Confirm,
+                execution_mode: ExecutionMode::SequentialOnly,
+                plan_mode: PlanModePolicy::AllowedWithScope,
+                rollback_policy: RollbackPolicy::None,
+            },
+            input,
+            extra_field_warnings: Vec::new(),
+        },
+    )
+}
+
+fn edit_req() -> (usize, ToolExecutionRequest) {
+    make_request(
+        "file.edit",
+        ToolKind::FileEdit,
+        ToolInput::FileEdit {
+            path: "src/foo.rs".into(),
+            old_string: "old".into(),
+            new_string: "new".into(),
+        },
+    )
+}
+
+fn write_req() -> (usize, ToolExecutionRequest) {
+    make_request(
+        "file.write",
+        ToolKind::FileWrite,
+        ToolInput::FileWrite {
+            path: "src/foo.rs".into(),
+            content: "content".into(),
+        },
+    )
+}
+
+fn read_req() -> (usize, ToolExecutionRequest) {
+    make_request(
+        "file.read",
+        ToolKind::FileRead,
+        ToolInput::FileRead {
+            path: "src/foo.rs".into(),
+        },
+    )
+}
+
+// ---------------------------------------------------------------------------
+// AgentTelemetry: should_force_fixslice_routing
+// ---------------------------------------------------------------------------
+
+#[test]
+fn force_fixslice_routing_true_under_worker_required_after_escalation() {
+    let mut tel = AgentTelemetry::new();
+    tel.pack_expectation = Some(PackExpectation::RequiresWorkerObservation);
+    tel.record_fixslice_escalation();
+    assert!(tel.should_force_fixslice_routing());
+}
+
+#[test]
+fn force_fixslice_routing_false_when_worker_invocation_already_recorded() {
+    let mut tel = AgentTelemetry::new();
+    tel.pack_expectation = Some(PackExpectation::RequiresWorkerObservation);
+    tel.record_fixslice_escalation();
+    tel.record_fixslice_worker_invocation();
+    assert!(!tel.should_force_fixslice_routing());
+}
+
+#[test]
+fn force_fixslice_routing_false_when_worker_observed() {
+    let mut tel = AgentTelemetry::new();
+    tel.pack_expectation = Some(PackExpectation::RequiresWorkerObservation);
+    tel.record_fixslice_escalation();
+    tel.record_worker_success();
+    assert!(!tel.should_force_fixslice_routing());
+}
+
+#[test]
+fn force_fixslice_routing_false_without_escalation() {
+    let mut tel = AgentTelemetry::new();
+    tel.pack_expectation = Some(PackExpectation::RequiresWorkerObservation);
+    assert!(!tel.should_force_fixslice_routing());
+}
+
+#[test]
+fn force_fixslice_routing_false_for_audit_only_pack() {
+    let mut tel = AgentTelemetry::new();
+    tel.pack_expectation = Some(PackExpectation::AuditOnly);
+    tel.record_fixslice_escalation();
+    assert!(!tel.should_force_fixslice_routing());
+}
+
+#[test]
+fn force_fixslice_routing_false_for_requires_mutation_pack() {
+    let mut tel = AgentTelemetry::new();
+    tel.pack_expectation = Some(PackExpectation::RequiresMutation);
+    tel.record_fixslice_escalation();
+    assert!(!tel.should_force_fixslice_routing());
+}
+
+#[test]
+fn force_fixslice_routing_false_when_pack_expectation_unset() {
+    let mut tel = AgentTelemetry::new();
+    tel.record_fixslice_escalation();
+    assert!(!tel.should_force_fixslice_routing());
+}
+
+// ---------------------------------------------------------------------------
+// AgentTelemetry: should_early_exit_after_worker_success
+// ---------------------------------------------------------------------------
+
+#[test]
+fn early_exit_true_under_worker_required_pack_when_worker_observed() {
+    let mut tel = AgentTelemetry::new();
+    tel.pack_expectation = Some(PackExpectation::RequiresWorkerObservation);
+    tel.record_worker_success();
+    assert!(tel.should_early_exit_after_worker_success());
+}
+
+#[test]
+fn early_exit_false_when_worker_not_observed() {
+    let mut tel = AgentTelemetry::new();
+    tel.pack_expectation = Some(PackExpectation::RequiresWorkerObservation);
+    assert!(!tel.should_early_exit_after_worker_success());
+}
+
+#[test]
+fn early_exit_false_for_audit_only_pack() {
+    let mut tel = AgentTelemetry::new();
+    tel.pack_expectation = Some(PackExpectation::AuditOnly);
+    tel.record_worker_success();
+    assert!(!tel.should_early_exit_after_worker_success());
+}
+
+#[test]
+fn early_exit_false_for_requires_mutation_pack() {
+    let mut tel = AgentTelemetry::new();
+    tel.pack_expectation = Some(PackExpectation::RequiresMutation);
+    tel.record_worker_success();
+    assert!(!tel.should_early_exit_after_worker_success());
+}
+
+#[test]
+fn early_exit_false_when_pack_expectation_unset() {
+    let mut tel = AgentTelemetry::new();
+    tel.record_worker_success();
+    assert!(!tel.should_early_exit_after_worker_success());
+}
+
+// ---------------------------------------------------------------------------
+// Telemetry counters
+// ---------------------------------------------------------------------------
+
+#[test]
+fn record_escalation_barrier_block_increments_counter() {
+    let mut tel = AgentTelemetry::new();
+    assert_eq!(tel.escalation_barrier_block_count, 0);
+    tel.record_escalation_barrier_block();
+    tel.record_escalation_barrier_block();
+    assert_eq!(tel.escalation_barrier_block_count, 2);
+}
+
+#[test]
+fn record_worker_required_early_exit_increments_counter() {
+    let mut tel = AgentTelemetry::new();
+    assert_eq!(tel.worker_required_early_exit_count, 0);
+    tel.record_worker_required_early_exit();
+    assert_eq!(tel.worker_required_early_exit_count, 1);
+}
+
+// ---------------------------------------------------------------------------
+// finalize_fixslice_outcome interaction
+// ---------------------------------------------------------------------------
+
+#[test]
+fn early_exit_path_does_not_mark_escalated_not_invoked() {
+    let mut tel = AgentTelemetry::new();
+    tel.pack_expectation = Some(PackExpectation::RequiresWorkerObservation);
+    tel.record_fixslice_escalation();
+    tel.record_fixslice_worker_invocation();
+    tel.record_worker_success();
+
+    tel.finalize_fixslice_outcome();
+    assert!(
+        tel.fixslice_failure_reason.is_none(),
+        "worker success path must not be classified as escalated_not_invoked"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Telemetry artifact serialization
+// ---------------------------------------------------------------------------
+
+#[test]
+fn telemetry_artifact_exposes_new_counters() {
+    let dir = tempfile::tempdir().unwrap();
+    let session_id = format!("test_escalation_routing_{}", std::process::id());
+
+    let mut tel = AgentTelemetry::new();
+    tel.record_escalation_barrier_block();
+    tel.record_escalation_barrier_block();
+    tel.record_worker_required_early_exit();
+    tel.write_artifact_to_dir(dir.path().to_str().unwrap(), &session_id)
+        .unwrap();
+
+    let file_path = dir.path().join(format!("{session_id}_telemetry.json"));
+    let contents = std::fs::read_to_string(&file_path).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&contents).unwrap();
+
+    assert_eq!(json["escalation_barrier_block_count"], 2);
+    assert_eq!(json["worker_required_early_exit_count"], 1);
+}
+
+#[test]
+fn telemetry_artifact_new_counters_default_to_zero() {
+    let dir = tempfile::tempdir().unwrap();
+    let session_id = format!("test_escalation_routing_default_{}", std::process::id());
+
+    let tel = AgentTelemetry::new();
+    tel.write_artifact_to_dir(dir.path().to_str().unwrap(), &session_id)
+        .unwrap();
+
+    let file_path = dir.path().join(format!("{session_id}_telemetry.json"));
+    let contents = std::fs::read_to_string(&file_path).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&contents).unwrap();
+
+    assert_eq!(json["escalation_barrier_block_count"], 0);
+    assert_eq!(json["worker_required_early_exit_count"], 0);
+}
+
+#[test]
+fn telemetry_serde_default_tolerates_missing_new_counters() {
+    let json = r#"{"premature_final_count":0,"total_final_requests":0,"plan_registration_count":0,"plan_update_count":0,"sync_from_touched_files_count":0}"#;
+    let tel: AgentTelemetry = serde_json::from_str(json).unwrap();
+    assert_eq!(tel.escalation_barrier_block_count, 0);
+    assert_eq!(tel.worker_required_early_exit_count, 0);
+}
+
+// ---------------------------------------------------------------------------
+// EscalationBarrier
+// ---------------------------------------------------------------------------
+
+#[test]
+fn escalation_barrier_blocks_file_edit_when_armed() {
+    let mut barrier = EscalationBarrier::new();
+    let result = barrier.check_and_filter(vec![edit_req()], true);
+
+    assert_eq!(result.blocked_count, 1);
+    assert!(result.passed_requests.is_empty());
+    let (_, blocked) = &result.blocked_results[0];
+    assert_eq!(blocked.tool_name, "file.edit");
+    assert_eq!(blocked.status, ToolExecutionStatus::Blocked);
+    assert!(
+        blocked.summary.starts_with("[fixslice_escalation_barrier]"),
+        "blocked summary should start with [fixslice_escalation_barrier], got: {}",
+        blocked.summary
+    );
+    assert!(
+        blocked.summary.contains(ESCALATION_BARRIER_MESSAGE),
+        "blocked summary should contain the escalation barrier message"
+    );
+}
+
+#[test]
+fn escalation_barrier_blocks_file_write_when_armed() {
+    let mut barrier = EscalationBarrier::new();
+    let result = barrier.check_and_filter(vec![write_req()], true);
+    assert_eq!(result.blocked_count, 1);
+    assert!(result.passed_requests.is_empty());
+}
+
+#[test]
+fn escalation_barrier_allows_reads_when_armed() {
+    let mut barrier = EscalationBarrier::new();
+    let result = barrier.check_and_filter(vec![read_req()], true);
+    assert_eq!(result.blocked_count, 0);
+    assert_eq!(result.passed_requests.len(), 1);
+}
+
+#[test]
+fn escalation_barrier_passes_all_when_disarmed() {
+    let mut barrier = EscalationBarrier::new();
+    let result = barrier.check_and_filter(vec![edit_req(), write_req()], false);
+    assert_eq!(result.blocked_count, 0);
+    assert_eq!(result.passed_requests.len(), 2);
+}
+
+#[test]
+fn escalation_barrier_respects_max_blocks() {
+    let mut barrier = EscalationBarrier::new();
+    for _ in 0..MAX_ESCALATION_BARRIER_BLOCKS {
+        let result = barrier.check_and_filter(vec![edit_req()], true);
+        assert_eq!(result.blocked_count, 1);
+    }
+    // Next call should auto-release.
+    let result = barrier.check_and_filter(vec![edit_req()], true);
+    assert_eq!(result.blocked_count, 0);
+    assert_eq!(result.passed_requests.len(), 1);
+}
+
+#[test]
+fn escalation_barrier_mixed_batch_blocks_only_mutations() {
+    let mut barrier = EscalationBarrier::new();
+    let result = barrier.check_and_filter(vec![read_req(), edit_req(), write_req()], true);
+    assert_eq!(result.passed_requests.len(), 1);
+    assert_eq!(result.passed_requests[0].1.spec.name, "file.read");
+    assert_eq!(result.blocked_count, 2);
+}

--- a/tests/escape_hatch_ordering.rs
+++ b/tests/escape_hatch_ordering.rs
@@ -1,0 +1,166 @@
+//! Tests for Issue #323: escape hatch ordering — late ANVIL_PLAN_UPDATE must
+//! be processed before the escape hatch terminates the loop.
+//!
+//! Covers:
+//! - Late zero-tool-call response with ANVIL_PLAN_UPDATE [x] is still applied
+//!   even when escape hatch fires on the same turn.
+//! - The final checked item reaches AlreadySatisfied before loop termination.
+//! - CompletionKind is not Partial for the no-change closure path.
+//! - plan_update_count reflects the late corrective update.
+
+use anvil::app::stagnation_state::{
+    StagnationState, compute_stagnation_score, should_allow_escape_hatch,
+};
+use anvil::contracts::{CompletionKind, ExecutionPlan, PlanItem, PlanItemStatus};
+
+// ---------------------------------------------------------------------------
+// Scenario: escape hatch fires on the same turn as the final checked update
+// ---------------------------------------------------------------------------
+
+/// Reproduces the B1 failure from Issue #323:
+/// - 6-item plan, 5 items already retired (AlreadySatisfied), 1 remaining.
+/// - ANVIL_PLAN_UPDATE with [x] for the last item arrives on a zero-tool-call
+///   response where escape hatch conditions are met.
+/// - Expected: plan update is applied first, last item becomes AlreadySatisfied,
+///   CompletionKind is CompleteUnverified (not Partial).
+#[test]
+fn escape_hatch_turn_with_final_checked_update_completes_plan() {
+    // Setup: 6-item plan, items 0-4 already done/satisfied, item 5 still pending
+    let mut plan = ExecutionPlan::new(vec![
+        PlanItem::new("src/a.rs: update module".into(), vec!["src/a.rs".into()]),
+        PlanItem::new("src/b.rs: update module".into(), vec!["src/b.rs".into()]),
+        PlanItem::new("src/c.rs: update module".into(), vec!["src/c.rs".into()]),
+        PlanItem::new("src/d.rs: update module".into(), vec!["src/d.rs".into()]),
+        PlanItem::new("src/e.rs: update module".into(), vec!["src/e.rs".into()]),
+        PlanItem::new(
+            "src/app/api/worktrees/[id]/current-output/route.ts: no change needed".into(),
+            vec!["src/app/api/worktrees/[id]/current-output/route.ts".into()],
+        ),
+    ]);
+    // Items 0-4 retired via prior checked markers
+    for i in 0..5 {
+        plan.items[i].status = PlanItemStatus::AlreadySatisfied;
+    }
+
+    // Stagnation state: set up conditions where escape hatch would fire
+    let mut stagnation = StagnationState::init_from_plan(&[
+        "src/app/api/worktrees/[id]/current-output/route.ts".to_string(),
+    ]);
+    // Simulate many turns of stagnation
+    for _ in 0..12 {
+        stagnation.begin_turn(&[]);
+        stagnation.end_turn(false);
+    }
+    let score = compute_stagnation_score(&stagnation);
+    assert!(score >= 3, "stagnation score should be >= 3, got {score}");
+
+    // Escape hatch should fire with these conditions
+    let plan_repair_count = 1;
+    let remaining_turns = 5;
+    assert!(
+        should_allow_escape_hatch(&stagnation, plan_repair_count, remaining_turns),
+        "escape hatch should be triggered"
+    );
+
+    // Before fix: plan is not complete (remaining=1), would break as Partial
+    assert!(!plan.is_successfully_completed());
+    let pre_kind = CompletionKind::classify(&plan, None, false);
+    assert_eq!(
+        pre_kind,
+        CompletionKind::Partial,
+        "before plan update, should be Partial"
+    );
+
+    // --- Simulate the fix: process plan update BEFORE escape hatch break ---
+    // The model's response contains ANVIL_PLAN_UPDATE with [x] for the last item.
+    let retired = plan.mark_unfinished_items_by_target(
+        &["src/app/api/worktrees/[id]/current-output/route.ts".to_string()],
+        PlanItemStatus::AlreadySatisfied,
+    );
+    assert_eq!(retired.len(), 1, "last item should be retired");
+    stagnation.retire_target_files(&retired);
+    stagnation.record_plan_item_completion();
+
+    // After fix: plan is complete, CompletionKind is not Partial
+    assert!(
+        plan.is_successfully_completed(),
+        "plan should be successfully completed after checked retire"
+    );
+    assert_eq!(plan.items[5].status, PlanItemStatus::AlreadySatisfied);
+    let post_kind = CompletionKind::classify(&plan, None, false);
+    assert_eq!(
+        post_kind,
+        CompletionKind::CompleteUnverified,
+        "after plan update, should be CompleteUnverified, not Partial"
+    );
+
+    // Stagnation should no longer have starved target files
+    assert!(
+        stagnation.starved_target_files.is_empty(),
+        "no starved files should remain after retire"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Escape hatch should not suppress plan completion
+// ---------------------------------------------------------------------------
+
+/// Even when escape hatch is active, if the plan update completes all items,
+/// is_successfully_completed() returns true and the loop should not be
+/// classified as partial.
+#[test]
+fn completed_plan_overrides_escape_hatch_partial_classification() {
+    let mut plan = ExecutionPlan::new(vec![
+        PlanItem::new("task1".into(), vec!["src/a.rs".into()]),
+        PlanItem::new("task2".into(), vec!["src/b.rs".into()]),
+    ]);
+    plan.items[0].status = PlanItemStatus::Done;
+    plan.items[1].status = PlanItemStatus::AlreadySatisfied;
+
+    // Even though escape hatch conditions may be true,
+    // CompletionKind should reflect the completed plan state
+    let kind = CompletionKind::classify(&plan, None, false);
+    assert_eq!(kind, CompletionKind::CompleteUnverified);
+    assert!(plan.is_successfully_completed());
+}
+
+// ---------------------------------------------------------------------------
+// Late plan update with all-checked items produces correct telemetry
+// ---------------------------------------------------------------------------
+
+/// When a late ANVIL_PLAN_UPDATE contains only [x] items (no new items),
+/// the plan should transition to completed state after retirement.
+#[test]
+fn late_all_checked_update_retires_remaining_item() {
+    let mut plan = ExecutionPlan::new(vec![
+        PlanItem::new("src/x.rs: impl".into(), vec!["src/x.rs".into()]),
+        PlanItem::new("src/y.rs: impl".into(), vec!["src/y.rs".into()]),
+        PlanItem::new("src/z.rs: verify".into(), vec!["src/z.rs".into()]),
+    ]);
+    plan.items[0].status = PlanItemStatus::Done;
+    plan.items[1].status = PlanItemStatus::Done;
+    // Item 2 is still Pending — this is the "remaining=1" case
+
+    let mut stagnation = StagnationState::init_from_plan(&["src/z.rs".to_string()]);
+
+    // Process the checked retire for the last item
+    let retired = plan.mark_unfinished_items_by_target(
+        &["src/z.rs".to_string()],
+        PlanItemStatus::AlreadySatisfied,
+    );
+    assert_eq!(retired.len(), 1);
+    stagnation.retire_target_files(&retired);
+    stagnation.record_plan_item_completion();
+
+    // All items finished
+    assert!(plan.all_finished());
+    assert!(plan.is_successfully_completed());
+
+    // CompletionKind should be complete, not partial
+    let kind = CompletionKind::classify(&plan, None, false);
+    assert_eq!(kind, CompletionKind::CompleteUnverified);
+
+    // Stagnation cleared
+    assert!(stagnation.starved_target_files.is_empty());
+    assert_eq!(stagnation.turns_since_plan_item_completion, 0);
+}

--- a/tests/fixslice_escalation.rs
+++ b/tests/fixslice_escalation.rs
@@ -2,9 +2,13 @@
 //!
 //! Tests that repeated single-file edit failures escalate to
 //! agent.fix_slice via EditFallbackAction::FixSliceEscalation.
+//!
+//! Issue #332 extensions test the broadened escalation trigger that
+//! fires on stagnation + cumulative edit failures across multiple paths,
+//! not only on same-path consecutive failures.
 
 use anvil::app::edit_fail_tracker::{
-    EditFailTracker, EditFallbackAction, determine_fallback_action,
+    EditFailTracker, EditFallbackAction, determine_fallback_action, should_escalate_for_stagnation,
 };
 use anvil::app::stagnation_state::{StagnationState, compute_stagnation_score};
 use anvil::contracts::AgentTelemetry;
@@ -245,4 +249,181 @@ fn test_agent_telemetry_fixslice_default_zero() {
     let json = r#"{"premature_final_count":0,"total_final_requests":0,"plan_registration_count":0,"plan_update_count":0,"sync_from_touched_files_count":0,"completion_kind":null}"#;
     let tel: AgentTelemetry = serde_json::from_str(json).unwrap();
     assert_eq!(tel.fixslice_escalation_count, 0);
+}
+
+// ============================================================
+// Issue #332: broadened escalation (stagnation + cross-path failures)
+// ============================================================
+
+#[test]
+fn test_config_defaults_for_stagnation_escalation_thresholds() {
+    let config = anvil::config::EffectiveConfig::default_for_test().unwrap();
+    assert_eq!(
+        config.runtime.edit_fixslice_stagnation_total_threshold, 4,
+        "default total-failures threshold should be 4"
+    );
+    assert_eq!(
+        config.runtime.edit_fixslice_stagnation_score_threshold, 2,
+        "default stagnation-score threshold should be 2"
+    );
+}
+
+#[test]
+fn test_tracker_total_failures_accumulates_across_paths() {
+    let mut tracker = EditFailTracker::new(3, 5, 7);
+    assert_eq!(tracker.total_failures(), 0);
+
+    tracker.record_failure("a.ts");
+    tracker.record_failure("b.ts");
+    tracker.record_failure("c.ts");
+    assert_eq!(tracker.total_failures(), 3);
+
+    // Success on one path does not decrease the cumulative total.
+    tracker.record_success("a.ts");
+    assert_eq!(tracker.total_failures(), 3);
+
+    tracker.record_failure("a.ts");
+    assert_eq!(tracker.total_failures(), 4);
+}
+
+#[test]
+fn test_should_escalate_for_stagnation_pure_function() {
+    // Disabled threshold: never escalate.
+    assert!(!should_escalate_for_stagnation(10, 4, 0, 2));
+    // Below failure threshold: no escalation.
+    assert!(!should_escalate_for_stagnation(3, 4, 4, 2));
+    // Below stagnation score: no escalation.
+    assert!(!should_escalate_for_stagnation(4, 1, 4, 2));
+    // Both conditions met: escalate.
+    assert!(should_escalate_for_stagnation(4, 2, 4, 2));
+    assert!(should_escalate_for_stagnation(10, 4, 4, 2));
+}
+
+#[test]
+fn test_cross_path_drift_triggers_stagnation_escalation() {
+    // Issue #332: model spreads edits across multiple files and no path
+    // reaches the same-path threshold, but cumulative failures + stagnation
+    // are high enough to escalate.
+    let mut tracker = EditFailTracker::new(3, 5, 7);
+    // 4 failures across 4 different files — no single path hits 3 reread,
+    // so EditFallbackAction never returns FixSliceEscalation.
+    for path in ["a.ts", "b.ts", "c.ts", "d.ts"] {
+        let action = tracker.record_failure(path);
+        assert_eq!(action, EditFallbackAction::Continue);
+    }
+    assert_eq!(tracker.total_failures(), 4);
+
+    // Simulate stagnation score = 2 (mutation drought + workset staleness).
+    let mut stag = StagnationState::new();
+    let workset = vec![0usize];
+    for _ in 0..5 {
+        stag.begin_turn(&workset);
+        stag.end_turn(false);
+    }
+    let score = compute_stagnation_score(&stag);
+    assert!(score >= 2, "expected score >= 2, got {score}");
+
+    // Broadened policy: should fire even though no same-path count >= 7.
+    assert!(should_escalate_for_stagnation(
+        tracker.total_failures(),
+        score as u32,
+        4,
+        2,
+    ));
+}
+
+#[test]
+fn test_telemetry_same_path_counter_bumped_by_legacy_method() {
+    let mut tel = AgentTelemetry::new();
+    tel.record_fixslice_escalation();
+    assert_eq!(tel.fixslice_escalation_count, 1);
+    assert_eq!(tel.fixslice_escalation_same_path_count, 1);
+    assert_eq!(tel.fixslice_escalation_stagnation_count, 0);
+    assert_eq!(tel.fixslice_escalation_repair_salvage_count, 0);
+    assert!(tel.worker_observed);
+}
+
+#[test]
+fn test_telemetry_stagnation_escalation_distinct_from_same_path() {
+    let mut tel = AgentTelemetry::new();
+    tel.record_fixslice_escalation_stagnation();
+    assert_eq!(tel.fixslice_escalation_count, 1);
+    assert_eq!(tel.fixslice_escalation_stagnation_count, 1);
+    assert_eq!(tel.fixslice_escalation_same_path_count, 0);
+    assert!(tel.worker_observed);
+
+    // A subsequent same-path escalation bumps only the same-path counter.
+    tel.record_fixslice_escalation();
+    assert_eq!(tel.fixslice_escalation_count, 2);
+    assert_eq!(tel.fixslice_escalation_same_path_count, 1);
+    assert_eq!(tel.fixslice_escalation_stagnation_count, 1);
+}
+
+#[test]
+fn test_telemetry_repair_salvage_classification_does_not_flip_worker() {
+    // Salvage is a retrospective label — it means repair turn produced
+    // a mutation without ever reaching the worker path.
+    let mut tel = AgentTelemetry::new();
+    tel.record_mutation_turn(3, Some(1.0), "file.edit");
+    tel.record_pre_exit_repair_injected();
+    tel.record_pre_exit_repair_consumed();
+    assert!(!tel.worker_observed);
+
+    tel.classify_repair_salvage();
+    assert_eq!(tel.fixslice_escalation_repair_salvage_count, 1);
+    assert!(
+        !tel.worker_observed,
+        "salvage must not flip worker_observed — it is a distinct classification"
+    );
+    // Salvage classification is idempotent.
+    tel.classify_repair_salvage();
+    assert_eq!(tel.fixslice_escalation_repair_salvage_count, 1);
+}
+
+#[test]
+fn test_telemetry_no_salvage_when_worker_already_observed() {
+    let mut tel = AgentTelemetry::new();
+    tel.record_mutation_turn(3, Some(1.0), "file.edit");
+    tel.record_pre_exit_repair_injected();
+    tel.record_fixslice_escalation_stagnation();
+
+    tel.classify_repair_salvage();
+    assert_eq!(tel.fixslice_escalation_repair_salvage_count, 0);
+}
+
+#[test]
+fn test_telemetry_no_salvage_without_mutation() {
+    let mut tel = AgentTelemetry::new();
+    tel.record_pre_exit_repair_injected();
+    tel.record_pre_exit_repair_consumed();
+
+    tel.classify_repair_salvage();
+    assert_eq!(tel.fixslice_escalation_repair_salvage_count, 0);
+}
+
+#[test]
+fn test_telemetry_serializes_new_counters() {
+    let mut tel = AgentTelemetry::new();
+    tel.record_fixslice_escalation();
+    tel.record_fixslice_escalation_stagnation();
+
+    let json = serde_json::to_string(&tel).unwrap();
+    assert!(json.contains("\"fixslice_escalation_same_path_count\":1"));
+    assert!(json.contains("\"fixslice_escalation_stagnation_count\":1"));
+    assert!(json.contains("\"fixslice_escalation_repair_salvage_count\":0"));
+
+    let round_trip: AgentTelemetry = serde_json::from_str(&json).unwrap();
+    assert_eq!(round_trip.fixslice_escalation_same_path_count, 1);
+    assert_eq!(round_trip.fixslice_escalation_stagnation_count, 1);
+    assert_eq!(round_trip.fixslice_escalation_repair_salvage_count, 0);
+}
+
+#[test]
+fn test_telemetry_new_counters_backward_compat_default_zero() {
+    // Old artifacts missing the new fields should deserialize cleanly.
+    let json = r#"{"premature_final_count":0,"total_final_requests":0,"plan_registration_count":0,"plan_update_count":0,"sync_from_touched_files_count":0,"completion_kind":null}"#;
+    let tel: AgentTelemetry = serde_json::from_str(json).unwrap();
+    assert_eq!(tel.fixslice_escalation_same_path_count, 0);
+    assert_eq!(tel.fixslice_escalation_stagnation_count, 0);
+    assert_eq!(tel.fixslice_escalation_repair_salvage_count, 0);
 }

--- a/tests/fixslice_escalation.rs
+++ b/tests/fixslice_escalation.rs
@@ -340,7 +340,12 @@ fn test_telemetry_same_path_counter_bumped_by_legacy_method() {
     assert_eq!(tel.fixslice_escalation_same_path_count, 1);
     assert_eq!(tel.fixslice_escalation_stagnation_count, 0);
     assert_eq!(tel.fixslice_escalation_repair_salvage_count, 0);
-    assert!(tel.worker_observed);
+    // Issue #339: escalation is request-side only and must not flip the
+    // success-side `worker_observed` flag.
+    assert!(
+        !tel.worker_observed,
+        "escalation-emission must not flip worker_observed"
+    );
 }
 
 #[test]
@@ -350,13 +355,15 @@ fn test_telemetry_stagnation_escalation_distinct_from_same_path() {
     assert_eq!(tel.fixslice_escalation_count, 1);
     assert_eq!(tel.fixslice_escalation_stagnation_count, 1);
     assert_eq!(tel.fixslice_escalation_same_path_count, 0);
-    assert!(tel.worker_observed);
+    // Issue #339: stagnation escalation is request-side only.
+    assert!(!tel.worker_observed);
 
     // A subsequent same-path escalation bumps only the same-path counter.
     tel.record_fixslice_escalation();
     assert_eq!(tel.fixslice_escalation_count, 2);
     assert_eq!(tel.fixslice_escalation_same_path_count, 1);
     assert_eq!(tel.fixslice_escalation_stagnation_count, 1);
+    assert!(!tel.worker_observed);
 }
 
 #[test]
@@ -385,7 +392,10 @@ fn test_telemetry_no_salvage_when_worker_already_observed() {
     let mut tel = AgentTelemetry::new();
     tel.record_mutation_turn(3, Some(1.0), "file.edit");
     tel.record_pre_exit_repair_injected();
+    // Issue #339: under the new semantics, salvage suppression requires
+    // real worker success, not merely an escalation request.
     tel.record_fixslice_escalation_stagnation();
+    tel.record_worker_success();
 
     tel.classify_repair_salvage();
     assert_eq!(tel.fixslice_escalation_repair_salvage_count, 0);

--- a/tests/fixslice_escalation.rs
+++ b/tests/fixslice_escalation.rs
@@ -1,0 +1,248 @@
+//! Integration tests for Issue #321: fix_slice escalation path.
+//!
+//! Tests that repeated single-file edit failures escalate to
+//! agent.fix_slice via EditFallbackAction::FixSliceEscalation.
+
+use anvil::app::edit_fail_tracker::{
+    EditFailTracker, EditFallbackAction, determine_fallback_action,
+};
+use anvil::app::stagnation_state::{StagnationState, compute_stagnation_score};
+use anvil::contracts::AgentTelemetry;
+
+// ============================================================
+// Test 1: config default for edit_fixslice_threshold
+// ============================================================
+
+#[test]
+fn test_fixslice_threshold_config_default() {
+    let config = anvil::config::EffectiveConfig::default_for_test().unwrap();
+    assert_eq!(
+        config.runtime.edit_fixslice_threshold, 7,
+        "default fixslice threshold should be 7"
+    );
+}
+
+#[test]
+fn test_fixslice_threshold_config_clamp_must_exceed_write_fallback() {
+    let mut config = anvil::config::EffectiveConfig::default_for_test().unwrap();
+    // Set fixslice to same as write_fallback (5) — should be bumped to write_fallback + 2
+    config.runtime.edit_fixslice_threshold = 5;
+    assert!(config.validate_for_test().is_ok());
+    assert!(
+        config.runtime.edit_fixslice_threshold > config.runtime.edit_write_fallback_threshold,
+        "fixslice threshold ({}) must be > write_fallback threshold ({})",
+        config.runtime.edit_fixslice_threshold,
+        config.runtime.edit_write_fallback_threshold,
+    );
+}
+
+#[test]
+fn test_fixslice_threshold_config_zero_disables() {
+    let mut config = anvil::config::EffectiveConfig::default_for_test().unwrap();
+    config.runtime.edit_fixslice_threshold = 0;
+    assert!(config.validate_for_test().is_ok());
+    assert_eq!(
+        config.runtime.edit_fixslice_threshold, 0,
+        "0 should remain 0 (disabled)"
+    );
+}
+
+// ============================================================
+// Test 2: determine_fallback_action escalation chain
+// ============================================================
+
+#[test]
+fn test_escalation_chain_with_fixslice() {
+    // reread=3, write_fallback=5, fixslice=7
+    // Verify the complete escalation chain
+    assert_eq!(
+        determine_fallback_action(1, 3, 5, 7),
+        EditFallbackAction::Continue
+    );
+    assert_eq!(
+        determine_fallback_action(3, 3, 5, 7),
+        EditFallbackAction::ReRead
+    );
+    assert_eq!(
+        determine_fallback_action(5, 3, 5, 7),
+        EditFallbackAction::WriteFallback
+    );
+    assert_eq!(
+        determine_fallback_action(7, 3, 5, 7),
+        EditFallbackAction::FixSliceEscalation
+    );
+    // Beyond threshold, persists
+    assert_eq!(
+        determine_fallback_action(10, 3, 5, 7),
+        EditFallbackAction::FixSliceEscalation
+    );
+}
+
+#[test]
+fn test_escalation_chain_fixslice_disabled() {
+    // fixslice=0 (disabled) — WriteFallback is the ceiling
+    assert_eq!(
+        determine_fallback_action(7, 3, 5, 0),
+        EditFallbackAction::WriteFallback
+    );
+    assert_eq!(
+        determine_fallback_action(100, 3, 5, 0),
+        EditFallbackAction::WriteFallback
+    );
+}
+
+// ============================================================
+// Test 3: EditFailTracker escalation flow
+// ============================================================
+
+#[test]
+fn test_tracker_fixslice_escalation_flow() {
+    // reread=3, write_fallback=5, fixslice=7
+    let mut tracker = EditFailTracker::new(3, 5, 7);
+    let path = "src/lib/auto-yes-poller.ts";
+
+    // Failures 1-2: Continue
+    assert_eq!(tracker.record_failure(path), EditFallbackAction::Continue);
+    assert_eq!(tracker.record_failure(path), EditFallbackAction::Continue);
+
+    // Failures 3-4: ReRead
+    assert_eq!(tracker.record_failure(path), EditFallbackAction::ReRead);
+    assert_eq!(tracker.record_failure(path), EditFallbackAction::ReRead);
+
+    // Failures 5-6: WriteFallback
+    assert_eq!(
+        tracker.record_failure(path),
+        EditFallbackAction::WriteFallback
+    );
+    assert_eq!(
+        tracker.record_failure(path),
+        EditFallbackAction::WriteFallback
+    );
+
+    // Failure 7+: FixSliceEscalation
+    assert_eq!(
+        tracker.record_failure(path),
+        EditFallbackAction::FixSliceEscalation
+    );
+    assert_eq!(tracker.failure_count(path), 7);
+
+    // Persists
+    assert_eq!(
+        tracker.record_failure(path),
+        EditFallbackAction::FixSliceEscalation
+    );
+}
+
+#[test]
+fn test_tracker_fixslice_independent_paths() {
+    let mut tracker = EditFailTracker::new(3, 5, 7);
+
+    // Drive path A to fixslice threshold
+    for _ in 0..7 {
+        tracker.record_failure("a.ts");
+    }
+    assert_eq!(
+        tracker.record_failure("a.ts"),
+        EditFallbackAction::FixSliceEscalation
+    );
+
+    // Path B should still be at Continue
+    assert_eq!(tracker.record_failure("b.ts"), EditFallbackAction::Continue);
+}
+
+#[test]
+fn test_tracker_fixslice_reset_on_success() {
+    let mut tracker = EditFailTracker::new(3, 5, 7);
+
+    // Drive to fixslice
+    for _ in 0..7 {
+        tracker.record_failure("a.ts");
+    }
+    assert_eq!(
+        tracker.record_failure("a.ts"),
+        EditFallbackAction::FixSliceEscalation
+    );
+
+    // Success resets
+    tracker.record_success("a.ts");
+    assert_eq!(tracker.failure_count("a.ts"), 0);
+    assert_eq!(tracker.record_failure("a.ts"), EditFallbackAction::Continue);
+}
+
+// ============================================================
+// Test 4: Stagnation + single-file edit failure reproduces Issue #321
+// ============================================================
+
+#[test]
+fn test_stagnation_with_single_file_edit_drift() {
+    // Reproduce the observed pattern from Issue #321:
+    // - Same file edited repeatedly with failures
+    // - Stagnation score rises
+    // - But fix_slice was never invoked
+    //
+    // After the fix, EditFailTracker returns FixSliceEscalation at count >= 7
+
+    let mut stagnation = StagnationState::new();
+    let mut tracker = EditFailTracker::new(3, 5, 7);
+    let path = "src/lib/auto-yes-poller.ts";
+
+    // Simulate 5 turns of same-file edit failures (no mutation)
+    let workset = vec![0usize];
+    for _ in 0..5 {
+        stagnation.begin_turn(&workset);
+        stagnation.end_turn(false); // no mutation
+    }
+    let score = compute_stagnation_score(&stagnation);
+    assert!(score >= 1, "Expected stagnation score >= 1, got {score}");
+
+    // After 7 consecutive edit failures, escalation should trigger
+    for _ in 0..6 {
+        tracker.record_failure(path);
+    }
+    let action = tracker.record_failure(path);
+    assert_eq!(
+        action,
+        EditFallbackAction::FixSliceEscalation,
+        "7th consecutive edit failure should trigger FixSliceEscalation"
+    );
+}
+
+// ============================================================
+// Test 5: AgentTelemetry records escalation
+// ============================================================
+
+#[test]
+fn test_agent_telemetry_fixslice_escalation() {
+    let mut tel = AgentTelemetry::new();
+    assert_eq!(tel.fixslice_escalation_count, 0);
+
+    tel.record_fixslice_escalation();
+    assert_eq!(tel.fixslice_escalation_count, 1);
+
+    tel.record_fixslice_escalation();
+    assert_eq!(tel.fixslice_escalation_count, 2);
+}
+
+#[test]
+fn test_agent_telemetry_fixslice_serialization() {
+    let mut tel = AgentTelemetry::new();
+    tel.record_fixslice_escalation();
+
+    let json = serde_json::to_string(&tel).unwrap();
+    assert!(
+        json.contains("\"fixslice_escalation_count\":1"),
+        "fixslice_escalation_count should appear in serialized telemetry"
+    );
+
+    // Deserialize back
+    let tel2: AgentTelemetry = serde_json::from_str(&json).unwrap();
+    assert_eq!(tel2.fixslice_escalation_count, 1);
+}
+
+#[test]
+fn test_agent_telemetry_fixslice_default_zero() {
+    // Backward compatibility: missing field defaults to 0
+    let json = r#"{"premature_final_count":0,"total_final_requests":0,"plan_registration_count":0,"plan_update_count":0,"sync_from_touched_files_count":0,"completion_kind":null}"#;
+    let tel: AgentTelemetry = serde_json::from_str(json).unwrap();
+    assert_eq!(tel.fixslice_escalation_count, 0);
+}

--- a/tests/fixslice_failure_control.rs
+++ b/tests/fixslice_failure_control.rs
@@ -1,0 +1,243 @@
+//! Integration tests for Issue #343: fix_slice failure control.
+//!
+//! Issue #343 covers the failure mode where `agent.fix_slice` is invoked
+//! (request side) but never reaches a successful worker mutation, yet the
+//! parent session continues to drift: `file.edit` lands a mutation later,
+//! the pre-exit repair turn is consumed, and telemetry ends with
+//! `worker_observed=false`, `mutation_observed=true`, `repair_turn_observed=true`.
+//!
+//! Under a `requires_worker_observation` pack expectation, that is a
+//! benchmark failure — the worker never produced observable evidence, but
+//! parent-side salvage kept the loop running and ended in `partial`.
+//!
+//! The fix:
+//! - classifies *why* fix_slice failed (no proposal, validation failure,
+//!   rewrite failure, max iterations),
+//! - exposes a failure counter + last reason on `AgentTelemetry`, and
+//! - provides `should_skip_pre_exit_repair_for_worker_failure()` so the
+//!   agentic loop can bail out cleanly instead of injecting a repair turn
+//!   that would otherwise flip `repair_turn_observed` and degrade
+//!   `completion_kind` to `partial`.
+
+use anvil::contracts::{
+    AgentTelemetry, FixSliceFailureReason, PackExpectation, PackValidationResult,
+};
+
+// ---------------------------------------------------------------------------
+// FixSliceFailureReason
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fixslice_failure_reason_display_roundtrip() {
+    for (variant, expected) in [
+        (FixSliceFailureReason::NoProposal, "no_proposal"),
+        (
+            FixSliceFailureReason::ProposalValidationFailed,
+            "proposal_validation_failed",
+        ),
+        (FixSliceFailureReason::RewriteFailed, "rewrite_failed"),
+        (
+            FixSliceFailureReason::MaxIterationsReached,
+            "max_iterations_reached",
+        ),
+    ] {
+        assert_eq!(variant.to_string(), expected);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// record_fixslice_worker_failure
+// ---------------------------------------------------------------------------
+
+#[test]
+fn record_fixslice_worker_failure_sets_count_and_reason() {
+    let mut tel = AgentTelemetry::new();
+    assert_eq!(tel.fixslice_worker_failure_count, 0);
+    assert!(tel.fixslice_failure_reason.is_none());
+
+    tel.record_fixslice_worker_failure(FixSliceFailureReason::MaxIterationsReached);
+
+    assert_eq!(tel.fixslice_worker_failure_count, 1);
+    assert_eq!(
+        tel.fixslice_failure_reason.as_deref(),
+        Some("max_iterations_reached")
+    );
+    assert!(
+        !tel.worker_observed,
+        "recording a fix_slice failure must NOT flip worker_observed"
+    );
+}
+
+#[test]
+fn record_fixslice_worker_failure_accumulates_count_and_tracks_latest_reason() {
+    let mut tel = AgentTelemetry::new();
+    tel.record_fixslice_worker_failure(FixSliceFailureReason::NoProposal);
+    tel.record_fixslice_worker_failure(FixSliceFailureReason::MaxIterationsReached);
+    tel.record_fixslice_worker_failure(FixSliceFailureReason::ProposalValidationFailed);
+
+    assert_eq!(tel.fixslice_worker_failure_count, 3);
+    assert_eq!(
+        tel.fixslice_failure_reason.as_deref(),
+        Some("proposal_validation_failed"),
+        "latest failure reason should win for observability"
+    );
+}
+
+#[test]
+fn has_fixslice_worker_failure_tracks_any_recorded_failure() {
+    let mut tel = AgentTelemetry::new();
+    assert!(!tel.has_fixslice_worker_failure());
+    tel.record_fixslice_worker_failure(FixSliceFailureReason::RewriteFailed);
+    assert!(tel.has_fixslice_worker_failure());
+}
+
+// ---------------------------------------------------------------------------
+// should_skip_pre_exit_repair_for_worker_failure
+// ---------------------------------------------------------------------------
+
+#[test]
+fn should_skip_repair_true_for_worker_required_after_fixslice_failure() {
+    // The A1 shape from Issue #343:
+    //  - pack expectation = requires_worker_observation
+    //  - fix_slice invoked and failed (e.g. max iterations)
+    //  - worker success never recorded
+    //
+    // Under the fix, the agentic loop must NOT inject a pre-exit repair
+    // turn — the pack cannot be satisfied and the repair turn would only
+    // flip repair_turn_observed and degrade completion_kind.
+    let mut tel = AgentTelemetry::new();
+    tel.pack_expectation = Some(PackExpectation::RequiresWorkerObservation);
+    tel.record_fixslice_escalation();
+    tel.record_fixslice_worker_failure(FixSliceFailureReason::MaxIterationsReached);
+
+    assert!(tel.should_skip_pre_exit_repair_for_worker_failure());
+}
+
+#[test]
+fn should_skip_repair_false_when_worker_success_was_recorded() {
+    let mut tel = AgentTelemetry::new();
+    tel.pack_expectation = Some(PackExpectation::RequiresWorkerObservation);
+    tel.record_fixslice_escalation();
+    tel.record_fixslice_worker_failure(FixSliceFailureReason::RewriteFailed);
+    // A later fix_slice attempt eventually succeeds:
+    tel.record_mutation_turn(6, Some(2.0), "file.rewrite");
+    tel.record_worker_success();
+
+    assert!(!tel.should_skip_pre_exit_repair_for_worker_failure());
+}
+
+#[test]
+fn should_skip_repair_false_without_any_fixslice_failure() {
+    let mut tel = AgentTelemetry::new();
+    tel.pack_expectation = Some(PackExpectation::RequiresWorkerObservation);
+    // Pack is worker-required but fix_slice was never called / never
+    // failed — the existing escape-hatch behavior should remain in effect.
+    assert!(!tel.should_skip_pre_exit_repair_for_worker_failure());
+}
+
+#[test]
+fn should_skip_repair_false_when_pack_expectation_is_unset() {
+    let mut tel = AgentTelemetry::new();
+    tel.record_fixslice_worker_failure(FixSliceFailureReason::NoProposal);
+    assert!(!tel.should_skip_pre_exit_repair_for_worker_failure());
+}
+
+#[test]
+fn should_skip_repair_false_for_requires_mutation_pack() {
+    let mut tel = AgentTelemetry::new();
+    tel.pack_expectation = Some(PackExpectation::RequiresMutation);
+    tel.record_fixslice_worker_failure(FixSliceFailureReason::MaxIterationsReached);
+    // requires_mutation can still be satisfied by a parent-side file.edit
+    // mutation, so the worker-failure skip must not kick in.
+    assert!(!tel.should_skip_pre_exit_repair_for_worker_failure());
+}
+
+#[test]
+fn should_skip_repair_false_for_audit_only_pack() {
+    let mut tel = AgentTelemetry::new();
+    tel.pack_expectation = Some(PackExpectation::AuditOnly);
+    tel.record_fixslice_worker_failure(FixSliceFailureReason::NoProposal);
+    assert!(!tel.should_skip_pre_exit_repair_for_worker_failure());
+}
+
+// ---------------------------------------------------------------------------
+// Interaction with pack validation
+// ---------------------------------------------------------------------------
+
+#[test]
+fn worker_required_gate_still_rejects_after_fixslice_failure_only() {
+    // Parity with Issue #339 semantics: a recorded fix_slice failure on
+    // its own must not accidentally flip worker_observed. The gate must
+    // continue to reject the session.
+    let mut tel = AgentTelemetry::new();
+    tel.record_fixslice_escalation();
+    tel.record_fixslice_worker_failure(FixSliceFailureReason::MaxIterationsReached);
+
+    let result = tel.validate_against(PackExpectation::RequiresWorkerObservation);
+    assert!(matches!(result, PackValidationResult::Mismatch { .. }));
+    assert!(!tel.worker_observed);
+}
+
+// ---------------------------------------------------------------------------
+// Telemetry artifact persistence
+// ---------------------------------------------------------------------------
+
+#[test]
+fn telemetry_artifact_includes_fixslice_failure_fields() {
+    let dir = tempfile::tempdir().unwrap();
+    let session_id = format!("test_fixslice_failure_{}", std::process::id());
+    let dir_str = dir.path().to_str().unwrap();
+
+    let mut tel = AgentTelemetry::new();
+    tel.record_fixslice_escalation();
+    tel.record_fixslice_worker_failure(FixSliceFailureReason::MaxIterationsReached);
+    tel.record_fixslice_worker_failure(FixSliceFailureReason::NoProposal);
+    tel.pack_expectation = Some(PackExpectation::RequiresWorkerObservation);
+
+    tel.write_artifact_to_dir(dir_str, &session_id).unwrap();
+
+    let file_path = dir.path().join(format!("{session_id}_telemetry.json"));
+    let contents = std::fs::read_to_string(&file_path).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&contents).unwrap();
+
+    assert_eq!(json["fixslice_worker_failure_count"], 2);
+    assert_eq!(json["fixslice_failure_reason"], "no_proposal");
+}
+
+#[test]
+fn telemetry_artifact_fixslice_failure_fields_default() {
+    let dir = tempfile::tempdir().unwrap();
+    let session_id = format!("test_fixslice_failure_default_{}", std::process::id());
+    let dir_str = dir.path().to_str().unwrap();
+
+    let tel = AgentTelemetry::new();
+    tel.write_artifact_to_dir(dir_str, &session_id).unwrap();
+
+    let file_path = dir.path().join(format!("{session_id}_telemetry.json"));
+    let contents = std::fs::read_to_string(&file_path).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&contents).unwrap();
+
+    assert_eq!(json["fixslice_worker_failure_count"], 0);
+    assert!(json["fixslice_failure_reason"].is_null());
+}
+
+// ---------------------------------------------------------------------------
+// Salvage classification interaction — the new failure counter is orthogonal
+// to the existing repair-salvage classifier and must not suppress it.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fixslice_failure_does_not_suppress_repair_salvage_classification() {
+    let mut tel = AgentTelemetry::new();
+    tel.record_fixslice_escalation();
+    tel.record_fixslice_worker_failure(FixSliceFailureReason::MaxIterationsReached);
+    tel.record_pre_exit_repair_injected();
+    tel.record_mutation_turn(11, Some(4.0), "file.edit");
+
+    tel.classify_repair_salvage();
+    assert_eq!(
+        tel.fixslice_escalation_repair_salvage_count, 1,
+        "repair-salvage classifier must still fire independently"
+    );
+    assert!(!tel.worker_observed);
+}

--- a/tests/fixslice_subagent.rs
+++ b/tests/fixslice_subagent.rs
@@ -1,18 +1,21 @@
 //! Integration tests for the FixSlice sub-agent (Issue #291).
 
 use anvil::agent::subagent::{
-    FIXSLICE_MAX_ITERATIONS, FIXSLICE_REPEATED_READ_THRESHOLD, FIXSLICE_TIMEOUT_SECS,
-    MAX_FIXSLICE_LINES, SubAgentKind, first_file_read_target, is_repeated_read_loop,
+    DEFAULT_FIXSLICE_REPEATED_READ_THRESHOLD, FIXSLICE_MAX_ITERATIONS,
+    FIXSLICE_REPEATED_READ_THRESHOLD, FIXSLICE_TIMEOUT_SECS, MAX_FIXSLICE_LINES, SubAgentKind,
+    first_file_read_target, is_repeated_read_loop,
 };
 use anvil::agent::tag_spec::find_spec;
 use anvil::app::agentic::{
     build_fixslice_user_prompt, build_rewrite_request, validate_fix_proposal,
 };
+use anvil::config::{ENV_OVERRIDE_WHITELIST, EffectiveConfig};
 use anvil::contracts::{FixSliceFailureReason, FixSliceProposal};
 use anvil::tooling::{
     ExecutionClass, ExecutionMode, PermissionClass, ToolCallRequest, ToolInput, ToolKind,
     ToolRegistry, ToolValidationError,
 };
+use std::collections::HashMap;
 
 // ---------------------------------------------------------------------------
 // Task 1.1: FixSliceProposal serde
@@ -608,9 +611,135 @@ fn test_fixslice_tool_kind_mapping() {
 
 #[test]
 fn test_fixslice_repeated_read_threshold_default() {
-    // The default threshold is 2: two consecutive iterations re-reading the
-    // same target path trip the guard.
-    assert_eq!(FIXSLICE_REPEATED_READ_THRESHOLD, 2);
+    // Issue #353: the default threshold is 5 — cycle-11 regressed on the
+    // previous value of 2, which killed legitimate qwen3.5:122b
+    // exploration. The back-compat alias tracks the default.
+    assert_eq!(DEFAULT_FIXSLICE_REPEATED_READ_THRESHOLD, 5);
+    assert_eq!(
+        FIXSLICE_REPEATED_READ_THRESHOLD,
+        DEFAULT_FIXSLICE_REPEATED_READ_THRESHOLD
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Issue #353: no-progress detector tunable — runtime config, env, and file
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_fixslice_no_progress_detector_default_is_raised_threshold() {
+    // Issue #353: the baseline runtime config must ship with the new
+    // raised default so legitimate A1/A2 exploration is not aborted.
+    let config = EffectiveConfig::default_for_test().expect("default config");
+    assert_eq!(
+        config.runtime.fixslice_no_progress_detector,
+        DEFAULT_FIXSLICE_REPEATED_READ_THRESHOLD
+    );
+}
+
+#[test]
+fn test_fixslice_no_progress_detector_allows_five_reads_before_firing() {
+    // Issue #353: with the raised default, five same-path reads in a row
+    // are needed before the guard trips. Four are still fine.
+    let threshold = DEFAULT_FIXSLICE_REPEATED_READ_THRESHOLD;
+    for prior in 0..(threshold - 1) {
+        assert!(
+            !is_repeated_read_loop(Some("src/main.rs"), Some("src/main.rs"), prior, threshold,),
+            "prior={prior} must not trip at default threshold"
+        );
+    }
+    assert!(is_repeated_read_loop(
+        Some("src/main.rs"),
+        Some("src/main.rs"),
+        threshold - 1,
+        threshold,
+    ));
+}
+
+#[test]
+fn test_fixslice_no_progress_detector_env_off_disables_guard() {
+    // Issue #353: `ANVIL_FIXSLICE_NO_PROGRESS_DETECTOR=off` must route to
+    // threshold=0 in RuntimeConfig; the SubAgentSession treats `0` as
+    // "detector disabled" and never aborts on read repetition.
+    let mut config = EffectiveConfig::default_for_test().expect("default config");
+    let file_values: HashMap<String, String> = HashMap::new();
+    let mut env_values: HashMap<String, String> = HashMap::new();
+    env_values.insert(
+        "ANVIL_FIXSLICE_NO_PROGRESS_DETECTOR".to_string(),
+        "off".to_string(),
+    );
+    let cli_values: HashMap<String, String> = HashMap::new();
+    config
+        .apply_overrides_for_test(&file_values, &env_values, &cli_values)
+        .expect("env override applies");
+    assert_eq!(config.runtime.fixslice_no_progress_detector, 0);
+}
+
+#[test]
+fn test_fixslice_no_progress_detector_env_numeric_override() {
+    // Numeric env values are accepted and clamped to [0, 20] by validate.
+    let mut config = EffectiveConfig::default_for_test().expect("default config");
+    let mut env = HashMap::new();
+    env.insert(
+        "ANVIL_FIXSLICE_NO_PROGRESS_DETECTOR".to_string(),
+        "7".to_string(),
+    );
+    config
+        .apply_overrides_for_test(&HashMap::new(), &env, &HashMap::new())
+        .expect("numeric env override applies");
+    assert_eq!(config.runtime.fixslice_no_progress_detector, 7);
+}
+
+#[test]
+fn test_fixslice_no_progress_detector_env_on_restores_default() {
+    let mut config = EffectiveConfig::default_for_test().expect("default config");
+    // Force a non-default state first.
+    config.runtime.fixslice_no_progress_detector = 0;
+    let mut env = HashMap::new();
+    env.insert(
+        "ANVIL_FIXSLICE_NO_PROGRESS_DETECTOR".to_string(),
+        "on".to_string(),
+    );
+    config
+        .apply_overrides_for_test(&HashMap::new(), &env, &HashMap::new())
+        .expect("on override applies");
+    assert_eq!(
+        config.runtime.fixslice_no_progress_detector,
+        DEFAULT_FIXSLICE_REPEATED_READ_THRESHOLD
+    );
+}
+
+#[test]
+fn test_fixslice_no_progress_detector_file_config_key_honored() {
+    // Issue #353: the file-config key must match the env name so users
+    // can set it via `.anvil/config`.
+    let mut config = EffectiveConfig::default_for_test().expect("default config");
+    let mut file = HashMap::new();
+    file.insert("fixslice_no_progress_detector".to_string(), "3".to_string());
+    config
+        .apply_overrides_for_test(&file, &HashMap::new(), &HashMap::new())
+        .expect("file override applies");
+    assert_eq!(config.runtime.fixslice_no_progress_detector, 3);
+}
+
+#[test]
+fn test_fixslice_no_progress_detector_env_whitelisted() {
+    // Issue #347 regression guard: env vars must be in the whitelist, or
+    // `apply_env_overrides()` silently drops them.
+    assert!(
+        ENV_OVERRIDE_WHITELIST.contains(&"ANVIL_FIXSLICE_NO_PROGRESS_DETECTOR"),
+        "ANVIL_FIXSLICE_NO_PROGRESS_DETECTOR must be in the env override \
+         whitelist so it reaches RuntimeConfig via apply_env_overrides"
+    );
+}
+
+#[test]
+fn test_fixslice_no_progress_detector_validate_clamps_upper_bound() {
+    // Values above 20 are clamped (misconfig guard — would exceed the
+    // max FixSlice iteration cap anyway).
+    let mut config = EffectiveConfig::default_for_test().expect("default config");
+    config.runtime.fixslice_no_progress_detector = 999;
+    config.validate_for_test().expect("validate");
+    assert_eq!(config.runtime.fixslice_no_progress_detector, 20);
 }
 
 #[test]

--- a/tests/fixslice_subagent.rs
+++ b/tests/fixslice_subagent.rs
@@ -476,7 +476,7 @@ fn test_fixslice_system_prompt_enforces_contract_issue_357() {
         "prompt must include a positive few-shot example: {prompt}"
     );
     assert!(
-        prompt.contains("Incorrect"),
+        prompt.contains("Avoid"),
         "prompt must include a negative few-shot example: {prompt}"
     );
 
@@ -955,6 +955,75 @@ fn test_first_file_read_target_ignores_non_file_read() {
     assert_eq!(
         first_file_read_target(&calls),
         Some("src/target.rs".to_string())
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Issue #359: balance fix_slice prompt — encouragement guidance + softened
+// negative examples to prevent proposal-avoidance under path ambiguity
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_fixslice_system_prompt_contains_encouragement_issue_359() {
+    use anvil::agent::subagent::{SubAgentPromptOptions, build_subagent_system_prompt};
+
+    let opts = SubAgentPromptOptions {
+        offline: false,
+        ui_language: None,
+    };
+    let prompt = build_subagent_system_prompt(&SubAgentKind::FixSlice, &opts);
+
+    // Encouragement section must exist to counterbalance strict contract.
+    assert!(
+        prompt.contains("imperfect proposal"),
+        "system prompt must encourage submitting imperfect proposals over no proposal: {prompt}"
+    );
+    assert!(
+        prompt.contains("retry"),
+        "system prompt must mention Anvil retry to reduce proposal-avoidance: {prompt}"
+    );
+}
+
+#[test]
+fn test_fixslice_system_prompt_softened_negative_examples_issue_359() {
+    use anvil::agent::subagent::{SubAgentPromptOptions, build_subagent_system_prompt};
+
+    let opts = SubAgentPromptOptions {
+        offline: false,
+        ui_language: None,
+    };
+    let prompt = build_subagent_system_prompt(&SubAgentKind::FixSlice, &opts);
+
+    // Negative examples must use "Avoid" instead of "Incorrect ... do NOT do this".
+    assert!(
+        prompt.contains("Avoid"),
+        "negative examples must use softened label 'Avoid': {prompt}"
+    );
+    assert!(
+        !prompt.contains("do NOT do this"),
+        "prompt must not contain 'do NOT do this' — softened in Issue #359: {prompt}"
+    );
+}
+
+#[test]
+fn test_fixslice_user_prompt_contains_guidance_issue_359() {
+    let prompt =
+        build_fixslice_user_prompt("src/lib/auto-yes-manager.ts", "fix path resolution bug", 80);
+
+    // IMPORTANT GUIDANCE must be present to counterbalance strict contract.
+    assert!(
+        prompt.contains("IMPORTANT GUIDANCE"),
+        "user prompt must contain IMPORTANT GUIDANCE section: {prompt}"
+    );
+    // Path ambiguity guidance — the primary regression trigger.
+    assert!(
+        prompt.contains("path ambiguity"),
+        "user prompt must address path ambiguity: {prompt}"
+    );
+    // Encourage proposal submission.
+    assert!(
+        prompt.contains("imperfect proposal"),
+        "user prompt must encourage imperfect proposals over no proposal: {prompt}"
     );
 }
 

--- a/tests/fixslice_subagent.rs
+++ b/tests/fixslice_subagent.rs
@@ -1,0 +1,553 @@
+//! Integration tests for the FixSlice sub-agent (Issue #291).
+
+use anvil::agent::subagent::{
+    FIXSLICE_MAX_ITERATIONS, FIXSLICE_TIMEOUT_SECS, MAX_FIXSLICE_LINES, SubAgentKind,
+};
+use anvil::agent::tag_spec::find_spec;
+use anvil::app::agentic::{build_rewrite_request, validate_fix_proposal};
+use anvil::contracts::FixSliceProposal;
+use anvil::tooling::{
+    ExecutionClass, ExecutionMode, PermissionClass, ToolCallRequest, ToolInput, ToolKind,
+    ToolRegistry, ToolValidationError,
+};
+
+// ---------------------------------------------------------------------------
+// Task 1.1: FixSliceProposal serde
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_fixslice_proposal_serde() {
+    let proposal = FixSliceProposal {
+        target_path: "src/main.rs".to_string(),
+        start_line: 10,
+        end_line: 15,
+        replacement_content: "fn fixed() {}\n".to_string(),
+        rationale: "Fix compilation error".to_string(),
+    };
+
+    let json = serde_json::to_string(&proposal).expect("serialize");
+    let deserialized: FixSliceProposal = serde_json::from_str(&json).expect("deserialize");
+    assert_eq!(proposal, deserialized);
+}
+
+#[test]
+fn test_fixslice_proposal_serde_default_rationale() {
+    // rationale has #[serde(default)], so it can be omitted in JSON
+    let json = r#"{
+        "target_path": "src/lib.rs",
+        "start_line": 1,
+        "end_line": 5,
+        "replacement_content": "new content"
+    }"#;
+    let proposal: FixSliceProposal = serde_json::from_str(json).expect("deserialize");
+    assert_eq!(proposal.target_path, "src/lib.rs");
+    assert_eq!(proposal.start_line, 1);
+    assert_eq!(proposal.end_line, 5);
+    assert_eq!(proposal.replacement_content, "new content");
+    assert_eq!(proposal.rationale, ""); // default
+}
+
+// ---------------------------------------------------------------------------
+// Task 2.1: ToolRegistry
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_fixslice_tool_registry() {
+    let mut registry = ToolRegistry::new();
+    registry.register_fixslice_tools();
+
+    // file.read should be registered
+    assert!(
+        registry.get("file.read").is_some(),
+        "file.read should be registered for FixSlice worker"
+    );
+
+    // Other tools should NOT be registered
+    assert!(registry.get("file.write").is_none());
+    assert!(registry.get("file.edit").is_none());
+    assert!(registry.get("file.search").is_none());
+    assert!(registry.get("shell.exec").is_none());
+    assert!(registry.get("agent.explore").is_none());
+    assert!(registry.get("agent.plan").is_none());
+}
+
+#[test]
+fn test_fixslice_permission_class_confirm() {
+    let mut registry = ToolRegistry::new();
+    registry.register_agent_fix_slice();
+
+    let spec = registry
+        .get("agent.fix_slice")
+        .expect("agent.fix_slice should be registered");
+    assert_eq!(spec.kind, ToolKind::AgentFixSlice);
+    assert_eq!(spec.execution_class, ExecutionClass::Mutating);
+    assert_eq!(spec.permission_class, PermissionClass::Confirm);
+    assert_eq!(spec.execution_mode, ExecutionMode::SequentialOnly);
+}
+
+// ---------------------------------------------------------------------------
+// Task 2.3: Budget defaults
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_fixslice_config_defaults() {
+    assert_eq!(FIXSLICE_MAX_ITERATIONS, 3);
+    assert_eq!(FIXSLICE_TIMEOUT_SECS, 60);
+    assert_eq!(MAX_FIXSLICE_LINES, 200);
+}
+
+// ---------------------------------------------------------------------------
+// Task 1.2: SubAgentKind::FixSlice
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_fixslice_subagent_kind_from_tool_input() {
+    let input = ToolInput::AgentFixSlice {
+        target_path: "src/main.rs".to_string(),
+        goal: "fix bug".to_string(),
+        max_lines: 50,
+    };
+    assert_eq!(
+        SubAgentKind::from_tool_input(&input),
+        Some(SubAgentKind::FixSlice)
+    );
+
+    // Explore/Plan should still work
+    let explore = ToolInput::AgentExplore {
+        prompt: "test".to_string(),
+        scope: None,
+    };
+    assert_eq!(
+        SubAgentKind::from_tool_input(&explore),
+        Some(SubAgentKind::Explore)
+    );
+
+    // Non-agent tools should return None
+    let read = ToolInput::FileRead {
+        path: "test".to_string(),
+    };
+    assert_eq!(SubAgentKind::from_tool_input(&read), None);
+}
+
+// ---------------------------------------------------------------------------
+// Task 1.3: ToolInput from_json
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_fixslice_json_parse() {
+    let value = serde_json::json!({
+        "target_path": "src/main.rs",
+        "goal": "fix the compilation error",
+        "max_lines": 100
+    });
+    let input = ToolInput::from_json("agent.fix_slice", &value).expect("parse should succeed");
+    match input {
+        ToolInput::AgentFixSlice {
+            target_path,
+            goal,
+            max_lines,
+        } => {
+            assert_eq!(target_path, "src/main.rs");
+            assert_eq!(goal, "fix the compilation error");
+            assert_eq!(max_lines, 100);
+        }
+        _ => panic!("expected AgentFixSlice"),
+    }
+}
+
+#[test]
+fn test_fixslice_json_parse_default_max_lines() {
+    let value = serde_json::json!({
+        "target_path": "src/main.rs",
+        "goal": "fix bug"
+    });
+    let input = ToolInput::from_json("agent.fix_slice", &value).expect("parse should succeed");
+    match input {
+        ToolInput::AgentFixSlice { max_lines, .. } => {
+            assert_eq!(max_lines, 50, "default max_lines should be 50");
+        }
+        _ => panic!("expected AgentFixSlice"),
+    }
+}
+
+#[test]
+fn test_fixslice_json_parse_missing_target_path() {
+    let value = serde_json::json!({
+        "goal": "fix bug"
+    });
+    let err = ToolInput::from_json("agent.fix_slice", &value).unwrap_err();
+    assert!(err.contains("missing target_path"));
+}
+
+#[test]
+fn test_fixslice_json_parse_missing_goal() {
+    let value = serde_json::json!({
+        "target_path": "src/main.rs"
+    });
+    let err = ToolInput::from_json("agent.fix_slice", &value).unwrap_err();
+    assert!(err.contains("missing goal"));
+}
+
+// ---------------------------------------------------------------------------
+// Task 3.2: Validation
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_fixslice_validation_good_proposal() {
+    let tmp = tempfile::tempdir().unwrap();
+    let sandbox_root = tmp.path();
+    // Create target directory and file
+    std::fs::create_dir_all(sandbox_root.join("src")).unwrap();
+    std::fs::write(sandbox_root.join("src/main.rs"), "line1\nline2\nline3\n").unwrap();
+
+    let proposal = FixSliceProposal {
+        target_path: "src/main.rs".to_string(),
+        start_line: 1,
+        end_line: 2,
+        replacement_content: "fixed\n".to_string(),
+        rationale: "fix bug".to_string(),
+    };
+
+    let result = validate_fix_proposal(&proposal, "src/main.rs", 50, sandbox_root);
+    assert!(result.is_ok(), "valid proposal should pass: {:?}", result);
+}
+
+#[test]
+fn test_fixslice_validation_bad_lines() {
+    let tmp = tempfile::tempdir().unwrap();
+    let sandbox_root = tmp.path();
+
+    let proposal = FixSliceProposal {
+        target_path: "src/main.rs".to_string(),
+        start_line: 1,
+        end_line: 100,
+        replacement_content: "fixed\n".to_string(),
+        rationale: "".to_string(),
+    };
+
+    // max_lines = 50, but range is 100 lines
+    let result = validate_fix_proposal(&proposal, "src/main.rs", 50, sandbox_root);
+    assert!(result.is_err());
+    assert!(result.unwrap_err().contains("exceeds max_lines"));
+}
+
+#[test]
+fn test_fixslice_sandbox_violation() {
+    let tmp = tempfile::tempdir().unwrap();
+    let sandbox_root = tmp.path();
+
+    let proposal = FixSliceProposal {
+        target_path: "../../../etc/passwd".to_string(),
+        start_line: 1,
+        end_line: 2,
+        replacement_content: "hacked\n".to_string(),
+        rationale: "".to_string(),
+    };
+
+    let result = validate_fix_proposal(&proposal, "../../../etc/passwd", 50, sandbox_root);
+    assert!(result.is_err());
+    assert!(result.unwrap_err().contains("sandbox violation"));
+}
+
+#[test]
+fn test_fixslice_control_char_rejected() {
+    let tmp = tempfile::tempdir().unwrap();
+    let sandbox_root = tmp.path();
+
+    let proposal = FixSliceProposal {
+        target_path: "src/main\0.rs".to_string(),
+        start_line: 1,
+        end_line: 2,
+        replacement_content: "fixed\n".to_string(),
+        rationale: "".to_string(),
+    };
+
+    let result = validate_fix_proposal(&proposal, "src/main\0.rs", 50, sandbox_root);
+    assert!(result.is_err());
+    assert!(result.unwrap_err().contains("control characters"));
+}
+
+#[test]
+fn test_fixslice_target_path_mismatch() {
+    let tmp = tempfile::tempdir().unwrap();
+    let sandbox_root = tmp.path();
+
+    let proposal = FixSliceProposal {
+        target_path: "src/other.rs".to_string(),
+        start_line: 1,
+        end_line: 2,
+        replacement_content: "fixed\n".to_string(),
+        rationale: "".to_string(),
+    };
+
+    let result = validate_fix_proposal(&proposal, "src/main.rs", 50, sandbox_root);
+    assert!(result.is_err());
+    assert!(result.unwrap_err().contains("mismatch"));
+}
+
+#[test]
+fn test_fixslice_empty_replacement_content() {
+    let tmp = tempfile::tempdir().unwrap();
+    let sandbox_root = tmp.path();
+
+    let proposal = FixSliceProposal {
+        target_path: "src/main.rs".to_string(),
+        start_line: 1,
+        end_line: 2,
+        replacement_content: "".to_string(),
+        rationale: "".to_string(),
+    };
+
+    let result = validate_fix_proposal(&proposal, "src/main.rs", 50, sandbox_root);
+    assert!(result.is_err());
+    assert!(result.unwrap_err().contains("must not be empty"));
+}
+
+// ---------------------------------------------------------------------------
+// Task 3.2: build_rewrite_request
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_fixslice_build_rewrite_request() {
+    let proposal = FixSliceProposal {
+        target_path: "src/main.rs".to_string(),
+        start_line: 10,
+        end_line: 15,
+        replacement_content: "new code\n".to_string(),
+        rationale: "fix bug".to_string(),
+    };
+
+    let request = build_rewrite_request(&proposal, "call_001");
+    assert_eq!(request.spec.name, "file.rewrite");
+    assert_eq!(request.spec.kind, ToolKind::FileRewrite);
+    assert_eq!(request.tool_call_id, "call_001_rewrite");
+    match &request.input {
+        ToolInput::FileRewrite {
+            path,
+            start_line,
+            end_line,
+            content,
+        } => {
+            assert_eq!(path, "src/main.rs");
+            assert_eq!(*start_line, 10);
+            assert_eq!(*end_line, 15);
+            assert_eq!(content, "new code\n");
+        }
+        _ => panic!("expected FileRewrite input"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// No replacement_content in failure summary
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_fixslice_no_replacement_content_in_failure() {
+    let tmp = tempfile::tempdir().unwrap();
+    let sandbox_root = tmp.path();
+
+    let proposal = FixSliceProposal {
+        target_path: "src/other.rs".to_string(), // mismatch
+        start_line: 1,
+        end_line: 2,
+        replacement_content: "SECRET_CONTENT_SHOULD_NOT_LEAK".to_string(),
+        rationale: "".to_string(),
+    };
+
+    let err = validate_fix_proposal(&proposal, "src/main.rs", 50, sandbox_root).unwrap_err();
+    assert!(
+        !err.contains("SECRET_CONTENT_SHOULD_NOT_LEAK"),
+        "replacement_content should not appear in error message"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Task 4.1: Tag spec and parser
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_fixslice_tag_spec() {
+    let spec = find_spec("agent.fix_slice").expect("agent.fix_slice should be in TOOL_TAG_SPECS");
+    assert_eq!(spec.name, "agent.fix_slice");
+    assert_eq!(spec.attributes, &["target_path", "max_lines"]);
+    assert_eq!(spec.child_elements, &["goal"]);
+    assert!(!spec.example.is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// Task 2.2: System prompt
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_fixslice_system_prompt_contents() {
+    use anvil::agent::subagent::{SubAgentPromptOptions, build_subagent_system_prompt};
+
+    let opts = SubAgentPromptOptions {
+        offline: false,
+        ui_language: None,
+    };
+    let prompt = build_subagent_system_prompt(&SubAgentKind::FixSlice, &opts);
+
+    assert!(
+        prompt.contains("ANVIL_FINAL"),
+        "FixSlice prompt should mention ANVIL_FINAL"
+    );
+    assert!(
+        prompt.contains("start_line"),
+        "FixSlice prompt should mention start_line"
+    );
+    assert!(
+        prompt.contains("end_line"),
+        "FixSlice prompt should mention end_line"
+    );
+    assert!(
+        prompt.contains("target_path"),
+        "FixSlice prompt should mention target_path"
+    );
+    assert!(
+        prompt.contains("replacement_content"),
+        "FixSlice prompt should mention replacement_content"
+    );
+    assert!(
+        prompt.contains("file.read"),
+        "FixSlice prompt should describe file.read tool"
+    );
+    assert!(
+        prompt.contains("FixSlice"),
+        "FixSlice prompt should mention FixSlice role"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Validation via ToolRegistry
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_fixslice_validation_empty_target_path() {
+    let mut registry = ToolRegistry::new();
+    registry.register_agent_fix_slice();
+
+    let call = ToolCallRequest::new(
+        "call_001",
+        "agent.fix_slice",
+        ToolInput::AgentFixSlice {
+            target_path: "".to_string(),
+            goal: "fix bug".to_string(),
+            max_lines: 50,
+        },
+    );
+
+    let err = registry.validate(call).unwrap_err();
+    assert_eq!(
+        err,
+        ToolValidationError::MissingRequiredField("target_path".to_string())
+    );
+}
+
+#[test]
+fn test_fixslice_validation_empty_goal() {
+    let mut registry = ToolRegistry::new();
+    registry.register_agent_fix_slice();
+
+    let call = ToolCallRequest::new(
+        "call_001",
+        "agent.fix_slice",
+        ToolInput::AgentFixSlice {
+            target_path: "src/main.rs".to_string(),
+            goal: "".to_string(),
+            max_lines: 50,
+        },
+    );
+
+    let err = registry.validate(call).unwrap_err();
+    assert_eq!(
+        err,
+        ToolValidationError::MissingRequiredField("goal".to_string())
+    );
+}
+
+#[test]
+fn test_fixslice_validation_max_lines_zero() {
+    let mut registry = ToolRegistry::new();
+    registry.register_agent_fix_slice();
+
+    let call = ToolCallRequest::new(
+        "call_001",
+        "agent.fix_slice",
+        ToolInput::AgentFixSlice {
+            target_path: "src/main.rs".to_string(),
+            goal: "fix bug".to_string(),
+            max_lines: 0,
+        },
+    );
+
+    let err = registry.validate(call).unwrap_err();
+    match err {
+        ToolValidationError::InvalidFieldValue { field, .. } => {
+            assert_eq!(field, "max_lines");
+        }
+        _ => panic!("expected InvalidFieldValue for max_lines"),
+    }
+}
+
+#[test]
+fn test_fixslice_validation_max_lines_exceeds_limit() {
+    let mut registry = ToolRegistry::new();
+    registry.register_agent_fix_slice();
+
+    let call = ToolCallRequest::new(
+        "call_001",
+        "agent.fix_slice",
+        ToolInput::AgentFixSlice {
+            target_path: "src/main.rs".to_string(),
+            goal: "fix bug".to_string(),
+            max_lines: MAX_FIXSLICE_LINES + 1,
+        },
+    );
+
+    let err = registry.validate(call).unwrap_err();
+    match err {
+        ToolValidationError::InvalidFieldValue { field, .. } => {
+            assert_eq!(field, "max_lines");
+        }
+        _ => panic!("expected InvalidFieldValue for max_lines"),
+    }
+}
+
+#[test]
+fn test_fixslice_validation_control_char_in_target_path() {
+    let mut registry = ToolRegistry::new();
+    registry.register_agent_fix_slice();
+
+    let call = ToolCallRequest::new(
+        "call_001",
+        "agent.fix_slice",
+        ToolInput::AgentFixSlice {
+            target_path: "src/main\x00.rs".to_string(),
+            goal: "fix bug".to_string(),
+            max_lines: 50,
+        },
+    );
+
+    let err = registry.validate(call).unwrap_err();
+    match err {
+        ToolValidationError::InvalidFieldValue { field, .. } => {
+            assert_eq!(field, "target_path");
+        }
+        _ => panic!("expected InvalidFieldValue for target_path"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ToolInput::kind() mapping
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_fixslice_tool_kind_mapping() {
+    let input = ToolInput::AgentFixSlice {
+        target_path: "src/main.rs".to_string(),
+        goal: "fix bug".to_string(),
+        max_lines: 50,
+    };
+    assert_eq!(input.kind(), ToolKind::AgentFixSlice);
+}

--- a/tests/fixslice_subagent.rs
+++ b/tests/fixslice_subagent.rs
@@ -4,7 +4,9 @@ use anvil::agent::subagent::{
     FIXSLICE_MAX_ITERATIONS, FIXSLICE_TIMEOUT_SECS, MAX_FIXSLICE_LINES, SubAgentKind,
 };
 use anvil::agent::tag_spec::find_spec;
-use anvil::app::agentic::{build_rewrite_request, validate_fix_proposal};
+use anvil::app::agentic::{
+    build_fixslice_user_prompt, build_rewrite_request, validate_fix_proposal,
+};
 use anvil::contracts::FixSliceProposal;
 use anvil::tooling::{
     ExecutionClass, ExecutionMode, PermissionClass, ToolCallRequest, ToolInput, ToolKind,
@@ -541,6 +543,53 @@ fn test_fixslice_validation_control_char_in_target_path() {
 // ---------------------------------------------------------------------------
 // ToolInput::kind() mapping
 // ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Issue #341: FixSlice worker must receive target_path and max_lines in its
+// user prompt, not only the free-form goal.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_fixslice_user_prompt_contains_target_and_budget() {
+    let prompt = build_fixslice_user_prompt(
+        "src/lib/auto-yes-manager.ts",
+        "remove stale branch and add regression test",
+        80,
+    );
+    assert!(
+        prompt.contains("src/lib/auto-yes-manager.ts"),
+        "prompt must embed the exact target_path: {prompt}"
+    );
+    assert!(
+        prompt.contains("80"),
+        "prompt must embed the max_lines budget: {prompt}"
+    );
+    assert!(
+        prompt.contains("remove stale branch and add regression test"),
+        "prompt must embed the goal verbatim: {prompt}"
+    );
+}
+
+#[test]
+fn test_fixslice_user_prompt_anchors_worker_to_target() {
+    let prompt =
+        build_fixslice_user_prompt("crates/foo/src/bar.rs", "fix panic on empty input", 40);
+    // The worker must be told to read the target first and to match the
+    // target_path in its proposal, otherwise exploration drifts (Issue #341).
+    assert!(
+        prompt.contains("file.read"),
+        "prompt should instruct the worker to read the target first"
+    );
+    assert!(
+        prompt.contains("ANVIL_FINAL"),
+        "prompt should reference the ANVIL_FINAL proposal format"
+    );
+    let target_occurrences = prompt.matches("crates/foo/src/bar.rs").count();
+    assert!(
+        target_occurrences >= 2,
+        "target_path should appear multiple times for redundancy, got {target_occurrences}: {prompt}"
+    );
+}
 
 #[test]
 fn test_fixslice_tool_kind_mapping() {

--- a/tests/fixslice_subagent.rs
+++ b/tests/fixslice_subagent.rs
@@ -425,6 +425,73 @@ fn test_fixslice_system_prompt_contents() {
 }
 
 // ---------------------------------------------------------------------------
+// Issue #357: FixSlice system prompt must hard-code the worker contract so
+// B1 (basename drift) and B2 (markdown / tool-call JSON under ANVIL_FINAL)
+// failure modes stop sneaking past the model.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_fixslice_system_prompt_enforces_contract_issue_357() {
+    use anvil::agent::subagent::{SubAgentPromptOptions, build_subagent_system_prompt};
+
+    let opts = SubAgentPromptOptions {
+        offline: false,
+        ui_language: None,
+    };
+    let prompt = build_subagent_system_prompt(&SubAgentKind::FixSlice, &opts);
+
+    // Strict final-message contract stated up front.
+    assert!(
+        prompt.contains("Final-message contract"),
+        "prompt must lead with the final-message contract: {prompt}"
+    );
+    assert!(
+        prompt.contains("exactly one ANVIL_FINAL"),
+        "prompt must forbid more than one ANVIL_FINAL block: {prompt}"
+    );
+
+    // Markdown / tool-call JSON drift must be explicitly forbidden.
+    assert!(
+        prompt.contains("Markdown"),
+        "prompt must forbid Markdown in the final message: {prompt}"
+    );
+    assert!(
+        prompt.contains("ANVIL_TOOL"),
+        "prompt must forbid ANVIL_TOOL re-pastes in the final message: {prompt}"
+    );
+
+    // target_path exact-match requirement — the B1 failure mode.
+    assert!(
+        prompt.contains("byte-for-byte"),
+        "prompt must require byte-for-byte target_path match: {prompt}"
+    );
+    assert!(
+        prompt.contains("basename"),
+        "prompt must call out basename drift: {prompt}"
+    );
+
+    // Few-shot examples — both positive and negative must be present.
+    assert!(
+        prompt.contains("Correct"),
+        "prompt must include a positive few-shot example: {prompt}"
+    );
+    assert!(
+        prompt.contains("Incorrect"),
+        "prompt must include a negative few-shot example: {prompt}"
+    );
+
+    // The cycle-13 B1 drift must appear as an explicit negative example.
+    assert!(
+        prompt.contains(r#""target_path":"src/lib/auto-yes-manager.ts""#),
+        "prompt must include the positive auto-yes-manager example: {prompt}"
+    );
+    assert!(
+        prompt.contains(r#""target_path":"auto-yes-manager.ts""#),
+        "prompt must include the basename-drift negative example: {prompt}"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // Validation via ToolRegistry
 // ---------------------------------------------------------------------------
 

--- a/tests/fixslice_subagent.rs
+++ b/tests/fixslice_subagent.rs
@@ -1,13 +1,14 @@
 //! Integration tests for the FixSlice sub-agent (Issue #291).
 
 use anvil::agent::subagent::{
-    FIXSLICE_MAX_ITERATIONS, FIXSLICE_TIMEOUT_SECS, MAX_FIXSLICE_LINES, SubAgentKind,
+    FIXSLICE_MAX_ITERATIONS, FIXSLICE_REPEATED_READ_THRESHOLD, FIXSLICE_TIMEOUT_SECS,
+    MAX_FIXSLICE_LINES, SubAgentKind, first_file_read_target, is_repeated_read_loop,
 };
 use anvil::agent::tag_spec::find_spec;
 use anvil::app::agentic::{
     build_fixslice_user_prompt, build_rewrite_request, validate_fix_proposal,
 };
-use anvil::contracts::FixSliceProposal;
+use anvil::contracts::{FixSliceFailureReason, FixSliceProposal};
 use anvil::tooling::{
     ExecutionClass, ExecutionMode, PermissionClass, ToolCallRequest, ToolInput, ToolKind,
     ToolRegistry, ToolValidationError,
@@ -599,4 +600,177 @@ fn test_fixslice_tool_kind_mapping() {
         max_lines: 50,
     };
     assert_eq!(input.kind(), ToolKind::AgentFixSlice);
+}
+
+// ---------------------------------------------------------------------------
+// Issue #351: same-target `file.read` oscillation guard
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_fixslice_repeated_read_threshold_default() {
+    // The default threshold is 2: two consecutive iterations re-reading the
+    // same target path trip the guard.
+    assert_eq!(FIXSLICE_REPEATED_READ_THRESHOLD, 2);
+}
+
+#[test]
+fn test_is_repeated_read_loop_first_read_never_triggers() {
+    // Prior count = 0, no last target: the first read should never trip
+    // the guard, regardless of threshold.
+    assert!(!is_repeated_read_loop(Some("src/main.rs"), None, 0, 2));
+}
+
+#[test]
+fn test_is_repeated_read_loop_different_paths_never_trigger() {
+    // Different target this iteration resets the chain.
+    assert!(!is_repeated_read_loop(
+        Some("src/other.rs"),
+        Some("src/main.rs"),
+        1,
+        2
+    ));
+    assert!(!is_repeated_read_loop(
+        Some("src/other.rs"),
+        Some("src/main.rs"),
+        5,
+        2
+    ));
+}
+
+#[test]
+fn test_is_repeated_read_loop_same_path_reaches_threshold() {
+    // Same target, prior count = 1, threshold = 2 -> next = 2 -> trip.
+    assert!(is_repeated_read_loop(
+        Some("src/main.rs"),
+        Some("src/main.rs"),
+        1,
+        2
+    ));
+}
+
+#[test]
+fn test_is_repeated_read_loop_same_path_below_threshold() {
+    // Same target but prior count = 0 -> next = 1 -> no trip at threshold 2.
+    assert!(!is_repeated_read_loop(
+        Some("src/main.rs"),
+        Some("src/main.rs"),
+        0,
+        2
+    ));
+}
+
+#[test]
+fn test_is_repeated_read_loop_no_current_read_is_safe() {
+    // Iteration with no file.read at all never trips the guard.
+    assert!(!is_repeated_read_loop(None, Some("src/main.rs"), 1, 2));
+}
+
+#[test]
+fn test_is_repeated_read_loop_custom_threshold() {
+    // Threshold = 3 — first two same-path iterations should not trip;
+    // the third should.
+    assert!(!is_repeated_read_loop(
+        Some("src/main.rs"),
+        Some("src/main.rs"),
+        0,
+        3
+    ));
+    assert!(!is_repeated_read_loop(
+        Some("src/main.rs"),
+        Some("src/main.rs"),
+        1,
+        3
+    ));
+    assert!(is_repeated_read_loop(
+        Some("src/main.rs"),
+        Some("src/main.rs"),
+        2,
+        3
+    ));
+}
+
+#[test]
+fn test_first_file_read_target_empty_calls() {
+    assert_eq!(first_file_read_target(&[]), None);
+}
+
+#[test]
+fn test_first_file_read_target_picks_file_read() {
+    let calls = vec![ToolCallRequest::new(
+        "call_001",
+        "file.read",
+        ToolInput::FileRead {
+            path: "src/main.rs".to_string(),
+        },
+    )];
+    assert_eq!(
+        first_file_read_target(&calls),
+        Some("src/main.rs".to_string())
+    );
+}
+
+#[test]
+fn test_first_file_read_target_picks_first_of_multiple() {
+    // When multiple file.read calls are present, the first one wins — it's
+    // the stable fingerprint for the iteration's dominant target.
+    let calls = vec![
+        ToolCallRequest::new(
+            "call_001",
+            "file.read",
+            ToolInput::FileRead {
+                path: "src/first.rs".to_string(),
+            },
+        ),
+        ToolCallRequest::new(
+            "call_002",
+            "file.read",
+            ToolInput::FileRead {
+                path: "src/second.rs".to_string(),
+            },
+        ),
+    ];
+    assert_eq!(
+        first_file_read_target(&calls),
+        Some("src/first.rs".to_string())
+    );
+}
+
+#[test]
+fn test_first_file_read_target_ignores_non_file_read() {
+    // Non-file.read tools in the batch are ignored.
+    let calls = vec![
+        ToolCallRequest::new(
+            "call_001",
+            "agent.fix_slice",
+            ToolInput::AgentFixSlice {
+                target_path: "src/main.rs".to_string(),
+                goal: "fix bug".to_string(),
+                max_lines: 50,
+            },
+        ),
+        ToolCallRequest::new(
+            "call_002",
+            "file.read",
+            ToolInput::FileRead {
+                path: "src/target.rs".to_string(),
+            },
+        ),
+    ];
+    assert_eq!(
+        first_file_read_target(&calls),
+        Some("src/target.rs".to_string())
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Issue #351: FixSliceFailureReason::RepeatedReadLoop Display form
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_fixslice_failure_reason_repeated_read_loop_display() {
+    // The Display form is what gets stored in telemetry.
+    assert_eq!(
+        FixSliceFailureReason::RepeatedReadLoop.to_string(),
+        "repeated_read_loop"
+    );
 }

--- a/tests/fixslice_worker_contract.rs
+++ b/tests/fixslice_worker_contract.rs
@@ -17,10 +17,12 @@
 //!    `ProposalValidationFailed`, plus the runtime-configurable
 //!    `fixslice_max_iterations` knob that replaces the hard-coded cap.
 
+use std::collections::HashMap;
+
 use anvil::agent::subagent::{
     DEFAULT_FIXSLICE_MAX_ITERATIONS, FixProposalParseOutcome, try_parse_fix_proposal,
 };
-use anvil::config::EffectiveConfig;
+use anvil::config::{ENV_OVERRIDE_WHITELIST, EffectiveConfig};
 use anvil::contracts::{AgentTelemetry, FixSliceFailureReason, FixSliceProposal};
 
 // ---------------------------------------------------------------------------
@@ -327,6 +329,55 @@ fn fixslice_max_iterations_clamped_lower_bound() {
     assert_eq!(
         config.runtime.fixslice_max_iterations, 1,
         "zero must be clamped up to 1 so the worker always gets one shot"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Issue #347: env whitelist must carry ANVIL_FIXSLICE_MAX_ITERATIONS
+// ---------------------------------------------------------------------------
+//
+// Regression: PR #346 added the parse arm for `ANVIL_FIXSLICE_MAX_ITERATIONS`
+// to `apply_map` but forgot the matching entry in `apply_env_overrides`'s
+// whitelist, so process-env values were silently dropped before `apply_map`
+// ever saw them. These tests exercise the whitelist path via
+// `apply_env_overrides_from_map_for_test` — not `apply_overrides_for_test`,
+// which calls `apply_map` directly and bypasses the whitelist.
+
+#[test]
+fn env_whitelist_contains_fixslice_max_iterations() {
+    assert!(
+        ENV_OVERRIDE_WHITELIST.contains(&"ANVIL_FIXSLICE_MAX_ITERATIONS"),
+        "ANVIL_FIXSLICE_MAX_ITERATIONS must be in the env override whitelist \
+         so process env values reach apply_map (Issue #347)"
+    );
+}
+
+#[test]
+fn fixslice_max_iterations_reaches_runtime_via_env_whitelist() {
+    let mut config = EffectiveConfig::default_for_test().expect("config");
+    let mut env = HashMap::new();
+    env.insert("ANVIL_FIXSLICE_MAX_ITERATIONS".to_string(), "8".to_string());
+    config
+        .apply_env_overrides_from_map_for_test(&env)
+        .expect("env override should apply");
+    assert_eq!(
+        config.runtime.fixslice_max_iterations, 8,
+        "ANVIL_FIXSLICE_MAX_ITERATIONS=8 must be reflected in RuntimeConfig"
+    );
+}
+
+#[test]
+fn unknown_env_key_is_ignored_by_whitelist() {
+    let mut config = EffectiveConfig::default_for_test().expect("config");
+    let baseline = config.runtime.fixslice_max_iterations;
+    let mut env = HashMap::new();
+    env.insert("ANVIL_NOT_A_REAL_TUNABLE_KEY".to_string(), "99".to_string());
+    config
+        .apply_env_overrides_from_map_for_test(&env)
+        .expect("unknown keys must be silently ignored");
+    assert_eq!(
+        config.runtime.fixslice_max_iterations, baseline,
+        "unrelated env keys must not mutate runtime state"
     );
 }
 

--- a/tests/fixslice_worker_contract.rs
+++ b/tests/fixslice_worker_contract.rs
@@ -1,0 +1,387 @@
+//! Integration tests for Issue #345: fix_slice worker contract robustness.
+//!
+//! Issue #345 extends the Issue #343 failure taxonomy in two directions:
+//!
+//! 1. **Layer 1 — escalation bypass (A1 shape).** When `[Anvil ESCALATION]`
+//!    fires but the LLM never actually calls `agent.fix_slice`, the parent's
+//!    own `file.edit` can land a mutation and the session ends with
+//!    `worker_observed=false` and no recorded failure reason. The tests in
+//!    this file cover the new `EscalatedNotInvoked` classification that
+//!    `finalize_fixslice_outcome` records at session wrap-up.
+//!
+//! 2. **Layer 2 — strict proposal contract.** The strict `serde_json` parse
+//!    of the worker's ANVIL_FINAL block was too brittle: any wrapper prose,
+//!    path drift, or extra field collapsed the whole proposal into a generic
+//!    `no_proposal`. The tests here cover the salvage parser
+//!    (`try_parse_fix_proposal`) and the split of `PathMismatch` out of
+//!    `ProposalValidationFailed`, plus the runtime-configurable
+//!    `fixslice_max_iterations` knob that replaces the hard-coded cap.
+
+use anvil::agent::subagent::{
+    DEFAULT_FIXSLICE_MAX_ITERATIONS, FixProposalParseOutcome, try_parse_fix_proposal,
+};
+use anvil::config::EffectiveConfig;
+use anvil::contracts::{AgentTelemetry, FixSliceFailureReason, FixSliceProposal};
+
+// ---------------------------------------------------------------------------
+// Layer 1: EscalatedNotInvoked classification
+// ---------------------------------------------------------------------------
+
+#[test]
+fn escalated_not_invoked_classifies_at_wrap_up() {
+    // A1 shape: escalation fired, but agent.fix_slice was never invoked and
+    // no worker success was ever recorded. finalize_fixslice_outcome must
+    // record this as the EscalatedNotInvoked failure class.
+    let mut tel = AgentTelemetry::new();
+    tel.record_fixslice_escalation();
+    assert_eq!(tel.fixslice_worker_invocation_count, 0);
+    assert_eq!(tel.fixslice_worker_failure_count, 0);
+
+    tel.finalize_fixslice_outcome();
+
+    assert_eq!(tel.fixslice_worker_failure_count, 1);
+    assert_eq!(
+        tel.fixslice_failure_reason.as_deref(),
+        Some("escalated_not_invoked")
+    );
+    assert!(
+        !tel.worker_observed,
+        "finalize must not flip worker_observed"
+    );
+}
+
+#[test]
+fn escalation_followed_by_invocation_does_not_classify_a1() {
+    // Escalation fired and the worker was actually invoked (even if it
+    // failed). finalize must be a no-op — the Layer-2 classification for
+    // why the invocation failed is the caller's job.
+    let mut tel = AgentTelemetry::new();
+    tel.record_fixslice_escalation();
+    tel.record_fixslice_worker_invocation();
+
+    tel.finalize_fixslice_outcome();
+
+    assert_eq!(
+        tel.fixslice_worker_failure_count, 0,
+        "finalize must not record failure when worker was invoked"
+    );
+    assert!(tel.fixslice_failure_reason.is_none());
+}
+
+#[test]
+fn finalize_skips_a1_classification_when_worker_observed() {
+    // Belt-and-braces: if worker_observed was already set, finalize must not
+    // retroactively record A1.
+    let mut tel = AgentTelemetry::new();
+    tel.record_fixslice_escalation();
+    tel.record_worker_success();
+
+    tel.finalize_fixslice_outcome();
+
+    assert_eq!(tel.fixslice_worker_failure_count, 0);
+    assert!(tel.fixslice_failure_reason.is_none());
+}
+
+#[test]
+fn finalize_is_idempotent() {
+    // Multiple exit branches may call finalize_fixslice_outcome. Calling it
+    // twice must not double-record the failure.
+    let mut tel = AgentTelemetry::new();
+    tel.record_fixslice_escalation();
+
+    tel.finalize_fixslice_outcome();
+    tel.finalize_fixslice_outcome();
+
+    assert_eq!(tel.fixslice_worker_failure_count, 1);
+}
+
+#[test]
+fn finalize_is_noop_without_escalation() {
+    // A session that never escalated must not receive a spurious failure.
+    let mut tel = AgentTelemetry::new();
+    tel.finalize_fixslice_outcome();
+
+    assert_eq!(tel.fixslice_worker_failure_count, 0);
+    assert!(tel.fixslice_failure_reason.is_none());
+}
+
+#[test]
+fn a1_classification_preserves_worker_required_repair_skip() {
+    // After finalize records EscalatedNotInvoked, the existing Issue #343
+    // guard must still fire under a requires_worker_observation pack.
+    use anvil::contracts::PackExpectation;
+
+    let mut tel = AgentTelemetry::new();
+    tel.pack_expectation = Some(PackExpectation::RequiresWorkerObservation);
+    tel.record_fixslice_escalation();
+    tel.finalize_fixslice_outcome();
+
+    assert!(
+        tel.should_skip_pre_exit_repair_for_worker_failure(),
+        "EscalatedNotInvoked must satisfy the worker-required repair skip"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Layer 2: try_parse_fix_proposal salvage
+// ---------------------------------------------------------------------------
+
+fn minimal_proposal_json() -> &'static str {
+    r#"{"target_path":"src/main.rs","start_line":1,"end_line":2,"replacement_content":"fn main(){}\n","rationale":"fix"}"#
+}
+
+#[test]
+fn try_parse_fix_proposal_strict() {
+    let outcome = try_parse_fix_proposal(minimal_proposal_json());
+    match outcome {
+        FixProposalParseOutcome::Parsed(p) => {
+            assert_eq!(p.target_path, "src/main.rs");
+            assert_eq!(p.start_line, 1);
+            assert_eq!(p.end_line, 2);
+        }
+        other => panic!("expected Parsed, got {other:?}"),
+    }
+}
+
+#[test]
+fn try_parse_fix_proposal_salvages_wrapped_json() {
+    // B1 shape: the worker produces a JSON proposal but surrounds it with
+    // prose or code-fence artifacts. Salvage must extract the first balanced
+    // JSON object and parse it.
+    let wrapped = format!(
+        "Here is the proposal as requested:\n```json\n{}\n```\nThanks!",
+        minimal_proposal_json()
+    );
+    let outcome = try_parse_fix_proposal(&wrapped);
+    match outcome {
+        FixProposalParseOutcome::Salvaged(p) => {
+            assert_eq!(p.target_path, "src/main.rs");
+        }
+        other => panic!("expected Salvaged, got {other:?}"),
+    }
+}
+
+#[test]
+fn try_parse_fix_proposal_empty_final() {
+    let outcome = try_parse_fix_proposal("");
+    assert!(matches!(outcome, FixProposalParseOutcome::EmptyFinal));
+
+    let outcome = try_parse_fix_proposal("   \n\t  ");
+    assert!(matches!(outcome, FixProposalParseOutcome::EmptyFinal));
+}
+
+#[test]
+fn try_parse_fix_proposal_non_json_text() {
+    let outcome = try_parse_fix_proposal("I was unable to produce a valid proposal.");
+    assert!(matches!(outcome, FixProposalParseOutcome::ParseFailed));
+}
+
+#[test]
+fn try_parse_fix_proposal_handles_escaped_braces_in_strings() {
+    // The salvage depth scanner must track JSON string state so that a brace
+    // inside `replacement_content` does not throw off the bracket count.
+    let proposal_with_braces = r#"{
+        "target_path": "src/main.rs",
+        "start_line": 1,
+        "end_line": 3,
+        "replacement_content": "if x { y } else { z }",
+        "rationale": "fix"
+    }"#;
+    let wrapped = format!("prose before\n{proposal_with_braces}\nprose after");
+    let outcome = try_parse_fix_proposal(&wrapped);
+    match outcome {
+        FixProposalParseOutcome::Salvaged(p) => {
+            assert_eq!(p.replacement_content, "if x { y } else { z }");
+        }
+        other => panic!("expected Salvaged, got {other:?}"),
+    }
+}
+
+#[test]
+fn try_parse_fix_proposal_rejects_unbalanced_json() {
+    // Unbalanced braces (e.g. a truncated payload) must not mis-salvage.
+    let outcome = try_parse_fix_proposal("{ \"target_path\": \"src/main.rs\"");
+    assert!(matches!(outcome, FixProposalParseOutcome::ParseFailed));
+}
+
+#[test]
+fn try_parse_fix_proposal_rejects_missing_required_fields() {
+    // A well-formed JSON object that lacks required proposal fields must be
+    // reported as ParseFailed (not Salvaged).
+    let outcome = try_parse_fix_proposal("prose {\"unrelated\": 1} more prose");
+    assert!(matches!(outcome, FixProposalParseOutcome::ParseFailed));
+}
+
+// ---------------------------------------------------------------------------
+// Layer 2: new FixSliceFailureReason variants
+// ---------------------------------------------------------------------------
+
+#[test]
+fn new_failure_reason_variants_have_distinct_snake_case_display() {
+    for (variant, expected) in [
+        (FixSliceFailureReason::NoProposal, "no_proposal"),
+        (
+            FixSliceFailureReason::ProposalParseFailed,
+            "proposal_parse_failed",
+        ),
+        (FixSliceFailureReason::PathMismatch, "path_mismatch"),
+        (
+            FixSliceFailureReason::ProposalValidationFailed,
+            "proposal_validation_failed",
+        ),
+        (FixSliceFailureReason::RewriteFailed, "rewrite_failed"),
+        (
+            FixSliceFailureReason::MaxIterationsReached,
+            "max_iterations_reached",
+        ),
+        (
+            FixSliceFailureReason::EscalatedNotInvoked,
+            "escalated_not_invoked",
+        ),
+    ] {
+        assert_eq!(variant.to_string(), expected);
+    }
+}
+
+#[test]
+fn path_mismatch_and_parse_failed_count_as_worker_failures() {
+    // Pre-exit repair skip and the failure counter must accept the new
+    // variants as first-class worker failures.
+    let mut tel = AgentTelemetry::new();
+    tel.record_fixslice_worker_failure(FixSliceFailureReason::ProposalParseFailed);
+    tel.record_fixslice_worker_failure(FixSliceFailureReason::PathMismatch);
+
+    assert_eq!(tel.fixslice_worker_failure_count, 2);
+    assert!(tel.has_fixslice_worker_failure());
+    assert_eq!(
+        tel.fixslice_failure_reason.as_deref(),
+        Some("path_mismatch")
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Layer 2: Proposal path mismatch classification (helper-level)
+// ---------------------------------------------------------------------------
+//
+// handle_fixslice_result lives on AppState so reproducing the full call in
+// a unit test is heavy. Instead, we exercise the telemetry path directly:
+// a session that saw a worker invocation + a PathMismatch must carry both
+// the invocation count and the distinct failure reason, and
+// finalize_fixslice_outcome must NOT overwrite it with EscalatedNotInvoked.
+
+#[test]
+fn path_mismatch_after_invocation_does_not_degrade_to_a1() {
+    let mut tel = AgentTelemetry::new();
+    tel.record_fixslice_escalation();
+    tel.record_fixslice_worker_invocation();
+    tel.record_fixslice_worker_failure(FixSliceFailureReason::PathMismatch);
+
+    tel.finalize_fixslice_outcome();
+
+    assert_eq!(
+        tel.fixslice_worker_failure_count, 1,
+        "finalize must not add a second failure"
+    );
+    assert_eq!(
+        tel.fixslice_failure_reason.as_deref(),
+        Some("path_mismatch"),
+        "finalize must not overwrite the concrete failure reason"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Configurable fixslice_max_iterations
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fixslice_max_iterations_defaults_to_three() {
+    let config = EffectiveConfig::default_for_test().expect("config");
+    assert_eq!(config.runtime.fixslice_max_iterations, 3);
+    assert_eq!(DEFAULT_FIXSLICE_MAX_ITERATIONS, 3);
+}
+
+#[test]
+fn fixslice_max_iterations_honored_by_validate() {
+    let mut config = EffectiveConfig::default_for_test().expect("config");
+    config.runtime.fixslice_max_iterations = 5;
+    config.validate_for_test().expect("validate");
+    assert_eq!(config.runtime.fixslice_max_iterations, 5);
+}
+
+#[test]
+fn fixslice_max_iterations_clamped_upper_bound() {
+    let mut config = EffectiveConfig::default_for_test().expect("config");
+    config.runtime.fixslice_max_iterations = 50;
+    config.validate_for_test().expect("validate");
+    assert_eq!(
+        config.runtime.fixslice_max_iterations, 10,
+        "values above 10 must be clamped"
+    );
+}
+
+#[test]
+fn fixslice_max_iterations_clamped_lower_bound() {
+    let mut config = EffectiveConfig::default_for_test().expect("config");
+    config.runtime.fixslice_max_iterations = 0;
+    config.validate_for_test().expect("validate");
+    assert_eq!(
+        config.runtime.fixslice_max_iterations, 1,
+        "zero must be clamped up to 1 so the worker always gets one shot"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Telemetry artifact JSON carries the new counter
+// ---------------------------------------------------------------------------
+
+#[test]
+fn telemetry_artifact_includes_worker_invocation_count() {
+    use std::fs;
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    // SAFETY: tests do not race on the env var in this crate; the telemetry
+    // dir write is guarded by absolute-path validation.
+    unsafe {
+        std::env::set_var("ANVIL_TELEMETRY_DIR", tmp.path());
+    }
+
+    let mut tel = AgentTelemetry::new();
+    tel.record_fixslice_escalation();
+    tel.record_fixslice_worker_invocation();
+    tel.record_fixslice_worker_failure(FixSliceFailureReason::ProposalParseFailed);
+
+    tel.write_artifact("issue345_smoke")
+        .expect("artifact should write");
+
+    let file_path = tmp.path().join("issue345_smoke_telemetry.json");
+    let json = fs::read_to_string(&file_path).expect("read artifact");
+    let value: serde_json::Value = serde_json::from_str(&json).expect("parse artifact");
+
+    assert_eq!(value["fixslice_worker_invocation_count"], 1);
+    assert_eq!(value["fixslice_worker_failure_count"], 1);
+    assert_eq!(value["fixslice_failure_reason"], "proposal_parse_failed");
+
+    unsafe {
+        std::env::remove_var("ANVIL_TELEMETRY_DIR");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Sanity: the salvage parser round-trips through a FixSliceProposal
+// ---------------------------------------------------------------------------
+
+#[test]
+fn salvaged_proposal_is_usable_by_downstream_tools() {
+    // Ensure the salvaged struct carries all fields downstream tools expect.
+    let wrapped = format!("wrap\n{}\nend", minimal_proposal_json());
+    let outcome = try_parse_fix_proposal(&wrapped);
+    let proposal: FixSliceProposal = match outcome {
+        FixProposalParseOutcome::Salvaged(p) => p,
+        other => panic!("expected Salvaged, got {other:?}"),
+    };
+    assert_eq!(proposal.target_path, "src/main.rs");
+    assert_eq!(proposal.start_line, 1);
+    assert_eq!(proposal.end_line, 2);
+    assert!(!proposal.replacement_content.is_empty());
+    assert_eq!(proposal.rationale, "fix");
+}

--- a/tests/pack_validation_gate.rs
+++ b/tests/pack_validation_gate.rs
@@ -1,0 +1,274 @@
+//! Tests for pack validation gate (Issue #329).
+//!
+//! Verifies that `PackExpectation` parsing, `AgentTelemetry` observability
+//! fields, and the validation gate behave correctly.
+
+use anvil::contracts::{AgentTelemetry, PackExpectation, PackValidationResult};
+
+// ---------------------------------------------------------------------------
+// PackExpectation parsing
+// ---------------------------------------------------------------------------
+
+#[test]
+fn pack_expectation_from_env_str_valid() {
+    assert_eq!(
+        PackExpectation::from_env_str("audit_only"),
+        Some(PackExpectation::AuditOnly)
+    );
+    assert_eq!(
+        PackExpectation::from_env_str("requires_mutation"),
+        Some(PackExpectation::RequiresMutation)
+    );
+    assert_eq!(
+        PackExpectation::from_env_str("requires_worker_observation"),
+        Some(PackExpectation::RequiresWorkerObservation)
+    );
+}
+
+#[test]
+fn pack_expectation_from_env_str_unknown() {
+    assert_eq!(PackExpectation::from_env_str("unknown_value"), None);
+    assert_eq!(PackExpectation::from_env_str(""), None);
+}
+
+#[test]
+fn pack_expectation_display_roundtrip() {
+    for (variant, expected) in [
+        (PackExpectation::AuditOnly, "audit_only"),
+        (PackExpectation::RequiresMutation, "requires_mutation"),
+        (
+            PackExpectation::RequiresWorkerObservation,
+            "requires_worker_observation",
+        ),
+    ] {
+        assert_eq!(variant.to_string(), expected);
+        assert_eq!(PackExpectation::from_env_str(expected), Some(variant));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Observability flags set by record_* methods
+// ---------------------------------------------------------------------------
+
+#[test]
+fn mutation_observed_set_by_record_mutation_turn() {
+    let mut tel = AgentTelemetry::new();
+    assert!(!tel.mutation_observed);
+    tel.record_mutation_turn(1, Some(0.5), "file.write");
+    assert!(tel.mutation_observed);
+}
+
+#[test]
+fn worker_observed_set_by_record_fixslice_escalation() {
+    let mut tel = AgentTelemetry::new();
+    assert!(!tel.worker_observed);
+    tel.record_fixslice_escalation();
+    assert!(tel.worker_observed);
+}
+
+#[test]
+fn repair_turn_observed_set_by_record_pre_exit_repair_injected() {
+    let mut tel = AgentTelemetry::new();
+    assert!(!tel.repair_turn_observed);
+    tel.record_pre_exit_repair_injected();
+    assert!(tel.repair_turn_observed);
+}
+
+#[test]
+fn repair_turn_observed_set_by_record_pre_exit_repair_consumed() {
+    let mut tel = AgentTelemetry::new();
+    assert!(!tel.repair_turn_observed);
+    tel.record_pre_exit_repair_consumed();
+    assert!(tel.repair_turn_observed);
+}
+
+// ---------------------------------------------------------------------------
+// validate_against: audit_only
+// ---------------------------------------------------------------------------
+
+#[test]
+fn validate_audit_only_satisfied_with_no_mutation() {
+    let mut tel = AgentTelemetry::new();
+    let result = tel.validate_against(PackExpectation::AuditOnly);
+    assert_eq!(result, PackValidationResult::Satisfied);
+    assert_eq!(tel.pack_expectation, Some(PackExpectation::AuditOnly));
+    assert!(tel.expectation_mismatch_reason.is_none());
+}
+
+#[test]
+fn validate_audit_only_satisfied_with_mutation() {
+    let mut tel = AgentTelemetry::new();
+    tel.record_mutation_turn(1, Some(0.5), "file.write");
+    let result = tel.validate_against(PackExpectation::AuditOnly);
+    assert_eq!(result, PackValidationResult::Satisfied);
+}
+
+// ---------------------------------------------------------------------------
+// validate_against: requires_mutation
+// ---------------------------------------------------------------------------
+
+#[test]
+fn validate_requires_mutation_mismatch_when_no_mutation() {
+    let mut tel = AgentTelemetry::new();
+    let result = tel.validate_against(PackExpectation::RequiresMutation);
+    match &result {
+        PackValidationResult::Mismatch {
+            expectation,
+            reason,
+        } => {
+            assert_eq!(*expectation, PackExpectation::RequiresMutation);
+            assert!(reason.contains("zero file changes"), "reason: {reason}");
+        }
+        other => panic!("expected Mismatch, got {other:?}"),
+    }
+    assert!(tel.expectation_mismatch_reason.is_some());
+}
+
+#[test]
+fn validate_requires_mutation_satisfied_when_mutation_observed() {
+    let mut tel = AgentTelemetry::new();
+    tel.record_mutation_turn(3, Some(1.0), "file.edit");
+    let result = tel.validate_against(PackExpectation::RequiresMutation);
+    assert_eq!(result, PackValidationResult::Satisfied);
+    assert!(tel.expectation_mismatch_reason.is_none());
+}
+
+// ---------------------------------------------------------------------------
+// validate_against: requires_worker_observation
+// ---------------------------------------------------------------------------
+
+#[test]
+fn validate_requires_worker_observation_mismatch_when_nothing_observed() {
+    let mut tel = AgentTelemetry::new();
+    let result = tel.validate_against(PackExpectation::RequiresWorkerObservation);
+    match &result {
+        PackValidationResult::Mismatch {
+            expectation,
+            reason,
+        } => {
+            assert_eq!(*expectation, PackExpectation::RequiresWorkerObservation);
+            assert!(reason.contains("no worker path"), "reason: {reason}");
+        }
+        other => panic!("expected Mismatch, got {other:?}"),
+    }
+}
+
+#[test]
+fn validate_requires_worker_observation_satisfied_by_fixslice() {
+    let mut tel = AgentTelemetry::new();
+    tel.record_fixslice_escalation();
+    let result = tel.validate_against(PackExpectation::RequiresWorkerObservation);
+    assert_eq!(result, PackValidationResult::Satisfied);
+}
+
+#[test]
+fn validate_requires_worker_observation_satisfied_by_repair_turn() {
+    let mut tel = AgentTelemetry::new();
+    tel.record_pre_exit_repair_injected();
+    let result = tel.validate_against(PackExpectation::RequiresWorkerObservation);
+    assert_eq!(result, PackValidationResult::Satisfied);
+}
+
+#[test]
+fn validate_requires_worker_observation_satisfied_by_mutation() {
+    let mut tel = AgentTelemetry::new();
+    tel.record_mutation_turn(2, Some(0.5), "file.write");
+    let result = tel.validate_against(PackExpectation::RequiresWorkerObservation);
+    assert_eq!(result, PackValidationResult::Satisfied);
+}
+
+// ---------------------------------------------------------------------------
+// Telemetry artifact includes pack validation fields (Issue #329)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn telemetry_artifact_includes_pack_validation_fields() {
+    let dir = tempfile::tempdir().unwrap();
+    let session_id = format!("test_pack_fields_{}", std::process::id());
+    let dir_str = dir.path().to_str().unwrap();
+
+    let mut tel = AgentTelemetry::new();
+    tel.record_mutation_turn(1, Some(0.3), "file.write");
+    tel.record_fixslice_escalation();
+    tel.record_pre_exit_repair_injected();
+    tel.pack_expectation = Some(PackExpectation::RequiresWorkerObservation);
+
+    tel.write_artifact_to_dir(dir_str, &session_id).unwrap();
+
+    let file_path = dir.path().join(format!("{session_id}_telemetry.json"));
+    let contents = std::fs::read_to_string(&file_path).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&contents).unwrap();
+
+    assert_eq!(json["mutation_observed"], true);
+    assert_eq!(json["worker_observed"], true);
+    assert_eq!(json["repair_turn_observed"], true);
+    assert_eq!(json["pack_expectation"], "requires_worker_observation");
+    assert!(json["expectation_mismatch_reason"].is_null());
+}
+
+#[test]
+fn telemetry_artifact_pack_fields_default_false() {
+    let dir = tempfile::tempdir().unwrap();
+    let session_id = format!("test_pack_defaults_{}", std::process::id());
+    let dir_str = dir.path().to_str().unwrap();
+
+    let tel = AgentTelemetry::new();
+    tel.write_artifact_to_dir(dir_str, &session_id).unwrap();
+
+    let file_path = dir.path().join(format!("{session_id}_telemetry.json"));
+    let contents = std::fs::read_to_string(&file_path).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&contents).unwrap();
+
+    assert_eq!(json["mutation_observed"], false);
+    assert_eq!(json["worker_observed"], false);
+    assert_eq!(json["repair_turn_observed"], false);
+    assert!(json["pack_expectation"].is_null());
+    assert!(json["expectation_mismatch_reason"].is_null());
+}
+
+#[test]
+fn telemetry_artifact_mismatch_reason_persisted() {
+    let dir = tempfile::tempdir().unwrap();
+    let session_id = format!("test_pack_mismatch_{}", std::process::id());
+    let dir_str = dir.path().to_str().unwrap();
+
+    let mut tel = AgentTelemetry::new();
+    // No mutations, no worker, no repair → mismatch for requires_mutation
+    tel.validate_against(PackExpectation::RequiresMutation);
+
+    tel.write_artifact_to_dir(dir_str, &session_id).unwrap();
+
+    let file_path = dir.path().join(format!("{session_id}_telemetry.json"));
+    let contents = std::fs::read_to_string(&file_path).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&contents).unwrap();
+
+    assert_eq!(json["pack_expectation"], "requires_mutation");
+    assert!(
+        json["expectation_mismatch_reason"]
+            .as_str()
+            .unwrap()
+            .contains("zero file changes")
+    );
+}
+
+// ---------------------------------------------------------------------------
+// PackValidationResult Display
+// ---------------------------------------------------------------------------
+
+#[test]
+fn pack_validation_result_display() {
+    assert_eq!(
+        PackValidationResult::NoExpectation.to_string(),
+        "no_expectation"
+    );
+    assert_eq!(PackValidationResult::Satisfied.to_string(), "satisfied");
+
+    let mismatch = PackValidationResult::Mismatch {
+        expectation: PackExpectation::RequiresMutation,
+        reason: "no changes".to_string(),
+    };
+    assert_eq!(
+        mismatch.to_string(),
+        "mismatch(requires_mutation): no changes"
+    );
+}

--- a/tests/pack_validation_gate.rs
+++ b/tests/pack_validation_gate.rs
@@ -58,11 +58,26 @@ fn mutation_observed_set_by_record_mutation_turn() {
     assert!(tel.mutation_observed);
 }
 
+// Issue #339: escalation is a request-side signal and MUST NOT flip the
+// success-side `worker_observed` flag. Only `record_worker_success()` —
+// called after a real post-execution worker mutation — may set it.
 #[test]
-fn worker_observed_set_by_record_fixslice_escalation() {
+fn worker_observed_not_set_by_record_fixslice_escalation() {
     let mut tel = AgentTelemetry::new();
     assert!(!tel.worker_observed);
     tel.record_fixslice_escalation();
+    assert!(
+        !tel.worker_observed,
+        "escalation-emission must not flip worker_observed"
+    );
+    assert_eq!(tel.fixslice_escalation_count, 1);
+}
+
+#[test]
+fn worker_observed_set_by_record_worker_success() {
+    let mut tel = AgentTelemetry::new();
+    assert!(!tel.worker_observed);
+    tel.record_worker_success();
     assert!(tel.worker_observed);
 }
 
@@ -153,10 +168,26 @@ fn validate_requires_worker_observation_mismatch_when_nothing_observed() {
     }
 }
 
+// Issue #339: escalation alone must NOT satisfy the worker gate.
+// Only a real post-execution worker success does.
 #[test]
-fn validate_requires_worker_observation_satisfied_by_fixslice() {
+fn validate_requires_worker_observation_mismatch_when_only_escalation_emitted() {
     let mut tel = AgentTelemetry::new();
     tel.record_fixslice_escalation();
+    let result = tel.validate_against(PackExpectation::RequiresWorkerObservation);
+    match &result {
+        PackValidationResult::Mismatch { expectation, .. } => {
+            assert_eq!(*expectation, PackExpectation::RequiresWorkerObservation);
+        }
+        other => panic!("expected Mismatch, got {other:?}"),
+    }
+}
+
+#[test]
+fn validate_requires_worker_observation_satisfied_by_worker_success() {
+    let mut tel = AgentTelemetry::new();
+    tel.record_fixslice_escalation();
+    tel.record_worker_success();
     let result = tel.validate_against(PackExpectation::RequiresWorkerObservation);
     assert_eq!(result, PackValidationResult::Satisfied);
 }
@@ -210,10 +241,21 @@ fn validate_requires_worker_observation_mismatch_when_repair_plus_mutation() {
     assert!(matches!(result, PackValidationResult::Mismatch { .. }));
 }
 
+// Issue #339: stagnation-triggered escalation alone must also not satisfy
+// the gate. Worker success telemetry must come from record_worker_success().
 #[test]
-fn validate_requires_worker_observation_satisfied_only_by_worker_observed() {
+fn validate_requires_worker_observation_mismatch_when_only_stagnation_escalation() {
     let mut tel = AgentTelemetry::new();
     tel.record_fixslice_escalation_stagnation();
+    let result = tel.validate_against(PackExpectation::RequiresWorkerObservation);
+    assert!(matches!(result, PackValidationResult::Mismatch { .. }));
+}
+
+#[test]
+fn validate_requires_worker_observation_satisfied_only_by_worker_success() {
+    let mut tel = AgentTelemetry::new();
+    tel.record_fixslice_escalation_stagnation();
+    tel.record_worker_success();
     let result = tel.validate_against(PackExpectation::RequiresWorkerObservation);
     assert_eq!(result, PackValidationResult::Satisfied);
 }
@@ -231,6 +273,7 @@ fn telemetry_artifact_includes_pack_validation_fields() {
     let mut tel = AgentTelemetry::new();
     tel.record_mutation_turn(1, Some(0.3), "file.write");
     tel.record_fixslice_escalation();
+    tel.record_worker_success();
     tel.record_pre_exit_repair_injected();
     tel.pack_expectation = Some(PackExpectation::RequiresWorkerObservation);
 

--- a/tests/pack_validation_gate.rs
+++ b/tests/pack_validation_gate.rs
@@ -147,7 +147,7 @@ fn validate_requires_worker_observation_mismatch_when_nothing_observed() {
             reason,
         } => {
             assert_eq!(*expectation, PackExpectation::RequiresWorkerObservation);
-            assert!(reason.contains("no worker path"), "reason: {reason}");
+            assert!(reason.contains("worker"), "reason: {reason}");
         }
         other => panic!("expected Mismatch, got {other:?}"),
     }
@@ -161,18 +161,59 @@ fn validate_requires_worker_observation_satisfied_by_fixslice() {
     assert_eq!(result, PackValidationResult::Satisfied);
 }
 
+// Issue #334: repair-turn-only and mutation-only sessions must NOT satisfy
+// the worker-observation gate.  Runtime semantics must agree with the
+// benchmark runner's strict classification, otherwise salvage runs mask
+// missing worker-path evidence.
 #[test]
-fn validate_requires_worker_observation_satisfied_by_repair_turn() {
+fn validate_requires_worker_observation_mismatch_when_only_repair_turn() {
     let mut tel = AgentTelemetry::new();
     tel.record_pre_exit_repair_injected();
     let result = tel.validate_against(PackExpectation::RequiresWorkerObservation);
-    assert_eq!(result, PackValidationResult::Satisfied);
+    match &result {
+        PackValidationResult::Mismatch {
+            expectation,
+            reason,
+        } => {
+            assert_eq!(*expectation, PackExpectation::RequiresWorkerObservation);
+            assert!(reason.contains("worker"), "reason: {reason}");
+        }
+        other => panic!("expected Mismatch, got {other:?}"),
+    }
 }
 
 #[test]
-fn validate_requires_worker_observation_satisfied_by_mutation() {
+fn validate_requires_worker_observation_mismatch_when_only_mutation() {
     let mut tel = AgentTelemetry::new();
     tel.record_mutation_turn(2, Some(0.5), "file.write");
+    let result = tel.validate_against(PackExpectation::RequiresWorkerObservation);
+    match &result {
+        PackValidationResult::Mismatch {
+            expectation,
+            reason,
+        } => {
+            assert_eq!(*expectation, PackExpectation::RequiresWorkerObservation);
+            assert!(reason.contains("worker"), "reason: {reason}");
+        }
+        other => panic!("expected Mismatch, got {other:?}"),
+    }
+}
+
+#[test]
+fn validate_requires_worker_observation_mismatch_when_repair_plus_mutation() {
+    // Even repair + mutation together must not satisfy the gate — this is
+    // exactly the salvage pattern the benchmark runner rejects.
+    let mut tel = AgentTelemetry::new();
+    tel.record_pre_exit_repair_injected();
+    tel.record_mutation_turn(4, Some(1.0), "file.edit");
+    let result = tel.validate_against(PackExpectation::RequiresWorkerObservation);
+    assert!(matches!(result, PackValidationResult::Mismatch { .. }));
+}
+
+#[test]
+fn validate_requires_worker_observation_satisfied_only_by_worker_observed() {
+    let mut tel = AgentTelemetry::new();
+    tel.record_fixslice_escalation_stagnation();
     let result = tel.validate_against(PackExpectation::RequiresWorkerObservation);
     assert_eq!(result, PackValidationResult::Satisfied);
 }

--- a/tests/phase_estimation.rs
+++ b/tests/phase_estimation.rs
@@ -173,3 +173,16 @@ fn suppressed_final_does_not_disable_fallback() {
     // Fallback should still work because accept_anvil_final() was not called
     assert_eq!(est.check_empty_response(), PhaseAction::FallbackComplete);
 }
+
+// ---------------------------------------------------------------------------
+// Issue #290: file.rewrite classified as Write tool
+// ---------------------------------------------------------------------------
+
+#[test]
+fn phase_estimator_file_rewrite_is_write_tool() {
+    let mut est = PhaseEstimator::new(5, 10, 5);
+
+    // file.rewrite should transition phase to Implementing
+    est.record_tool_call("file.rewrite", true);
+    assert_eq!(est.current_phase(), Phase::Implementing);
+}

--- a/tests/read_heavy_worker_escalation.rs
+++ b/tests/read_heavy_worker_escalation.rs
@@ -101,10 +101,23 @@ fn runtime_gate_rejects_repair_only_salvage_for_worker_required_pack() {
     }
 }
 
+// Issue #339: stagnation escalation alone is the request side and must NOT
+// satisfy the gate. The session must also record a real worker success.
 #[test]
-fn runtime_gate_accepts_stagnation_triggered_worker_escalation() {
+fn runtime_gate_rejects_stagnation_escalation_without_worker_success() {
     let mut tel = AgentTelemetry::new();
     tel.record_fixslice_escalation_stagnation();
+    assert!(!tel.worker_observed);
+
+    let result = tel.validate_against(PackExpectation::RequiresWorkerObservation);
+    assert!(matches!(result, PackValidationResult::Mismatch { .. }));
+}
+
+#[test]
+fn runtime_gate_accepts_stagnation_escalation_followed_by_worker_success() {
+    let mut tel = AgentTelemetry::new();
+    tel.record_fixslice_escalation_stagnation();
+    tel.record_worker_success();
     assert!(tel.worker_observed);
 
     let result = tel.validate_against(PackExpectation::RequiresWorkerObservation);

--- a/tests/read_heavy_worker_escalation.rs
+++ b/tests/read_heavy_worker_escalation.rs
@@ -1,0 +1,112 @@
+//! Regression tests for Issue #334: read-heavy stagnation must reach the
+//! worker path even when no edit failures accumulate.
+//!
+//! Issue #332 solved the cross-path edit-failure case, but Phase2 drift
+//! manifests as repeated reads / audits with no mutation and almost no
+//! failed edit attempts. The stagnation-driven escalation therefore needs
+//! a second trigger that does not depend on `edit_fail_tracker.total_failures()`.
+
+use anvil::app::edit_fail_tracker::should_escalate_for_read_heavy_drift;
+use anvil::app::stagnation_state::{StagnationState, compute_stagnation_score};
+use anvil::contracts::{AgentTelemetry, PackExpectation, PackValidationResult};
+
+// ---------------------------------------------------------------------------
+// Policy pure function
+// ---------------------------------------------------------------------------
+
+#[test]
+fn read_heavy_escalation_disabled_when_score_threshold_is_zero() {
+    assert!(!should_escalate_for_read_heavy_drift(4, false, 10, 0, 5));
+}
+
+#[test]
+fn read_heavy_escalation_requires_no_mutation_observed() {
+    // Mutation already happened — not a read-heavy session anymore.
+    assert!(!should_escalate_for_read_heavy_drift(4, true, 10, 2, 5));
+}
+
+#[test]
+fn read_heavy_escalation_requires_score_above_threshold() {
+    assert!(!should_escalate_for_read_heavy_drift(1, false, 10, 2, 5));
+}
+
+#[test]
+fn read_heavy_escalation_requires_drought() {
+    assert!(!should_escalate_for_read_heavy_drift(3, false, 4, 2, 5));
+}
+
+#[test]
+fn read_heavy_escalation_fires_on_boundary_conditions() {
+    // Exactly at both thresholds → fire.
+    assert!(should_escalate_for_read_heavy_drift(2, false, 5, 2, 5));
+}
+
+#[test]
+fn read_heavy_escalation_fires_when_score_and_drought_exceed_thresholds() {
+    assert!(should_escalate_for_read_heavy_drift(4, false, 12, 2, 5));
+}
+
+// ---------------------------------------------------------------------------
+// Integrated: stagnation state + policy reproduces the Issue #334 drift
+// ---------------------------------------------------------------------------
+
+#[test]
+fn read_heavy_session_reaches_escalation_without_any_edit_failures() {
+    // Reproduce the Phase2 pattern:
+    //   - repeated read-only turns
+    //   - no mutation observed
+    //   - edit_fail_tracker.total_failures() == 0 (no failed edits)
+    //   - stagnation score climbs
+    //
+    // The existing `should_escalate_for_stagnation` never fires because
+    // it requires `total_failures >= threshold`. The new policy must.
+    let mut state = StagnationState::new();
+    let workset = vec![0usize];
+    for _ in 0..6 {
+        state.begin_turn(&workset);
+        state.end_turn(false);
+    }
+    let score = compute_stagnation_score(&state);
+    assert!(score >= 2, "expected score >= 2, got {score}");
+
+    // mutation_observed == false, turns_since_last_mutation >= drought threshold.
+    assert!(should_escalate_for_read_heavy_drift(
+        score as u32,
+        false,
+        state.turns_since_last_mutation as u32,
+        2,
+        5,
+    ));
+}
+
+// ---------------------------------------------------------------------------
+// Runtime pack-validation gate must only accept worker_observed=true
+// ---------------------------------------------------------------------------
+
+#[test]
+fn runtime_gate_rejects_repair_only_salvage_for_worker_required_pack() {
+    let mut tel = AgentTelemetry::new();
+    tel.record_pre_exit_repair_injected();
+    tel.record_pre_exit_repair_consumed();
+    tel.record_mutation_turn(8, Some(1.5), "file.edit");
+    // Retrospectively classify as salvage — this is the exact A1 log pattern.
+    tel.classify_repair_salvage();
+    assert_eq!(tel.fixslice_escalation_repair_salvage_count, 1);
+    assert!(!tel.worker_observed);
+
+    let result = tel.validate_against(PackExpectation::RequiresWorkerObservation);
+    match result {
+        PackValidationResult::Mismatch { .. } => {}
+        other => panic!("expected Mismatch, got {other:?}"),
+    }
+}
+
+#[test]
+fn runtime_gate_accepts_stagnation_triggered_worker_escalation() {
+    let mut tel = AgentTelemetry::new();
+    tel.record_fixslice_escalation_stagnation();
+    assert!(tel.worker_observed);
+
+    let result = tel.validate_against(PackExpectation::RequiresWorkerObservation);
+    assert_eq!(result, PackValidationResult::Satisfied);
+}

--- a/tests/repair_turn_closure.rs
+++ b/tests/repair_turn_closure.rs
@@ -1,0 +1,272 @@
+//! Tests for Issue #327: pre-exit repair turn closure — unchecked plan
+//! expansion must be rejected during repair closure mode.
+//!
+//! Covers:
+//! - When repair closure mode is active, unchecked ANVIL_PLAN_UPDATE items
+//!   must NOT be appended to the plan.
+//! - Checked [x] items are still retired during repair closure mode.
+//! - Telemetry tracks rejected items, retired items, and pending counts.
+//! - Post-repair termination is decided from plan state, not just from
+//!   the fact that one repair response was consumed.
+
+use anvil::contracts::{AgentTelemetry, CompletionKind, ExecutionPlan, PlanItem, PlanItemStatus};
+
+// ---------------------------------------------------------------------------
+// Scenario: repair turn response contains checked + unchecked items
+// ---------------------------------------------------------------------------
+
+/// Reproduces the B1 failure from Issue #327:
+/// - Plan with 26 items, 24 done, 2 pending.
+/// - Repair turn is injected and consumed.
+/// - Repair-turn response contains ANVIL_PLAN_UPDATE with:
+///   - 1 checked [x] item (retire)
+///   - 2 new unchecked items (should be rejected)
+/// - Expected: checked item is retired, unchecked items are NOT appended,
+///   plan ends with 1 remaining item (not 3).
+#[test]
+fn repair_turn_rejects_unchecked_items_and_retires_checked() {
+    // Setup: 4-item plan, items 0-1 done, items 2-3 pending
+    let mut plan = ExecutionPlan::new(vec![
+        PlanItem::new("src/a.rs: update".into(), vec!["src/a.rs".into()]),
+        PlanItem::new("src/b.rs: update".into(), vec!["src/b.rs".into()]),
+        PlanItem::new(
+            "src/lib/auto-yes-poller.ts: implement polling".into(),
+            vec!["src/lib/auto-yes-poller.ts".into()],
+        ),
+        PlanItem::new(
+            "src/lib/detection/status-detector.ts: fix detection".into(),
+            vec!["src/lib/detection/status-detector.ts".into()],
+        ),
+    ]);
+    plan.items[0].status = PlanItemStatus::Done;
+    plan.items[1].status = PlanItemStatus::Done;
+
+    let mut telemetry = AgentTelemetry::new();
+
+    // Step 1: Record pending count before repair turn
+    let pending_before = plan.items.iter().filter(|i| !i.is_finished()).count() as u32;
+    telemetry.record_repair_turn_pending_before(pending_before);
+    assert_eq!(pending_before, 2);
+
+    // Step 2: Simulate repair-turn response processing
+    // The model's response retires item 2 (auto-yes-poller.ts) via [x]
+    let retired = plan.mark_unfinished_items_by_target(
+        &["src/lib/auto-yes-poller.ts".to_string()],
+        PlanItemStatus::AlreadySatisfied,
+    );
+    assert_eq!(retired.len(), 1, "one item should be retired");
+    telemetry.record_repair_turn_items_retired(retired.len() as u32);
+
+    // Step 3: The model also emits 2 new unchecked items — these must be rejected.
+    // In the real code, apply_plan_update_pipeline checks self.repair_closure_active
+    // and skips append_items. Here we verify the invariant directly.
+    let new_unchecked_items = [
+        PlanItem::new(
+            "src/lib/detection/status-detector.ts: refactor approach".into(),
+            vec!["src/lib/detection/status-detector.ts".into()],
+        ),
+        PlanItem::new(
+            "src/app/api/worktrees/[id]/current-output/route.ts: add handler".into(),
+            vec!["src/app/api/worktrees/[id]/current-output/route.ts".into()],
+        ),
+    ];
+
+    // In repair closure mode: reject unchecked items
+    let rejected_count = new_unchecked_items.len() as u32;
+    telemetry.record_repair_turn_items_rejected(rejected_count);
+
+    // Do NOT append: plan.append_items(new_unchecked_items);
+
+    // Step 4: Record pending count after repair turn
+    let pending_after = plan.items.iter().filter(|i| !i.is_finished()).count() as u32;
+    telemetry.record_repair_turn_pending_after(pending_after);
+
+    // Assertions
+    assert_eq!(
+        plan.items.len(),
+        4,
+        "plan should still have 4 items (no new items appended)"
+    );
+    assert_eq!(
+        pending_after, 1,
+        "only 1 item should remain pending (item 3)"
+    );
+    assert_eq!(
+        plan.items[2].status,
+        PlanItemStatus::AlreadySatisfied,
+        "item 2 should be retired"
+    );
+    assert_eq!(
+        plan.items[3].status,
+        PlanItemStatus::Pending,
+        "item 3 should still be pending"
+    );
+
+    // Telemetry assertions
+    assert_eq!(telemetry.repair_turn_items_retired, 1);
+    assert_eq!(telemetry.repair_turn_items_rejected, 2);
+    assert_eq!(telemetry.repair_turn_pending_before, Some(2));
+    assert_eq!(telemetry.repair_turn_pending_after, Some(1));
+
+    // CompletionKind: still Partial because item 3 remains
+    let kind = CompletionKind::classify(&plan, None, false);
+    assert_eq!(
+        kind,
+        CompletionKind::Partial,
+        "with 1 remaining item, should be Partial"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Scenario: repair turn retires all remaining items — plan cleanly finishes
+// ---------------------------------------------------------------------------
+
+/// When the repair-turn response successfully retires all remaining items
+/// (and emits no unchecked items), the plan should be cleanly finished
+/// and CompletionKind should be CompleteUnverified.
+#[test]
+fn repair_turn_retires_all_remaining_completes_plan() {
+    let mut plan = ExecutionPlan::new(vec![
+        PlanItem::new("src/a.rs: update".into(), vec!["src/a.rs".into()]),
+        PlanItem::new("src/b.rs: update".into(), vec!["src/b.rs".into()]),
+        PlanItem::new(
+            "src/detector.ts: fix detection".into(),
+            vec!["src/detector.ts".into()],
+        ),
+    ]);
+    plan.items[0].status = PlanItemStatus::Done;
+    plan.items[1].status = PlanItemStatus::Done;
+
+    let mut telemetry = AgentTelemetry::new();
+
+    // Pending before repair
+    let pending_before = plan.items.iter().filter(|i| !i.is_finished()).count() as u32;
+    telemetry.record_repair_turn_pending_before(pending_before);
+    assert_eq!(pending_before, 1);
+
+    // Repair turn retires the last item
+    let retired = plan.mark_unfinished_items_by_target(
+        &["src/detector.ts".to_string()],
+        PlanItemStatus::AlreadySatisfied,
+    );
+    assert_eq!(retired.len(), 1);
+    telemetry.record_repair_turn_items_retired(retired.len() as u32);
+
+    let pending_after = plan.items.iter().filter(|i| !i.is_finished()).count() as u32;
+    telemetry.record_repair_turn_pending_after(pending_after);
+
+    telemetry.record_pre_exit_repair_consumed();
+
+    // Plan should be cleanly finished
+    assert!(plan.is_cleanly_finished());
+    assert_eq!(pending_after, 0);
+    assert_eq!(
+        CompletionKind::classify(&plan, None, false),
+        CompletionKind::CompleteUnverified,
+    );
+
+    // Telemetry
+    assert_eq!(telemetry.repair_turn_items_retired, 1);
+    assert_eq!(telemetry.repair_turn_items_rejected, 0);
+    assert_eq!(telemetry.repair_turn_pending_before, Some(1));
+    assert_eq!(telemetry.repair_turn_pending_after, Some(0));
+}
+
+// ---------------------------------------------------------------------------
+// Scenario: without repair closure, unchecked items WOULD be appended
+// ---------------------------------------------------------------------------
+
+/// Baseline: when NOT in repair closure mode, unchecked items are normally
+/// appended. This proves the suppression is repair-mode-specific.
+#[test]
+fn normal_mode_appends_unchecked_items() {
+    let mut plan = ExecutionPlan::new(vec![PlanItem::new(
+        "src/a.rs: update".into(),
+        vec!["src/a.rs".into()],
+    )]);
+    plan.items[0].status = PlanItemStatus::Done;
+
+    // Normal mode: append works
+    let new_items = vec![PlanItem::new(
+        "src/new.rs: add feature".into(),
+        vec!["src/new.rs".into()],
+    )];
+    plan.append_items(new_items);
+
+    assert_eq!(
+        plan.items.len(),
+        2,
+        "new item should be appended in normal mode"
+    );
+    assert_eq!(plan.items[1].status, PlanItemStatus::Pending);
+}
+
+// ---------------------------------------------------------------------------
+// Scenario: repair turn telemetry consistency with Issue #325 counters
+// ---------------------------------------------------------------------------
+
+/// Validates that Issue #327 telemetry is consistent with the Issue #325
+/// repair turn injection/consumption counters.
+#[test]
+fn repair_turn_telemetry_consistency() {
+    let mut telemetry = AgentTelemetry::new();
+
+    // Initial state
+    assert_eq!(telemetry.repair_turn_items_retired, 0);
+    assert_eq!(telemetry.repair_turn_items_rejected, 0);
+    assert_eq!(telemetry.repair_turn_pending_before, None);
+    assert_eq!(telemetry.repair_turn_pending_after, None);
+
+    // Simulate full repair cycle
+    telemetry.record_pre_exit_repair_injected();
+    telemetry.record_repair_turn_pending_before(3);
+
+    // Repair response processing
+    telemetry.record_repair_turn_items_retired(1);
+    telemetry.record_repair_turn_items_rejected(2);
+
+    telemetry.record_pre_exit_repair_consumed();
+    telemetry.record_repair_turn_pending_after(2);
+
+    // All counters set
+    assert_eq!(telemetry.pre_exit_repair_injected_count, 1);
+    assert_eq!(telemetry.pre_exit_repair_consumed_count, 1);
+    assert_eq!(telemetry.repair_turn_items_retired, 1);
+    assert_eq!(telemetry.repair_turn_items_rejected, 2);
+    assert_eq!(telemetry.repair_turn_pending_before, Some(3));
+    assert_eq!(telemetry.repair_turn_pending_after, Some(2));
+}
+
+// ---------------------------------------------------------------------------
+// Scenario: repair turn with only unchecked items — all rejected
+// ---------------------------------------------------------------------------
+
+/// When the repair-turn response contains only new unchecked items (no
+/// checked retires), all items should be rejected and the plan state
+/// should be unchanged.
+#[test]
+fn repair_turn_all_unchecked_items_rejected() {
+    let mut plan = ExecutionPlan::new(vec![
+        PlanItem::new("src/a.rs: update".into(), vec!["src/a.rs".into()]),
+        PlanItem::new("src/b.rs: update".into(), vec!["src/b.rs".into()]),
+    ]);
+    plan.items[0].status = PlanItemStatus::Done;
+
+    let mut telemetry = AgentTelemetry::new();
+
+    let pending_before = plan.items.iter().filter(|i| !i.is_finished()).count() as u32;
+    telemetry.record_repair_turn_pending_before(pending_before);
+    assert_eq!(pending_before, 1);
+
+    // Model emits 3 unchecked items — all rejected in repair closure mode
+    telemetry.record_repair_turn_items_rejected(3);
+
+    let pending_after = plan.items.iter().filter(|i| !i.is_finished()).count() as u32;
+    telemetry.record_repair_turn_pending_after(pending_after);
+
+    // Plan unchanged
+    assert_eq!(plan.items.len(), 2);
+    assert_eq!(pending_after, 1);
+    assert_eq!(telemetry.repair_turn_items_retired, 0);
+    assert_eq!(telemetry.repair_turn_items_rejected, 3);
+}

--- a/tests/repair_turn_continuation.rs
+++ b/tests/repair_turn_continuation.rs
@@ -1,0 +1,208 @@
+//! Tests for Issue #325: pre-exit repair turn continuation.
+//!
+//! Covers:
+//! - When escape hatch fires with an incomplete plan, the repair message must
+//!   be followed by one more LLM turn before the loop terminates.
+//! - The "inject + immediate break" pattern from Issue #309 is no longer possible.
+//! - Telemetry tracks both injected and consumed repair turns.
+//! - When the plan is already complete at escape hatch time, no repair is needed
+//!   and the loop breaks immediately.
+
+use anvil::app::stagnation_state::{
+    StagnationState, compute_stagnation_score, should_allow_escape_hatch,
+};
+use anvil::contracts::{AgentTelemetry, CompletionKind, ExecutionPlan, PlanItem, PlanItemStatus};
+
+// ---------------------------------------------------------------------------
+// Scenario: escape hatch fires with incomplete plan — repair turn must continue
+// ---------------------------------------------------------------------------
+
+/// Reproduces the B1 failure from Issue #325:
+/// - Plan with remaining=1 item.
+/// - Escape hatch conditions are met (score >= 3, plan repair attempted).
+/// - Expected: repair message is injected, loop continues for one more turn
+///   (pre_exit_repair_injected = true), and only breaks after the next iteration.
+///
+/// This test validates the control flow invariant: when the plan is incomplete
+/// and escape hatch fires, the code must NOT break on the same iteration.
+#[test]
+fn escape_hatch_with_incomplete_plan_sets_repair_flag() {
+    // Setup: 3-item plan, items 0-1 done, item 2 still pending
+    let plan = ExecutionPlan::new(vec![
+        PlanItem::new("src/a.rs: update".into(), vec!["src/a.rs".into()]),
+        PlanItem::new("src/b.rs: update".into(), vec!["src/b.rs".into()]),
+        PlanItem::new(
+            "src/status-detector.ts: fix detectSessionStatus".into(),
+            vec!["src/status-detector.ts".into()],
+        ),
+    ]);
+
+    // Verify plan is not complete (remaining=1)
+    assert!(!plan.is_successfully_completed());
+    assert!(!plan.is_empty());
+
+    // Stagnation state: escape hatch conditions met
+    let mut stagnation = StagnationState::init_from_plan(&["src/status-detector.ts".to_string()]);
+    for _ in 0..12 {
+        stagnation.begin_turn(&[]);
+        stagnation.end_turn(false);
+    }
+    let score = compute_stagnation_score(&stagnation);
+    assert!(score >= 3, "stagnation score should be >= 3, got {score}");
+
+    let plan_repair_count = 1; // repair already attempted
+    let remaining_turns = 5;
+    assert!(
+        should_allow_escape_hatch(&stagnation, plan_repair_count, remaining_turns),
+        "escape hatch should be triggered"
+    );
+
+    // Simulate the fixed control flow:
+    // When plan is incomplete and escape hatch fires, the flag is set to true
+    // and the loop continues (no break).
+    let mut pre_exit_repair_injected = false;
+    let mut telemetry = AgentTelemetry::new();
+
+    // This is the fixed branch: inject repair, set flag, continue
+    if !plan.is_empty() && !plan.is_successfully_completed() {
+        // Repair message would be injected here
+        telemetry.record_pre_exit_repair_injected();
+        pre_exit_repair_injected = true;
+        // In the real code: `current = next_structured; continue;`
+    }
+
+    assert!(
+        pre_exit_repair_injected,
+        "repair flag must be set when plan is incomplete at escape hatch"
+    );
+    assert_eq!(
+        telemetry.pre_exit_repair_injected_count, 1,
+        "injected count should be 1"
+    );
+
+    // On the next iteration (after LLM processes the repair message),
+    // the flag causes the loop to terminate.
+    if pre_exit_repair_injected {
+        telemetry.record_pre_exit_repair_consumed();
+        // In the real code: `break;`
+    }
+
+    assert_eq!(
+        telemetry.pre_exit_repair_consumed_count, 1,
+        "consumed count should be 1 after repair turn is processed"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Scenario: escape hatch with complete plan — no repair needed
+// ---------------------------------------------------------------------------
+
+/// When the plan is already complete at escape hatch time, no repair message
+/// is needed and the loop should break immediately without setting the flag.
+#[test]
+fn escape_hatch_with_complete_plan_breaks_immediately() {
+    let mut plan = ExecutionPlan::new(vec![
+        PlanItem::new("src/a.rs: update".into(), vec!["src/a.rs".into()]),
+        PlanItem::new("src/b.rs: update".into(), vec!["src/b.rs".into()]),
+    ]);
+    plan.items[0].status = PlanItemStatus::Done;
+    plan.items[1].status = PlanItemStatus::AlreadySatisfied;
+
+    assert!(plan.is_successfully_completed());
+
+    // Simulate the control flow: plan is complete, so no repair is injected
+    let mut pre_exit_repair_injected = false;
+    let telemetry = AgentTelemetry::new();
+
+    if !plan.is_empty() && !plan.is_successfully_completed() {
+        pre_exit_repair_injected = true;
+        // Would never reach here
+    }
+
+    assert!(
+        !pre_exit_repair_injected,
+        "repair flag must NOT be set when plan is already complete"
+    );
+    assert_eq!(
+        telemetry.pre_exit_repair_injected_count, 0,
+        "no injection when plan is complete"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Scenario: repair turn telemetry consistency
+// ---------------------------------------------------------------------------
+
+/// Validates that injected count >= consumed count (a repair can be injected
+/// but not consumed if the loop hits max iterations before the next turn).
+#[test]
+fn repair_telemetry_injected_ge_consumed() {
+    let mut telemetry = AgentTelemetry::new();
+
+    assert_eq!(telemetry.pre_exit_repair_injected_count, 0);
+    assert_eq!(telemetry.pre_exit_repair_consumed_count, 0);
+
+    telemetry.record_pre_exit_repair_injected();
+    assert_eq!(telemetry.pre_exit_repair_injected_count, 1);
+    assert_eq!(telemetry.pre_exit_repair_consumed_count, 0);
+
+    // injected >= consumed holds
+    assert!(telemetry.pre_exit_repair_injected_count >= telemetry.pre_exit_repair_consumed_count);
+
+    telemetry.record_pre_exit_repair_consumed();
+    assert_eq!(telemetry.pre_exit_repair_consumed_count, 1);
+    assert_eq!(
+        telemetry.pre_exit_repair_injected_count, telemetry.pre_exit_repair_consumed_count,
+        "after consumption, counts should match"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Scenario: empty plan at escape hatch — no repair injected
+// ---------------------------------------------------------------------------
+
+/// When the execution plan is empty (no plan was ever registered), escape hatch
+/// should break immediately without attempting a repair turn.
+#[test]
+fn escape_hatch_with_empty_plan_breaks_without_repair() {
+    let plan = ExecutionPlan::default();
+    assert!(plan.is_empty());
+
+    // In the real code, this condition gates repair injection vs immediate break.
+    let pre_exit_repair_injected = !plan.is_empty() && !plan.is_successfully_completed();
+
+    assert!(!pre_exit_repair_injected, "no repair turn for empty plan");
+}
+
+// ---------------------------------------------------------------------------
+// Scenario: CompletionKind reflects repair-turn opportunity
+// ---------------------------------------------------------------------------
+
+/// After the repair turn is consumed, if the LLM's response successfully
+/// completes the remaining item, CompletionKind should be CompleteUnverified
+/// (not Partial).
+#[test]
+fn repair_turn_can_resolve_remaining_item() {
+    let mut plan = ExecutionPlan::new(vec![
+        PlanItem::new("src/a.rs: update".into(), vec!["src/a.rs".into()]),
+        PlanItem::new(
+            "src/detector.ts: fix detection".into(),
+            vec!["src/detector.ts".into()],
+        ),
+    ]);
+    plan.items[0].status = PlanItemStatus::Done;
+    // Item 1 is still Pending — this triggers repair
+
+    let pre_kind = CompletionKind::classify(&plan, None, false);
+    assert_eq!(pre_kind, CompletionKind::Partial);
+
+    // Simulate: after repair turn, the LLM response retires the remaining item
+    plan.items[1].status = PlanItemStatus::AlreadySatisfied;
+
+    let post_kind = CompletionKind::classify(&plan, None, false);
+    assert_eq!(
+        post_kind,
+        CompletionKind::CompleteUnverified,
+        "after repair turn resolves the item, completion should not be Partial"
+    );
+}

--- a/tests/runtime_flow.rs
+++ b/tests/runtime_flow.rs
@@ -1014,6 +1014,33 @@ fn tag_protocol_prompt_contains_tag_examples() {
     );
 }
 
+// --- Issue #290: file.rewrite tag parsing ---
+
+#[test]
+fn parse_tag_based_file_rewrite() {
+    let response = anvil::agent::BasicAgentLoop::parse_structured_response(concat!(
+        "```ANVIL_TOOL\n",
+        "<tool name=\"file.rewrite\" path=\"./src/main.rs\" start_line=\"10\" end_line=\"15\"><content>new code here</content></tool>\n",
+        "```\n",
+        "```ANVIL_FINAL\n",
+        "Rewrote lines 10-15.\n",
+        "```\n"
+    ))
+    .expect("Tag-based file.rewrite parsing should work");
+
+    assert_eq!(response.tool_calls.len(), 1);
+    assert_eq!(response.tool_calls[0].tool_name, "file.rewrite");
+    assert_eq!(
+        response.tool_calls[0].input,
+        anvil::tooling::ToolInput::FileRewrite {
+            path: "./src/main.rs".to_string(),
+            start_line: 10,
+            end_line: 15,
+            content: "new code here".to_string(),
+        }
+    );
+}
+
 // --- Issue #186: 同一ターン内の重複ツール呼び出し排除テスト ---
 
 #[test]

--- a/tests/tag_spec_system.rs
+++ b/tests/tag_spec_system.rs
@@ -3,8 +3,8 @@
 use anvil::agent::tag_spec::{TOOL_TAG_SPECS, find_spec};
 
 #[test]
-fn tool_tag_specs_has_eleven_entries() {
-    assert_eq!(TOOL_TAG_SPECS.len(), 11);
+fn tool_tag_specs_has_twelve_entries() {
+    assert_eq!(TOOL_TAG_SPECS.len(), 12);
 }
 
 #[test]

--- a/tests/tag_spec_system.rs
+++ b/tests/tag_spec_system.rs
@@ -3,8 +3,8 @@
 use anvil::agent::tag_spec::{TOOL_TAG_SPECS, find_spec};
 
 #[test]
-fn tool_tag_specs_has_ten_entries() {
-    assert_eq!(TOOL_TAG_SPECS.len(), 10);
+fn tool_tag_specs_has_eleven_entries() {
+    assert_eq!(TOOL_TAG_SPECS.len(), 11);
 }
 
 #[test]
@@ -80,6 +80,15 @@ fn find_spec_file_edit_anchor() {
     assert_eq!(spec.name, "file.edit_anchor");
     assert_eq!(spec.attributes, &["path"]);
     assert_eq!(spec.child_elements, &["old_content", "new_content"]);
+    assert!(!spec.example.is_empty());
+}
+
+#[test]
+fn find_spec_file_rewrite() {
+    let spec = find_spec("file.rewrite").expect("file.rewrite should exist");
+    assert_eq!(spec.name, "file.rewrite");
+    assert_eq!(spec.attributes, &["path", "start_line", "end_line"]);
+    assert_eq!(spec.child_elements, &["content"]);
     assert!(!spec.example.is_empty());
 }
 

--- a/tests/telemetry_artifact.rs
+++ b/tests/telemetry_artifact.rs
@@ -138,6 +138,12 @@ fn telemetry_artifact_all_fields_present() {
         "first_mutation_event_elapsed_s",
         "first_mutation_event_tool",
         "first_mutation_event_semantic_basis",
+        // Issue #329: pack validation gate
+        "mutation_observed",
+        "worker_observed",
+        "repair_turn_observed",
+        "pack_expectation",
+        "expectation_mismatch_reason",
     ];
 
     for key in &expected_keys {

--- a/tests/tooling_system.rs
+++ b/tests/tooling_system.rs
@@ -6374,3 +6374,345 @@ fn file_write_different_content_produces_diff() {
         "different-content write should produce diff_summary"
     );
 }
+
+// ============================================================
+// file.rewrite tests (Issue #290)
+// ============================================================
+
+#[test]
+fn file_rewrite_basic_success() {
+    let root = std::env::temp_dir().join("anvil_rewrite_basic");
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(&root).expect("dir should exist");
+    fs::write(root.join("test.rs"), "line1\nline2\nline3\nline4\nline5\n")
+        .expect("write should succeed");
+
+    let mut executor = LocalToolExecutor::new_without_rate_limit(root.clone());
+    let result = executor
+        .execute(ToolExecutionRequest {
+            tool_call_id: "call_rewrite_001".to_string(),
+            spec: build_registry()
+                .get("file.rewrite")
+                .expect("file.rewrite spec")
+                .clone(),
+            input: ToolInput::FileRewrite {
+                path: "./test.rs".to_string(),
+                start_line: 2,
+                end_line: 4,
+                content: "new2\nnew3\nnew4".to_string(),
+            },
+            extra_field_warnings: vec![],
+        })
+        .expect("rewrite should succeed");
+
+    assert_eq!(result.status, ToolExecutionStatus::Completed);
+    let content = fs::read_to_string(root.join("test.rs")).expect("read should succeed");
+    assert_eq!(content, "line1\nnew2\nnew3\nnew4\nline5\n");
+    assert!(!result.artifacts.is_empty());
+}
+
+#[test]
+fn file_rewrite_single_line() {
+    let root = std::env::temp_dir().join("anvil_rewrite_single");
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(&root).expect("dir should exist");
+    fs::write(root.join("test.rs"), "aaa\nbbb\nccc\n").expect("write should succeed");
+
+    let mut executor = LocalToolExecutor::new_without_rate_limit(root.clone());
+    let result = executor
+        .execute(ToolExecutionRequest {
+            tool_call_id: "call_rewrite_002".to_string(),
+            spec: build_registry()
+                .get("file.rewrite")
+                .expect("file.rewrite spec")
+                .clone(),
+            input: ToolInput::FileRewrite {
+                path: "./test.rs".to_string(),
+                start_line: 2,
+                end_line: 2,
+                content: "BBB".to_string(),
+            },
+            extra_field_warnings: vec![],
+        })
+        .expect("rewrite should succeed");
+
+    assert_eq!(result.status, ToolExecutionStatus::Completed);
+    let content = fs::read_to_string(root.join("test.rs")).expect("read should succeed");
+    assert_eq!(content, "aaa\nBBB\nccc\n");
+}
+
+#[test]
+fn file_rewrite_last_lines() {
+    let root = std::env::temp_dir().join("anvil_rewrite_last");
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(&root).expect("dir should exist");
+    fs::write(root.join("test.rs"), "line1\nline2\nline3\n").expect("write should succeed");
+
+    let mut executor = LocalToolExecutor::new_without_rate_limit(root.clone());
+    let result = executor
+        .execute(ToolExecutionRequest {
+            tool_call_id: "call_rewrite_003".to_string(),
+            spec: build_registry()
+                .get("file.rewrite")
+                .expect("file.rewrite spec")
+                .clone(),
+            input: ToolInput::FileRewrite {
+                path: "./test.rs".to_string(),
+                start_line: 2,
+                end_line: 3,
+                content: "replaced2\nreplaced3".to_string(),
+            },
+            extra_field_warnings: vec![],
+        })
+        .expect("rewrite should succeed");
+
+    assert_eq!(result.status, ToolExecutionStatus::Completed);
+    let content = fs::read_to_string(root.join("test.rs")).expect("read should succeed");
+    assert_eq!(content, "line1\nreplaced2\nreplaced3\n");
+}
+
+#[test]
+fn file_rewrite_invalid_range() {
+    // Validation catches end_line < start_line before execution
+    // This is caught by validate_required_fields
+    let registry = build_registry();
+    let err = registry.validate(ToolCallRequest::new(
+        "call_rewrite_invalid",
+        "file.rewrite",
+        ToolInput::FileRewrite {
+            path: "./test.rs".to_string(),
+            start_line: 3,
+            end_line: 1,
+            content: "x".to_string(),
+        },
+    ));
+    assert!(err.is_err(), "end_line < start_line should fail validation");
+}
+
+#[test]
+fn file_rewrite_out_of_bounds() {
+    let root = std::env::temp_dir().join("anvil_rewrite_oob");
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(&root).expect("dir should exist");
+    fs::write(root.join("test.rs"), "line1\nline2\nline3\n").expect("write should succeed");
+
+    let mut executor = LocalToolExecutor::new_without_rate_limit(root.clone());
+    let result = executor.execute(ToolExecutionRequest {
+        tool_call_id: "call_rewrite_005".to_string(),
+        spec: build_registry()
+            .get("file.rewrite")
+            .expect("file.rewrite spec")
+            .clone(),
+        input: ToolInput::FileRewrite {
+            path: "./test.rs".to_string(),
+            start_line: 1,
+            end_line: 10,
+            content: "x".to_string(),
+        },
+        extra_field_warnings: vec![],
+    });
+
+    assert!(result.is_err(), "out of bounds should fail");
+    let err_str = result.unwrap_err().to_string();
+    assert!(
+        err_str.contains("invalid line range"),
+        "error should mention invalid line range, got: {err_str}"
+    );
+}
+
+#[test]
+fn file_rewrite_noop() {
+    let root = std::env::temp_dir().join("anvil_rewrite_noop");
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(&root).expect("dir should exist");
+    fs::write(root.join("test.rs"), "line1\nline2\nline3\n").expect("write should succeed");
+
+    let mut executor = LocalToolExecutor::new_without_rate_limit(root.clone());
+    let result = executor.execute(ToolExecutionRequest {
+        tool_call_id: "call_rewrite_006".to_string(),
+        spec: build_registry()
+            .get("file.rewrite")
+            .expect("file.rewrite spec")
+            .clone(),
+        input: ToolInput::FileRewrite {
+            path: "./test.rs".to_string(),
+            start_line: 2,
+            end_line: 2,
+            content: "line2".to_string(),
+        },
+        extra_field_warnings: vec![],
+    });
+
+    assert!(result.is_err(), "no-op should fail");
+    let err_str = result.unwrap_err().to_string();
+    assert!(
+        err_str.contains("identical"),
+        "error should mention identical content, got: {err_str}"
+    );
+}
+
+#[test]
+fn file_rewrite_empty_content_deletes_lines() {
+    let root = std::env::temp_dir().join("anvil_rewrite_empty");
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(&root).expect("dir should exist");
+    fs::write(root.join("test.rs"), "line1\nline2\nline3\nline4\n").expect("write should succeed");
+
+    let mut executor = LocalToolExecutor::new_without_rate_limit(root.clone());
+    let result = executor
+        .execute(ToolExecutionRequest {
+            tool_call_id: "call_rewrite_007".to_string(),
+            spec: build_registry()
+                .get("file.rewrite")
+                .expect("file.rewrite spec")
+                .clone(),
+            input: ToolInput::FileRewrite {
+                path: "./test.rs".to_string(),
+                start_line: 2,
+                end_line: 3,
+                content: String::new(),
+            },
+            extra_field_warnings: vec![],
+        })
+        .expect("rewrite should succeed");
+
+    assert_eq!(result.status, ToolExecutionStatus::Completed);
+    let content = fs::read_to_string(root.join("test.rs")).expect("read should succeed");
+    assert_eq!(content, "line1\nline4\n");
+}
+
+#[test]
+fn file_rewrite_empty_path_fails_validation() {
+    let registry = build_registry();
+    let err = registry.validate(ToolCallRequest::new(
+        "call_rewrite_empty_path",
+        "file.rewrite",
+        ToolInput::FileRewrite {
+            path: String::new(),
+            start_line: 1,
+            end_line: 1,
+            content: "x".to_string(),
+        },
+    ));
+    assert!(matches!(
+        err,
+        Err(ToolValidationError::MissingRequiredField(ref f)) if f == "path"
+    ));
+}
+
+#[test]
+fn file_rewrite_from_json() {
+    let json = serde_json::json!({
+        "path": "./src/main.rs",
+        "start_line": 5,
+        "end_line": 10,
+        "content": "new code"
+    });
+    let input = ToolInput::from_json("file.rewrite", &json).expect("parse should succeed");
+    assert_eq!(
+        input,
+        ToolInput::FileRewrite {
+            path: "./src/main.rs".to_string(),
+            start_line: 5,
+            end_line: 10,
+            content: "new code".to_string(),
+        }
+    );
+}
+
+#[test]
+fn file_rewrite_from_json_missing_start_line() {
+    let json = serde_json::json!({
+        "path": "./src/main.rs",
+        "end_line": 10,
+        "content": "new code"
+    });
+    let result = ToolInput::from_json("file.rewrite", &json);
+    assert!(result.is_err(), "missing start_line should fail");
+}
+
+#[test]
+fn file_rewrite_diff_summary() {
+    let root = std::env::temp_dir().join("anvil_rewrite_diff");
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(&root).expect("dir should exist");
+    fs::write(root.join("test.rs"), "aaa\nbbb\nccc\n").expect("write should succeed");
+
+    let mut executor = LocalToolExecutor::new_without_rate_limit(root.clone());
+    let result = executor
+        .execute(ToolExecutionRequest {
+            tool_call_id: "call_rewrite_diff".to_string(),
+            spec: build_registry()
+                .get("file.rewrite")
+                .expect("file.rewrite spec")
+                .clone(),
+            input: ToolInput::FileRewrite {
+                path: "./test.rs".to_string(),
+                start_line: 2,
+                end_line: 2,
+                content: "BBB".to_string(),
+            },
+            extra_field_warnings: vec![],
+        })
+        .expect("rewrite should succeed");
+
+    assert!(
+        result.diff_summary.is_some(),
+        "file.rewrite should produce a diff_summary"
+    );
+    let diff = result.diff_summary.unwrap();
+    assert!(
+        diff.contains("-bbb") && diff.contains("+BBB"),
+        "diff should contain the actual changes, got: {diff}"
+    );
+}
+
+#[test]
+fn file_rewrite_artifacts() {
+    let root = std::env::temp_dir().join("anvil_rewrite_artifacts");
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(&root).expect("dir should exist");
+    fs::write(root.join("test.rs"), "line1\nline2\n").expect("write should succeed");
+
+    let mut executor = LocalToolExecutor::new_without_rate_limit(root.clone());
+    let result = executor
+        .execute(ToolExecutionRequest {
+            tool_call_id: "call_rewrite_art".to_string(),
+            spec: build_registry()
+                .get("file.rewrite")
+                .expect("file.rewrite spec")
+                .clone(),
+            input: ToolInput::FileRewrite {
+                path: "./test.rs".to_string(),
+                start_line: 1,
+                end_line: 1,
+                content: "LINE1".to_string(),
+            },
+            extra_field_warnings: vec![],
+        })
+        .expect("rewrite should succeed");
+
+    assert_eq!(result.status, ToolExecutionStatus::Completed);
+    assert!(
+        !result.artifacts.is_empty(),
+        "artifacts should contain the file path"
+    );
+    assert!(
+        result.artifacts[0].contains("test.rs"),
+        "artifact should contain the file path"
+    );
+}
+
+#[test]
+fn file_rewrite_registered_in_registry() {
+    let registry = build_registry();
+    let spec = registry
+        .get("file.rewrite")
+        .expect("file.rewrite should be registered");
+    assert_eq!(spec.kind, ToolKind::FileRewrite);
+    assert_eq!(spec.execution_class, ExecutionClass::Mutating);
+    assert_eq!(spec.permission_class, PermissionClass::Confirm);
+    assert_eq!(spec.execution_mode, ExecutionMode::SequentialOnly);
+    assert_eq!(spec.plan_mode, PlanModePolicy::AllowedWithScope);
+    assert_eq!(spec.rollback_policy, RollbackPolicy::CheckpointBeforeWrite);
+}

--- a/tests/tooling_system.rs
+++ b/tests/tooling_system.rs
@@ -3044,6 +3044,7 @@ fn subagent_result_into_tool_execution_result_json_payload() {
         estimated_tokens: 100,
         iterations_used: 2,
         fix_proposal: None,
+        fix_proposal_failure: None,
     };
 
     let tool_result = result.into_tool_execution_result(&call);
@@ -3081,6 +3082,7 @@ fn subagent_result_timeout_into_tool_execution_result() {
         estimated_tokens: 0,
         iterations_used: 5,
         fix_proposal: None,
+        fix_proposal_failure: None,
     };
 
     let tool_result = result.into_tool_execution_result(&call);

--- a/tests/tooling_system.rs
+++ b/tests/tooling_system.rs
@@ -3043,6 +3043,7 @@ fn subagent_result_into_tool_execution_result_json_payload() {
         },
         estimated_tokens: 100,
         iterations_used: 2,
+        fix_proposal: None,
     };
 
     let tool_result = result.into_tool_execution_result(&call);
@@ -3079,6 +3080,7 @@ fn subagent_result_timeout_into_tool_execution_result() {
         payload: SubAgentPayload::fallback("partial work".to_string(), TerminationReason::Timeout),
         estimated_tokens: 0,
         iterations_used: 5,
+        fix_proposal: None,
     };
 
     let tool_result = result.into_tool_execution_result(&call);

--- a/tests/worker_observed_success_side.rs
+++ b/tests/worker_observed_success_side.rs
@@ -1,0 +1,173 @@
+//! Regression tests for Issue #339: worker_observed must be a success-side
+//! telemetry flag, not a request-side one.
+//!
+//! The exact A1 false-positive shape Issue #339 rejects:
+//!
+//! - runtime emitted a fix_slice escalation hint
+//! - `worker_observed` was flipped to `true` at emission time
+//! - the agent never produced a real mutation
+//! - `mutation_observed` remained `false`
+//! - pack validation returned `Satisfied` for `RequiresWorkerObservation`
+//!
+//! These tests pin the corrected semantics: `worker_observed` only becomes
+//! `true` after `record_worker_success()`, which in runtime is called only
+//! from `handle_fixslice_result` after the worker-owned `file.rewrite`
+//! actually completes without rollback.
+
+use anvil::contracts::{AgentTelemetry, PackExpectation, PackValidationResult};
+
+// ---------------------------------------------------------------------------
+// Negative: escalation-emission must NOT flip worker_observed
+// ---------------------------------------------------------------------------
+
+#[test]
+fn same_path_escalation_alone_does_not_flip_worker_observed() {
+    let mut tel = AgentTelemetry::new();
+    tel.record_fixslice_escalation();
+    assert_eq!(tel.fixslice_escalation_count, 1);
+    assert_eq!(tel.fixslice_escalation_same_path_count, 1);
+    assert!(
+        !tel.worker_observed,
+        "same-path escalation is request-side and must not flip worker_observed"
+    );
+    assert!(!tel.mutation_observed);
+}
+
+#[test]
+fn stagnation_escalation_alone_does_not_flip_worker_observed() {
+    let mut tel = AgentTelemetry::new();
+    tel.record_fixslice_escalation_stagnation();
+    assert_eq!(tel.fixslice_escalation_count, 1);
+    assert_eq!(tel.fixslice_escalation_stagnation_count, 1);
+    assert!(
+        !tel.worker_observed,
+        "stagnation escalation is request-side and must not flip worker_observed"
+    );
+    assert!(!tel.mutation_observed);
+}
+
+#[test]
+fn repeated_escalations_never_flip_worker_observed() {
+    let mut tel = AgentTelemetry::new();
+    for _ in 0..5 {
+        tel.record_fixslice_escalation();
+        tel.record_fixslice_escalation_stagnation();
+    }
+    assert_eq!(tel.fixslice_escalation_count, 10);
+    assert!(!tel.worker_observed);
+}
+
+// ---------------------------------------------------------------------------
+// A1 false-positive shape: must be rejected by the pack validation gate
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a1_false_positive_shape_is_rejected_by_worker_gate() {
+    // Reproduces the exact failure mode captured in Issue #339's A1 run:
+    //   worker_observed=true (pre-fix) + mutation_observed=false + zero-diff
+    //
+    // After the fix, `worker_observed` is false because only escalation
+    // hints were emitted, so the gate correctly reports Mismatch.
+    let mut tel = AgentTelemetry::new();
+    tel.record_fixslice_escalation_stagnation(); // "A1 read-heavy stagnation"
+    assert!(!tel.worker_observed);
+    assert!(!tel.mutation_observed);
+
+    let result = tel.validate_against(PackExpectation::RequiresWorkerObservation);
+    match &result {
+        PackValidationResult::Mismatch { expectation, .. } => {
+            assert_eq!(*expectation, PackExpectation::RequiresWorkerObservation);
+        }
+        other => panic!("expected Mismatch, got {other:?}"),
+    }
+    assert!(tel.expectation_mismatch_reason.is_some());
+}
+
+#[test]
+fn escalation_plus_unrelated_edit_mutation_still_rejected_by_worker_gate() {
+    // Even if the agent later produces a mutation via ordinary `file.edit`
+    // (not the worker path), a worker-required pack must still fail because
+    // no real worker success was recorded.
+    let mut tel = AgentTelemetry::new();
+    tel.record_fixslice_escalation();
+    tel.record_mutation_turn(5, Some(2.0), "file.edit");
+    assert!(tel.mutation_observed);
+    assert!(!tel.worker_observed);
+
+    let result = tel.validate_against(PackExpectation::RequiresWorkerObservation);
+    assert!(matches!(result, PackValidationResult::Mismatch { .. }));
+}
+
+// ---------------------------------------------------------------------------
+// Positive: escalation + real worker success satisfies the gate
+// ---------------------------------------------------------------------------
+
+#[test]
+fn escalation_plus_worker_success_satisfies_worker_gate() {
+    let mut tel = AgentTelemetry::new();
+    // Runtime emits the escalation hint (request side).
+    tel.record_fixslice_escalation();
+    // Agent invokes agent.fix_slice; the resulting file.rewrite completes
+    // without rollback — `handle_fixslice_result` calls both helpers.
+    tel.record_mutation_turn(6, Some(3.0), "file.rewrite");
+    tel.record_worker_success();
+
+    assert!(tel.worker_observed);
+    assert!(tel.mutation_observed);
+    assert_eq!(tel.fixslice_escalation_count, 1);
+
+    let result = tel.validate_against(PackExpectation::RequiresWorkerObservation);
+    assert_eq!(result, PackValidationResult::Satisfied);
+    assert!(tel.expectation_mismatch_reason.is_none());
+}
+
+#[test]
+fn worker_success_without_prior_escalation_also_satisfies_gate() {
+    // The agent may call agent.fix_slice proactively without a preceding
+    // escalation hint. That path should still count as worker observation.
+    let mut tel = AgentTelemetry::new();
+    tel.record_mutation_turn(2, Some(0.8), "file.rewrite");
+    tel.record_worker_success();
+
+    assert!(tel.worker_observed);
+    let result = tel.validate_against(PackExpectation::RequiresWorkerObservation);
+    assert_eq!(result, PackValidationResult::Satisfied);
+}
+
+// ---------------------------------------------------------------------------
+// Salvage classification interaction with the new semantics
+// ---------------------------------------------------------------------------
+
+#[test]
+fn salvage_classification_fires_when_escalation_emitted_but_worker_did_not_succeed() {
+    // Repair-only mutation after escalation: the escalation fired, but the
+    // worker never actually succeeded. The session is a salvage, not a
+    // worker-backed run.
+    let mut tel = AgentTelemetry::new();
+    tel.record_fixslice_escalation();
+    tel.record_pre_exit_repair_injected();
+    tel.record_mutation_turn(7, Some(2.5), "file.edit");
+    assert!(!tel.worker_observed);
+
+    tel.classify_repair_salvage();
+    assert_eq!(tel.fixslice_escalation_repair_salvage_count, 1);
+
+    // And the worker gate still rejects salvage, even with escalation emitted.
+    let result = tel.validate_against(PackExpectation::RequiresWorkerObservation);
+    assert!(matches!(result, PackValidationResult::Mismatch { .. }));
+}
+
+#[test]
+fn salvage_classification_suppressed_by_real_worker_success() {
+    let mut tel = AgentTelemetry::new();
+    tel.record_fixslice_escalation_stagnation();
+    tel.record_pre_exit_repair_injected();
+    tel.record_mutation_turn(8, Some(3.0), "file.rewrite");
+    tel.record_worker_success();
+
+    tel.classify_repair_salvage();
+    assert_eq!(
+        tel.fixslice_escalation_repair_salvage_count, 0,
+        "real worker success must suppress salvage classification"
+    );
+}

--- a/workspace/orchestration/runs/2026-04-12/plan-355.md
+++ b/workspace/orchestration/runs/2026-04-12/plan-355.md
@@ -1,0 +1,36 @@
+# Orchestration Plan — 2026-04-12 (Issue #355)
+
+## 対象Issue
+
+| Issue | タイトル | 種別 |
+|-------|---------|------|
+| #355 | Phase2: fix escalated_not_invoked and early-exit after worker success | BUG |
+
+## 実行計画
+
+1. Phase 2: Worktree準備（feature/issue-355-escalation-routing-and-early-exit）
+2. Phase 2.5: スキップ（Issue本文に詳細分析済み）
+3. Phase 3: /bug-fix 355
+4. Phase 5: 品質確認
+5. Phase 6: PR作成・developマージ
+6. Phase 8: 完了報告
+
+## 修正方針（Issue 本文より）
+
+### 即時対策 (1) escalated_not_invoked fix
+- parent で escalation flag が立った直後、他のヒューリスティクスを一時 suspend して必ず agent.fix_slice を呼ぶ gated routing を追加
+- 呼べない場合は fixslice_failure_reason に明示的な分類追加 (escalation_suppressed_by_<reason>)
+
+### 即時対策 (2) post-success early-exit
+- session ループで worker_observed=true AND pack_validation_result=satisfied を検知した直後、session_completed で break
+- worker-required pack でない場合は適用しない
+
+### 恒久対策
+- pack expectation と session termination の結合を明示化（pack.termination_on_satisfied = true 等）
+- escalation routing を pack-aware にする
+
+### 回帰テスト
+- escalation flagged and worker invoked under worker-required pack
+- session terminates cleanly after worker success in worker-required pack
+- elapsed_seconds <= pack_satisfied_turn_ms + 60s で post-success continuation を観測
+- cycle 6 相当の正常 run が regression しない

--- a/workspace/orchestration/runs/2026-04-12/plan-357.md
+++ b/workspace/orchestration/runs/2026-04-12/plan-357.md
@@ -1,0 +1,44 @@
+# Orchestration Plan — 2026-04-12 (Issue #357)
+
+## 対象Issue
+
+| Issue | タイトル | 種別 |
+|-------|---------|------|
+| #357 | Phase2: enforce FixSliceProposal contract in fix_slice prompt | BUG |
+
+## 実行計画
+
+1. Phase 2: Worktree準備（feature/issue-357-fixslice-prompt-contract）
+2. Phase 2.5: スキップ（Issue本文に詳細分析済み）
+3. Phase 3: /bug-fix 357
+4. Phase 5: 品質確認
+5. Phase 6: PR作成・developマージ
+6. Phase 8: 完了報告
+
+## 修正方針（Issue 本文より）
+
+### 即時対策（prompt 変更のみ）
+1. Strict contract statement を prompt 冒頭に追加
+   - FINAL message は ANVIL_FINAL 内の FixSliceProposal JSON object のみ許可
+   - markdown / explanations / tool call JSON は final に含めると fail
+2. target_path exact-match requirement を明示
+   - request で渡された path を directory prefix 含め exact に再利用
+   - basename-only path や prefix drop を禁止
+3. Inline schema definition を prompt に埋め込む
+   - target_path / line_range / replacement / rationale
+4. Few-shot examples を追加
+   - positive 2 件 + negative 1 件
+5. Final message rules を末尾に追加
+
+### 恒久対策
+- prompt と Rust validator で schema を single source of truth 化
+- 失敗例を prompt 内の負例へ継続的に反映できる仕組み
+
+### 回帰テスト
+- subagent final output を FixSliceProposal として複数回 parse し、揺れに対する耐性を確認
+- A1/A2 の正常 path が regression しないこと
+- prompt 長が context 65536 内に収まること
+
+## 関連ファイル
+- `src/agent/subagent.rs` — fix_slice subagent prompt 構築
+- `tests/fixslice_subagent.rs` — 既存 48 件の subagent 回帰テスト

--- a/workspace/orchestration/runs/2026-04-12/plan-359.md
+++ b/workspace/orchestration/runs/2026-04-12/plan-359.md
@@ -1,0 +1,38 @@
+# Orchestration Plan — 2026-04-12 (Issue #359)
+
+## 対象Issue
+
+| Issue | タイトル | 種別 |
+|-------|---------|------|
+| #359 | Phase2: balance fix_slice prompt under path ambiguity | BUG |
+
+## 実行計画
+
+1. Phase 2: Worktree準備（feature/issue-359-fixslice-prompt-balance）
+2. Phase 2.5: スキップ（Issue本文に詳細分析済み）
+3. Phase 3: /bug-fix 359
+4. Phase 5: 品質確認
+5. Phase 6: PR作成・developマージ
+6. Phase 8: 完了報告
+
+## 修正方針（Issue 本文より）
+
+### 即時対策 (1) 行動促進 guidance 追加
+- build_fixslice_user_prompt の RULES 直後に encouragement block を追加
+  - path ambiguity (./src/ vs src/) は ORIGINAL target_path を使えば OK
+  - partial file context でも proposal 可
+  - 不完全な proposal > proposal なし
+  - reasoning ではなく FixSliceProposal JSON に集中
+
+### 即時対策 (2) negative example の softening
+- "This is WRONG" → "Avoid this pattern" へ寄せる
+- model が proposal 回避に向かわないよう禁止→誘導へ
+
+### 回帰テスト
+- cycle 15 A1 が worker_observed=true に戻るか
+- long reasoning loop が消えるか
+- path_mismatch が増えすぎないか
+
+## 関連ファイル
+- `src/agent/subagent.rs` — fix_slice subagent prompt
+- `tests/fixslice_subagent.rs` — 既存 49 件の subagent 回帰テスト

--- a/workspace/orchestration/runs/2026-04-12/summary-355.md
+++ b/workspace/orchestration/runs/2026-04-12/summary-355.md
@@ -1,0 +1,43 @@
+## オーケストレーション完了報告 — Issue #355
+
+### 対象Issue
+
+| Issue | タイトル | ステータス |
+|-------|---------|-----------|
+| #355 | Phase2: fix escalated_not_invoked and early-exit after worker success | 完了 |
+
+### 実行フェーズ結果
+
+| Phase | 内容 | ステータス |
+|-------|------|-----------|
+| 1 | 依存関係分析 | 完了 |
+| 2 | Worktree準備 | 完了（feature/issue-355-escalation-routing-and-early-exit） |
+| 2.5 | 根本原因分析 | スキップ（Issue本文に詳細分析済み） |
+| 3 | 並列開発 | 完了（/bug-fix 355） |
+| 5 | 品質確認 | 完了（全Pass、新規10件テスト含む） |
+| 6 | PR・マージ | 完了（PR #356） |
+
+### 品質チェック
+
+| チェック項目 | 結果 |
+|-------------|------|
+| cargo build | Pass |
+| cargo clippy --all-targets | Pass（警告0件） |
+| cargo test | Pass（全テストパス） |
+| cargo fmt --check | Pass（差分なし） |
+
+### 変更内容
+
+- `src/app/escalation_barrier.rs` (NEW +108): `EscalationBarrier` でエスカレーションフラグ立ち上げ後は agent.fix_slice 以外のルーティングを抑制
+- `src/app/agentic.rs` (+56/-2): バリア統合、pack-aware early-exit（worker_observed=true && pack_validation_result=satisfied）
+- `src/contracts/mod.rs` (+65): `FixSliceFailureReason::EscalationSuppressedBy*` variants
+- `src/app/mod.rs` (+1): モジュール宣言
+- `tests/escalation_routing_control.rs` (NEW +342): forced routing、suppression classification、pack-aware early exit、cycle 6 normal flow non-regression
+
+### 成果物
+
+- 実行計画: workspace/orchestration/runs/2026-04-12/plan-355.md
+- 統合サマリー: workspace/orchestration/runs/2026-04-12/summary-355.md
+- PR: https://github.com/Kewton/Anvil/pull/356
+- マージコミット: `4f2d2dd`
+- 開発コミット: `f341b9c`

--- a/workspace/orchestration/runs/2026-04-12/summary-357.md
+++ b/workspace/orchestration/runs/2026-04-12/summary-357.md
@@ -1,0 +1,45 @@
+## オーケストレーション完了報告 — Issue #357
+
+### 対象Issue
+
+| Issue | タイトル | ステータス |
+|-------|---------|-----------|
+| #357 | Phase2: enforce FixSliceProposal contract in fix_slice prompt | 完了 |
+
+### 実行フェーズ結果
+
+| Phase | 内容 | ステータス |
+|-------|------|-----------|
+| 1 | 依存関係分析 | 完了 |
+| 2 | Worktree準備 | 完了（feature/issue-357-fixslice-prompt-contract） |
+| 2.5 | 根本原因分析 | スキップ（Issue本文に詳細分析済み） |
+| 3 | 並列開発 | 完了（/bug-fix 357、cargo test 承認プロンプトで2回中断 → "a" 再開で完了） |
+| 5 | 品質確認 | 完了（全Pass、新規 fixslice_subagent regression テスト追加） |
+| 6 | PR・マージ | 完了（PR #358） |
+
+### 品質チェック
+
+| チェック項目 | 結果 |
+|-------------|------|
+| cargo build | Pass |
+| cargo clippy --all-targets | Pass（警告0件） |
+| cargo test | Pass（全テストパス） |
+| cargo fmt --check | Pass（差分なし） |
+
+### 変更内容
+
+- `src/agent/subagent.rs` (+87/-21): fix_slice subagent system prompt の強化
+  - Strict contract statement（ANVIL_FINAL は FixSliceProposal JSON のみ）
+  - target_path exact-match requirement（basename drift 禁止）
+  - Inline FixSliceProposal schema 埋め込み
+  - Few-shot examples（positive 2件 + negative markdown 1件）
+  - Final message rules block
+- `tests/fixslice_subagent.rs` (+67): prompt contract マーカー存在確認 regression test
+
+### 成果物
+
+- 実行計画: workspace/orchestration/runs/2026-04-12/plan-357.md
+- 統合サマリー: workspace/orchestration/runs/2026-04-12/summary-357.md
+- PR: https://github.com/Kewton/Anvil/pull/358
+- マージコミット: `81f3ba6`
+- 開発コミット: `60e9054`

--- a/workspace/orchestration/runs/2026-04-12/summary-359.md
+++ b/workspace/orchestration/runs/2026-04-12/summary-359.md
@@ -1,0 +1,41 @@
+## オーケストレーション完了報告 — Issue #359
+
+### 対象Issue
+
+| Issue | タイトル | ステータス |
+|-------|---------|-----------|
+| #359 | Phase2: balance fix_slice prompt under path ambiguity | 完了 |
+
+### 実行フェーズ結果
+
+| Phase | 内容 | ステータス |
+|-------|------|-----------|
+| 1 | 依存関係分析 | 完了 |
+| 2 | Worktree準備 | 完了（feature/issue-359-fixslice-prompt-balance） |
+| 2.5 | 根本原因分析 | スキップ（Issue本文に詳細分析済み） |
+| 3 | 並列開発 | 完了（/bug-fix 359、gh issue view 承認プロンプト1回中断 → 自動再開） |
+| 5 | 品質確認 | 完了（全Pass） |
+| 6 | PR・マージ | 完了（PR #360） |
+
+### 品質チェック
+
+| チェック項目 | 結果 |
+|-------------|------|
+| cargo build | Pass |
+| cargo clippy --all-targets | Pass（警告0件） |
+| cargo test | Pass（全テストパス） |
+| cargo fmt --check | Pass（差分なし） |
+
+### 変更内容
+
+- `src/agent/subagent.rs` (+10/-2): encouragement guidance 追加（path ambiguity → ORIGINAL target_path 使用、partial context OK、imperfect proposal > no proposal）、negative example softening
+- `src/app/agentic.rs` (+12/-1): prompt balance 統合調整
+- `tests/fixslice_subagent.rs` (+71/-1): encouragement markers・softened wording の回帰テスト
+
+### 成果物
+
+- 実行計画: workspace/orchestration/runs/2026-04-12/plan-359.md
+- 統合サマリー: workspace/orchestration/runs/2026-04-12/summary-359.md
+- PR: https://github.com/Kewton/Anvil/pull/360
+- マージコミット: `697b812`
+- 開発コミット: `651eac0`


### PR DESCRIPTION
## Summary

Phase 2 `autonomy-v2-p2-fix-slice-v2` benchmark stabilization batch. This PR merges the complete set of fixes developed on the `develop` branch since the last main merge.

### Core feature
- **#290 / #291**: `file.rewrite` bounded rewrite primitive + `agent.fix_slice` microtask sub-agent

### Benchmark stabilization (Issues #321-#359)
- **#321**: Reactive fix_slice escalation from repeated edit failures
- **#323**: Process ANVIL_PLAN_UPDATE before escape hatch break
- **#325**: Continue loop after pre-exit repair turn injection
- **#327**: Reject unchecked plan expansion during repair closure mode
- **#329**: Pack validation gate for benchmark expectation mismatch detection
- **#332**: Broaden fix_slice escalation to cover cross-path drift
- **#334**: Read-heavy worker escalation and tighten worker-required gate
- **#336**: Structural closure guard for late-stage remaining=1
- **#339**: Only flip worker_observed after real post-execution worker success
- **#341**: Embed target_path and max_lines in FixSlice worker prompt
- **#343**: Suppress pre-exit repair salvage after fix_slice worker failure
- **#345**: Strengthen fix_slice worker contract brittleness
- **#347**: Add ANVIL_FIXSLICE_MAX_ITERATIONS to env whitelist
- **#349**: Closure-mode reasoning loop guard (ClosureLoopDetector)
- **#351**: Subagent + parent thrash detectors (PostFailureThrashDetector)
- **#353**: Make fix_slice no-progress detector tunable
- **#355**: Force agent.fix_slice routing and early-exit on worker success (EscalationBarrier)
- **#357**: Enforce FixSliceProposal contract in fix_slice prompt (strict contract + few-shot)
- **#359**: Balance fix_slice prompt under path ambiguity (encouragement guidance)

## Test plan

- [x] `cargo build` — OK
- [x] `cargo clippy --all-targets` — 0 warnings
- [x] `cargo test` — all pass
- [x] `cargo fmt --check` — no diff
- [x] Each Issue passed quality checks before merge to develop
- [x] Orchestration summaries: `workspace/orchestration/runs/2026-04-*/`

## Stats

- 48 files changed, ~8400 insertions, ~240 deletions
- 20 Issues closed
- 20 PRs merged to develop

🤖 Generated with [Claude Code](https://claude.com/claude-code)