### PR TITLE
fix(issue-364): widen classifier boundaries and wire delegation mutation telemetry

### DIFF
--- a/src/agent/model_classifier.rs
+++ b/src/agent/model_classifier.rs
@@ -12,7 +12,7 @@ pub enum ToolProtocolMode {
     /// JSON format (default, for large models).
     #[default]
     Json,
-    /// Tag-based format (for small models, <= 13B).
+    /// Tag-based format (for small/medium models, <=50B).
     TagBased,
 }
 
@@ -22,23 +22,23 @@ pub enum ToolProtocolMode {
 /// models to receive a more concise prompt that fits their context window.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum PromptTier {
-    /// Full prompt with all sections (default, for large models >13B).
+    /// Full prompt with all sections (default, for large models >50B).
     #[default]
     Full,
-    /// Compact prompt: basic tools + rules, guides omitted (for 7B-13B models).
+    /// Compact prompt: basic tools + rules, guides omitted (for 11B-50B models).
     Compact,
-    /// Tiny prompt: minimal tool syntax only (for <7B models).
+    /// Tiny prompt: minimal tool syntax only (for <=10B models).
     Tiny,
 }
 
 /// Model size classification.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ModelSizeClass {
-    /// Small model (<7B parameters).
+    /// Small model (≤10B parameters).
     Small,
-    /// Medium model (7B-13B parameters).
+    /// Medium model (11B-50B parameters).
     Medium,
-    /// Large model (>13B parameters or unknown).
+    /// Large model (>50B parameters or unknown).
     Large,
 }
 
@@ -151,8 +151,8 @@ fn classify_size_class(model_name: &str) -> ModelSizeClass {
         && let Ok(size) = caps[1].parse::<u64>()
     {
         return match size {
-            0..7 => ModelSizeClass::Small,
-            7..=13 => ModelSizeClass::Medium,
+            0..=10 => ModelSizeClass::Small,
+            11..=50 => ModelSizeClass::Medium,
             _ => ModelSizeClass::Large,
         };
     }
@@ -198,6 +198,70 @@ mod tests {
         assert_eq!(
             classify_model_size("qwen2-instruct"),
             ToolProtocolMode::TagBased
+        );
+    }
+
+    // Issue #364: verify classifier boundaries for delegation-relevant models
+    #[test]
+    fn issue_364_35b_is_medium() {
+        assert_eq!(
+            classify_size_class("qwen3.5:35b"),
+            ModelSizeClass::Medium,
+            "35B model should be Medium for delegation eligibility"
+        );
+    }
+
+    #[test]
+    fn issue_364_31b_is_medium() {
+        assert_eq!(
+            classify_size_class("gemma4:31b"),
+            ModelSizeClass::Medium,
+            "31B model should be Medium for delegation eligibility"
+        );
+    }
+
+    #[test]
+    fn issue_364_122b_remains_large() {
+        assert_eq!(
+            classify_size_class("qwen3.5:122b"),
+            ModelSizeClass::Large,
+            "122B model should remain Large"
+        );
+    }
+
+    #[test]
+    fn issue_364_boundary_10b_is_small() {
+        assert_eq!(
+            classify_size_class("model:10b"),
+            ModelSizeClass::Small,
+            "10B model should be Small"
+        );
+    }
+
+    #[test]
+    fn issue_364_boundary_11b_is_medium() {
+        assert_eq!(
+            classify_size_class("model:11b"),
+            ModelSizeClass::Medium,
+            "11B model should be Medium"
+        );
+    }
+
+    #[test]
+    fn issue_364_boundary_50b_is_medium() {
+        assert_eq!(
+            classify_size_class("model:50b"),
+            ModelSizeClass::Medium,
+            "50B model should be Medium"
+        );
+    }
+
+    #[test]
+    fn issue_364_boundary_51b_is_large() {
+        assert_eq!(
+            classify_size_class("model:51b"),
+            ModelSizeClass::Large,
+            "51B model should be Large"
         );
     }
 }

--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -615,6 +615,11 @@ impl App {
             && !rewrite_result.summary.contains("(no changes)");
         if rewrite_succeeded {
             self.agent_telemetry.record_worker_success();
+            // Issue #364: record mutation produced via model-aware delegation
+            if self.agent_telemetry.model_aware_delegation_count > 0 {
+                self.agent_telemetry
+                    .record_model_aware_delegation_mutation();
+            }
         } else {
             // Issue #343: the worker produced a valid proposal but
             // file.rewrite did not land a real mutation.
@@ -894,6 +899,13 @@ impl App {
                             elapsed_s,
                             &r.tool_name, // already validated by MUTATION_TOOLS.contains()
                         );
+
+                        // Issue #364: attribute mutation to proactive delegation if pending.
+                        if self.proactive_delegation_pending {
+                            self.agent_telemetry
+                                .record_model_aware_delegation_mutation();
+                            self.proactive_delegation_pending = false;
+                        }
                     }
                 }
             }
@@ -1192,6 +1204,7 @@ impl App {
                     self.session.push_message(msg);
 
                     self.agent_telemetry.record_model_aware_delegation();
+                    self.proactive_delegation_pending = true;
                     proactive_delegation_fired = true;
                 }
             }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -299,6 +299,9 @@ pub struct App {
     stagnation_state: stagnation_state::StagnationState,
     /// Whether forced mode is active for the current turn (Issue #263).
     forced_mode_active: bool,
+    /// Whether a proactive delegation hint was injected and a subsequent
+    /// mutation should be attributed to that delegation (Issue #364).
+    proactive_delegation_pending: bool,
     /// Recovery read budget for file.edit failure recovery (Issue #299).
     tool_recovery_budget: tool_recovery_budget::ToolRecoveryBudget,
     /// Whether the session is in pre-exit repair closure mode (Issue #327).
@@ -659,6 +662,7 @@ impl App {
             },
             stagnation_state: stagnation_state::StagnationState::new(),
             forced_mode_active: false,
+            proactive_delegation_pending: false,
             tool_recovery_budget: tool_recovery_budget::ToolRecoveryBudget::new(
                 edit_recovery_read_budget,
             ),

--- a/tests/model_aware_delegation.rs
+++ b/tests/model_aware_delegation.rs
@@ -381,6 +381,67 @@ fn telemetry_serde_default_backward_compat() {
 }
 
 // ---------------------------------------------------------------------------
+// Issue #364: classifier boundary regression tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn issue_364_35b_model_is_delegation_eligible() {
+    // qwen3.5:35b should be Medium, thus eligible for proactive delegation
+    let cap = anvil::agent::model_classifier::classify_model_capability("qwen3.5:35b", None, None);
+    assert_eq!(
+        cap.size_class,
+        ModelSizeClass::Medium,
+        "35B model must be Medium for delegation eligibility"
+    );
+}
+
+#[test]
+fn issue_364_31b_model_is_delegation_eligible() {
+    // gemma4:31b should be Medium, thus eligible for proactive delegation
+    let cap = anvil::agent::model_classifier::classify_model_capability("gemma4:31b", None, None);
+    assert_eq!(
+        cap.size_class,
+        ModelSizeClass::Medium,
+        "31B model must be Medium for delegation eligibility"
+    );
+}
+
+#[test]
+fn issue_364_122b_model_excluded_from_delegation() {
+    // qwen3.5:122b should remain Large, excluded from proactive delegation
+    let cap = anvil::agent::model_classifier::classify_model_capability("qwen3.5:122b", None, None);
+    assert_eq!(
+        cap.size_class,
+        ModelSizeClass::Large,
+        "122B model must remain Large"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Issue #364: delegation mutation telemetry runtime connectivity
+// ---------------------------------------------------------------------------
+
+#[test]
+fn issue_364_delegation_mutation_telemetry_independent() {
+    // Verify that record_model_aware_delegation_mutation works independently
+    // and is callable from runtime code (not just tests).
+    let mut tel = AgentTelemetry::new();
+    assert_eq!(tel.model_aware_delegation_produced_mutation, 0);
+
+    // Simulate: delegation fires, then mutation detected
+    tel.record_model_aware_delegation();
+    assert_eq!(tel.model_aware_delegation_count, 1);
+    assert_eq!(tel.model_aware_delegation_produced_mutation, 0);
+
+    tel.record_model_aware_delegation_mutation();
+    assert_eq!(tel.model_aware_delegation_produced_mutation, 1);
+
+    // Multiple mutations after delegation
+    tel.record_model_aware_delegation_mutation();
+    assert_eq!(tel.model_aware_delegation_produced_mutation, 2);
+}
+
+// ---------------------------------------------------------------------------
 // ModelSizeClass Display
 // ---------------------------------------------------------------------------
 

--- a/tests/model_classifier.rs
+++ b/tests/model_classifier.rs
@@ -44,10 +44,11 @@ fn boundary_13b_returns_tag_based() {
 }
 
 #[test]
-fn boundary_14b_returns_json() {
+fn boundary_14b_returns_tag_based() {
+    // Issue #364: 14B is now Medium (11-50B), so TagBased
     assert_eq!(
         determine_protocol_mode("llama3:14b", None),
-        ToolProtocolMode::Json,
+        ToolProtocolMode::TagBased,
     );
 }
 
@@ -78,10 +79,11 @@ fn capability_small_model_3b_returns_tiny() {
 }
 
 #[test]
-fn capability_medium_model_8b_returns_compact() {
+fn capability_small_model_8b_returns_tiny() {
+    // Issue #364: 8B is now Small (≤10B)
     let cap = classify_model_capability("llama3:8b", None, None);
-    assert_eq!(cap.size_class, ModelSizeClass::Medium);
-    assert_eq!(cap.prompt_tier, PromptTier::Compact);
+    assert_eq!(cap.size_class, ModelSizeClass::Small);
+    assert_eq!(cap.prompt_tier, PromptTier::Tiny);
     assert_eq!(cap.protocol_mode, ToolProtocolMode::TagBased);
 }
 
@@ -124,16 +126,17 @@ fn capability_config_tier_full_on_small_model() {
 
 #[test]
 fn capability_invalid_tier_falls_back_to_auto() {
+    // Issue #364: 8B is now Small, auto-detect → Tiny
     let cap = classify_model_capability("llama3:8b", None, Some("invalid"));
-    // Should fall back to auto-detect (Medium -> Compact)
-    assert_eq!(cap.prompt_tier, PromptTier::Compact);
+    assert_eq!(cap.prompt_tier, PromptTier::Tiny);
 }
 
 #[test]
-fn capability_boundary_7b_is_medium() {
+fn capability_boundary_7b_is_small() {
+    // Issue #364: 7B is now Small (≤10B)
     let cap = classify_model_capability("model:7b", None, None);
-    assert_eq!(cap.size_class, ModelSizeClass::Medium);
-    assert_eq!(cap.prompt_tier, PromptTier::Compact);
+    assert_eq!(cap.size_class, ModelSizeClass::Small);
+    assert_eq!(cap.prompt_tier, PromptTier::Tiny);
 }
 
 #[test]
@@ -144,10 +147,11 @@ fn capability_boundary_13b_is_medium() {
 }
 
 #[test]
-fn capability_boundary_14b_is_large() {
+fn capability_boundary_14b_is_medium() {
+    // Issue #364: 14B is now Medium (11-50B)
     let cap = classify_model_capability("model:14b", None, None);
-    assert_eq!(cap.size_class, ModelSizeClass::Large);
-    assert_eq!(cap.prompt_tier, PromptTier::Full);
+    assert_eq!(cap.size_class, ModelSizeClass::Medium);
+    assert_eq!(cap.prompt_tier, PromptTier::Compact);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Fixes Issue #364 — Phase 3 bench showed `model_aware_delegation_count=0` for all models because the classifier threshold was too low (>13B = Large), excluding 35B/31B models from delegation.

## Changes

- `src/agent/model_classifier.rs`: Widen ModelSizeClass boundaries
  - Small: ≤10B (was <7B)
  - Medium: 11-50B (was 7-13B)
  - Large: >50B (was >13B)
  - Result: qwen3.5:35b / gemma4:31b → Medium (delegation eligible), qwen3.5:122b → Large (unchanged)
- `src/app/agentic.rs`: Add runtime call to `record_model_aware_delegation_mutation()` after worker rewrite success when delegation was active
- `tests/model_classifier.rs`: Update 5 existing tests for new boundaries
- `src/agent/model_classifier.rs` (tests): Add 7 Issue #364 boundary regression tests
- `tests/model_aware_delegation.rs`: Add 4 Issue #364 integration tests (classifier eligibility + mutation telemetry)

## Test plan

- [x] `cargo fmt --check` — no diff
- [x] `cargo clippy --all-targets` — 0 warnings
- [x] `cargo test` — all pass (0 failed across all suites)

Closes #364

🤖 Generated with Claude Code