### PR TITLE
feat: mode split - separate plan/act/repair for local-model stability

### DIFF
--- a/src/app/agentic.rs
+++ b/src/app/agentic.rs
@@ -34,6 +34,91 @@ use super::termination_fsm::{
 use super::write_repeat_tracker::WriteRepeatAction;
 use super::{App, AppError, CompactInfo, format_tool_counts};
 
+/// Explicit phase of the agentic loop within a single
+/// [`App::complete_structured_response`] call (Issue #380).
+///
+/// Orthogonal to [`crate::contracts::RuntimeState`] (App lifecycle) and
+/// [`crate::app::termination_fsm::TerminationLoopState`] (exit decision).
+/// Lives entirely within `complete_structured_response`: initialized to
+/// [`AgenticMode::Plan`] at the start of each user turn and discarded when the
+/// function returns.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AgenticMode {
+    /// Runtime is awaiting or parsing an `ANVIL_PLAN` block.
+    Plan,
+    /// Runtime is executing plan items via tool calls.
+    Act,
+    /// Runtime is attempting to recover from stagnation or failure.
+    Repair(RepairReason),
+}
+
+/// Reason for entering [`AgenticMode::Repair`] (Issue #380).
+///
+/// Determines which recovery semantics apply. Only
+/// [`RepairReason::PreExit`] activates the strict
+/// `apply_plan_update_pipeline` gate (unchecked-item rejection,
+/// Issue #327).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RepairReason {
+    /// Pre-exit repair heuristic fired (`should_allow_escape_hatch`).
+    /// Only this variant activates the strict `apply_plan_update_pipeline`
+    /// gate (unchecked-item rejection, Issue #327).
+    PreExit,
+    /// `edit_fail_tracker` consecutive-failure threshold exceeded
+    /// (FixSliceEscalation was emitted by [`determine_fallback_action`]).
+    EditFailRecovery,
+    /// Stagnation score OR read-heavy drift threshold exceeded.
+    StagnationRecovery,
+}
+
+impl RepairReason {
+    /// Determine whether a Repair→Act recovery signal has fired for this
+    /// reason (Issue #380).
+    ///
+    /// - [`RepairReason::PreExit`] recovers when `worker_observed` is true
+    ///   (fix_slice worker finished successfully OR a plan re-issue occurred).
+    /// - [`RepairReason::EditFailRecovery`] recovers when the edit fail
+    ///   tracker has fallen below the escalation threshold (caller passes
+    ///   `edit_fail_resolved`).
+    /// - [`RepairReason::StagnationRecovery`] recovers when the stagnation
+    ///   score drops (`stagnation_resolved`) or a worker mutation is
+    ///   observed.
+    pub fn is_recovery_signal(
+        &self,
+        worker_observed: bool,
+        edit_fail_resolved: bool,
+        stagnation_resolved: bool,
+    ) -> bool {
+        match self {
+            RepairReason::PreExit => worker_observed,
+            RepairReason::EditFailRecovery => edit_fail_resolved,
+            RepairReason::StagnationRecovery => stagnation_resolved || worker_observed,
+        }
+    }
+}
+
+/// Per-turn count of iterations spent in each [`AgenticMode`] (Issue #380).
+///
+/// Used to populate the `agentic_mode_turns_in_*` fields of
+/// [`crate::contracts::AgentTelemetry`] at the end of
+/// `complete_structured_response`.
+#[derive(Debug, Default)]
+struct ModeTurnCounts {
+    plan: u32,
+    act: u32,
+    repair: u32,
+}
+
+impl ModeTurnCounts {
+    fn increment(&mut self, mode: &AgenticMode) {
+        match mode {
+            AgenticMode::Plan => self.plan += 1,
+            AgenticMode::Act => self.act += 1,
+            AgenticMode::Repair(_) => self.repair += 1,
+        }
+    }
+}
+
 /// Turn summary information for structured logging (Issue #206).
 #[derive(Debug)]
 pub struct TurnSummary<'a> {
@@ -51,6 +136,8 @@ pub struct TurnSummary<'a> {
     pub mutations_this_turn: Option<u32>,
     /// Items advanced this turn.
     pub items_advanced_this_turn: Option<u32>,
+    /// Current agentic mode (Plan / Act / Repair) for this turn (Issue #380).
+    pub agentic_mode: Option<AgenticMode>,
 }
 
 /// Log a turn summary using structured tracing.
@@ -79,6 +166,11 @@ pub fn log_turn_summary(summary: &TurnSummary<'_>) {
         },
     };
     let tool_summary = summarize_tool_names(summary.tool_names);
+    let agentic_mode_str = summary
+        .agentic_mode
+        .as_ref()
+        .map(|m| format!("{:?}", m))
+        .unwrap_or_else(|| "none".to_string());
     tracing::info!(
         turn = summary.turn,
         max_turns = summary.max_turns,
@@ -90,6 +182,7 @@ pub fn log_turn_summary(summary: &TurnSummary<'_>) {
         files_modified = summary.files_modified,
         compact = %compact_str,
         phase = %summary.phase,
+        agentic_mode = %agentic_mode_str,
         "turn completed"
     );
 }
@@ -1179,7 +1272,11 @@ impl App {
         // Issue #249: Detect ANVIL_PLAN from initial response
         // Issue #287: re-initialize stagnation_state on plan registration
         // Issue #305: match on PlanRegistrationResult
-        match self.try_register_plan(&current.raw_content) {
+        // Issue #380: initial plan registration at turn start runs with the
+        // strict closure gate disabled (a new turn always begins in Plan /
+        // Act mode; the Repair(PreExit) variant is entered mid-turn by the
+        // pre-exit repair heuristic).
+        match self.try_register_plan(&current.raw_content, false) {
             crate::app::execution_plan::PlanRegistrationResult::Registered => {
                 let target_files: Vec<String> = self
                     .execution_plan
@@ -1231,10 +1328,26 @@ impl App {
         // gate in all subsequent iterations of the same turn.
         let mut turn_has_subagent = false;
 
+        // Issue #380: explicit agentic mode tracked across iterations.
+        // Start in Plan; transitions to Act when ANVIL_PLAN parses successfully.
+        let mut current_mode = AgenticMode::Plan;
+        let mut mode_turn_counts = ModeTurnCounts::default();
+
+        // Issue #380: if an initial ANVIL_PLAN block was already parsed above
+        // (try_register_plan → Registered / Replan), we are already in Act at
+        // the start of iteration 0.
+        if !self.execution_plan.is_empty() && matches!(current_mode, AgenticMode::Plan) {
+            current_mode = AgenticMode::Act;
+            self.agent_telemetry.agentic_mode_plan_to_act_count += 1;
+        }
+
         for iteration in 0..max_iterations {
             let iteration_started = std::time::Instant::now();
 
             // (prev_forced_mode_active is snapshotted from the previous iteration)
+
+            // Issue #380: count this iteration toward the current mode.
+            mode_turn_counts.increment(&current_mode);
 
             // Check shutdown flag before tool execution
             if self.is_shutdown_requested() {
@@ -1290,6 +1403,11 @@ impl App {
             // Skip intermediate Thinking frames — the user already sees
             // live streaming output on stderr (Issue #1).
 
+            // Issue #380: snapshot fixslice_escalation_count before tool
+            // execution so we can detect a FixSliceEscalation fired via
+            // `determine_fallback_action` inside `record_tool_result`.
+            let fixslice_escalation_before = self.agent_telemetry.fixslice_escalation_count;
+
             // Execute normal tool calls and record results WITH payload
             let (results, loop_action, recovery_read_count) = self.execute_structured_tool_calls(
                 &current_normal,
@@ -1297,6 +1415,16 @@ impl App {
                 &mut escalation_barrier,
             )?;
             total_tool_count += results.len();
+
+            // Issue #380: Act → Repair(EditFailRecovery) transition. If a
+            // FixSliceEscalation fired during this turn's tool execution, we
+            // are now in edit-fail recovery.
+            if self.agent_telemetry.fixslice_escalation_count > fixslice_escalation_before
+                && matches!(current_mode, AgenticMode::Act | AgenticMode::Plan)
+            {
+                current_mode = AgenticMode::Repair(RepairReason::EditFailRecovery);
+                self.agent_telemetry.agentic_mode_act_to_repair_count += 1;
+            }
 
             // Update plan item status from tool results; capture telemetry.
             let (mut turn_mutations, turn_items_advanced) = self.update_plan_from_results(&results);
@@ -1713,6 +1841,12 @@ impl App {
                 let msg = SessionMessage::new(MessageRole::Tool, "system", hint)
                     .with_id(self.next_message_id("tool"));
                 self.session.push_message(msg);
+
+                // Issue #380: Act → Repair(StagnationRecovery) transition.
+                if matches!(current_mode, AgenticMode::Act | AgenticMode::Plan) {
+                    current_mode = AgenticMode::Repair(RepairReason::StagnationRecovery);
+                    self.agent_telemetry.agentic_mode_act_to_repair_count += 1;
+                }
             }
 
             // Issue #334: read-heavy drift escalation.
@@ -1754,6 +1888,13 @@ impl App {
                 let msg = SessionMessage::new(MessageRole::Tool, "system", hint)
                     .with_id(self.next_message_id("tool"));
                 self.session.push_message(msg);
+
+                // Issue #380: Act → Repair(StagnationRecovery) transition
+                // (read-heavy drift).
+                if matches!(current_mode, AgenticMode::Act | AgenticMode::Plan) {
+                    current_mode = AgenticMode::Repair(RepairReason::StagnationRecovery);
+                    self.agent_telemetry.agentic_mode_act_to_repair_count += 1;
+                }
             }
 
             // Issue #285: staged stagnation recovery.
@@ -1775,7 +1916,10 @@ impl App {
             // Scan the raw token buffer since ANVIL_PLAN may be outside the ANVIL_FINAL block.
             // Issue #287: re-initialize stagnation_state on plan registration
             // Issue #305: match on PlanRegistrationResult for replan support
-            match self.try_register_plan(&next_token_buffer) {
+            // Issue #380: derive the strict closure gate from AgenticMode.
+            let strict_closure_gate =
+                matches!(current_mode, AgenticMode::Repair(RepairReason::PreExit));
+            match self.try_register_plan(&next_token_buffer, strict_closure_gate) {
                 crate::app::execution_plan::PlanRegistrationResult::Registered => {
                     // Issue #349: a newly registered plan is a fresh course
                     // of action — clear any accumulated closure-loop state.
@@ -1826,7 +1970,7 @@ impl App {
                     // ANVIL_PLAN なし → ANVIL_PLAN_UPDATE を通常処理
                     // DR2-005: Replan 時はスキップして二重処理を防ぐ
                     // Issue #287: merge new target_files into starved_target_files on plan update
-                    if self.try_update_plan(&next_token_buffer) {
+                    if self.try_update_plan(&next_token_buffer, strict_closure_gate) {
                         let existing = &self.stagnation_state.starved_target_files;
                         // CB-003: only include unfinished items to avoid re-adding completed files
                         let new_targets: Vec<String> = self
@@ -1846,6 +1990,15 @@ impl App {
                             .extend(new_targets);
                     }
                 }
+            }
+
+            // Issue #380: Plan→Act transition on successful plan registration /
+            // update. An execution plan now exists, so the agent has left the
+            // planning phase and is in the Act phase until escalation or
+            // completion.
+            if matches!(current_mode, AgenticMode::Plan) && !self.execution_plan.is_empty() {
+                current_mode = AgenticMode::Act;
+                self.agent_telemetry.agentic_mode_plan_to_act_count += 1;
             }
 
             // Issue #173: Update ANVIL_FINAL tracking from the new response
@@ -2039,7 +2192,21 @@ impl App {
                             .count() as u32;
                         self.agent_telemetry
                             .record_repair_turn_pending_before(pending_before);
-                        self.repair_closure_active = true;
+                        // Issue #380: Act/Plan → Repair(PreExit) transition.
+                        // This is the variant that activates the strict
+                        // `apply_plan_update_pipeline` closure gate — the
+                        // semantic replacement for the old
+                        // `repair_closure_active` boolean.
+                        if matches!(current_mode, AgenticMode::Act | AgenticMode::Plan) {
+                            current_mode = AgenticMode::Repair(RepairReason::PreExit);
+                            self.agent_telemetry.agentic_mode_act_to_repair_count += 1;
+                        } else {
+                            // Already in Repair (e.g. StagnationRecovery
+                            // escalated earlier this turn). Upgrade to
+                            // PreExit because the strict closure gate now
+                            // applies.
+                            current_mode = AgenticMode::Repair(RepairReason::PreExit);
+                        }
 
                         let repair_msg = self.build_pre_exit_repair_message();
                         let msg = SessionMessage::new(MessageRole::Tool, "system", repair_msg)
@@ -2065,6 +2232,28 @@ impl App {
             // Update prev_forced_mode_active at turn end.
             prev_forced_mode_active = self.forced_mode_active;
 
+            // Issue #380: evaluate Repair → Act recovery signals.
+            //
+            // - PreExit recovers once a worker mutation has been observed
+            //   (fix_slice success or plan re-issue).
+            // - EditFailRecovery recovers once the edit_fail_tracker has
+            //   drained back to zero outstanding consecutive failures.
+            // - StagnationRecovery recovers on stagnation score easing
+            //   (forced mode cleared) OR worker observation.
+            if let AgenticMode::Repair(ref reason) = current_mode {
+                let worker_observed = self.agent_telemetry.worker_observed;
+                let edit_fail_resolved = self.edit_fail_tracker.total_failures() == 0;
+                let stagnation_resolved = !self.forced_mode_active;
+                if reason.is_recovery_signal(
+                    worker_observed,
+                    edit_fail_resolved,
+                    stagnation_resolved,
+                ) {
+                    current_mode = AgenticMode::Act;
+                    self.agent_telemetry.agentic_mode_repair_to_act_count += 1;
+                }
+            }
+
             log_turn_summary(&TurnSummary {
                 turn: self.session_stats.total_turns,
                 max_turns: max_iterations as u32,
@@ -2078,6 +2267,7 @@ impl App {
                 phase: self.phase_estimator.current_phase(),
                 mutations_this_turn: Some(turn_mutations),
                 items_advanced_this_turn: Some(turn_items_advanced),
+                agentic_mode: Some(current_mode.clone()),
             });
             // Reset last_compact_info after it's been consumed by the turn summary
             self.last_compact_info = None;
@@ -2114,6 +2304,22 @@ impl App {
             }
             current = next_structured;
         }
+
+        // Issue #380: persist per-turn mode counts into telemetry. Each field
+        // aggregates across iterations of the single `complete_structured_response`
+        // call (session-scoped counters are incremented, never reset here).
+        self.agent_telemetry.agentic_mode_turns_in_plan = self
+            .agent_telemetry
+            .agentic_mode_turns_in_plan
+            .saturating_add(mode_turn_counts.plan);
+        self.agent_telemetry.agentic_mode_turns_in_act = self
+            .agent_telemetry
+            .agentic_mode_turns_in_act
+            .saturating_add(mode_turn_counts.act);
+        self.agent_telemetry.agentic_mode_turns_in_repair = self
+            .agent_telemetry
+            .agentic_mode_turns_in_repair
+            .saturating_add(mode_turn_counts.repair);
 
         // Issue #372: (B) final guard retry success — retries fired and files
         // were ultimately modified.
@@ -3616,6 +3822,7 @@ impl App {
                 phase: self.phase_estimator.current_phase(),
                 mutations_this_turn: None,
                 items_advanced_this_turn: None,
+                agentic_mode: None,
             });
             return Ok(None);
         }

--- a/src/app/execution_plan.rs
+++ b/src/app/execution_plan.rs
@@ -79,7 +79,14 @@ impl App {
     /// - `Registered`: a new plan was created (plan was empty).
     /// - `Replan`: follow-up `ANVIL_PLAN` on an active plan was treated as update (Issue #305).
     /// - `NoBlock`: no `ANVIL_PLAN` block found, or replan had no effect.
-    pub(crate) fn try_register_plan(&mut self, content: &str) -> PlanRegistrationResult {
+    ///
+    /// Issue #380: `strict_closure_gate` forwards the Issue #327 closure
+    /// semantics (reject unchecked expansion) through the replan path.
+    pub(crate) fn try_register_plan(
+        &mut self,
+        content: &str,
+        strict_closure_gate: bool,
+    ) -> PlanRegistrationResult {
         if let Some(block) = extract_plan_block(content) {
             let items = parse_plan_items(&block);
             if items.is_empty() {
@@ -108,7 +115,7 @@ impl App {
                 "follow-up ANVIL_PLAN on active plan; treating as replan (Issue #305)"
             );
             self.agent_telemetry.record_anvil_plan_visible();
-            let changed = self.apply_replan_items(&block, items);
+            let changed = self.apply_replan_items(&block, items, strict_closure_gate);
             if changed {
                 return PlanRegistrationResult::Replan;
             }
@@ -122,7 +129,17 @@ impl App {
     ///
     /// Executes: checked-first retire → supersede stale → dedup → append.
     /// Returns `true` if any meaningful change occurred (retire, supersede, or append).
-    fn apply_plan_update_pipeline(&mut self, block: &str, all_items: Vec<PlanItem>) -> bool {
+    ///
+    /// Issue #380: the strict closure gate (Issue #327 — reject unchecked
+    /// expansion, record repair-turn telemetry) is passed in explicitly.
+    /// Callers translate the current [`crate::app::AgenticMode`] into this
+    /// bool (the old `repair_closure_active` boolean field has been removed).
+    fn apply_plan_update_pipeline(
+        &mut self,
+        block: &str,
+        all_items: Vec<PlanItem>,
+        strict_closure_gate: bool,
+    ) -> bool {
         // --- checked-first retire (Issue #301 + Issue #315) ---
         let checked_indices = detect_checked_lines(block);
         let mut had_retire = false;
@@ -161,7 +178,7 @@ impl App {
             }
         }
         // Issue #327: record retired item count during repair closure mode.
-        if self.repair_closure_active && retire_count > 0 {
+        if strict_closure_gate && retire_count > 0 {
             self.agent_telemetry
                 .record_repair_turn_items_retired(retire_count);
         }
@@ -178,7 +195,7 @@ impl App {
         // Issue #327: During repair closure mode, reject unchecked items instead
         // of appending them. The repair turn is for closing remaining work, not
         // expanding it.
-        if self.repair_closure_active {
+        if strict_closure_gate {
             let rejected = new_items.len() as u32;
             self.agent_telemetry
                 .record_repair_turn_items_rejected(rejected);
@@ -288,8 +305,15 @@ impl App {
 
     /// Apply replan items from a follow-up ANVIL_PLAN on an active plan (Issue #305).
     /// Delegates to shared pipeline. Returns whether any meaningful change occurred.
-    fn apply_replan_items(&mut self, block: &str, all_items: Vec<PlanItem>) -> bool {
-        self.apply_plan_update_pipeline(block, all_items)
+    ///
+    /// Issue #380: forwards the strict closure gate to the pipeline.
+    fn apply_replan_items(
+        &mut self,
+        block: &str,
+        all_items: Vec<PlanItem>,
+        strict_closure_gate: bool,
+    ) -> bool {
+        self.apply_plan_update_pipeline(block, all_items, strict_closure_gate)
     }
 
     /// Internal helper: register a plan from pre-parsed items (Issue #303).
@@ -323,7 +347,10 @@ impl App {
     /// Issue #305: refactored to use `apply_plan_update_pipeline()` shared helper.
     ///
     /// Returns `true` if the plan was updated.
-    pub(crate) fn try_update_plan(&mut self, content: &str) -> bool {
+    ///
+    /// Issue #380: `strict_closure_gate` forwards the Issue #327 closure
+    /// semantics (reject unchecked expansion) through the plan-update pipeline.
+    pub(crate) fn try_update_plan(&mut self, content: &str, strict_closure_gate: bool) -> bool {
         if let Some(block) = extract_plan_update_block(content) {
             let all_items = parse_plan_items(&block);
             if all_items.is_empty() {
@@ -336,7 +363,7 @@ impl App {
                 return true;
             }
 
-            return self.apply_plan_update_pipeline(&block, all_items);
+            return self.apply_plan_update_pipeline(&block, all_items, strict_closure_gate);
         }
         false
     }
@@ -737,13 +764,13 @@ mod tests {
         // Initial registration
         let content1 =
             "```ANVIL_PLAN\n- [ ] src/a.rs: implement feature\n- [ ] src/b.rs: add tests\n```";
-        let result1 = app.try_register_plan(content1);
+        let result1 = app.try_register_plan(content1, false);
         assert_eq!(result1, PlanRegistrationResult::Registered);
         assert_eq!(app.execution_plan.items.len(), 2);
 
         // Follow-up ANVIL_PLAN on active plan → should be treated as replan
         let content2 = "```ANVIL_PLAN\n- [ ] src/c.rs: new task\n```";
-        let result2 = app.try_register_plan(content2);
+        let result2 = app.try_register_plan(content2, false);
         assert_eq!(result2, PlanRegistrationResult::Replan);
         // New item should be appended
         assert_eq!(app.execution_plan.items.len(), 3);
@@ -753,14 +780,14 @@ mod tests {
     fn replan_telemetry_update_count_increases() {
         let mut app = build_test_app();
         let content1 = "```ANVIL_PLAN\n- [ ] src/a.rs: task\n```";
-        app.try_register_plan(content1);
+        app.try_register_plan(content1, false);
         assert_eq!(app.agent_telemetry.plan_registration_count, 1);
         assert_eq!(app.agent_telemetry.plan_update_count, 0);
         assert_eq!(app.agent_telemetry.anvil_plan_visible_count, 1);
 
         // Replan
         let content2 = "```ANVIL_PLAN\n- [ ] src/b.rs: new task\n```";
-        app.try_register_plan(content2);
+        app.try_register_plan(content2, false);
         // registration_count should NOT increase
         assert_eq!(app.agent_telemetry.plan_registration_count, 1);
         // update_count SHOULD increase
@@ -773,11 +800,11 @@ mod tests {
     fn replan_supersede_stale_items() {
         let mut app = build_test_app();
         let content1 = "```ANVIL_PLAN\n- [ ] src/a.rs: old task\n```";
-        app.try_register_plan(content1);
+        app.try_register_plan(content1, false);
 
         // Replan with same file but different description → supersede
         let content2 = "```ANVIL_PLAN\n- [ ] src/a.rs: new approach\n```";
-        let result = app.try_register_plan(content2);
+        let result = app.try_register_plan(content2, false);
         assert_eq!(result, PlanRegistrationResult::Replan);
         // Old item should be superseded, new one appended
         assert!(
@@ -792,7 +819,7 @@ mod tests {
     fn replan_dedup_existing_items() {
         let mut app = build_test_app();
         let content1 = "```ANVIL_PLAN\n- [ ] src/a.rs: task\n```";
-        app.try_register_plan(content1);
+        app.try_register_plan(content1, false);
         // Simulate a mutation so the item won't be superseded
         app.execution_plan.items[0]
             .mutated_files
@@ -800,7 +827,7 @@ mod tests {
 
         // Replan with exact same item → should be deduped (target match)
         let content2 = "```ANVIL_PLAN\n- [ ] src/a.rs: task\n```";
-        let result = app.try_register_plan(content2);
+        let result = app.try_register_plan(content2, false);
         // All items deduped, no supersede → NoBlock
         assert_eq!(result, PlanRegistrationResult::NoBlock);
         // Item count unchanged
@@ -811,13 +838,13 @@ mod tests {
     fn replan_done_items_not_appended() {
         let mut app = build_test_app();
         let content1 = "```ANVIL_PLAN\n- [ ] src/a.rs: task\n- [ ] src/b.rs: task2\n```";
-        app.try_register_plan(content1);
+        app.try_register_plan(content1, false);
         // Mark first item as done
         app.execution_plan.mark_done(0);
 
         // Replan includes only a new item + the done item description
         let content2 = "```ANVIL_PLAN\n- [ ] src/a.rs: task\n- [ ] src/c.rs: new task\n```";
-        let result = app.try_register_plan(content2);
+        let result = app.try_register_plan(content2, false);
         assert_eq!(result, PlanRegistrationResult::Replan);
         // src/c.rs should be added, src/a.rs should be deduped (already done)
         let new_items: Vec<_> = app
@@ -833,11 +860,11 @@ mod tests {
     fn replan_checked_first_retire() {
         let mut app = build_test_app();
         let content1 = "```ANVIL_PLAN\n- [ ] src/a.rs: task\n- [ ] src/b.rs: task2\n```";
-        app.try_register_plan(content1);
+        app.try_register_plan(content1, false);
 
         // Replan with [x] checked items → should retire
         let content2 = "```ANVIL_PLAN\n- [x] src/a.rs: task\n- [ ] src/c.rs: new task\n```";
-        let result = app.try_register_plan(content2);
+        let result = app.try_register_plan(content2, false);
         assert_eq!(result, PlanRegistrationResult::Replan);
         // src/a.rs item should be AlreadySatisfied
         let a_item = app
@@ -856,12 +883,12 @@ mod tests {
     fn replan_subset_items() {
         let mut app = build_test_app();
         let content1 = "```ANVIL_PLAN\n- [ ] src/a.rs: task\n- [ ] src/b.rs: task2\n- [ ] src/c.rs: task3\n```";
-        app.try_register_plan(content1);
+        app.try_register_plan(content1, false);
         assert_eq!(app.execution_plan.items.len(), 3);
 
         // Replan with only a subset of new items
         let content2 = "```ANVIL_PLAN\n- [ ] src/d.rs: new task\n```";
-        let result = app.try_register_plan(content2);
+        let result = app.try_register_plan(content2, false);
         assert_eq!(result, PlanRegistrationResult::Replan);
         assert_eq!(app.execution_plan.items.len(), 4);
     }
@@ -870,7 +897,7 @@ mod tests {
     fn replan_no_effect_returns_noblock() {
         let mut app = build_test_app();
         let content1 = "```ANVIL_PLAN\n- [ ] src/a.rs: task\n```";
-        app.try_register_plan(content1);
+        app.try_register_plan(content1, false);
         // Simulate a mutation so the item won't be superseded by replan
         app.execution_plan.items[0]
             .mutated_files
@@ -878,7 +905,7 @@ mod tests {
 
         // Replan with same item (deduped, not superseded) → no effect
         let content2 = "```ANVIL_PLAN\n- [ ] src/a.rs: task\n```";
-        let result = app.try_register_plan(content2);
+        let result = app.try_register_plan(content2, false);
         assert_eq!(result, PlanRegistrationResult::NoBlock);
     }
 
@@ -886,7 +913,7 @@ mod tests {
     fn first_registration_unchanged() {
         let mut app = build_test_app();
         let content = "```ANVIL_PLAN\n- [ ] src/a.rs: implement feature\n```";
-        let result = app.try_register_plan(content);
+        let result = app.try_register_plan(content, false);
         assert_eq!(result, PlanRegistrationResult::Registered);
         assert_eq!(app.execution_plan.items.len(), 1);
         assert_eq!(app.agent_telemetry.plan_registration_count, 1);
@@ -898,11 +925,11 @@ mod tests {
         let mut app = build_test_app();
         // Register initial plan
         let content1 = "```ANVIL_PLAN\n- [ ] src/a.rs: task\n```";
-        app.try_register_plan(content1);
+        app.try_register_plan(content1, false);
 
         // Update via ANVIL_PLAN_UPDATE (not ANVIL_PLAN)
         let content2 = "```ANVIL_PLAN_UPDATE\n- [ ] src/b.rs: new task\n```";
-        let updated = app.try_update_plan(content2);
+        let updated = app.try_update_plan(content2, false);
         assert!(updated);
         assert_eq!(app.execution_plan.items.len(), 2);
         assert_eq!(app.agent_telemetry.plan_update_count, 1);
@@ -917,14 +944,14 @@ mod tests {
     fn late_stage_closure_rejects_same_target_replan() {
         let mut app = build_test_app();
         let content1 = "```ANVIL_PLAN\n- [ ] src/a.rs: item A\n- [ ] src/b.rs: item B\n```";
-        app.try_register_plan(content1);
+        app.try_register_plan(content1, false);
         // Simulate item A completed via mutation.
         app.execution_plan.mark_done(0);
         assert_eq!(app.execution_plan.finished_count(), 1);
 
         // Follow-up restating item B's file with a "refined" description.
         let update = "```ANVIL_PLAN_UPDATE\n- [ ] src/b.rs: refined item B\n```";
-        let updated = app.try_update_plan(update);
+        let updated = app.try_update_plan(update, false);
 
         // No new item appended, existing item B stays actionable.
         assert_eq!(
@@ -952,11 +979,11 @@ mod tests {
     fn late_stage_closure_allows_different_target_replan() {
         let mut app = build_test_app();
         let content1 = "```ANVIL_PLAN\n- [ ] src/a.rs: A\n- [ ] src/b.rs: B\n```";
-        app.try_register_plan(content1);
+        app.try_register_plan(content1, false);
         app.execution_plan.mark_done(0);
 
         let update = "```ANVIL_PLAN_UPDATE\n- [ ] src/c.rs: genuinely new task\n```";
-        let updated = app.try_update_plan(update);
+        let updated = app.try_update_plan(update, false);
 
         assert!(updated);
         assert_eq!(app.execution_plan.items.len(), 3);
@@ -970,12 +997,12 @@ mod tests {
         let mut app = build_test_app();
         let content1 =
             "```ANVIL_PLAN\n- [ ] src/a.rs: A\n- [ ] src/b.rs: B\n- [ ] src/c.rs: C\n```";
-        app.try_register_plan(content1);
+        app.try_register_plan(content1, false);
         app.execution_plan.mark_done(0);
         // remaining == 2 → closure guard inactive.
 
         let update = "```ANVIL_PLAN_UPDATE\n- [ ] src/b.rs: refined B\n```";
-        let updated = app.try_update_plan(update);
+        let updated = app.try_update_plan(update, false);
 
         assert!(updated);
         assert_eq!(app.agent_telemetry.late_stage_closure_items_rejected, 0);
@@ -988,7 +1015,7 @@ mod tests {
     fn late_stage_closure_reconciles_touched_files_first() {
         let mut app = build_test_app();
         let content1 = "```ANVIL_PLAN\n- [ ] src/a.rs: A\n- [ ] src/b.rs: B\n```";
-        app.try_register_plan(content1);
+        app.try_register_plan(content1, false);
         app.execution_plan.mark_done(0);
         // External evidence: src/b.rs was already touched.
         app.session
@@ -997,7 +1024,7 @@ mod tests {
             .push("src/b.rs".into());
 
         let update = "```ANVIL_PLAN_UPDATE\n- [ ] src/b.rs: refined B\n```";
-        let _ = app.try_update_plan(update);
+        let _ = app.try_update_plan(update, false);
 
         assert!(
             app.execution_plan.all_finished(),
@@ -1013,12 +1040,12 @@ mod tests {
     fn late_stage_closure_partial_overlap_rejects_only_overlapping() {
         let mut app = build_test_app();
         let content1 = "```ANVIL_PLAN\n- [ ] src/a.rs: A\n- [ ] src/b.rs: B\n```";
-        app.try_register_plan(content1);
+        app.try_register_plan(content1, false);
         app.execution_plan.mark_done(0);
 
         let update =
             "```ANVIL_PLAN_UPDATE\n- [ ] src/b.rs: refined B\n- [ ] src/d.rs: new work\n```";
-        let updated = app.try_update_plan(update);
+        let updated = app.try_update_plan(update, false);
 
         assert!(updated);
         // Original B stays, d.rs appended, refined B rejected.

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -66,6 +66,9 @@ use std::sync::{Arc, Mutex};
 // Re-export render helpers that form the public API.
 pub use render::{cli_prompt, render_help_frame, slash_commands};
 
+// Re-export AgenticMode / RepairReason for tests and external inspection (Issue #380).
+pub use agentic::{AgenticMode, RepairReason};
+
 /// Mutation tools tracked for telemetry purposes.
 /// Note: shell.exec is intentionally excluded — see Issue #273 for rationale
 /// (first_mutation_event_* fields are runtime_lower_bound, not strict post-hoc values).
@@ -314,9 +317,6 @@ pub struct App {
     proactive_delegation_pending: bool,
     /// Recovery read budget for file.edit failure recovery (Issue #299).
     tool_recovery_budget: tool_recovery_budget::ToolRecoveryBudget,
-    /// Whether the session is in pre-exit repair closure mode (Issue #327).
-    /// When active, ANVIL_PLAN_UPDATE unchecked items are rejected.
-    repair_closure_active: bool,
     /// Detects closure-mode natural-language reasoning loops that reoccur
     /// after a `fix_slice` worker failure with no tool-advancing output
     /// (Issue #349).
@@ -716,7 +716,6 @@ impl App {
             tool_recovery_budget: tool_recovery_budget::ToolRecoveryBudget::new(
                 edit_recovery_read_budget,
             ),
-            repair_closure_active: false,
             closure_loop_detector: closure_loop_detector::ClosureLoopDetector::with_threshold(
                 closure_jaccard_threshold,
             ),

--- a/src/app/termination_fsm.rs
+++ b/src/app/termination_fsm.rs
@@ -283,8 +283,9 @@ pub fn decide_no_tool_call(input: NoToolCallInput) -> NoToolCallDecision {
 /// and consumed only within that method (or within
 /// `handle_done_path_anvil_final_guard`, where a fresh instance is created
 /// each call).  App-level session state (`forced_mode_active`,
-/// `repair_closure_active`, `proactive_delegation_pending`) is intentionally
-/// excluded — see Issue #385 scope boundary.
+/// `proactive_delegation_pending`, plus the `AgenticMode` variable local to
+/// `complete_structured_response` that replaced `repair_closure_active` in
+/// Issue #380) is intentionally excluded — see Issue #385 scope boundary.
 #[derive(Debug)]
 pub(crate) struct TerminationLoopState {
     anvil_final_seen: bool,

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -664,6 +664,30 @@ pub struct AgentTelemetry {
     #[serde(default)]
     pub model_aware_delegation_produced_mutation: u32,
 
+    /// Count of Plan→Act transitions observed in this session (Issue #380).
+    #[serde(default)]
+    pub agentic_mode_plan_to_act_count: u32,
+
+    /// Count of Act→Repair transitions observed in this session (Issue #380).
+    #[serde(default)]
+    pub agentic_mode_act_to_repair_count: u32,
+
+    /// Count of Repair→Act transitions observed in this session (Issue #380).
+    #[serde(default)]
+    pub agentic_mode_repair_to_act_count: u32,
+
+    /// Total iterations spent in [`AgenticMode::Plan`] (Issue #380).
+    #[serde(default)]
+    pub agentic_mode_turns_in_plan: u32,
+
+    /// Total iterations spent in [`AgenticMode::Act`] (Issue #380).
+    #[serde(default)]
+    pub agentic_mode_turns_in_act: u32,
+
+    /// Total iterations spent in [`AgenticMode::Repair`] (Issue #380).
+    #[serde(default)]
+    pub agentic_mode_turns_in_repair: u32,
+
     /// Issue #372: retry path telemetry (flattened into artifact JSON).
     #[serde(flatten, default)]
     pub retry: RetryTelemetry,

--- a/tests/mode_split.rs
+++ b/tests/mode_split.rs
@@ -1,0 +1,263 @@
+//! Integration tests for Issue #380: mode split — separate plan / act / repair
+//! modes for local-model stability.
+//!
+//! These tests verify:
+//! - [`AgenticMode`] / [`RepairReason`] enum semantics
+//! - [`RepairReason::is_recovery_signal`] behavior (Repair→Act transitions)
+//! - Strict closure gate semantics (only [`RepairReason::PreExit`] activates
+//!   the Issue #327 unchecked-item rejection path)
+//! - [`AgentTelemetry`] counter fields used to observe mode churn
+//!
+//! Note: the transition logic itself is private to
+//! `complete_structured_response` (see `src/app/agentic.rs`); the external
+//! contract exposed to integration tests is the enum API and telemetry. These
+//! tests exercise the boundaries of that contract rather than mocking the
+//! agentic loop.
+
+use anvil::app::{AgenticMode, RepairReason};
+use anvil::contracts::AgentTelemetry;
+
+// ---------------------------------------------------------------------------
+// Test 1: Plan→Act — `ANVIL_PLAN` detection triggers the Act transition
+// ---------------------------------------------------------------------------
+
+/// When a non-empty `ExecutionPlan` becomes present, the turn-local mode
+/// transitions from `Plan` to `Act` and the telemetry counter is bumped.
+///
+/// This test verifies the semantic contract: starting the turn in `Plan`,
+/// flipping to `Act` is a distinguishable state change and the telemetry
+/// counter is zero by default.
+#[test]
+fn plan_to_act_on_anvil_plan() {
+    // Default: turn begins in Plan.
+    let initial = AgenticMode::Plan;
+    assert_eq!(initial, AgenticMode::Plan);
+
+    // Plan and Act are distinct.
+    assert_ne!(AgenticMode::Plan, AgenticMode::Act);
+
+    // Telemetry counter defaults to zero, and is used to record Plan→Act.
+    let telemetry = AgentTelemetry::default();
+    assert_eq!(telemetry.agentic_mode_plan_to_act_count, 0);
+
+    // Simulate one Plan→Act transition at the boundary of the agentic loop.
+    let mut telemetry = telemetry;
+    let mode = AgenticMode::Act;
+    telemetry.agentic_mode_plan_to_act_count += 1;
+    assert_eq!(mode, AgenticMode::Act);
+    assert_eq!(telemetry.agentic_mode_plan_to_act_count, 1);
+}
+
+// ---------------------------------------------------------------------------
+// Test 2: Act→Repair on FixSliceEscalation → EditFailRecovery
+// ---------------------------------------------------------------------------
+
+/// When the edit-fail tracker escalates, the Act→Repair transition uses
+/// [`RepairReason::EditFailRecovery`]. This test verifies:
+/// - the Repair variant wraps the expected reason
+/// - `is_recovery_signal` only returns true when the edit_fail tracker
+///   has recovered
+#[test]
+fn act_to_repair_on_edit_fail_escalation() {
+    let repair_mode = AgenticMode::Repair(RepairReason::EditFailRecovery);
+
+    // Repair variants are distinct from Act and Plan.
+    assert_ne!(repair_mode, AgenticMode::Act);
+    assert_ne!(repair_mode, AgenticMode::Plan);
+
+    // Recovery semantics: EditFailRecovery recovers only when
+    // `edit_fail_resolved` is true. Other signals do NOT clear it.
+    let reason = RepairReason::EditFailRecovery;
+    assert!(
+        !reason.is_recovery_signal(
+            /*worker_observed=*/ true, /*edit_fail_resolved=*/ false,
+            /*stagnation_resolved=*/ true,
+        ),
+        "EditFailRecovery must not recover on worker_observed alone"
+    );
+    assert!(
+        reason.is_recovery_signal(
+            /*worker_observed=*/ false, /*edit_fail_resolved=*/ true,
+            /*stagnation_resolved=*/ false,
+        ),
+        "EditFailRecovery must recover when edit_fail_resolved=true"
+    );
+
+    // Telemetry: Act→Repair increments the counter.
+    let mut telemetry = AgentTelemetry::default();
+    telemetry.agentic_mode_act_to_repair_count += 1;
+    assert_eq!(telemetry.agentic_mode_act_to_repair_count, 1);
+}
+
+// ---------------------------------------------------------------------------
+// Test 3: Act→Repair on stagnation → StagnationRecovery
+// ---------------------------------------------------------------------------
+
+/// When stagnation or read-heavy drift fires, the Act→Repair transition uses
+/// [`RepairReason::StagnationRecovery`]. Recovery clears either via a
+/// stagnation drop OR a worker-observed mutation.
+#[test]
+fn act_to_repair_on_stagnation() {
+    let repair_mode = AgenticMode::Repair(RepairReason::StagnationRecovery);
+    assert_ne!(repair_mode, AgenticMode::Repair(RepairReason::PreExit));
+    assert_ne!(
+        repair_mode,
+        AgenticMode::Repair(RepairReason::EditFailRecovery)
+    );
+
+    let reason = RepairReason::StagnationRecovery;
+
+    // Stagnation recovers on stagnation_resolved.
+    assert!(
+        reason.is_recovery_signal(
+            /*worker_observed=*/ false, /*edit_fail_resolved=*/ false,
+            /*stagnation_resolved=*/ true,
+        ),
+        "StagnationRecovery must recover when stagnation_resolved=true"
+    );
+
+    // Stagnation also recovers on worker_observed (worker progress clears
+    // the stagnation heuristic).
+    assert!(
+        reason.is_recovery_signal(
+            /*worker_observed=*/ true, /*edit_fail_resolved=*/ false,
+            /*stagnation_resolved=*/ false,
+        ),
+        "StagnationRecovery must recover when worker_observed=true"
+    );
+
+    // Neither signal → no recovery.
+    assert!(
+        !reason.is_recovery_signal(
+            /*worker_observed=*/ false, /*edit_fail_resolved=*/ true,
+            /*stagnation_resolved=*/ false,
+        ),
+        "StagnationRecovery must not recover on edit_fail_resolved alone"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 4: Repair→Act on worker_observed=true
+// ---------------------------------------------------------------------------
+
+/// When a worker mutation is observed while in `Repair(PreExit)`, the mode
+/// transitions back to `Act`. This is the happy-path recovery for the
+/// pre-exit repair heuristic (fix_slice worker produced a mutation OR a
+/// plan re-issue occurred).
+#[test]
+fn repair_to_act_on_worker_observed() {
+    let reason = RepairReason::PreExit;
+
+    // worker_observed is the sole recovery signal for PreExit.
+    assert!(
+        reason.is_recovery_signal(
+            /*worker_observed=*/ true, /*edit_fail_resolved=*/ false,
+            /*stagnation_resolved=*/ false,
+        ),
+        "PreExit must recover when worker_observed=true"
+    );
+
+    // edit_fail_resolved / stagnation_resolved alone are NOT sufficient
+    // for PreExit.
+    assert!(
+        !reason.is_recovery_signal(
+            /*worker_observed=*/ false, /*edit_fail_resolved=*/ true,
+            /*stagnation_resolved=*/ true,
+        ),
+        "PreExit must not recover without worker_observed"
+    );
+
+    // Telemetry: Repair→Act increments the counter.
+    let mut telemetry = AgentTelemetry::default();
+    telemetry.agentic_mode_repair_to_act_count += 1;
+    assert_eq!(telemetry.agentic_mode_repair_to_act_count, 1);
+}
+
+// ---------------------------------------------------------------------------
+// Test 5: PreExit activates the strict closure gate
+// ---------------------------------------------------------------------------
+
+/// The strict closure gate (Issue #327: reject unchecked plan expansion during
+/// repair closure mode) is activated only when the turn-local mode is
+/// `Repair(PreExit)`. This test verifies the translation rule the agentic
+/// loop uses before forwarding the bool to `apply_plan_update_pipeline`.
+#[test]
+fn pre_exit_repair_activates_strict_gate() {
+    // The translation rule used in src/app/agentic.rs:
+    //   let strict_closure_gate =
+    //       matches!(current_mode, AgenticMode::Repair(RepairReason::PreExit));
+    let mode_preexit = AgenticMode::Repair(RepairReason::PreExit);
+    let strict_closure_gate = matches!(mode_preexit, AgenticMode::Repair(RepairReason::PreExit));
+    assert!(
+        strict_closure_gate,
+        "Repair(PreExit) must activate the strict closure gate"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 6: StagnationRecovery / EditFailRecovery / Act / Plan do NOT activate
+// the strict closure gate
+// ---------------------------------------------------------------------------
+
+/// Repair variants other than `PreExit`, and both `Plan` and `Act`, must NOT
+/// activate the strict closure gate. Only `PreExit` carries the Issue #327
+/// repair-closure semantics; other recovery reasons are intended to allow
+/// normal plan updates (e.g., follow-up `ANVIL_PLAN` blocks during stagnation
+/// recovery must still be able to append items).
+#[test]
+fn stagnation_recovery_no_strict_gate() {
+    // StagnationRecovery must NOT activate the gate.
+    let mode_stagnation = AgenticMode::Repair(RepairReason::StagnationRecovery);
+    let strict_closure_gate = matches!(mode_stagnation, AgenticMode::Repair(RepairReason::PreExit));
+    assert!(
+        !strict_closure_gate,
+        "Repair(StagnationRecovery) must not activate the strict closure gate"
+    );
+
+    // EditFailRecovery must NOT activate the gate.
+    let mode_edit_fail = AgenticMode::Repair(RepairReason::EditFailRecovery);
+    let strict_closure_gate = matches!(mode_edit_fail, AgenticMode::Repair(RepairReason::PreExit));
+    assert!(
+        !strict_closure_gate,
+        "Repair(EditFailRecovery) must not activate the strict closure gate"
+    );
+
+    // Plan must NOT activate the gate.
+    let mode_plan = AgenticMode::Plan;
+    let strict_closure_gate = matches!(mode_plan, AgenticMode::Repair(RepairReason::PreExit));
+    assert!(
+        !strict_closure_gate,
+        "Plan must not activate the strict closure gate"
+    );
+
+    // Act must NOT activate the gate.
+    let mode_act = AgenticMode::Act;
+    let strict_closure_gate = matches!(mode_act, AgenticMode::Repair(RepairReason::PreExit));
+    assert!(
+        !strict_closure_gate,
+        "Act must not activate the strict closure gate"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Additional coverage: telemetry turn-count fields default to zero and are
+// independent (serde-backward-compatible via #[serde(default)]).
+// ---------------------------------------------------------------------------
+
+/// All six Issue #380 telemetry fields default to zero and exist as
+/// independent u32 counters in [`AgentTelemetry`]. This guards the
+/// telemetry contract that downstream reporters rely on.
+#[test]
+fn agent_telemetry_issue_380_fields_default_to_zero() {
+    let telemetry = AgentTelemetry::default();
+
+    // Transition counts.
+    assert_eq!(telemetry.agentic_mode_plan_to_act_count, 0);
+    assert_eq!(telemetry.agentic_mode_act_to_repair_count, 0);
+    assert_eq!(telemetry.agentic_mode_repair_to_act_count, 0);
+
+    // Per-mode turn counts.
+    assert_eq!(telemetry.agentic_mode_turns_in_plan, 0);
+    assert_eq!(telemetry.agentic_mode_turns_in_act, 0);
+    assert_eq!(telemetry.agentic_mode_turns_in_repair, 0);
+}

--- a/tests/phase_estimation.rs
+++ b/tests/phase_estimation.rs
@@ -147,6 +147,7 @@ fn turn_summary_includes_phase_field() {
         phase: Phase::Exploring,
         mutations_this_turn: None,
         items_advanced_this_turn: None,
+        agentic_mode: None,
     };
     // Verify phase field exists and log_turn_summary is callable
     assert_eq!(format!("{}", summary.phase), "exploring");


### PR DESCRIPTION
## Summary
- Introduce explicit `AgenticMode` enum (Plan/Act/Repair) with `RepairReason` sub-classification
- Replace implicit mode switching via scattered flags with explicit transitions
- Improves local-model stability by making mode transitions observable and reportable

## Changes
- **New types in `src/app/agentic.rs`**:
  - `AgenticMode::Plan | Act | Repair(RepairReason)`
  - `RepairReason::PreExit | EditFailRecovery | StagnationRecovery`
- **Removed field**: `repair_closure_active` (Phase 3 complete)
- **New field**: `strict_closure_gate: bool` for gate control
- **AgentTelemetry**: 6 new mode-tracking fields
- **TurnSummary**: `agentic_mode` field for per-turn mode reporting
- **New test file**: `tests/mode_split.rs` with 7 test cases

## Motivation
Before this change, Anvil mixed planning, implementation, and repair inside one loop, with mode switching driven by implicit flags like `repair_closure_active`. For local models, this implicit mode switching was brittle and contributed to premature termination or drift.

This refactor makes mode transitions explicit:
- Each turn has a clear `AgenticMode`
- Repair mode has sub-reason classification
- Telemetry tracks mode transitions and per-mode turn counts
- Per-turn mode is included in summary output

## Quality checks
- [x] `cargo build` — Pass
- [x] `cargo clippy --all-targets` — Pass (0 warnings)
- [x] `cargo test` — Pass (2356 tests, 0 failures)
- [x] `cargo fmt --check` — Pass

Closes #380

🤖 Generated with [Claude Code](https://claude.com/claude-code)