### PR TITLE
refactor: extract agentic termination flow into an explicit state machine

### DIFF
--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -27,6 +27,10 @@ use crate::tooling::{PermissionClass, effective_permission_class};
 use super::policy::{OFFLINE_BLOCK_PAYLOAD, check_offline_blocked};
 use super::read_repeat_tracker::ReadRepeatAction;
 use super::read_transition_guard::ReadTransitionAction;
+use super::termination_fsm::{
+    EndOfTurnOutcome, MAX_FINAL_GUARD_RETRIES, NoToolCallInput, RetryKind, TerminationLoopState,
+    TerminationTransition, decide_agentic_loop, decide_done_path,
+};
 use super::write_repeat_tracker::WriteRepeatAction;
 use super::{App, AppError, CompactInfo, format_tool_counts};
 
@@ -97,215 +101,6 @@ pub fn summarize_tool_names(names: &[String]) -> String {
         *counts.entry(name.clone()).or_insert(0) += 1;
     }
     format_tool_counts(counts.into_iter())
-}
-
-/// Result of a termination decision helper.
-/// Tells the main loop what control-flow action to take.
-enum TerminationDecision {
-    /// Exit the agentic loop with the given reason (for tracing).
-    Break(TerminalReason),
-    /// Continue the loop (suppression applied or retry injected).
-    Continue,
-}
-
-/// Action returned by the Done-path ANVIL_FINAL guard.
-enum DonePathAction {
-    /// Plan gate triggered — invoke guarded retry turn.
-    PlanGateRetry,
-    /// Final guard triggered — inject retry and invoke guarded retry turn.
-    FinalGuardRetry,
-    /// Task-semantics gate triggered — inject retry for implementation (Issue #382).
-    TaskSemanticsRetry,
-    /// Guard did not fire — no special action needed.
-    NotFired,
-}
-
-/// All valid outcomes of evaluating a no-tool-call LLM response.
-/// Returned by [`decide_no_tool_call`] and consumed by both
-/// `handle_empty_tool_response` and `handle_done_path_anvil_final_guard`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum NoToolCallDecision {
-    /// Response follows a synthetic guidance injection; accepted as follow-up.
-    GuidanceFollowupComplete,
-    /// ANVIL_FINAL guard fires: no file modifications detected, retry injected.
-    FinalGuardRetry,
-    /// Phase estimator detected the write+verify+empty completion pattern.
-    FallbackCompleted,
-    /// Execution plan has incomplete items; termination suppressed.
-    PlanGateSuppression,
-    /// Task requires implementation but no file changes occurred; retry injected.
-    TaskSemanticsSuppression,
-    /// Unconditional acceptance as the final answer.
-    FinalAnswer,
-}
-
-/// Reason carried by TerminationDecision::Break for observability.
-/// Used in tracing output only — NOT serialized.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum TerminalReason {
-    /// no-tool-call path: accepted via NoToolCallDecision.
-    NoToolCall(NoToolCallDecision),
-    /// post-tool path: ANVIL_FINAL accepted after tool execution.
-    PostToolAnvilFinalAccepted,
-}
-
-/// Unified input for [`decide_no_tool_call`].
-/// Normalizes the asymmetry between the agentic loop path (has TerminationLoopState)
-/// and the Done path (no TerminationLoopState, uses hardcoded defaults).
-///
-/// Done path construction rules (hardcoded defaults):
-///   - final_guard_retries = 0 (first-turn completion always gets one retry)
-///   - anvil_final_detected = is_complete_structured_response_lenient(assistant_message)
-///   - awaiting_guidance_followup = false (no prior guidance on Done path)
-///   - task_semantics_fires = false if task_semantics_done_path_fired is already set
-///
-/// Agentic loop construction rules:
-///   - anvil_final_detected = term_state.is_anvil_final_seen()
-///   - plan_gate_fires = check_plan_final_gate_with_require(require_plan_here) [pre-computed]
-///   - plan_has_incomplete_items = !execution_plan.is_empty() && !execution_plan.all_finished()
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct NoToolCallInput {
-    /// Whether ANVIL_FINAL was detected in this response.
-    /// Done path: result of is_complete_structured_response_lenient() && touched_files_empty.
-    /// Agentic loop: term_state.is_anvil_final_seen().
-    /// Branch 2 only fires if this is true.
-    anvil_final_detected: bool,
-    /// Whether we are awaiting a guidance follow-up response.
-    /// Always false on Done path.
-    awaiting_guidance_followup: bool,
-    /// Number of final guard retries already used (0 for Done path).
-    final_guard_retries: u8,
-    /// Whether `touched_files` is empty (no file modifications this turn).
-    touched_files_empty: bool,
-    /// Phase action from the phase estimator (for fallback completion detection).
-    /// Done path: always PhaseAction::Continue (fallback detection not applicable).
-    phase_action: super::phase_estimator::PhaseAction,
-    /// Whether the execution plan is non-empty and has incomplete items.
-    /// Used exclusively in Branch 3 (fallback completion suppression).
-    /// Independent from `plan_gate_fires`.
-    plan_has_incomplete_items: bool,
-    /// Whether the plan gate should fire (Branch 4).
-    /// Computed independently from `plan_has_incomplete_items`.
-    /// Done path: false (plan gate handled directly in caller for ordering reasons).
-    plan_gate_fires: bool,
-    /// Whether the task-semantics gate should fire.
-    /// Pass `false` for Done path when `task_semantics_done_path_fired` is set.
-    task_semantics_fires: bool,
-}
-
-/// Single source of truth for evaluating a no-tool-call response.
-/// Pure function: no side-effects (side-effects are left to callers).
-///
-/// Caller responsibilities per variant:
-///   - FinalGuardRetry: inject retry message, increment final_guard_retries
-///   - FallbackCompleted: record assistant output, set terminal_reason
-///   - PlanGateSuppression: record plan suppression, suppress ANVIL_FINAL
-///   - TaskSemanticsSuppression: inject task-semantics retry message
-///   - GuidanceFollowupComplete: record assistant output, set terminal_reason
-///   - FinalAnswer: accept ANVIL_FINAL if seen, record assistant output
-fn decide_no_tool_call(input: NoToolCallInput) -> NoToolCallDecision {
-    use super::phase_estimator::PhaseAction;
-
-    // Branch 1: guidance follow-up
-    if input.awaiting_guidance_followup {
-        // Guidance escalation uses the same retry budget as Branch 2 but does NOT
-        // require anvil_final_detected. ANVIL_FINAL may have been suppressed via
-        // suppress_anvil_final() when the guidance injection was posted, so
-        // anvil_final_seen is false at this point. The guard fires based solely
-        // on the absence of file edits and available retries.
-        if input.touched_files_empty && input.final_guard_retries < MAX_FINAL_GUARD_RETRIES {
-            return NoToolCallDecision::FinalGuardRetry;
-        }
-        return NoToolCallDecision::GuidanceFollowupComplete;
-    }
-
-    // Branch 2: ANVIL_FINAL guard (DR2-003: requires anvil_final_detected)
-    if input.anvil_final_detected
-        && input.touched_files_empty
-        && input.final_guard_retries < MAX_FINAL_GUARD_RETRIES
-    {
-        return NoToolCallDecision::FinalGuardRetry;
-    }
-
-    // Branch 3: fallback completion
-    // Issue #307: if plan has incomplete items, fallthrough to plan gate instead.
-    if matches!(input.phase_action, PhaseAction::FallbackComplete)
-        && !input.plan_has_incomplete_items
-    {
-        return NoToolCallDecision::FallbackCompleted;
-    }
-
-    // Branch 4: plan gate
-    if input.plan_gate_fires {
-        return NoToolCallDecision::PlanGateSuppression;
-    }
-
-    // Branch 5: task-semantics gate
-    if input.task_semantics_fires {
-        return NoToolCallDecision::TaskSemanticsSuppression;
-    }
-
-    // Final: accept as answer
-    NoToolCallDecision::FinalAnswer
-}
-
-/// Loop-local state governing termination decisions in the agentic loop.
-///
-/// All fields are initialised at the start of `complete_structured_response`
-/// and consumed only within that method. App-level session state
-/// (forced_mode_active, repair_closure_active, proactive_delegation_pending)
-/// is intentionally excluded — see Issue #385 scope boundary.
-struct TerminationLoopState {
-    /// Whether an ANVIL_FINAL marker has been detected in the current or
-    /// a prior response within this turn.
-    anvil_final_seen: bool,
-    /// Number of "final guard" retries attempted (max: MAX_FINAL_GUARD_RETRIES).
-    final_guard_retries: u8,
-    /// Whether a synthetic guidance retry has been consumed in this turn.
-    guidance_retry_used: bool,
-    /// Set after guidance injection; cleared when the follow-up response arrives.
-    awaiting_guidance_followup: bool,
-    /// Number of times the plan gate has suppressed termination
-    /// (max 1 per Issue #285 A2).
-    noplan_suppression_count: u8,
-    /// Whether a pre-exit repair turn was injected (Issue #325).
-    pre_exit_repair_injected: bool,
-    /// Task-semantics gate suppression count (max 1, independent from noplan, Issue #382).
-    task_semantics_suppression_count: u8,
-}
-
-impl TerminationLoopState {
-    fn new(anvil_final_already: bool, initial_anvil_final_detected: bool) -> Self {
-        Self {
-            anvil_final_seen: anvil_final_already || initial_anvil_final_detected,
-            final_guard_retries: 0,
-            guidance_retry_used: false,
-            awaiting_guidance_followup: false,
-            noplan_suppression_count: 0,
-            pre_exit_repair_injected: false,
-            task_semantics_suppression_count: 0,
-        }
-    }
-
-    /// Query: has ANVIL_FINAL been detected?
-    fn is_anvil_final_seen(&self) -> bool {
-        self.anvil_final_seen
-    }
-
-    /// Suppress the current ANVIL_FINAL detection (plan gate / guidance retry).
-    fn suppress_anvil_final(&mut self) {
-        self.anvil_final_seen = false;
-    }
-
-    /// Record that ANVIL_FINAL was newly detected in an LLM response.
-    fn observe_anvil_final(&mut self) {
-        self.anvil_final_seen = true;
-    }
-
-    /// Record a plan-gate suppression event.
-    fn record_plan_suppression(&mut self) {
-        self.noplan_suppression_count += 1;
-    }
 }
 
 /// Mutation tool names used for the successful-mutation check (Issue #285).
@@ -536,8 +331,6 @@ fn task_likely_requires_file_changes(task: &str) -> bool {
         || japanese_markers.iter().any(|m| task.contains(m))
 }
 
-/// Maximum number of ANVIL_FINAL guard retries (no-file-modification detection).
-const MAX_FINAL_GUARD_RETRIES: u8 = 1;
 const FILE_READ_RESULT_MAX_CHARS: usize = 2_000;
 const SYNTHETIC_GUIDANCE_RESULT_MAX_CHARS: usize = 1_200;
 const EXPLORATION_TOOL_NAMES: &[&str] = &["file.read", "file.search", "web.fetch"];
@@ -1068,14 +861,14 @@ impl App {
 
     /// Evaluate the ANVIL_FINAL gate after tool execution.
     ///
-    /// Returns `TerminationDecision::Break` if ANVIL_FINAL should be accepted,
-    /// or `TerminationDecision::Continue` if termination was suppressed
+    /// Returns `TerminationTransition::Break` if ANVIL_FINAL should be accepted,
+    /// or `TerminationTransition::Continue` if termination was suppressed
     /// (by plan gate or guidance retry injection).
     fn handle_post_tool_anvil_final_gate(
         &mut self,
         results: &[ToolExecutionResult],
         term_state: &mut TerminationLoopState,
-    ) -> TerminationDecision {
+    ) -> TerminationTransition {
         // Issue #249/#285: Plan-aware ANVIL_FINAL gate — suppress if plan is incomplete.
         // A2 fix: only require plan when session has no file changes AND
         // the current batch contains no successful mutation.
@@ -1088,28 +881,28 @@ impl App {
         let is_effectively_mutation_task = batch_has_mutation_attempts
             && self.session_stats.files_modified.is_empty()
             && !results_contain_successful_mutation(results)
-            && term_state.noplan_suppression_count == 0;
+            && term_state.noplan_suppression_count() == 0;
         if self.check_plan_final_gate_with_require(is_effectively_mutation_task) {
             if is_effectively_mutation_task {
                 term_state.record_plan_suppression();
             }
             tracing::info!("ANVIL_FINAL suppressed by plan gate; continuing execution");
             term_state.suppress_anvil_final();
-            TerminationDecision::Continue
-        } else if self.should_activate_guidance_retry(term_state.guidance_retry_used, results) {
+            TerminationTransition::Continue
+        } else if self.should_activate_guidance_retry(term_state.guidance_retry_used(), results) {
             tracing::info!(
                 "ANVIL_FINAL delayed: synthetic guidance injected, sending one follow-up turn"
             );
             // Issue #372: (A) guidance retry telemetry
             self.agent_telemetry.retry.record_guidance_retry_attempted();
-            term_state.guidance_retry_used = true;
-            term_state.awaiting_guidance_followup = true;
+            term_state.mark_guidance_retry_used();
+            term_state.set_awaiting_guidance_followup();
             term_state.suppress_anvil_final();
-            TerminationDecision::Continue
+            TerminationTransition::Continue
         } else {
             tracing::info!("ANVIL_FINAL detected; terminating after tool execution");
             self.phase_estimator.accept_anvil_final();
-            TerminationDecision::Break(TerminalReason::PostToolAnvilFinalAccepted)
+            TerminationTransition::Break(EndOfTurnOutcome::PostToolAnvilFinalAccepted)
         }
     }
 
@@ -1122,8 +915,8 @@ impl App {
         next_structured: &mut StructuredAssistantResponse,
         term_state: &mut TerminationLoopState,
         turn_has_subagent: bool,
-    ) -> Result<TerminationDecision, AppError> {
-        // Pre-compute all inputs for decide_no_tool_call.
+    ) -> Result<TerminationTransition, AppError> {
+        // Pre-compute all inputs for the FSM.
         let touched_files_empty = self.session.working_memory.touched_files.is_empty();
         let phase_action = self.phase_estimator.check_empty_response();
         let is_fallback_complete = matches!(
@@ -1142,52 +935,52 @@ impl App {
             .any(|t| self.session_stats.tool_calls.contains_key(*t));
         let require_plan_here = ((session_has_mutation_attempts
             && self.session_stats.files_modified.is_empty())
-            || self
-                .should_require_plan_for_implementation_task(term_state.noplan_suppression_count))
-            && term_state.noplan_suppression_count == 0;
+            || self.should_require_plan_for_implementation_task(
+                term_state.noplan_suppression_count(),
+            ))
+            && term_state.noplan_suppression_count() == 0;
 
         // CB-001 fix: check_plan_final_gate_with_require has side effects
         // (record_final_request, record_premature_final, session message injection).
         // In the original code it was only called when reaching Branch 4.
         // Guard the call so it only fires when branches 1/2/3 would not short-circuit.
-        let branches_123_fire = term_state.awaiting_guidance_followup
+        let branches_123_fire = term_state.awaiting_guidance_followup()
             || (term_state.is_anvil_final_seen()
                 && touched_files_empty
-                && term_state.final_guard_retries < MAX_FINAL_GUARD_RETRIES)
+                && term_state.final_guard_retries() < MAX_FINAL_GUARD_RETRIES)
             || (is_fallback_complete && !plan_has_incomplete_items);
         let plan_gate_fires =
             !branches_123_fire && self.check_plan_final_gate_with_require(require_plan_here);
 
         // Branch 5 pre-computation: task-semantics gate (Issue #382).
         let task_semantics_fires = self.should_fire_task_semantics_gate_branch5(
-            term_state.task_semantics_suppression_count,
+            term_state.task_semantics_suppression_count(),
             turn_has_subagent,
         );
 
-        let input = NoToolCallInput {
-            anvil_final_detected: term_state.is_anvil_final_seen(),
-            awaiting_guidance_followup: term_state.awaiting_guidance_followup,
-            final_guard_retries: term_state.final_guard_retries,
+        // Capture state flags before the FSM consumes `input`; these drive
+        // the side-effect dispatch below.
+        let was_awaiting_guidance = term_state.awaiting_guidance_followup();
+        let anvil_final_before_fsm = term_state.is_anvil_final_seen();
+
+        let input = NoToolCallInput::for_agentic_loop(
+            term_state,
             touched_files_empty,
             phase_action,
             plan_has_incomplete_items,
             plan_gate_fires,
             task_semantics_fires,
-        };
+        );
 
-        // Capture the guidance flag before `input` is consumed by decide_no_tool_call
-        // (used below to clear term_state and to gate the FinalGuardRetry log message).
-        let was_awaiting_guidance = input.awaiting_guidance_followup;
+        let transition = decide_agentic_loop(term_state, input);
 
-        let decision = decide_no_tool_call(input);
-
-        // Clear guidance followup state (was cleared at top of Branch 1 in original code).
+        // Clear guidance followup state (originally done at the top of Branch 1).
         if was_awaiting_guidance {
-            term_state.awaiting_guidance_followup = false;
+            term_state.clear_awaiting_guidance_followup();
         }
 
-        match decision {
-            NoToolCallDecision::FinalGuardRetry => {
+        match transition {
+            TerminationTransition::Retry(RetryKind::FinalGuard) => {
                 if was_awaiting_guidance {
                     tracing::info!(
                         "Guidance follow-up ended without edits; escalating to final guard retry"
@@ -1198,33 +991,41 @@ impl App {
                     .retry
                     .record_final_guard_retry_attempted();
                 self.inject_final_guard_retry();
-                term_state.final_guard_retries += 1;
-                Ok(TerminationDecision::Continue)
+                term_state.increment_final_guard_retries();
+                Ok(TerminationTransition::Continue)
             }
-            NoToolCallDecision::GuidanceFollowupComplete => {
+            TerminationTransition::Retry(RetryKind::TaskSemantics) => {
+                term_state.record_task_semantics_suppression();
+                self.inject_task_semantics_gate_retry();
+                Ok(TerminationTransition::Continue)
+            }
+            TerminationTransition::Break(EndOfTurnOutcome::GuidanceFollowupComplete) => {
                 tracing::info!("Guidance follow-up completed; accepting response");
                 let message_id = self.next_message_id("assistant");
                 self.record_assistant_output(
                     message_id,
                     std::mem::take(&mut next_structured.final_response),
                 )?;
-                Ok(TerminationDecision::Break(TerminalReason::NoToolCall(
-                    decision,
-                )))
+                Ok(TerminationTransition::Break(
+                    EndOfTurnOutcome::GuidanceFollowupComplete,
+                ))
             }
-            NoToolCallDecision::FallbackCompleted => {
+            TerminationTransition::Break(EndOfTurnOutcome::FallbackCompleted) => {
                 tracing::info!("Phase estimator: fallback completion detected");
                 let message_id = self.next_message_id("assistant");
                 self.record_assistant_output(
                     message_id,
                     std::mem::take(&mut next_structured.final_response),
                 )?;
-                Ok(TerminationDecision::Break(TerminalReason::NoToolCall(
-                    decision,
-                )))
+                Ok(TerminationTransition::Break(
+                    EndOfTurnOutcome::FallbackCompleted,
+                ))
             }
-            NoToolCallDecision::PlanGateSuppression => {
-                // Issue #307: log if coming from fallback completion fallthrough
+            TerminationTransition::Continue => {
+                // Plan-gate suppression path (the FSM emits Continue both for
+                // plan-gate and task-semantics suppression; task semantics is
+                // handled above via Retry variant, so Continue here is the
+                // plan gate).
                 if is_fallback_complete && plan_has_incomplete_items {
                     tracing::info!(
                         "Phase estimator: fallback completion suppressed \
@@ -1235,16 +1036,11 @@ impl App {
                     term_state.record_plan_suppression();
                 }
                 tracing::info!("Plan gate: suppressing termination with empty tool calls");
-                Ok(TerminationDecision::Continue)
+                Ok(TerminationTransition::Continue)
             }
-            NoToolCallDecision::TaskSemanticsSuppression => {
-                term_state.task_semantics_suppression_count += 1;
-                self.inject_task_semantics_gate_retry();
-                Ok(TerminationDecision::Continue)
-            }
-            NoToolCallDecision::FinalAnswer => {
+            TerminationTransition::Break(EndOfTurnOutcome::FinalAnswer) => {
                 // Issue #261 Task 0.4: Mark ANVIL_FINAL as accepted (not suppressed)
-                if term_state.is_anvil_final_seen() {
+                if anvil_final_before_fsm {
                     self.phase_estimator.accept_anvil_final();
                 }
                 let message_id = self.next_message_id("assistant");
@@ -1252,9 +1048,17 @@ impl App {
                     message_id,
                     std::mem::take(&mut next_structured.final_response),
                 )?;
-                Ok(TerminationDecision::Break(TerminalReason::NoToolCall(
-                    decision,
-                )))
+                Ok(TerminationTransition::Break(EndOfTurnOutcome::FinalAnswer))
+            }
+            TerminationTransition::Retry(RetryKind::PlanGate)
+            | TerminationTransition::Retry(RetryKind::GuidanceFollowup)
+            | TerminationTransition::Break(EndOfTurnOutcome::PostToolAnvilFinalAccepted) => {
+                // These transitions are not produced by `decide_agentic_loop`
+                // for the no-tool-call path. Treat as defensive unreachable.
+                unreachable!(
+                    "decide_agentic_loop should not return {:?} on the no-tool-call path",
+                    transition
+                )
             }
         }
     }
@@ -1262,12 +1066,15 @@ impl App {
     /// Evaluate the ANVIL_FINAL guard on the Done path (no agentic loop).
     ///
     /// The Done path runs outside `complete_structured_response` so there is
-    /// no `TerminationLoopState`. The final_guard_retries counter is
-    /// hardcoded to 0 (first-turn completion always gets one retry).
-    ///
-    /// The caller is responsible for `record_assistant_output` and
-    /// `run_guarded_retry_turn` based on the returned action.
-    fn handle_done_path_anvil_final_guard(&mut self, assistant_message: &str) -> DonePathAction {
+    /// no persistent `TerminationLoopState` — a fresh instance is created
+    /// for each invocation (Issue #381 DR2-005).  The returned
+    /// [`TerminationTransition`] tells the caller which side-effect to
+    /// perform (the caller is also responsible for `record_assistant_output`
+    /// and `run_guarded_retry_turn`).
+    fn handle_done_path_anvil_final_guard(
+        &mut self,
+        assistant_message: &str,
+    ) -> TerminationTransition {
         // CB-002: Retry count is always 0 here because this path handles
         // the first-turn Done event (before any agentic loop iteration).
         // MAX_FINAL_GUARD_RETRIES = 1 ensures at most one retry, so the
@@ -1275,8 +1082,7 @@ impl App {
         //
         // Issue #173: Use lenient detection for Done path (response is complete).
         // DR2-001: On Done path, plan gate is evaluated BEFORE FinalGuardRetry.
-        // This ordering difference from the agentic loop is preserved by handling
-        // the plan gate directly here, before calling decide_no_tool_call.
+        // The ordering is enforced inside `decide_done_path`.
         let anvil_final_detected =
             BasicAgentLoop::is_complete_structured_response_lenient(assistant_message);
         let touched_files_empty = self.session.working_memory.touched_files.is_empty();
@@ -1284,46 +1090,41 @@ impl App {
         if anvil_final_detected && touched_files_empty {
             // ANVIL_FINAL detected → record observation (Issue #159)
             self.phase_estimator.observe_anvil_final();
-            // Issue #253: Apply plan gate FIRST (Done path ordering).
-            if self.check_plan_final_gate_require_plan() {
-                return DonePathAction::PlanGateRetry;
-            }
         }
 
-        // Use decide_no_tool_call for the remaining cases.
-        // plan_gate_fires=false because the plan gate was handled directly above.
-        let input = NoToolCallInput {
-            anvil_final_detected,
-            awaiting_guidance_followup: false,
-            final_guard_retries: 0,
-            touched_files_empty,
-            phase_action: super::phase_estimator::PhaseAction::Continue,
-            plan_has_incomplete_items: false,
-            plan_gate_fires: false,
-            task_semantics_fires: self.should_fire_task_semantics_gate_done_path(),
+        // Compute plan_gate_fires (the FSM expects a pre-computed bool;
+        // `check_plan_final_gate_require_plan` has side-effects so we only
+        // invoke it when it is meaningful to do so — i.e. when ANVIL_FINAL
+        // is detected and no file modifications were made).
+        let plan_gate_fires = if anvil_final_detected && touched_files_empty {
+            self.check_plan_final_gate_require_plan()
+        } else {
+            false
         };
+        let task_semantics_fires = self.should_fire_task_semantics_gate_done_path();
 
-        match decide_no_tool_call(input) {
-            NoToolCallDecision::FinalGuardRetry => {
-                // Issue #372: (B) final guard retry telemetry (Done path)
-                self.agent_telemetry
-                    .retry
-                    .record_final_guard_retry_attempted();
-                self.inject_final_guard_retry();
-                DonePathAction::FinalGuardRetry
-            }
-            NoToolCallDecision::TaskSemanticsSuppression => DonePathAction::TaskSemanticsRetry,
-            NoToolCallDecision::FinalAnswer => DonePathAction::NotFired,
-            NoToolCallDecision::PlanGateSuppression => {
-                unreachable!("plan_gate_fires=false; plan gate handled directly")
-            }
-            NoToolCallDecision::GuidanceFollowupComplete => {
-                unreachable!("Done path never sets awaiting_guidance_followup")
-            }
-            NoToolCallDecision::FallbackCompleted => {
-                unreachable!("Done path uses PhaseAction::Continue; no fallback completion")
-            }
+        // Done path: fresh state per invocation (not reused across calls).
+        let mut state = TerminationLoopState::new(false, anvil_final_detected);
+        let transition = decide_done_path(
+            &mut state,
+            anvil_final_detected,
+            plan_gate_fires,
+            task_semantics_fires,
+            touched_files_empty,
+            super::phase_estimator::PhaseAction::Continue,
+            /*plan_has_incomplete_items=*/ false,
+        );
+
+        // Dispatch the resulting transition — side-effects stay in this
+        // orchestration layer.
+        if let TerminationTransition::Retry(RetryKind::FinalGuard) = transition {
+            // Issue #372: (B) final guard retry telemetry (Done path)
+            self.agent_telemetry
+                .retry
+                .record_final_guard_retry_attempted();
+            self.inject_final_guard_retry();
         }
+        transition
     }
 
     /// Execute tool calls and feed results back to the LLM in a loop.
@@ -1355,8 +1156,8 @@ impl App {
         let mut term_state =
             TerminationLoopState::new(anvil_final_already, current.anvil_final_detected);
         // Issue #383: Track terminal reason for post-loop observability.
-        // Set on every TerminationDecision::Break before breaking; debug_assert below.
-        let mut terminal_reason: Option<TerminalReason> = None;
+        // Set on every TerminationTransition::Break before breaking; debug_assert below.
+        let mut terminal_reason: Option<EndOfTurnOutcome> = None;
 
         // Reset loop detector at the start of each top-level turn (Issue #145)
         self.loop_detector.reset();
@@ -1593,11 +1394,20 @@ impl App {
             // executing the current tool batch (no further LLM round-trips).
             if term_state.is_anvil_final_seen() {
                 match self.handle_post_tool_anvil_final_gate(&results, &mut term_state) {
-                    TerminationDecision::Break(reason) => {
+                    TerminationTransition::Break(reason) => {
                         terminal_reason = Some(reason);
                         break;
                     }
-                    TerminationDecision::Continue => {}
+                    TerminationTransition::Continue => {}
+                    TerminationTransition::Retry(kind) => {
+                        // `handle_post_tool_anvil_final_gate` never returns a
+                        // Retry — defensively catch it so future refactors
+                        // cannot silently drop the transition.
+                        unreachable!(
+                            "handle_post_tool_anvil_final_gate returned unexpected Retry({:?})",
+                            kind
+                        );
+                    }
                 }
             }
 
@@ -2144,7 +1954,7 @@ impl App {
             // the previous iteration, the LLM has now consumed it and responded.
             // Decide termination based on the resulting plan state, not just the
             // fact that one repair response was consumed.
-            if term_state.pre_exit_repair_injected {
+            if term_state.pre_exit_repair_injected() {
                 self.agent_telemetry.record_pre_exit_repair_consumed();
                 let pending_after = self
                     .execution_plan
@@ -2240,7 +2050,7 @@ impl App {
                             pending_before,
                             "pre-exit repair turn injected; continuing for one more LLM turn"
                         );
-                        term_state.pre_exit_repair_injected = true;
+                        term_state.mark_pre_exit_repair_injected();
                         current = next_structured;
                         continue;
                     }
@@ -2278,30 +2088,36 @@ impl App {
                     &mut term_state,
                     turn_has_subagent,
                 )? {
-                    TerminationDecision::Break(reason) => {
+                    TerminationTransition::Break(reason) => {
                         terminal_reason = Some(reason);
                         break;
                     }
-                    TerminationDecision::Continue => {
+                    TerminationTransition::Continue => {
                         current = next_structured;
                         continue;
+                    }
+                    TerminationTransition::Retry(kind) => {
+                        unreachable!(
+                            "handle_empty_tool_response returned unexpected Retry({:?})",
+                            kind
+                        );
                     }
                 }
             }
 
             // More tool calls — continue the loop
-            if term_state.awaiting_guidance_followup {
+            if term_state.awaiting_guidance_followup() {
                 // Issue #372: (A) guidance retry succeeded — follow-up turn
                 // produced tool calls.
                 self.agent_telemetry.retry.record_guidance_retry_succeeded();
-                term_state.awaiting_guidance_followup = false;
+                term_state.clear_awaiting_guidance_followup();
             }
             current = next_structured;
         }
 
         // Issue #372: (B) final guard retry success — retries fired and files
         // were ultimately modified.
-        if term_state.final_guard_retries > 0
+        if term_state.final_guard_retries() > 0
             && !self.session.working_memory.touched_files.is_empty()
         {
             self.agent_telemetry
@@ -2312,7 +2128,7 @@ impl App {
         // Issue #382: task-semantics gate succeeded — gate fired during
         // THIS turn (Branch 5 path only; Done path is handled separately)
         // and files were ultimately modified.
-        if term_state.task_semantics_suppression_count > 0
+        if term_state.task_semantics_suppression_count() > 0
             && !self.session.working_memory.touched_files.is_empty()
         {
             self.agent_telemetry
@@ -2337,17 +2153,13 @@ impl App {
             );
         }
 
-        // Issue #383: terminal_reason is set on TerminationDecision::Break paths.
+        // Issue #383: terminal_reason is set on TerminationTransition::Break paths.
         // It is None when the loop exits via other means: max-iterations, shutdown,
         // loop detector, worker-required early exit, etc. Observability of the None
         // case is provided by the completion_kind tracing above.
 
-        let is_fallback_completion = matches!(
-            terminal_reason,
-            Some(TerminalReason::NoToolCall(
-                NoToolCallDecision::FallbackCompleted
-            ))
-        );
+        let is_fallback_completion =
+            matches!(terminal_reason, Some(EndOfTurnOutcome::FallbackCompleted));
 
         // Transition to Done
         let mut done = AppStateSnapshot::new(RuntimeState::Done)
@@ -3731,7 +3543,7 @@ impl App {
             // complete_structured_response, which would wastefully execute the
             // empty tool_calls pipeline).
             match self.handle_done_path_anvil_final_guard(assistant_message) {
-                DonePathAction::PlanGateRetry => {
+                TerminationTransition::Retry(RetryKind::PlanGate) => {
                     self.record_assistant_output(
                         self.next_message_id("assistant"),
                         assistant_message,
@@ -3745,7 +3557,7 @@ impl App {
                         provider_client,
                     )?));
                 }
-                DonePathAction::FinalGuardRetry => {
+                TerminationTransition::Retry(RetryKind::FinalGuard) => {
                     // Record the assistant message that triggered the guard
                     self.record_assistant_output(
                         self.next_message_id("assistant"),
@@ -3761,7 +3573,7 @@ impl App {
                         provider_client,
                     )?));
                 }
-                DonePathAction::TaskSemanticsRetry => {
+                TerminationTransition::Retry(RetryKind::TaskSemantics) => {
                     // Issue #382 AC-2a: task-semantics gate fired on Done path.
                     self.task_semantics_done_path_fired = true;
                     self.inject_task_semantics_gate_retry();
@@ -3778,7 +3590,15 @@ impl App {
                         provider_client,
                     )?));
                 }
-                DonePathAction::NotFired => {}
+                TerminationTransition::Break(EndOfTurnOutcome::FinalAnswer) => {}
+                // Done path never produces these variants.
+                TerminationTransition::Retry(RetryKind::GuidanceFollowup)
+                | TerminationTransition::Continue
+                | TerminationTransition::Break(_) => {
+                    unreachable!(
+                        "handle_done_path_anvil_final_guard returned unexpected transition"
+                    );
+                }
             }
             // CB-002: Record turn stats for non-tool turns
             self.session_stats.record_turn();
@@ -4526,49 +4346,6 @@ mod trust_tests {
         );
     }
 
-    // --- TerminationLoopState unit tests (Issue #385) ---
-
-    #[test]
-    fn termination_loop_state_new_both_false() {
-        let state = TerminationLoopState::new(false, false);
-        assert!(!state.is_anvil_final_seen());
-        assert_eq!(state.final_guard_retries, 0);
-        assert!(!state.guidance_retry_used);
-        assert!(!state.awaiting_guidance_followup);
-        assert_eq!(state.noplan_suppression_count, 0);
-        assert!(!state.pre_exit_repair_injected);
-        assert_eq!(state.task_semantics_suppression_count, 0);
-    }
-
-    #[test]
-    fn termination_loop_state_new_already_true() {
-        let state = TerminationLoopState::new(true, false);
-        assert!(state.is_anvil_final_seen());
-    }
-
-    #[test]
-    fn termination_loop_state_new_detected_true() {
-        let state = TerminationLoopState::new(false, true);
-        assert!(state.is_anvil_final_seen());
-    }
-
-    #[test]
-    fn termination_loop_state_suppress_and_observe() {
-        let mut state = TerminationLoopState::new(true, false);
-        assert!(state.is_anvil_final_seen());
-        state.suppress_anvil_final();
-        assert!(!state.is_anvil_final_seen());
-        state.observe_anvil_final();
-        assert!(state.is_anvil_final_seen());
-    }
-
-    #[test]
-    fn termination_loop_state_record_plan_suppression() {
-        let mut state = TerminationLoopState::new(false, false);
-        assert_eq!(state.noplan_suppression_count, 0);
-        state.record_plan_suppression();
-        assert_eq!(state.noplan_suppression_count, 1);
-        state.record_plan_suppression();
-        assert_eq!(state.noplan_suppression_count, 2);
-    }
+    // TerminationLoopState unit tests moved to src/app/termination_fsm.rs
+    // as part of Issue #381.
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -22,6 +22,7 @@ pub(crate) mod read_repeat_tracker;
 pub mod read_transition_guard;
 pub mod render;
 pub mod stagnation_state;
+pub mod termination_fsm;
 pub(crate) mod tool_recovery_budget;
 pub(crate) mod write_fail_tracker;
 pub(crate) mod write_repeat_tracker;

--- a/src/app/termination_fsm.rs
+++ b/src/app/termination_fsm.rs
@@ -1,0 +1,796 @@
+//! Termination finite-state machine for the agentic loop (Issue #381).
+//!
+//! This module provides a pure state + decision-table layer that governs
+//! termination decisions inside `complete_structured_response` and on the
+//! Done path.  It has two parts:
+//!
+//! * [`TerminationLoopState`] — per-turn mutable state bag whose fields are
+//!   private and can only be updated through dedicated methods that enforce
+//!   invariants (e.g. `final_guard_retries <= MAX_FINAL_GUARD_RETRIES`).
+//! * [`decide_no_tool_call`] — a pure decision table that determines how to
+//!   classify a no-tool-call LLM response given a fully-materialised
+//!   [`NoToolCallInput`].
+//!
+//! The orchestration layer in `agentic.rs` is responsible for all
+//! side-effects (message injection, telemetry, assistant output recording).
+//! The FSM itself performs no I/O and holds no references to `App`.
+//!
+//! # Design notes
+//!
+//! The module is named `termination_fsm` for consistency with Issue #381,
+//! even though the implementation is a "state bag + pure decision table"
+//! rather than a classical Mealy/Moore FSM.  See
+//! `dev-reports/design/issue-381-termination-state-machine-design-policy.md`
+//! for details.
+
+use super::phase_estimator::PhaseAction;
+
+/// Maximum number of ANVIL_FINAL guard retries (no-file-modification detection).
+pub const MAX_FINAL_GUARD_RETRIES: u8 = 1;
+
+/// Maximum number of plan-gate suppression events per turn (Issue #285 A2).
+const MAX_PLAN_SUPPRESSIONS: u8 = 1;
+
+/// Maximum number of task-semantics gate suppression events per turn (Issue #382).
+const MAX_TASK_SEMANTICS_SUPPRESSIONS: u8 = 1;
+
+/// All valid outcomes of evaluating a no-tool-call LLM response.
+///
+/// This enum is exposed publicly so that integration tests in
+/// `tests/termination_semantics.rs` can use `decide_no_tool_call` as the
+/// single source of truth for decision semantics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NoToolCallDecision {
+    /// Response follows a synthetic guidance injection; accepted as follow-up.
+    GuidanceFollowupComplete,
+    /// ANVIL_FINAL guard fires: no file modifications detected, retry injected.
+    FinalGuardRetry,
+    /// Phase estimator detected the write+verify+empty completion pattern.
+    FallbackCompleted,
+    /// Execution plan has incomplete items; termination suppressed.
+    PlanGateSuppression,
+    /// Task requires implementation but no file changes occurred; retry injected.
+    TaskSemanticsSuppression,
+    /// Unconditional acceptance as the final answer.
+    FinalAnswer,
+}
+
+/// Transition result returned by FSM entry points.
+///
+/// The orchestration layer in `agentic.rs` consumes this to decide what
+/// side-effect (if any) to perform: break out of the loop, continue
+/// iterating, or inject a retry message.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TerminationTransition {
+    /// Exit the agentic loop with the given terminal outcome.
+    Break(EndOfTurnOutcome),
+    /// Continue the loop (suppression applied or retry injected).
+    Continue,
+    /// Activate a retry turn of the given kind (caller performs the side
+    /// effect — message injection etc.).
+    Retry(RetryKind),
+}
+
+/// Retry kind carried by [`TerminationTransition::Retry`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RetryKind {
+    /// ANVIL_FINAL guard retry (no file modifications detected).
+    FinalGuard,
+    /// Plan gate retry (Done path: incomplete plan requires more work).
+    PlanGate,
+    /// Task-semantics gate retry (Issue #382).
+    TaskSemantics,
+    /// Guidance follow-up retry (Issue #372 (A)).
+    ///
+    /// Currently no code path emits this variant — the guidance retry is
+    /// treated as a `Continue` transition because the orchestration layer
+    /// has already injected the guidance message in
+    /// `handle_post_tool_anvil_final_gate`.  The variant is kept for API
+    /// completeness and for future refactors that may surface guidance as
+    /// an explicit retry.
+    #[allow(dead_code)]
+    GuidanceFollowup,
+}
+
+/// Terminal outcome carried by [`TerminationTransition::Break`].
+///
+/// Named `EndOfTurnOutcome` (not `TerminationReason`) to avoid naming
+/// collision with [`crate::contracts::TerminationReason`], which is the
+/// sub-agent protocol type (out of scope for this module).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum EndOfTurnOutcome {
+    /// Clean final answer — no guards fired.
+    FinalAnswer,
+    /// Fallback completion accepted (phase estimator).
+    FallbackCompleted,
+    /// Post-tool ANVIL_FINAL was accepted after tool execution.
+    PostToolAnvilFinalAccepted,
+    /// Guidance follow-up completed (no retry needed / budget exhausted).
+    GuidanceFollowupComplete,
+}
+
+/// Unified input for [`decide_no_tool_call`].
+///
+/// Fields are kept private; instances are constructed via one of the three
+/// named constructors (`for_agentic_loop`, `for_done_path`, `for_testing`).
+///
+/// This avoids the 8-positional-argument footgun: six of the fields are
+/// booleans, and getting two of them in the wrong order is an easy and
+/// silent source of bugs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NoToolCallInput {
+    /// Whether ANVIL_FINAL was detected in this response.
+    anvil_final_detected: bool,
+    /// Whether we are awaiting a guidance follow-up response.
+    awaiting_guidance_followup: bool,
+    /// Number of final-guard retries already used.
+    final_guard_retries: u8,
+    /// Whether `touched_files` is empty (no file modifications this turn).
+    touched_files_empty: bool,
+    /// Phase action from the phase estimator.
+    phase_action: PhaseAction,
+    /// Whether the execution plan has incomplete items (Branch 3 fallthrough).
+    plan_has_incomplete_items: bool,
+    /// Whether the plan gate should fire (Branch 4).
+    plan_gate_fires: bool,
+    /// Whether the task-semantics gate should fire (Branch 5).
+    task_semantics_fires: bool,
+}
+
+impl NoToolCallInput {
+    /// Constructor used on the agentic-loop path.
+    ///
+    /// Derives `anvil_final_detected`, `awaiting_guidance_followup` and
+    /// `final_guard_retries` from the supplied [`TerminationLoopState`].
+    ///
+    /// Note: visibility is `pub(crate)` because `TerminationLoopState` is
+    /// a `pub(crate)` type — exposing this constructor at `pub` would leak
+    /// a private type through its signature.
+    pub(crate) fn for_agentic_loop(
+        state: &TerminationLoopState,
+        touched_files_empty: bool,
+        phase_action: PhaseAction,
+        plan_has_incomplete_items: bool,
+        plan_gate_fires: bool,
+        task_semantics_fires: bool,
+    ) -> Self {
+        Self {
+            anvil_final_detected: state.is_anvil_final_seen(),
+            awaiting_guidance_followup: state.awaiting_guidance_followup(),
+            final_guard_retries: state.final_guard_retries(),
+            touched_files_empty,
+            phase_action,
+            plan_has_incomplete_items,
+            plan_gate_fires,
+            task_semantics_fires,
+        }
+    }
+
+    /// Constructor used on the Done path.
+    ///
+    /// Hardcodes Done-path invariants: `awaiting_guidance_followup=false`,
+    /// `final_guard_retries=0`, `plan_gate_fires=false` (the plan gate is
+    /// handled directly inside [`decide_done_path`] before this constructor
+    /// is called, preserving the `plan gate → final guard → task semantics`
+    /// ordering from Issue #253).
+    ///
+    /// `phase_action` and `plan_has_incomplete_items` are passed through
+    /// from the caller.  The caller contract for Done-path invocations is
+    /// `phase_action=Continue` and `plan_has_incomplete_items=false`;
+    /// [`decide_done_path`] will panic via `unreachable!` if these invariants
+    /// are violated, so callers must uphold them.
+    pub fn for_done_path(
+        anvil_final_detected: bool,
+        touched_files_empty: bool,
+        phase_action: PhaseAction,
+        plan_has_incomplete_items: bool,
+        task_semantics_fires: bool,
+    ) -> Self {
+        Self {
+            anvil_final_detected,
+            awaiting_guidance_followup: false,
+            final_guard_retries: 0,
+            touched_files_empty,
+            phase_action,
+            plan_has_incomplete_items,
+            plan_gate_fires: false,
+            task_semantics_fires,
+        }
+    }
+
+    /// Full-control constructor used by integration tests.
+    ///
+    /// This constructor is intentionally not cfg-gated so that
+    /// `tests/termination_semantics.rs` can build arbitrary inputs without
+    /// relying on a `testing` feature flag.  It is `#[doc(hidden)]` to
+    /// discourage production callers from using it directly.
+    #[doc(hidden)]
+    #[allow(clippy::too_many_arguments)]
+    pub fn for_testing(
+        anvil_final_detected: bool,
+        awaiting_guidance_followup: bool,
+        final_guard_retries: u8,
+        touched_files_empty: bool,
+        phase_action: PhaseAction,
+        plan_has_incomplete_items: bool,
+        plan_gate_fires: bool,
+        task_semantics_fires: bool,
+    ) -> Self {
+        Self {
+            anvil_final_detected,
+            awaiting_guidance_followup,
+            final_guard_retries,
+            touched_files_empty,
+            phase_action,
+            plan_has_incomplete_items,
+            plan_gate_fires,
+            task_semantics_fires,
+        }
+    }
+}
+
+/// Single source of truth for evaluating a no-tool-call response.
+///
+/// Pure function with no side-effects.  Side-effects (message injection,
+/// telemetry, assistant output recording) are the responsibility of the
+/// orchestration layer in `agentic.rs`.
+pub fn decide_no_tool_call(input: NoToolCallInput) -> NoToolCallDecision {
+    // Branch 1: guidance follow-up
+    if input.awaiting_guidance_followup {
+        // Guidance escalation uses the same retry budget as Branch 2 but
+        // does NOT require `anvil_final_detected`.  ANVIL_FINAL may have
+        // been suppressed via `suppress_anvil_final()` when the guidance
+        // injection was posted.
+        if input.touched_files_empty && input.final_guard_retries < MAX_FINAL_GUARD_RETRIES {
+            return NoToolCallDecision::FinalGuardRetry;
+        }
+        return NoToolCallDecision::GuidanceFollowupComplete;
+    }
+
+    // Branch 2: ANVIL_FINAL guard (requires anvil_final_detected, DR2-003)
+    if input.anvil_final_detected
+        && input.touched_files_empty
+        && input.final_guard_retries < MAX_FINAL_GUARD_RETRIES
+    {
+        return NoToolCallDecision::FinalGuardRetry;
+    }
+
+    // Branch 3: fallback completion (Issue #307: if plan has incomplete
+    // items, fall through to plan gate instead).
+    if matches!(input.phase_action, PhaseAction::FallbackComplete)
+        && !input.plan_has_incomplete_items
+    {
+        return NoToolCallDecision::FallbackCompleted;
+    }
+
+    // Branch 4: plan gate
+    if input.plan_gate_fires {
+        return NoToolCallDecision::PlanGateSuppression;
+    }
+
+    // Branch 5: task-semantics gate
+    if input.task_semantics_fires {
+        return NoToolCallDecision::TaskSemanticsSuppression;
+    }
+
+    // Final: accept as answer
+    NoToolCallDecision::FinalAnswer
+}
+
+/// Loop-local state governing termination decisions in the agentic loop.
+///
+/// All fields are initialised at the start of `complete_structured_response`
+/// and consumed only within that method (or within
+/// `handle_done_path_anvil_final_guard`, where a fresh instance is created
+/// each call).  App-level session state (`forced_mode_active`,
+/// `repair_closure_active`, `proactive_delegation_pending`) is intentionally
+/// excluded — see Issue #385 scope boundary.
+#[derive(Debug)]
+pub(crate) struct TerminationLoopState {
+    anvil_final_seen: bool,
+    final_guard_retries: u8,
+    guidance_retry_used: bool,
+    awaiting_guidance_followup: bool,
+    noplan_suppression_count: u8,
+    pre_exit_repair_injected: bool,
+    task_semantics_suppression_count: u8,
+}
+
+impl TerminationLoopState {
+    /// Create a new state bag for the start of a turn.
+    ///
+    /// `anvil_final_already` captures whether a prior response (in the
+    /// Done path) had already carried an ANVIL_FINAL marker;
+    /// `initial_anvil_final_detected` captures whether the current
+    /// structured response carries one.
+    pub(crate) fn new(anvil_final_already: bool, initial_anvil_final_detected: bool) -> Self {
+        Self {
+            anvil_final_seen: anvil_final_already || initial_anvil_final_detected,
+            final_guard_retries: 0,
+            guidance_retry_used: false,
+            awaiting_guidance_followup: false,
+            noplan_suppression_count: 0,
+            pre_exit_repair_injected: false,
+            task_semantics_suppression_count: 0,
+        }
+    }
+
+    // --- Read-only accessors --------------------------------------------------
+
+    /// Has ANVIL_FINAL been observed (and not subsequently suppressed)?
+    pub(crate) fn is_anvil_final_seen(&self) -> bool {
+        self.anvil_final_seen
+    }
+
+    /// Number of final-guard retries already used this turn.
+    pub(crate) fn final_guard_retries(&self) -> u8 {
+        self.final_guard_retries
+    }
+
+    /// Has the one-shot guidance retry been consumed?
+    pub(crate) fn guidance_retry_used(&self) -> bool {
+        self.guidance_retry_used
+    }
+
+    /// Are we awaiting a guidance follow-up response?
+    pub(crate) fn awaiting_guidance_followup(&self) -> bool {
+        self.awaiting_guidance_followup
+    }
+
+    /// Current plan-gate suppression count (capped at `MAX_PLAN_SUPPRESSIONS`).
+    pub(crate) fn noplan_suppression_count(&self) -> u8 {
+        self.noplan_suppression_count
+    }
+
+    /// Has the pre-exit repair turn been injected (Issue #325)?
+    pub(crate) fn pre_exit_repair_injected(&self) -> bool {
+        self.pre_exit_repair_injected
+    }
+
+    /// Current task-semantics gate suppression count
+    /// (capped at `MAX_TASK_SEMANTICS_SUPPRESSIONS`).
+    pub(crate) fn task_semantics_suppression_count(&self) -> u8 {
+        self.task_semantics_suppression_count
+    }
+
+    // --- Mutating methods -----------------------------------------------------
+
+    /// Record that ANVIL_FINAL was newly detected in an LLM response.
+    pub(crate) fn observe_anvil_final(&mut self) {
+        self.anvil_final_seen = true;
+    }
+
+    /// Suppress the current ANVIL_FINAL detection (plan gate / guidance
+    /// retry).  The state may be re-observed later in the same turn.
+    pub(crate) fn suppress_anvil_final(&mut self) {
+        self.anvil_final_seen = false;
+    }
+
+    /// Increment the final-guard retry counter.
+    ///
+    /// Invariant: the counter never exceeds [`MAX_FINAL_GUARD_RETRIES`].
+    pub(crate) fn increment_final_guard_retries(&mut self) {
+        debug_assert!(
+            self.final_guard_retries < MAX_FINAL_GUARD_RETRIES,
+            "final_guard_retries exceeded MAX_FINAL_GUARD_RETRIES"
+        );
+        self.final_guard_retries = self.final_guard_retries.saturating_add(1);
+    }
+
+    /// Mark the one-shot guidance retry as consumed.  Monotonic: once set,
+    /// never cleared within the same turn.
+    pub(crate) fn mark_guidance_retry_used(&mut self) {
+        self.guidance_retry_used = true;
+    }
+
+    /// Record that we posted a guidance injection and are now awaiting the
+    /// follow-up response.
+    pub(crate) fn set_awaiting_guidance_followup(&mut self) {
+        self.awaiting_guidance_followup = true;
+    }
+
+    /// Clear the awaiting-guidance-followup flag (called after the
+    /// follow-up arrives).
+    pub(crate) fn clear_awaiting_guidance_followup(&mut self) {
+        self.awaiting_guidance_followup = false;
+    }
+
+    /// Record a plan-gate suppression event.
+    ///
+    /// Invariant: count stays at or below [`MAX_PLAN_SUPPRESSIONS`]
+    /// (Issue #285 A2).
+    pub(crate) fn record_plan_suppression(&mut self) {
+        debug_assert!(
+            self.noplan_suppression_count < MAX_PLAN_SUPPRESSIONS,
+            "noplan_suppression_count exceeded MAX_PLAN_SUPPRESSIONS"
+        );
+        self.noplan_suppression_count = self.noplan_suppression_count.saturating_add(1);
+    }
+
+    /// Record that the pre-exit repair turn was injected (Issue #325).
+    pub(crate) fn mark_pre_exit_repair_injected(&mut self) {
+        self.pre_exit_repair_injected = true;
+    }
+
+    /// Record a task-semantics gate suppression event.
+    ///
+    /// Invariant: count stays at or below
+    /// [`MAX_TASK_SEMANTICS_SUPPRESSIONS`] (Issue #382).
+    pub(crate) fn record_task_semantics_suppression(&mut self) {
+        debug_assert!(
+            self.task_semantics_suppression_count < MAX_TASK_SEMANTICS_SUPPRESSIONS,
+            "task_semantics_suppression_count exceeded MAX_TASK_SEMANTICS_SUPPRESSIONS"
+        );
+        self.task_semantics_suppression_count =
+            self.task_semantics_suppression_count.saturating_add(1);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Entry points
+// ---------------------------------------------------------------------------
+
+/// Done-path termination decision.
+///
+/// This entry point enforces the Done-path ordering (Issue #253 DR2-001):
+///   plan gate → final guard → task semantics → FinalAnswer.
+///
+/// Unlike the agentic loop, Done-path state is not persisted across calls;
+/// the caller creates a fresh [`TerminationLoopState`] for each invocation.
+pub(crate) fn decide_done_path(
+    state: &mut TerminationLoopState,
+    anvil_final_detected: bool,
+    plan_gate_fires: bool,
+    task_semantics_fires: bool,
+    touched_files_empty: bool,
+    phase_action: PhaseAction,
+    plan_has_incomplete_items: bool,
+) -> TerminationTransition {
+    // Mirror the caller-side bookkeeping: observe ANVIL_FINAL so subsequent
+    // introspection of the state object is consistent.
+    if anvil_final_detected {
+        state.observe_anvil_final();
+    }
+
+    // Done-path ordering (Issue #253 DR2-001):
+    // 1. Plan gate fires BEFORE the final guard.  Only fires when
+    //    ANVIL_FINAL was detected and no file edits were made — this
+    //    mirrors the existing `handle_done_path_anvil_final_guard` shape.
+    if anvil_final_detected && touched_files_empty && plan_gate_fires {
+        return TerminationTransition::Retry(RetryKind::PlanGate);
+    }
+
+    // 2. Delegate to the pure decision table for the remaining branches.
+    //    The Done path always passes `plan_gate_fires=false` to
+    //    `decide_no_tool_call` because the plan gate was handled above.
+    let input = NoToolCallInput::for_done_path(
+        anvil_final_detected,
+        touched_files_empty,
+        phase_action,
+        plan_has_incomplete_items,
+        task_semantics_fires,
+    );
+
+    match decide_no_tool_call(input) {
+        NoToolCallDecision::FinalGuardRetry => TerminationTransition::Retry(RetryKind::FinalGuard),
+        NoToolCallDecision::TaskSemanticsSuppression => {
+            TerminationTransition::Retry(RetryKind::TaskSemantics)
+        }
+        NoToolCallDecision::FinalAnswer => {
+            TerminationTransition::Break(EndOfTurnOutcome::FinalAnswer)
+        }
+        // The remaining variants are unreachable on the Done path because
+        // we hardcode `awaiting_guidance_followup=false`,
+        // `phase_action=Continue` (no fallback) and `plan_gate_fires=false`
+        // (handled directly above).
+        NoToolCallDecision::PlanGateSuppression => {
+            unreachable!("Done path: plan gate is handled directly before decide_no_tool_call")
+        }
+        NoToolCallDecision::GuidanceFollowupComplete => {
+            unreachable!("Done path never sets awaiting_guidance_followup")
+        }
+        NoToolCallDecision::FallbackCompleted => {
+            unreachable!("Done path uses PhaseAction::Continue; no fallback completion")
+        }
+    }
+}
+
+/// Agentic-loop termination decision for no-tool-call responses.
+///
+/// Mirrors `decide_no_tool_call` but returns a [`TerminationTransition`]
+/// (instead of the raw decision enum) so that the orchestration layer can
+/// dispatch on the appropriate control-flow action.
+pub(crate) fn decide_agentic_loop(
+    state: &mut TerminationLoopState,
+    input: NoToolCallInput,
+) -> TerminationTransition {
+    match decide_no_tool_call(input) {
+        NoToolCallDecision::FinalGuardRetry => TerminationTransition::Retry(RetryKind::FinalGuard),
+        NoToolCallDecision::GuidanceFollowupComplete => {
+            TerminationTransition::Break(EndOfTurnOutcome::GuidanceFollowupComplete)
+        }
+        NoToolCallDecision::FallbackCompleted => {
+            TerminationTransition::Break(EndOfTurnOutcome::FallbackCompleted)
+        }
+        NoToolCallDecision::PlanGateSuppression => {
+            // Plan gate fired — orchestration layer is responsible for
+            // recording the suppression on the state (the FSM returns
+            // Continue so the loop picks up the next LLM turn).
+            let _ = state;
+            TerminationTransition::Continue
+        }
+        NoToolCallDecision::TaskSemanticsSuppression => {
+            TerminationTransition::Retry(RetryKind::TaskSemantics)
+        }
+        NoToolCallDecision::FinalAnswer => {
+            TerminationTransition::Break(EndOfTurnOutcome::FinalAnswer)
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- TerminationLoopState unit tests (moved from agentic.rs, Issue #385) ---
+
+    #[test]
+    fn termination_loop_state_new_both_false() {
+        let state = TerminationLoopState::new(false, false);
+        assert!(!state.is_anvil_final_seen());
+        assert_eq!(state.final_guard_retries(), 0);
+        assert!(!state.guidance_retry_used());
+        assert!(!state.awaiting_guidance_followup());
+        assert_eq!(state.noplan_suppression_count(), 0);
+        assert!(!state.pre_exit_repair_injected());
+        assert_eq!(state.task_semantics_suppression_count(), 0);
+    }
+
+    #[test]
+    fn termination_loop_state_new_already_true() {
+        let state = TerminationLoopState::new(true, false);
+        assert!(state.is_anvil_final_seen());
+    }
+
+    #[test]
+    fn termination_loop_state_new_detected_true() {
+        let state = TerminationLoopState::new(false, true);
+        assert!(state.is_anvil_final_seen());
+    }
+
+    #[test]
+    fn termination_loop_state_suppress_and_observe() {
+        let mut state = TerminationLoopState::new(true, false);
+        assert!(state.is_anvil_final_seen());
+        state.suppress_anvil_final();
+        assert!(!state.is_anvil_final_seen());
+        state.observe_anvil_final();
+        assert!(state.is_anvil_final_seen());
+    }
+
+    #[test]
+    fn termination_loop_state_record_plan_suppression() {
+        let mut state = TerminationLoopState::new(false, false);
+        assert_eq!(state.noplan_suppression_count(), 0);
+        state.record_plan_suppression();
+        assert_eq!(state.noplan_suppression_count(), 1);
+    }
+
+    // --- New FSM-level tests (Issue #381) --------------------------------
+
+    /// (a) Issue #173: ANVIL_FINAL detected + empty touched_files →
+    /// FSM requests a final-guard retry.
+    #[test]
+    fn fsm_anvil_final_and_empty_touched_files_retries_final_guard() {
+        let mut state = TerminationLoopState::new(false, true); // ANVIL_FINAL observed
+        let input = NoToolCallInput::for_agentic_loop(
+            &state,
+            /*touched_files_empty=*/ true,
+            PhaseAction::Continue,
+            /*plan_has_incomplete_items=*/ false,
+            /*plan_gate_fires=*/ false,
+            /*task_semantics_fires=*/ false,
+        );
+        let transition = decide_agentic_loop(&mut state, input);
+        assert_eq!(
+            transition,
+            TerminationTransition::Retry(RetryKind::FinalGuard),
+            "ANVIL_FINAL + empty touched_files must trigger FinalGuard retry (Issue #173)"
+        );
+    }
+
+    /// (b) Issue #307: FallbackCompleted + incomplete plan must NOT accept
+    /// as final.  With plan_gate_fires=true (as the caller would compute
+    /// when the plan is incomplete), FSM returns Continue (PlanGateSuppression).
+    #[test]
+    fn fsm_fallback_completed_with_incomplete_plan_suppresses() {
+        let mut state = TerminationLoopState::new(false, false);
+        let input = NoToolCallInput::for_agentic_loop(
+            &state,
+            /*touched_files_empty=*/ false,
+            PhaseAction::FallbackComplete,
+            /*plan_has_incomplete_items=*/ true,
+            /*plan_gate_fires=*/ true,
+            /*task_semantics_fires=*/ false,
+        );
+        let transition = decide_agentic_loop(&mut state, input);
+        assert_eq!(
+            transition,
+            TerminationTransition::Continue,
+            "FallbackCompleted + incomplete plan must be suppressed (Issue #307)"
+        );
+    }
+
+    /// (c) Issue #382: implementation task + task-semantics gate fires →
+    /// FSM requests a task-semantics retry.
+    #[test]
+    fn fsm_implementation_task_fires_task_semantics_retry() {
+        let mut state = TerminationLoopState::new(false, false);
+        let input = NoToolCallInput::for_agentic_loop(
+            &state,
+            /*touched_files_empty=*/ true,
+            PhaseAction::Continue,
+            /*plan_has_incomplete_items=*/ false,
+            /*plan_gate_fires=*/ false,
+            /*task_semantics_fires=*/ true,
+        );
+        let transition = decide_agentic_loop(&mut state, input);
+        assert_eq!(
+            transition,
+            TerminationTransition::Retry(RetryKind::TaskSemantics),
+            "implementation task with task_semantics_fires must trigger TaskSemantics retry \
+             (Issue #382)"
+        );
+    }
+
+    /// (d) Issue #285 / #249: plan gate budget exhausted on the second
+    /// invocation.  Once `record_plan_suppression` has been called, the
+    /// caller would pass `plan_gate_fires=false`, and with no other gate
+    /// active the FSM must accept as FinalAnswer (Break).
+    #[test]
+    fn fsm_plan_gate_budget_exhausted_breaks() {
+        let mut state = TerminationLoopState::new(false, false);
+        // First invocation: plan gate fires, suppression recorded.
+        let input1 = NoToolCallInput::for_agentic_loop(
+            &state,
+            /*touched_files_empty=*/ true,
+            PhaseAction::Continue,
+            /*plan_has_incomplete_items=*/ true,
+            /*plan_gate_fires=*/ true,
+            /*task_semantics_fires=*/ false,
+        );
+        let t1 = decide_agentic_loop(&mut state, input1);
+        assert_eq!(t1, TerminationTransition::Continue);
+        state.record_plan_suppression();
+
+        // Second invocation: budget exceeded; caller passes plan_gate_fires=false.
+        let input2 = NoToolCallInput::for_agentic_loop(
+            &state,
+            /*touched_files_empty=*/ true,
+            PhaseAction::Continue,
+            /*plan_has_incomplete_items=*/ true,
+            /*plan_gate_fires=*/ false,
+            /*task_semantics_fires=*/ false,
+        );
+        let t2 = decide_agentic_loop(&mut state, input2);
+        assert_eq!(
+            t2,
+            TerminationTransition::Break(EndOfTurnOutcome::FinalAnswer),
+            "plan gate exhausted + no other gates must break with FinalAnswer (Issue #285/#249)"
+        );
+    }
+
+    /// (e) Issue #372: once `final_guard_retries >= MAX_FINAL_GUARD_RETRIES`,
+    /// the FSM must NOT retry again.  The result is Break(FinalAnswer) when
+    /// no other gates are active.
+    #[test]
+    fn fsm_final_guard_retries_exhausted_breaks_final_answer() {
+        let mut state = TerminationLoopState::new(false, true);
+        state.increment_final_guard_retries();
+        assert_eq!(state.final_guard_retries(), MAX_FINAL_GUARD_RETRIES);
+
+        let input = NoToolCallInput::for_agentic_loop(
+            &state,
+            /*touched_files_empty=*/ true,
+            PhaseAction::Continue,
+            /*plan_has_incomplete_items=*/ false,
+            /*plan_gate_fires=*/ false,
+            /*task_semantics_fires=*/ false,
+        );
+        let transition = decide_agentic_loop(&mut state, input);
+        assert_eq!(
+            transition,
+            TerminationTransition::Break(EndOfTurnOutcome::FinalAnswer),
+            "final_guard_retries >= MAX must not retry; break with FinalAnswer (Issue #372)"
+        );
+    }
+
+    // --- Done-path ordering tests ----------------------------------------
+
+    /// Done path: plan gate ordering (Issue #253 DR2-001) — plan gate
+    /// fires BEFORE final guard.
+    #[test]
+    fn done_path_plan_gate_ordered_before_final_guard() {
+        let mut state = TerminationLoopState::new(false, false);
+        let transition = decide_done_path(
+            &mut state,
+            /*anvil_final_detected=*/ true,
+            /*plan_gate_fires=*/ true,
+            /*task_semantics_fires=*/ false,
+            /*touched_files_empty=*/ true,
+            PhaseAction::Continue,
+            /*plan_has_incomplete_items=*/ true,
+        );
+        assert_eq!(
+            transition,
+            TerminationTransition::Retry(RetryKind::PlanGate),
+            "Done path: plan gate must fire before final guard (Issue #253 DR2-001)"
+        );
+    }
+
+    /// Done path: final guard fires when plan gate does not.
+    #[test]
+    fn done_path_final_guard_fires_when_plan_gate_inactive() {
+        let mut state = TerminationLoopState::new(false, false);
+        let transition = decide_done_path(
+            &mut state,
+            /*anvil_final_detected=*/ true,
+            /*plan_gate_fires=*/ false,
+            /*task_semantics_fires=*/ false,
+            /*touched_files_empty=*/ true,
+            PhaseAction::Continue,
+            /*plan_has_incomplete_items=*/ false,
+        );
+        assert_eq!(
+            transition,
+            TerminationTransition::Retry(RetryKind::FinalGuard),
+            "Done path: final guard must fire when plan gate is inactive"
+        );
+    }
+
+    /// Done path: task-semantics gate fires last in the ordering.
+    #[test]
+    fn done_path_task_semantics_fires_after_final_guard() {
+        let mut state = TerminationLoopState::new(false, false);
+        // ANVIL_FINAL absent → plan gate doesn't fire; final guard doesn't
+        // fire (requires anvil_final_detected).  Task semantics wins.
+        let transition = decide_done_path(
+            &mut state,
+            /*anvil_final_detected=*/ false,
+            /*plan_gate_fires=*/ true, // ignored because anvil_final_detected=false
+            /*task_semantics_fires=*/ true,
+            /*touched_files_empty=*/ true,
+            PhaseAction::Continue,
+            /*plan_has_incomplete_items=*/ false,
+        );
+        assert_eq!(
+            transition,
+            TerminationTransition::Retry(RetryKind::TaskSemantics),
+            "Done path: task-semantics gate fires when plan gate/final guard inactive"
+        );
+    }
+
+    /// Done path: clean final answer when no gates fire.
+    #[test]
+    fn done_path_clean_final_answer() {
+        let mut state = TerminationLoopState::new(false, false);
+        let transition = decide_done_path(
+            &mut state,
+            /*anvil_final_detected=*/ false,
+            /*plan_gate_fires=*/ false,
+            /*task_semantics_fires=*/ false,
+            /*touched_files_empty=*/ true,
+            PhaseAction::Continue,
+            /*plan_has_incomplete_items=*/ false,
+        );
+        assert_eq!(
+            transition,
+            TerminationTransition::Break(EndOfTurnOutcome::FinalAnswer),
+            "Done path: clean response must be accepted as FinalAnswer"
+        );
+    }
+}

--- a/tests/task_semantics_gate.rs
+++ b/tests/task_semantics_gate.rs
@@ -316,12 +316,15 @@ fn runtime_config_default_preserves_gate_enabled() {
 
 #[test]
 fn termination_loop_state_new_includes_task_semantics() {
-    // Verified via the unit test in agentic.rs; this test ensures the
-    // integration test can also reference the constant MAX_TASK_SEMANTICS_GATE_RETRIES
-    // indirectly by asserting the initial value is 0.
-    // Note: TerminationLoopState is private — this is tested via the unit
-    // tests in src/app/agentic.rs (termination_loop_state_new_both_false).
-    // Here we just verify the function and telemetry are accessible.
+    // Verified via the unit tests in src/app/termination_fsm.rs (Issue #381
+    // moved `TerminationLoopState` and its tests to that module).  This test
+    // ensures the integration test can also reference the constant
+    // MAX_TASK_SEMANTICS_GATE_RETRIES indirectly by asserting the initial
+    // value is 0.
+    // Note: `TerminationLoopState` is `pub(crate)` — the unit tests in
+    // src/app/termination_fsm.rs (`termination_loop_state_new_both_false`)
+    // cover state-level behaviour.  Here we just verify the telemetry is
+    // accessible.
     let tel = RetryTelemetry::default();
     assert_eq!(tel.task_semantics_gate_attempted, 0);
     assert_eq!(tel.task_semantics_gate_succeeded, 0);

--- a/tests/termination_semantics.rs
+++ b/tests/termination_semantics.rs
@@ -1,9 +1,8 @@
 //! Integration tests for Issue #383: termination semantics — unify the meaning
 //! of no-tool-call responses.
 //!
-//! These tests verify the decision logic of `decide_no_tool_call` by mirroring
-//! its branching rules here (the function and its types are private to agentic.rs).
-//! The tests serve as a living specification for the expected semantics.
+//! These tests exercise the public FSM API from
+//! `src/app/termination_fsm.rs` (see Issue #381).
 //!
 //! Covers (7 scenarios):
 //! - T1: guidance follow-up escalates to final guard retry
@@ -13,83 +12,18 @@
 //! - T5: Task-semantics gate fires on Branch 5
 //! - T6: Clean final answer accepted
 //! - T7: Post-tool ANVIL_FINAL plan gate suppression
+//!
+//! Note: `decide_done_path` / `decide_agentic_loop` are `pub(crate)` (they
+//! return `TerminationTransition`, which is also `pub(crate)`), so they are
+//! not importable from integration tests.  Done-path / agentic-loop
+//! ordering tests live alongside the FSM in
+//! `src/app/termination_fsm.rs::tests`.
 
 use anvil::app::phase_estimator::{PhaseAction, PhaseEstimator};
+use anvil::app::termination_fsm::{
+    MAX_FINAL_GUARD_RETRIES, NoToolCallDecision, NoToolCallInput, decide_no_tool_call,
+};
 use anvil::contracts::{ExecutionPlan, PlanItem};
-
-// ---------------------------------------------------------------------------
-// Mirror types and logic from agentic.rs (decide_no_tool_call)
-// ---------------------------------------------------------------------------
-
-const MAX_FINAL_GUARD_RETRIES: u8 = 1;
-
-/// Mirrors `NoToolCallDecision` from `src/app/agentic.rs`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum NoToolCallDecision {
-    GuidanceFollowupComplete,
-    FinalGuardRetry,
-    FallbackCompleted,
-    PlanGateSuppression,
-    TaskSemanticsSuppression,
-    FinalAnswer,
-}
-
-/// Mirrors `NoToolCallInput` from `src/app/agentic.rs`.
-struct NoToolCallInput {
-    anvil_final_detected: bool,
-    awaiting_guidance_followup: bool,
-    final_guard_retries: u8,
-    touched_files_empty: bool,
-    phase_action: PhaseAction,
-    plan_has_incomplete_items: bool,
-    plan_gate_fires: bool,
-    task_semantics_fires: bool,
-}
-
-/// Mirrors `decide_no_tool_call` from `src/app/agentic.rs`.
-///
-/// This is the single source of truth for no-tool-call decision semantics.
-/// Any change to branching in agentic.rs should be reflected here.
-fn decide_no_tool_call(input: NoToolCallInput) -> NoToolCallDecision {
-    // Branch 1: guidance follow-up
-    if input.awaiting_guidance_followup {
-        // Does NOT require anvil_final_detected — ANVIL_FINAL may have been
-        // suppressed when the guidance injection was posted.
-        if input.touched_files_empty && input.final_guard_retries < MAX_FINAL_GUARD_RETRIES {
-            return NoToolCallDecision::FinalGuardRetry;
-        }
-        return NoToolCallDecision::GuidanceFollowupComplete;
-    }
-
-    // Branch 2: ANVIL_FINAL guard (requires anvil_final_detected, DR2-003)
-    if input.anvil_final_detected
-        && input.touched_files_empty
-        && input.final_guard_retries < MAX_FINAL_GUARD_RETRIES
-    {
-        return NoToolCallDecision::FinalGuardRetry;
-    }
-
-    // Branch 3: fallback completion
-    // Issue #307: if plan has incomplete items, fallthrough to plan gate instead.
-    if matches!(input.phase_action, PhaseAction::FallbackComplete)
-        && !input.plan_has_incomplete_items
-    {
-        return NoToolCallDecision::FallbackCompleted;
-    }
-
-    // Branch 4: plan gate
-    if input.plan_gate_fires {
-        return NoToolCallDecision::PlanGateSuppression;
-    }
-
-    // Branch 5: task-semantics gate
-    if input.task_semantics_fires {
-        return NoToolCallDecision::TaskSemanticsSuppression;
-    }
-
-    // Final: accept as answer
-    NoToolCallDecision::FinalAnswer
-}
 
 // ---------------------------------------------------------------------------
 // T1: guidance follow-up escalates to final guard retry
@@ -101,16 +35,16 @@ fn decide_no_tool_call(input: NoToolCallInput) -> NoToolCallDecision {
 /// the guidance injection was posted.
 #[test]
 fn guidance_followup_escalates_to_final_guard_retry() {
-    let input = NoToolCallInput {
-        anvil_final_detected: false, // suppressed by guidance injection
-        awaiting_guidance_followup: true,
-        final_guard_retries: 0, // budget not yet consumed
-        touched_files_empty: true,
-        phase_action: PhaseAction::Continue,
-        plan_has_incomplete_items: false,
-        plan_gate_fires: false,
-        task_semantics_fires: false,
-    };
+    let input = NoToolCallInput::for_testing(
+        /*anvil_final_detected=*/ false, // suppressed by guidance injection
+        /*awaiting_guidance_followup=*/ true,
+        /*final_guard_retries=*/ 0, // budget not yet consumed
+        /*touched_files_empty=*/ true,
+        PhaseAction::Continue,
+        /*plan_has_incomplete_items=*/ false,
+        /*plan_gate_fires=*/ false,
+        /*task_semantics_fires=*/ false,
+    );
     assert_eq!(
         decide_no_tool_call(input),
         NoToolCallDecision::FinalGuardRetry,
@@ -121,16 +55,16 @@ fn guidance_followup_escalates_to_final_guard_retry() {
 /// When the retry budget is exhausted, guidance follow-up resolves as complete.
 #[test]
 fn guidance_followup_complete_when_budget_exhausted() {
-    let input = NoToolCallInput {
-        anvil_final_detected: false,
-        awaiting_guidance_followup: true,
-        final_guard_retries: MAX_FINAL_GUARD_RETRIES, // budget exhausted
-        touched_files_empty: true,
-        phase_action: PhaseAction::Continue,
-        plan_has_incomplete_items: false,
-        plan_gate_fires: false,
-        task_semantics_fires: false,
-    };
+    let input = NoToolCallInput::for_testing(
+        false,
+        true,
+        MAX_FINAL_GUARD_RETRIES, // budget exhausted
+        true,
+        PhaseAction::Continue,
+        false,
+        false,
+        false,
+    );
     assert_eq!(
         decide_no_tool_call(input),
         NoToolCallDecision::GuidanceFollowupComplete,
@@ -142,16 +76,16 @@ fn guidance_followup_complete_when_budget_exhausted() {
 /// regardless of retry budget.
 #[test]
 fn guidance_followup_complete_when_files_modified() {
-    let input = NoToolCallInput {
-        anvil_final_detected: false,
-        awaiting_guidance_followup: true,
-        final_guard_retries: 0,
-        touched_files_empty: false, // files were modified
-        phase_action: PhaseAction::Continue,
-        plan_has_incomplete_items: false,
-        plan_gate_fires: false,
-        task_semantics_fires: false,
-    };
+    let input = NoToolCallInput::for_testing(
+        false,
+        true,
+        0,
+        /*touched_files_empty=*/ false, // files were modified
+        PhaseAction::Continue,
+        false,
+        false,
+        false,
+    );
     assert_eq!(
         decide_no_tool_call(input),
         NoToolCallDecision::GuidanceFollowupComplete,
@@ -187,16 +121,16 @@ fn fallback_completed_suppressed_when_plan_incomplete() {
     let phase_action = estimator.check_empty_response();
     assert_eq!(phase_action, PhaseAction::FallbackComplete);
 
-    let input = NoToolCallInput {
-        anvil_final_detected: false,
-        awaiting_guidance_followup: false,
-        final_guard_retries: 0,
-        touched_files_empty: false,
+    let input = NoToolCallInput::for_testing(
+        false,
+        false,
+        0,
+        false,
         phase_action,
         plan_has_incomplete_items,
-        plan_gate_fires: true, // plan gate fires because plan has incomplete items
-        task_semantics_fires: false,
-    };
+        /*plan_gate_fires=*/ true, // plan gate fires because plan has incomplete items
+        false,
+    );
     assert_eq!(
         decide_no_tool_call(input),
         NoToolCallDecision::PlanGateSuppression,
@@ -224,16 +158,16 @@ fn fallback_completed_fires_when_plan_finished() {
     let phase_action = estimator.check_empty_response();
     assert_eq!(phase_action, PhaseAction::FallbackComplete);
 
-    let input = NoToolCallInput {
-        anvil_final_detected: false,
-        awaiting_guidance_followup: false,
-        final_guard_retries: 0,
-        touched_files_empty: false,
+    let input = NoToolCallInput::for_testing(
+        false,
+        false,
+        0,
+        false,
         phase_action,
         plan_has_incomplete_items,
-        plan_gate_fires: false,
-        task_semantics_fires: false,
-    };
+        false,
+        false,
+    );
     assert_eq!(
         decide_no_tool_call(input),
         NoToolCallDecision::FallbackCompleted,
@@ -250,16 +184,13 @@ fn fallback_completed_fires_when_plan_finished() {
 /// (Done path defaults: awaiting_guidance_followup=false, final_guard_retries=0)
 #[test]
 fn done_path_final_guard_retry() {
-    let input = NoToolCallInput {
-        anvil_final_detected: true,          // ANVIL_FINAL detected in response
-        awaiting_guidance_followup: false,   // Done path: always false
-        final_guard_retries: 0,              // Done path: first turn
-        touched_files_empty: true,           // no file modifications
-        phase_action: PhaseAction::Continue, // Done path: always Continue
-        plan_has_incomplete_items: false,
-        plan_gate_fires: false, // Done path: plan gate handled before calling this
-        task_semantics_fires: false,
-    };
+    let input = NoToolCallInput::for_done_path(
+        /*anvil_final_detected=*/ true, // ANVIL_FINAL detected in response
+        /*touched_files_empty=*/ true,                  // no file modifications
+        PhaseAction::Continue, // Done path: always Continue
+        /*plan_has_incomplete_items=*/ false,
+        /*task_semantics_fires=*/ false,
+    );
     assert_eq!(
         decide_no_tool_call(input),
         NoToolCallDecision::FinalGuardRetry,
@@ -271,16 +202,13 @@ fn done_path_final_guard_retry() {
 /// (Branch 2 requires anvil_final_detected=true — DR2-003)
 #[test]
 fn done_path_no_final_guard_retry_without_anvil_final() {
-    let input = NoToolCallInput {
-        anvil_final_detected: false, // no ANVIL_FINAL
-        awaiting_guidance_followup: false,
-        final_guard_retries: 0,
-        touched_files_empty: true,
-        phase_action: PhaseAction::Continue,
-        plan_has_incomplete_items: false,
-        plan_gate_fires: false,
-        task_semantics_fires: false,
-    };
+    let input = NoToolCallInput::for_done_path(
+        /*anvil_final_detected=*/ false, // no ANVIL_FINAL
+        true,
+        PhaseAction::Continue,
+        false,
+        false,
+    );
     // Without anvil_final_detected, Branch 2 does not fire.
     // All other branches are inactive → FinalAnswer.
     assert_eq!(
@@ -306,16 +234,16 @@ fn done_path_plan_gate_suppresses_before_final_guard_retry() {
     // Both conditions would fire if ordering weren't enforced:
     // - anvil_final_detected=true + touched_files_empty=true → would be FinalGuardRetry
     // - plan_gate_fires=true → PlanGateSuppression
-    let input = NoToolCallInput {
-        anvil_final_detected: true,
-        awaiting_guidance_followup: false,
-        final_guard_retries: 0,
-        touched_files_empty: true,
-        phase_action: PhaseAction::Continue,
-        plan_has_incomplete_items: true,
-        plan_gate_fires: true, // plan gate fires
-        task_semantics_fires: false,
-    };
+    let input = NoToolCallInput::for_testing(
+        true,
+        false,
+        0,
+        true,
+        PhaseAction::Continue,
+        true,
+        /*plan_gate_fires=*/ true,
+        false,
+    );
     // Branch 2 (FinalGuardRetry) fires BEFORE Branch 4 (PlanGateSuppression)
     // in the agentic loop ordering. So with both conditions active, FinalGuardRetry wins.
     assert_eq!(
@@ -331,16 +259,13 @@ fn done_path_plan_gate_suppresses_before_final_guard_retry() {
 fn done_path_plan_gate_handled_externally() {
     // Simulates what handle_done_path_anvil_final_guard passes after handling
     // the plan gate externally: plan_gate_fires=false.
-    let input = NoToolCallInput {
-        anvil_final_detected: true,
-        awaiting_guidance_followup: false,
-        final_guard_retries: 0,
-        touched_files_empty: true,
-        phase_action: PhaseAction::Continue,
-        plan_has_incomplete_items: true,
-        plan_gate_fires: false, // Done path: plan gate already handled by caller
-        task_semantics_fires: false,
-    };
+    let input = NoToolCallInput::for_done_path(
+        true,
+        true,
+        PhaseAction::Continue,
+        /*plan_has_incomplete_items=*/ true,
+        false,
+    );
     assert_eq!(
         decide_no_tool_call(input),
         NoToolCallDecision::FinalGuardRetry,
@@ -356,16 +281,16 @@ fn done_path_plan_gate_handled_externally() {
 /// the task-semantics gate fires (Branch 5).
 #[test]
 fn task_semantics_gate_fires_on_branch5() {
-    let input = NoToolCallInput {
-        anvil_final_detected: false, // no ANVIL_FINAL
-        awaiting_guidance_followup: false,
-        final_guard_retries: 0,
-        touched_files_empty: true,
-        phase_action: PhaseAction::Continue,
-        plan_has_incomplete_items: false,
-        plan_gate_fires: false,
-        task_semantics_fires: true, // task-semantics gate fires
-    };
+    let input = NoToolCallInput::for_testing(
+        false,
+        false,
+        0,
+        true,
+        PhaseAction::Continue,
+        false,
+        false,
+        /*task_semantics_fires=*/ true,
+    );
     assert_eq!(
         decide_no_tool_call(input),
         NoToolCallDecision::TaskSemanticsSuppression,
@@ -377,16 +302,16 @@ fn task_semantics_gate_fires_on_branch5() {
 /// Plan gate (Branch 4) takes priority over task-semantics gate (Branch 5).
 #[test]
 fn plan_gate_takes_priority_over_task_semantics() {
-    let input = NoToolCallInput {
-        anvil_final_detected: false,
-        awaiting_guidance_followup: false,
-        final_guard_retries: 0,
-        touched_files_empty: false,
-        phase_action: PhaseAction::Continue,
-        plan_has_incomplete_items: true,
-        plan_gate_fires: true,
-        task_semantics_fires: true, // both active
-    };
+    let input = NoToolCallInput::for_testing(
+        false,
+        false,
+        0,
+        false,
+        PhaseAction::Continue,
+        true,
+        /*plan_gate_fires=*/ true,
+        /*task_semantics_fires=*/ true, // both active
+    );
     assert_eq!(
         decide_no_tool_call(input),
         NoToolCallDecision::PlanGateSuppression,
@@ -402,16 +327,16 @@ fn plan_gate_takes_priority_over_task_semantics() {
 /// final answer (FinalAnswer path).
 #[test]
 fn clean_final_answer_accepted() {
-    let input = NoToolCallInput {
-        anvil_final_detected: false,
-        awaiting_guidance_followup: false,
-        final_guard_retries: 0,
-        touched_files_empty: false, // files were modified — guard does not fire
-        phase_action: PhaseAction::Continue, // no fallback completion
-        plan_has_incomplete_items: false,
-        plan_gate_fires: false,
-        task_semantics_fires: false,
-    };
+    let input = NoToolCallInput::for_testing(
+        false,
+        false,
+        0,
+        /*touched_files_empty=*/ false, // files were modified — guard does not fire
+        PhaseAction::Continue, // no fallback completion
+        false,
+        false,
+        false,
+    );
     assert_eq!(
         decide_no_tool_call(input),
         NoToolCallDecision::FinalAnswer,
@@ -423,16 +348,16 @@ fn clean_final_answer_accepted() {
 /// were made (the guard condition on touched_files_empty is not met).
 #[test]
 fn final_answer_accepted_when_files_modified_despite_anvil_final() {
-    let input = NoToolCallInput {
-        anvil_final_detected: true, // ANVIL_FINAL present
-        awaiting_guidance_followup: false,
-        final_guard_retries: 0,
-        touched_files_empty: false, // but files were modified → guard skipped
-        phase_action: PhaseAction::Continue,
-        plan_has_incomplete_items: false,
-        plan_gate_fires: false,
-        task_semantics_fires: false,
-    };
+    let input = NoToolCallInput::for_testing(
+        /*anvil_final_detected=*/ true, // ANVIL_FINAL present
+        false,
+        0,
+        /*touched_files_empty=*/ false, // but files were modified → guard skipped
+        PhaseAction::Continue,
+        false,
+        false,
+        false,
+    );
     assert_eq!(
         decide_no_tool_call(input),
         NoToolCallDecision::FinalAnswer,
@@ -444,16 +369,16 @@ fn final_answer_accepted_when_files_modified_despite_anvil_final() {
 /// conditions are otherwise met.
 #[test]
 fn final_guard_budget_exhausted_falls_through_to_final_answer() {
-    let input = NoToolCallInput {
-        anvil_final_detected: true,
-        awaiting_guidance_followup: false,
-        final_guard_retries: MAX_FINAL_GUARD_RETRIES, // budget exhausted
-        touched_files_empty: true,
-        phase_action: PhaseAction::Continue,
-        plan_has_incomplete_items: false,
-        plan_gate_fires: false,
-        task_semantics_fires: false,
-    };
+    let input = NoToolCallInput::for_testing(
+        true,
+        false,
+        MAX_FINAL_GUARD_RETRIES, // budget exhausted
+        true,
+        PhaseAction::Continue,
+        false,
+        false,
+        false,
+    );
     assert_eq!(
         decide_no_tool_call(input),
         NoToolCallDecision::FinalAnswer,
@@ -493,16 +418,16 @@ fn post_tool_anvil_final_plan_gate_suppression() {
     // require_plan_here is satisfied (plan is non-empty and has incomplete items).
     let plan_gate_fires = plan_has_incomplete_items; // simplified: fires when incomplete
 
-    let input = NoToolCallInput {
-        anvil_final_detected: true, // ANVIL_FINAL detected after tool execution
-        awaiting_guidance_followup: false,
-        final_guard_retries: 0,
-        touched_files_empty: true, // no file edits in this turn
-        phase_action: PhaseAction::Continue,
+    let input = NoToolCallInput::for_testing(
+        /*anvil_final_detected=*/ true, // ANVIL_FINAL detected after tool execution
+        false,
+        0,
+        /*touched_files_empty=*/ true, // no file edits in this turn
+        PhaseAction::Continue,
         plan_has_incomplete_items,
         plan_gate_fires,
-        task_semantics_fires: false,
-    };
+        false,
+    );
 
     // Branch 2 (FinalGuardRetry) fires first because anvil_final_detected=true.
     // This verifies the ordering: plan gate (Branch 4) only fires when Branch 2 is not active.
@@ -519,16 +444,16 @@ fn post_tool_anvil_final_plan_gate_suppression() {
 /// the plan gate fires and suppresses termination.
 #[test]
 fn post_tool_plan_gate_fires_when_guard_budget_exhausted() {
-    let input = NoToolCallInput {
-        anvil_final_detected: true,
-        awaiting_guidance_followup: false,
-        final_guard_retries: MAX_FINAL_GUARD_RETRIES, // guard budget exhausted
-        touched_files_empty: true,
-        phase_action: PhaseAction::Continue,
-        plan_has_incomplete_items: true,
-        plan_gate_fires: true, // plan gate fires
-        task_semantics_fires: false,
-    };
+    let input = NoToolCallInput::for_testing(
+        true,
+        false,
+        MAX_FINAL_GUARD_RETRIES, // guard budget exhausted
+        true,
+        PhaseAction::Continue,
+        true,
+        /*plan_gate_fires=*/ true, // plan gate fires
+        false,
+    );
     assert_eq!(
         decide_no_tool_call(input),
         NoToolCallDecision::PlanGateSuppression,


### PR DESCRIPTION
## Summary
- Extract termination decision logic into a new pure FSM module `src/app/termination_fsm.rs` (791 lines)
- Consolidate Done path, post-tool path, and Branch 5 into a single state machine with explicit transitions
- All `TerminationLoopState` fields now private, accessed via update methods

## Changes
- **New**: `src/app/termination_fsm.rs`
  - `TerminationLoopState` with 7 private fields and update methods
  - `decide_done_path()` / `decide_agentic_loop()` (pub(crate))
  - Done path ordering: plan gate → final guard → task semantics → FinalAnswer
  - 5 relocated unit tests + 9 new FSM tests
- `src/app/agentic.rs`: Remove legacy types, dispatch via FSM
- `tests/termination_semantics.rs`: Replace mirror definitions with imports

## Motivation
Before this refactor, the termination logic was scattered across `agentic.rs` in a large function with implicit state transitions. This FSM extraction:
- Makes termination transitions explicit and testable in isolation
- Prevents direct mutation of termination state (all updates go through methods)
- Reduces `agentic.rs` complexity significantly (529 lines removed from main file)

## Quality checks
- [x] `cargo build` — Pass
- [x] `cargo clippy --all-targets` — Pass (0 warnings)
- [x] `cargo test` — Pass (609 tests, 0 failures)
- [x] `cargo fmt --check` — Pass

Closes #381

🤖 Generated with [Claude Code](https://claude.com/claude-code)