### PR TITLE
feat(issue-369): lower temperature to 0.3 for tool calls

### DIFF
--- a/src/agent/subagent.rs
+++ b/src/agent/subagent.rs
@@ -790,6 +790,7 @@ impl<'a, C: ProviderClient> SubAgentSession<'a, C> {
             self.config.runtime.context_budget,
         );
         request.max_output_tokens = self.config.runtime.max_output_tokens;
+        request.temperature = self.config.runtime.tool_temperature;
 
         // Stream the LLM response, collecting token deltas
         let mut token_buffer = String::new();

--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -1039,6 +1039,7 @@ impl App {
                 self.config.runtime.context_budget,
             );
             request.max_output_tokens = self.config.runtime.max_output_tokens;
+            request.temperature = self.config.runtime.tool_temperature;
 
             // Budget pressure WARN (Issue #206 D-2)
             let token_budget = self.effective_token_budget();
@@ -2922,6 +2923,7 @@ impl App {
             self.config.runtime.context_budget,
         );
         request.max_output_tokens = self.config.runtime.max_output_tokens;
+        request.temperature = self.config.runtime.tool_temperature;
 
         let spinner = Spinner::start(
             format!("ANVIL_FINAL guard retry. model={}", self.effective_model()),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1474,6 +1474,7 @@ impl App {
             self.config.runtime.context_budget,
         );
         request.max_output_tokens = self.config.runtime.max_output_tokens;
+        // temperature intentionally left as None for non-agentic (conversational) turns
         self.last_estimated_prompt_tokens = Some(estimated_prompt_tokens);
 
         // Phase 1: Collect events from provider with spinner + streaming output.

--- a/src/config/cli_args.rs
+++ b/src/config/cli_args.rs
@@ -128,6 +128,10 @@ pub struct CliArgs {
     /// Log file format (text|json) [default: text]
     #[arg(long = "log-format")]
     pub log_format: Option<String>,
+
+    /// LLM sampling temperature for agentic turns (0.0-2.0) [default: 0.3]
+    #[arg(long = "tool-temperature")]
+    pub tool_temperature: Option<f64>,
 }
 
 impl CliArgs {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -244,6 +244,10 @@ pub struct RuntimeConfig {
     /// Per-path recovery read budget after file.edit failure (Issue #299).
     /// Controls how many file.read calls are suppressed from detector signals.
     pub edit_recovery_read_budget: u32,
+    /// LLM sampling temperature for agentic / sub-agent turns (Issue #369).
+    /// `Some(v)` overrides the model default; `None` leaves it to the model.
+    /// Default: `Some(0.3)` for tool-output stability.
+    pub tool_temperature: Option<f64>,
 }
 
 #[derive(Debug, Clone)]
@@ -372,6 +376,7 @@ pub const ENV_OVERRIDE_WHITELIST: &[&str] = &[
     "ANVIL_MAX_TOOL_CALLS",
     "ANVIL_GUIDANCE_MODE",
     "ANVIL_EDIT_RECOVERY_READ_BUDGET",
+    "ANVIL_TOOL_TEMPERATURE",
 ];
 
 impl EffectiveConfig {
@@ -484,6 +489,7 @@ impl EffectiveConfig {
                 max_output_tokens: Some(DEFAULT_MAX_OUTPUT_TOKENS),
                 guidance_mode: GuidanceMode::default(),
                 edit_recovery_read_budget: 3,
+                tool_temperature: Some(0.3),
             },
             mode: ModeConfig {
                 prompt_source: PromptSource::Interactive,
@@ -714,6 +720,16 @@ impl EffectiveConfig {
         // Max output tokens (Issue #204)
         if let Some(v) = cli.max_output_tokens {
             self.runtime.max_output_tokens = if v == 0 { None } else { Some(v) };
+        }
+
+        // Tool temperature (Issue #369)
+        if let Some(v) = cli.tool_temperature {
+            if !is_valid_temperature(v) {
+                return Err(ConfigError::InvalidNumericValue(format!(
+                    "tool_temperature must be between 0.0 and 2.0, got {v}"
+                )));
+            }
+            self.runtime.tool_temperature = Some(v);
         }
 
         // Log format (Issue #206)
@@ -1088,6 +1104,15 @@ impl EffectiveConfig {
                         .parse::<GuidanceMode>()
                         .unwrap_or(GuidanceMode::Sequential);
                 }
+                "tool_temperature" | "ANVIL_TOOL_TEMPERATURE" => {
+                    let v: f64 = value
+                        .parse()
+                        .map_err(|_| ConfigError::InvalidNumericValue(value.clone()))?;
+                    if !is_valid_temperature(v) {
+                        return Err(ConfigError::InvalidNumericValue(value.clone()));
+                    }
+                    self.runtime.tool_temperature = Some(v);
+                }
                 _ => {}
             }
         }
@@ -1403,6 +1428,11 @@ const MIN_AGENT_ITERATIONS: usize = 1;
 /// Validate that a deletion ratio value is finite and within [0.0, 1.0].
 fn is_valid_deletion_ratio(v: f64) -> bool {
     v.is_finite() && (0.0..=1.0).contains(&v)
+}
+
+/// Validate that a temperature value is finite and within [0.0, 2.0] (Issue #369).
+fn is_valid_temperature(v: f64) -> bool {
+    v.is_finite() && (0.0..=2.0).contains(&v)
 }
 
 /// Validate sidecar_provider_url: must start with http:// or https://.
@@ -1745,6 +1775,7 @@ impl std::fmt::Debug for RuntimeConfig {
             .field("safe_write_max_lines", &self.safe_write_max_lines)
             .field("safe_write_deletion_ratio", &self.safe_write_deletion_ratio)
             .field("edit_recovery_read_budget", &self.edit_recovery_read_budget)
+            .field("tool_temperature", &self.tool_temperature)
             .finish()
     }
 }

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -100,7 +100,7 @@ impl ProviderMessage {
 }
 
 /// Request payload sent to a provider for one turn.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct ProviderTurnRequest {
     pub model: String,
     pub messages: Vec<ProviderMessage>,
@@ -109,6 +109,10 @@ pub struct ProviderTurnRequest {
     /// When set, providers translate this to their native limit parameter
     /// (e.g. Ollama `num_predict`, OpenAI `max_tokens`).
     pub max_output_tokens: Option<u32>,
+    /// LLM sampling temperature for this turn.
+    /// `Some(v)` sets explicit temperature; `None` uses the model default.
+    /// Agentic turns default to 0.3 for tool-output stability (Issue #369).
+    pub temperature: Option<f64>,
 }
 
 impl ProviderTurnRequest {
@@ -118,6 +122,7 @@ impl ProviderTurnRequest {
             messages,
             stream,
             max_output_tokens: None,
+            temperature: None,
         }
     }
 }

--- a/src/provider/ollama.rs
+++ b/src/provider/ollama.rs
@@ -33,15 +33,18 @@ pub struct OllamaChatMessage {
 }
 
 /// Ollama request options (e.g. `num_predict` for output token limit).
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 pub struct OllamaRequestOptions {
     /// Maximum number of tokens to generate (maps to Ollama `num_predict`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub num_predict: Option<u32>,
+    /// Sampling temperature (Issue #369).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub temperature: Option<f64>,
 }
 
 /// Wire format for an Ollama `/api/chat` request.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct OllamaChatRequest {
     pub model: String,
     pub messages: Vec<OllamaChatMessage>,
@@ -146,9 +149,14 @@ impl<T> OllamaProviderClient<T> {
                 .collect(),
             stream: request.stream,
             think: false,
-            options: request.max_output_tokens.map(|n| OllamaRequestOptions {
-                num_predict: Some(n),
-            }),
+            options: if request.max_output_tokens.is_some() || request.temperature.is_some() {
+                Some(OllamaRequestOptions {
+                    num_predict: request.max_output_tokens,
+                    temperature: request.temperature,
+                })
+            } else {
+                None
+            },
         }
     }
 

--- a/src/provider/openai.rs
+++ b/src/provider/openai.rs
@@ -34,6 +34,8 @@ struct OpenAiChatRequest {
     stream_options: Option<serde_json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     max_tokens: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    temperature: Option<f64>,
 }
 
 /// Request message: content is `Value` to support both plain text and
@@ -403,6 +405,7 @@ impl<T> OpenAiCompatibleProviderClient<T> {
             stream: request.stream,
             stream_options,
             max_tokens: request.max_output_tokens,
+            temperature: request.temperature,
         }
     }
 }

--- a/tests/config_bootstrap.rs
+++ b/tests/config_bootstrap.rs
@@ -1425,3 +1425,88 @@ fn guidance_mode_env_var_parses_batch() {
         .unwrap();
     assert_eq!(config.runtime.guidance_mode, GuidanceMode::Batch);
 }
+
+// ── Issue #369: tool_temperature config tests ───────────────────────────
+
+#[test]
+fn tool_temperature_default_is_0_3() {
+    let config = EffectiveConfig::load().expect("config should load");
+    assert_eq!(config.runtime.tool_temperature, Some(0.3));
+}
+
+#[test]
+fn tool_temperature_set_via_config_file() {
+    let mut config = EffectiveConfig::load().expect("config should load");
+    let mut map = HashMap::new();
+    map.insert("tool_temperature".to_string(), "0.5".to_string());
+    config
+        .apply_overrides_for_test(&map, &HashMap::new(), &HashMap::new())
+        .unwrap();
+    assert_eq!(config.runtime.tool_temperature, Some(0.5));
+}
+
+#[test]
+fn tool_temperature_set_via_env_var() {
+    let mut config = EffectiveConfig::load().expect("config should load");
+    let mut env_map = HashMap::new();
+    env_map.insert("ANVIL_TOOL_TEMPERATURE".to_string(), "0.7".to_string());
+    config
+        .apply_overrides_for_test(&HashMap::new(), &env_map, &HashMap::new())
+        .unwrap();
+    assert_eq!(config.runtime.tool_temperature, Some(0.7));
+}
+
+#[test]
+fn tool_temperature_rejects_value_above_range() {
+    let mut config = EffectiveConfig::load().expect("config should load");
+    let mut map = HashMap::new();
+    map.insert("tool_temperature".to_string(), "2.1".to_string());
+    let result = config.apply_overrides_for_test(&map, &HashMap::new(), &HashMap::new());
+    assert!(result.is_err(), "value 2.1 should be rejected");
+}
+
+#[test]
+fn tool_temperature_rejects_value_below_range() {
+    let mut config = EffectiveConfig::load().expect("config should load");
+    let mut map = HashMap::new();
+    map.insert("tool_temperature".to_string(), "-0.1".to_string());
+    let result = config.apply_overrides_for_test(&map, &HashMap::new(), &HashMap::new());
+    assert!(result.is_err(), "value -0.1 should be rejected");
+}
+
+#[test]
+fn tool_temperature_rejects_nan() {
+    let mut config = EffectiveConfig::load().expect("config should load");
+    let mut map = HashMap::new();
+    map.insert("tool_temperature".to_string(), "NaN".to_string());
+    let result = config.apply_overrides_for_test(&map, &HashMap::new(), &HashMap::new());
+    assert!(result.is_err(), "NaN should be rejected");
+}
+
+#[test]
+fn tool_temperature_rejects_infinity() {
+    let mut config = EffectiveConfig::load().expect("config should load");
+    let mut map = HashMap::new();
+    map.insert("tool_temperature".to_string(), "inf".to_string());
+    let result = config.apply_overrides_for_test(&map, &HashMap::new(), &HashMap::new());
+    assert!(result.is_err(), "inf should be rejected");
+}
+
+/// Issue #347 regression prevention: ANVIL_TOOL_TEMPERATURE must be in
+/// ENV_OVERRIDE_WHITELIST so it reaches apply_map from env overrides.
+/// Uses `apply_env_overrides_from_map_for_test` which goes through the
+/// actual whitelist filter, unlike `apply_overrides_for_test`.
+#[test]
+fn tool_temperature_env_whitelist_regression_test() {
+    let mut config = EffectiveConfig::load().expect("config should load");
+    let mut env_map = HashMap::new();
+    env_map.insert("ANVIL_TOOL_TEMPERATURE".to_string(), "0.5".to_string());
+    config
+        .apply_env_overrides_from_map_for_test(&env_map)
+        .unwrap();
+    assert_eq!(
+        config.runtime.tool_temperature,
+        Some(0.5),
+        "ANVIL_TOOL_TEMPERATURE must reach apply_map via ENV_OVERRIDE_WHITELIST (Issue #347)"
+    );
+}

--- a/tests/provider_integration.rs
+++ b/tests/provider_integration.rs
@@ -4515,3 +4515,185 @@ fn openai_request_omits_max_tokens_when_none() {
         "request body should NOT contain max_tokens when None: {body_str}"
     );
 }
+
+// ── Issue #369: tool temperature tests ──────────────────────────────────
+
+#[test]
+fn ollama_request_includes_temperature_in_options_when_set() {
+    let mut request = ProviderTurnRequest::new(
+        "test-model".to_string(),
+        vec![anvil::provider::ProviderMessage::new(
+            ProviderMessageRole::User,
+            "hello",
+        )],
+        true,
+    );
+    request.temperature = Some(0.3);
+
+    let ollama_request =
+        OllamaProviderClient::<anvil::provider::ReqwestHttpTransport>::build_chat_request(&request);
+
+    let options = ollama_request
+        .options
+        .expect("options should be set when temperature is Some");
+    assert_eq!(options.temperature, Some(0.3));
+    assert_eq!(options.num_predict, None);
+}
+
+#[test]
+fn ollama_request_includes_both_num_predict_and_temperature() {
+    let mut request = ProviderTurnRequest::new(
+        "test-model".to_string(),
+        vec![anvil::provider::ProviderMessage::new(
+            ProviderMessageRole::User,
+            "hello",
+        )],
+        true,
+    );
+    request.max_output_tokens = Some(8192);
+    request.temperature = Some(0.3);
+
+    let ollama_request =
+        OllamaProviderClient::<anvil::provider::ReqwestHttpTransport>::build_chat_request(&request);
+
+    let json = serde_json::to_string(&ollama_request).expect("should serialize");
+
+    let options = ollama_request
+        .options
+        .expect("options should be set when both fields are Some");
+    assert_eq!(options.num_predict, Some(8192));
+    assert_eq!(options.temperature, Some(0.3));
+    assert!(
+        json.contains("\"temperature\":0.3"),
+        "serialized request should contain temperature: {json}"
+    );
+    assert!(
+        json.contains("\"num_predict\":8192"),
+        "serialized request should contain num_predict: {json}"
+    );
+}
+
+#[test]
+fn ollama_request_omits_options_when_both_none() {
+    let request = ProviderTurnRequest::new(
+        "test-model".to_string(),
+        vec![anvil::provider::ProviderMessage::new(
+            ProviderMessageRole::User,
+            "hello",
+        )],
+        true,
+    );
+    // Both max_output_tokens and temperature are None by default
+
+    let ollama_request =
+        OllamaProviderClient::<anvil::provider::ReqwestHttpTransport>::build_chat_request(&request);
+
+    assert!(
+        ollama_request.options.is_none(),
+        "options should be None when both max_output_tokens and temperature are None"
+    );
+}
+
+#[test]
+fn ollama_request_omits_temperature_from_json_when_none() {
+    let mut request = ProviderTurnRequest::new(
+        "test-model".to_string(),
+        vec![anvil::provider::ProviderMessage::new(
+            ProviderMessageRole::User,
+            "hello",
+        )],
+        true,
+    );
+    request.max_output_tokens = Some(8192);
+    // temperature is None
+
+    let ollama_request =
+        OllamaProviderClient::<anvil::provider::ReqwestHttpTransport>::build_chat_request(&request);
+
+    let json = serde_json::to_string(&ollama_request).expect("should serialize");
+    assert!(
+        !json.contains("temperature"),
+        "serialized request should NOT contain temperature when None: {json}"
+    );
+}
+
+#[test]
+fn openai_request_includes_temperature_when_set() {
+    let mut request = ProviderTurnRequest::new(
+        "test-model".to_string(),
+        vec![anvil::provider::ProviderMessage::new(
+            ProviderMessageRole::User,
+            "hello",
+        )],
+        false,
+    );
+    request.temperature = Some(0.3);
+
+    let seen_bodies = Rc::new(RefCell::new(Vec::new()));
+    let transport = MockHttpTransport {
+        seen_urls: Rc::new(RefCell::new(Vec::new())),
+        seen_bodies: seen_bodies.clone(),
+        seen_headers: Rc::new(RefCell::new(Vec::new())),
+        response: HttpResponse {
+            status_code: 200,
+            body: br#"{"choices":[{"message":{"role":"assistant","content":"hi"}}]}"#.to_vec(),
+        },
+        get_response: None,
+    };
+    let client = anvil::provider::openai::OpenAiCompatibleProviderClient::with_transport(
+        "http://test",
+        transport,
+    );
+
+    let mut events = Vec::new();
+    client
+        .stream_turn(&request, &mut |event| events.push(event))
+        .expect("should succeed");
+
+    let bodies = seen_bodies.borrow();
+    let body_str = String::from_utf8_lossy(&bodies[0]);
+    assert!(
+        body_str.contains("\"temperature\":0.3"),
+        "request body should contain temperature: {body_str}"
+    );
+}
+
+#[test]
+fn openai_request_omits_temperature_when_none() {
+    let request = ProviderTurnRequest::new(
+        "test-model".to_string(),
+        vec![anvil::provider::ProviderMessage::new(
+            ProviderMessageRole::User,
+            "hello",
+        )],
+        false,
+    );
+
+    let seen_bodies = Rc::new(RefCell::new(Vec::new()));
+    let transport = MockHttpTransport {
+        seen_urls: Rc::new(RefCell::new(Vec::new())),
+        seen_bodies: seen_bodies.clone(),
+        seen_headers: Rc::new(RefCell::new(Vec::new())),
+        response: HttpResponse {
+            status_code: 200,
+            body: br#"{"choices":[{"message":{"role":"assistant","content":"hi"}}]}"#.to_vec(),
+        },
+        get_response: None,
+    };
+    let client = anvil::provider::openai::OpenAiCompatibleProviderClient::with_transport(
+        "http://test",
+        transport,
+    );
+
+    let mut events = Vec::new();
+    client
+        .stream_turn(&request, &mut |event| events.push(event))
+        .expect("should succeed");
+
+    let bodies = seen_bodies.borrow();
+    let body_str = String::from_utf8_lossy(&bodies[0]);
+    assert!(
+        !body_str.contains("temperature"),
+        "request body should NOT contain temperature when None: {body_str}"
+    );
+}


### PR DESCRIPTION
## Summary
Closes #369 — Lower LLM temperature to 0.3 when generating tool calls for more stable JSON/tag output.

## Changes
- `src/provider/ollama.rs`, `src/provider/openai.rs`: Set temperature=0.3 for tool-call turns
- `src/config/mod.rs`, `src/config/cli_args.rs`: `--tool-temperature` CLI arg + `ANVIL_TOOL_TEMPERATURE` env var
- Tests: provider integration + config bootstrap coverage

🤖 Generated with Claude Code