### PR TITLE
feat(issue-370): pass num_ctx to Ollama chat requests

### DIFF
--- a/src/agent/subagent.rs
+++ b/src/agent/subagent.rs
@@ -791,6 +791,11 @@ impl<'a, C: ProviderClient> SubAgentSession<'a, C> {
         );
         request.max_output_tokens = self.config.runtime.max_output_tokens;
         request.temperature = self.config.runtime.tool_temperature;
+        request.context_window = if self.config.runtime.context_window_explicitly_set {
+            Some(self.effective_context_window())
+        } else {
+            None
+        };
 
         // Stream the LLM response, collecting token deltas
         let mut token_buffer = String::new();

--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -1040,6 +1040,11 @@ impl App {
             );
             request.max_output_tokens = self.config.runtime.max_output_tokens;
             request.temperature = self.config.runtime.tool_temperature;
+            request.context_window = if self.config.runtime.context_window_explicitly_set {
+                Some(self.effective_context_window())
+            } else {
+                None
+            };
 
             // Budget pressure WARN (Issue #206 D-2)
             let token_budget = self.effective_token_budget();
@@ -2924,6 +2929,11 @@ impl App {
         );
         request.max_output_tokens = self.config.runtime.max_output_tokens;
         request.temperature = self.config.runtime.tool_temperature;
+        request.context_window = if self.config.runtime.context_window_explicitly_set {
+            Some(self.effective_context_window())
+        } else {
+            None
+        };
 
         let spinner = Spinner::start(
             format!("ANVIL_FINAL guard retry. model={}", self.effective_model()),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1475,6 +1475,11 @@ impl App {
         );
         request.max_output_tokens = self.config.runtime.max_output_tokens;
         // temperature intentionally left as None for non-agentic (conversational) turns
+        request.context_window = if self.config.runtime.context_window_explicitly_set {
+            Some(self.effective_context_window())
+        } else {
+            None
+        };
         self.last_estimated_prompt_tokens = Some(estimated_prompt_tokens);
 
         // Phase 1: Collect events from provider with spinner + streaming output.

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -113,6 +113,10 @@ pub struct ProviderTurnRequest {
     /// `Some(v)` sets explicit temperature; `None` uses the model default.
     /// Agentic turns default to 0.3 for tool-output stability (Issue #369).
     pub temperature: Option<f64>,
+    /// Context window size to pass to the provider (e.g. Ollama `num_ctx`).
+    /// Only set when the user explicitly specifies `--context-window` so that
+    /// the default model context length is not overridden unintentionally.
+    pub context_window: Option<u32>,
 }
 
 impl ProviderTurnRequest {
@@ -123,6 +127,7 @@ impl ProviderTurnRequest {
             stream,
             max_output_tokens: None,
             temperature: None,
+            context_window: None,
         }
     }
 }

--- a/src/provider/ollama.rs
+++ b/src/provider/ollama.rs
@@ -41,6 +41,10 @@ pub struct OllamaRequestOptions {
     /// Sampling temperature (Issue #369).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub temperature: Option<f64>,
+    /// Context window size to use for this request (maps to Ollama `num_ctx`).
+    /// Only set when the user explicitly specifies `--context-window`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub num_ctx: Option<u32>,
 }
 
 /// Wire format for an Ollama `/api/chat` request.
@@ -149,10 +153,11 @@ impl<T> OllamaProviderClient<T> {
                 .collect(),
             stream: request.stream,
             think: false,
-            options: if request.max_output_tokens.is_some() || request.temperature.is_some() {
+            options: if request.max_output_tokens.is_some() || request.temperature.is_some() || request.context_window.is_some() {
                 Some(OllamaRequestOptions {
                     num_predict: request.max_output_tokens,
                     temperature: request.temperature,
+                    num_ctx: request.context_window,
                 })
             } else {
                 None

--- a/src/provider/openai.rs
+++ b/src/provider/openai.rs
@@ -388,6 +388,10 @@ impl<T> OpenAiCompatibleProviderClient<T> {
     }
 
     /// Build an OpenAI chat request from a provider turn request.
+    ///
+    /// Note: `request.context_window` (Ollama `num_ctx`) is intentionally not
+    /// mapped here. The OpenAI chat completions API does not support a
+    /// per-request context window override.
     fn build_chat_request(
         request: &ProviderTurnRequest,
         stream_options: Option<serde_json::Value>,

--- a/tests/provider_integration.rs
+++ b/tests/provider_integration.rs
@@ -4697,3 +4697,112 @@ fn openai_request_omits_temperature_when_none() {
         "request body should NOT contain temperature when None: {body_str}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Issue #370: num_ctx / context_window pass-through to Ollama
+// ---------------------------------------------------------------------------
+
+#[test]
+fn ollama_request_includes_num_ctx_when_context_window_set() {
+    let mut request = ProviderTurnRequest::new(
+        "test-model".to_string(),
+        vec![anvil::provider::ProviderMessage::new(
+            ProviderMessageRole::User,
+            "hello",
+        )],
+        true,
+    );
+    request.context_window = Some(32768);
+
+    let ollama_request =
+        OllamaProviderClient::<anvil::provider::ReqwestHttpTransport>::build_chat_request(&request);
+
+    let options = ollama_request
+        .options
+        .expect("options should be set when context_window is Some");
+    assert_eq!(options.num_ctx, Some(32768));
+}
+
+#[test]
+fn ollama_request_omits_num_ctx_when_context_window_none() {
+    let mut request = ProviderTurnRequest::new(
+        "test-model".to_string(),
+        vec![anvil::provider::ProviderMessage::new(
+            ProviderMessageRole::User,
+            "hello",
+        )],
+        true,
+    );
+    request.max_output_tokens = Some(16384);
+
+    let ollama_request =
+        OllamaProviderClient::<anvil::provider::ReqwestHttpTransport>::build_chat_request(&request);
+
+    let options = ollama_request.options.expect("options should be set");
+    assert_eq!(options.num_ctx, None);
+}
+
+#[test]
+fn ollama_request_includes_both_num_predict_and_num_ctx() {
+    let mut request = ProviderTurnRequest::new(
+        "test-model".to_string(),
+        vec![anvil::provider::ProviderMessage::new(
+            ProviderMessageRole::User,
+            "hello",
+        )],
+        true,
+    );
+    request.max_output_tokens = Some(16384);
+    request.context_window = Some(32768);
+
+    let ollama_request =
+        OllamaProviderClient::<anvil::provider::ReqwestHttpTransport>::build_chat_request(&request);
+
+    let options = ollama_request.options.expect("options should be set");
+    assert_eq!(options.num_predict, Some(16384));
+    assert_eq!(options.num_ctx, Some(32768));
+}
+
+#[test]
+fn ollama_request_serializes_num_ctx_correctly() {
+    let mut request = ProviderTurnRequest::new(
+        "test-model".to_string(),
+        vec![anvil::provider::ProviderMessage::new(
+            ProviderMessageRole::User,
+            "hello",
+        )],
+        true,
+    );
+    request.context_window = Some(65536);
+
+    let ollama_request =
+        OllamaProviderClient::<anvil::provider::ReqwestHttpTransport>::build_chat_request(&request);
+    let json = serde_json::to_string(&ollama_request).expect("should serialize");
+    assert!(
+        json.contains("\"num_ctx\":65536"),
+        "should contain num_ctx: {json}"
+    );
+}
+
+#[test]
+fn ollama_request_includes_num_ctx_only_when_num_predict_none() {
+    let mut request = ProviderTurnRequest::new(
+        "test-model".to_string(),
+        vec![anvil::provider::ProviderMessage::new(
+            ProviderMessageRole::User,
+            "hello",
+        )],
+        true,
+    );
+    request.context_window = Some(8192);
+    // max_output_tokens is None (default)
+
+    let ollama_request =
+        OllamaProviderClient::<anvil::provider::ReqwestHttpTransport>::build_chat_request(&request);
+
+    let options = ollama_request
+        .options
+        .expect("options should be set when context_window is Some");
+    assert_eq!(options.num_predict, None);
+    assert_eq!(options.num_ctx, Some(8192));
+}


### PR DESCRIPTION
## Summary
Closes #370 — Pass num_ctx to Ollama /api/chat requests so --context-window is respected by the model.

## Changes
- `src/provider/ollama.rs`: Add num_ctx to OllamaOptions, propagate context_window
- `src/provider/mod.rs`: Provider trait context_window plumbing
- Tests: provider integration coverage

🤖 Generated with Claude Code