### PR TITLE
ci: publish binaries to AnvilBinary on release

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -194,7 +194,8 @@ git push origin "v$new_version"
 
 タグのプッシュにより GitHub Actions（`.github/workflows/release.yml`）が自動で以下を実行します：
 - 4プラットフォーム向けバイナリビルド（linux-amd64, linux-arm64, darwin-amd64, darwin-arm64）
-- GitHub Release作成とバイナリアップロード
+- Anvil リポジトリの GitHub Release 作成とバイナリアップロード
+- AnvilBinary リポジトリ（`Kewton/AnvilBinary`）にも同じバイナリを GitHub Release として自動公開（`ANVILBINARY_TOKEN` Secret 使用）
 
 ### 11. リリースworktreeのクリーンアップ
 
@@ -262,6 +263,8 @@ gh run list --limit 3
 | `cargo clippy` に警告がある | 警告修正を促し、リリースを中断。worktreeを削除 |
 | PRのCIが失敗 | commandmatedev send で修正コミットを追加 |
 | GitHub Actionsのビルド失敗 | ワークフロー修正後にタグを削除して再作成 |
+| `ANVILBINARY_TOKEN` が未設定 | Anvil リポジトリの Settings → Secrets → Actions に `ANVILBINARY_TOKEN` を追加（`Kewton/AnvilBinary` への `contents: write` 権限を持つ PAT） |
+| AnvilBinary へのリリース失敗 | `gh release delete <tag> --repo Kewton/AnvilBinary` で削除後、`gh release create` を手動実行 |
 | リリース中断時のクリーンアップ | `git worktree remove` → `git branch -D` → `git push origin --delete` |
 
 ## 参考

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,3 +82,14 @@ jobs:
             --title "${{ github.ref_name }}" \
             --generate-notes \
             artifacts/*.gz
+
+      - name: Publish to AnvilBinary
+        env:
+          GH_TOKEN: ${{ secrets.ANVILBINARY_TOKEN }}
+        run: |
+          RELEASE_NOTES="Binary release of [Anvil ${{ github.ref_name }}](https://github.com/Kewton/Anvil/releases/tag/${{ github.ref_name }}). See [CHANGELOG](https://github.com/Kewton/Anvil/blob/main/CHANGELOG.md) for details."
+          gh release create "${{ github.ref_name }}" \
+            --repo Kewton/AnvilBinary \
+            --title "${{ github.ref_name }}" \
+            --notes "$RELEASE_NOTES" \
+            artifacts/*.gz


### PR DESCRIPTION
## Summary

- `release.yml` にタグリリース時に `Kewton/AnvilBinary` へも同じバイナリを自動公開するステップを追加
- リリーススキル (`SKILL.md`) に AnvilBinary 関連のエラーハンドリングを追記

## 前提条件

**このPRをマージする前に以下の Secret を設定してください：**

1. [Anvil の Settings → Secrets → Actions](https://github.com/Kewton/Anvil/settings/secrets/actions) を開く
2. `ANVILBINARY_TOKEN` という名前で PAT を追加
   - PAT に必要な権限: `Kewton/AnvilBinary` リポジトリへの `contents: write`
   - Fine-grained PAT の場合: Repository → AnvilBinary → Contents: Read and write

## Test plan

- [ ] `ANVILBINARY_TOKEN` Secret を Anvil リポジトリに設定
- [ ] PR マージ後、次回リリース時に AnvilBinary にもバイナリが公開されることを確認
- [ ] `gh release view <tag> --repo Kewton/AnvilBinary` でバイナリ4本が存在することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)