### PR TITLE
feat(issue-408): suppress DEBUG noise by default, add --verbose/--trace log levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,9 @@ anvil [OPTIONS]
       --ollama-host <URL>            Ollama base URL (localhost only)
       --context-budget <TOKENS>      message budget for compaction
       --max-iterations <N>           max agent loop iterations
-      --debug                        verbose logging
+      --verbose                      anvil-side DEBUG logs (reqwest/hyper は warn に抑制)
+      --trace                        全クレート TRACE ログ（reqwest/hyper 含む）
+      --debug                        deprecated alias for --trace
       --stream                       stream assistant text in interactive turns
       --tui                          run the lightweight terminal UI
       --watch                        enable file watcher on startup
@@ -121,6 +123,7 @@ tui=false
 watch=false
 auto_test_command=
 yes_mode=false
+log_level=info            # info | verbose | trace
 ```
 
 環境変数も使える。
@@ -137,6 +140,7 @@ export ANVIL_WATCH=1
 export ANVIL_AUTO_TEST="cargo test --lib"
 export ANVIL_YES=1
 export ANVIL_STATE_DIR=/custom/path/to/anvil-state
+export ANVIL_LOG_LEVEL=info     # info | verbose | trace
 ```
 
 優先順位は `CLI > 環境変数 > .anvil/config > デフォルト値`。
@@ -151,7 +155,7 @@ $XDG_STATE_HOME/anvil/           (未設定時: ~/.local/state/anvil)
     {session_id}/
       session.json               ← 会話履歴・モード状態
       logs/
-        llm-io.jsonl             ← LLM I/O ログ（--debug 時）
+        llm-io.jsonl             ← LLM I/O ログ（log level によらず常時保存）
       plans/
         plan.md                  ← Plan mode のプランファイル
 ```

--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -7,12 +7,13 @@
 #   --models <list>   カンマ区切りで複数モデル（matrix 実行、逐次）
 #   --runs <n>        実行回数（デフォルト: 5）
 #   --dry-run         anvil 呼び出しを echo で代替
-#   --bench-no-debug  anvil に --debug を付けない（BENCH_DEBUG=0 と同義）
+#   --bench-no-debug  anvil に --trace を付けない（BENCH_DEBUG=0 と同義）
 #   --help            この用例を表示して終了
 #
 # Environment:
-#   BENCH_DEBUG=1 (default) anvil を --debug 付きで起動し、llm-io.jsonl を収集する
-#   BENCH_DEBUG=0           --debug を付けない。--bench-no-debug と等価。
+#   BENCH_DEBUG=1 (default) anvil を --trace 付きで起動し、詳細ログを stderr に流す
+#                           （llm-io.jsonl は log level によらず常時保存される）
+#   BENCH_DEBUG=0           --trace を付けない。--bench-no-debug と等価。
 #
 # Examples:
 #   scripts/bench.sh heavy --model qwen3.5:122b --runs 5
@@ -31,7 +32,7 @@ Usage: scripts/bench.sh <benchmark-name> [options]
   --models <list>   カンマ区切りで複数モデル（matrix 実行、逐次）
   --runs <n>        実行回数（デフォルト: 5）
   --dry-run         anvil 呼び出しを echo で代替
-  --bench-no-debug  anvil に --debug を付けない（BENCH_DEBUG=0 と同義）
+  --bench-no-debug  anvil に --trace を付けない（BENCH_DEBUG=0 と同義）
   --help            この用例を表示して終了
 
 Examples:
@@ -46,7 +47,7 @@ model_arg=""
 models_arg=""
 runs=5
 DRY_RUN=0
-# BENCH_DEBUG toggles `--debug` on the anvil invocation. Allowed values: "0" or "1".
+# BENCH_DEBUG toggles `--trace` on the anvil invocation. Allowed values: "0" or "1".
 BENCH_DEBUG="${BENCH_DEBUG:-1}"
 case "$BENCH_DEBUG" in
   0|1) ;;
@@ -475,7 +476,7 @@ for model in "${cleaned_models[@]}"; do
         anvil_args+=(--sidecar-model "$sidecar_model")
       fi
       if [[ "$BENCH_DEBUG" -eq 1 ]]; then
-        anvil_args+=(--debug)
+        anvil_args+=(--trace)
       fi
       # set -e is not enabled; capture rc directly
       "$ANVIL_BIN" "${anvil_args[@]}" > ../stdout.log 2>&1

--- a/src/agent/loop_run/commands.rs
+++ b/src/agent/loop_run/commands.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::config::LogLevel;
 
 impl Agent {
     pub fn initial_prompt_from_cli_or_stdin(&self) -> Result<Option<String>, String> {
@@ -27,10 +28,10 @@ impl Agent {
             self.session.mode_state.mode,
             self.work_root.display()
         );
-        if self.config.debug
+        if self.config.log_level >= LogLevel::Verbose
             && let Some(path) = crate::logging::llm_io_log_path()
         {
-            println!("debug llm log={}", path.display());
+            println!("llm log={}", path.display());
         }
 
         let mut line = String::new();
@@ -93,7 +94,7 @@ impl Agent {
                 "/help /status /model /plan /approve /compact /logs /yes /no /exit".to_string(),
             ))),
             "/status" => Ok(AgentEvent::Continue(Some(format!(
-                "mode={:?} auto_approve={} native_tools={} cwd={} session={} plan={} approx_tokens={} core_only=true",
+                "mode={:?} auto_approve={} native_tools={} cwd={} session={} plan={} approx_tokens={} log_level={} core_only=true",
                 self.session.mode_state.mode,
                 self.config.yes_mode,
                 self.native_tools_enabled,
@@ -106,6 +107,7 @@ impl Agent {
                     .map(|path| path.display().to_string())
                     .unwrap_or_else(|| "-".to_string()),
                 approximate_token_count(&self.session.messages),
+                self.config.log_level,
             )))),
             "/model" => Ok(AgentEvent::Continue(Some(format_model_banner(
                 &self.models,

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -1,5 +1,22 @@
 use super::*;
 
+/// Maximum number of characters of tool-call arguments retained in trace logs.
+const LOG_ARGS_MAX_CHARS: usize = 200;
+
+/// UTF-8-safe truncation: keeps at most `max` characters and appends `...`
+/// when the input was longer. Never splits a multi-byte code point.
+fn truncate(s: &str, max: usize) -> String {
+    match s.char_indices().nth(max) {
+        Some((byte_idx, _)) => {
+            let mut out = String::with_capacity(byte_idx + 3);
+            out.push_str(&s[..byte_idx]);
+            out.push_str("...");
+            out
+        }
+        None => s.to_string(),
+    }
+}
+
 impl Agent {
     pub(super) fn handle_user_message(
         &mut self,
@@ -31,7 +48,9 @@ impl Agent {
         let mut recent_bash_commands = Vec::<String>::new();
         let mut install_commands_seen = 0usize;
 
-        for _ in 0..self.config.max_iterations {
+        for iter_count in 0..self.config.max_iterations {
+            let approx_tokens = approximate_token_count(&self.session.messages);
+            tracing::debug!(iter = iter_count, tokens = approx_tokens, "iter");
             let reply = self.request_assistant_reply_with_retry(stream_output)?;
             let prepared_tool_calls = reply
                 .tool_calls
@@ -58,6 +77,12 @@ impl Agent {
                 let mut emitted_bash_loop_note = false;
                 for tool_call in prepared_tool_calls {
                     let tool_name = tool_call.name.clone();
+                    let args_str = tool_call.arguments.to_string();
+                    tracing::debug!(
+                        tool = %tool_name,
+                        args = %truncate(&args_str, LOG_ARGS_MAX_CHARS),
+                        "tool call"
+                    );
                     let raw_result = if recovery::should_block_restart_discovery(
                         &tool_name,
                         restart_convergence_mode && repo_edit_calls_made_this_turn == 0,
@@ -318,5 +343,27 @@ impl Agent {
         self.session
             .messages
             .push(ConversationMessage::user(content));
+    }
+}
+
+#[cfg(test)]
+mod truncate_tests {
+    use super::truncate;
+
+    #[test]
+    fn preserves_short_strings_verbatim() {
+        assert_eq!(truncate("hello", 10), "hello");
+        assert_eq!(truncate("exact", 5), "exact");
+    }
+
+    #[test]
+    fn truncates_long_strings_with_ellipsis() {
+        assert_eq!(truncate("abcdefgh", 3), "abc...");
+    }
+
+    #[test]
+    fn never_splits_multibyte_code_points() {
+        // Each Japanese char is 3 bytes in UTF-8; taking 2 must not slice mid-char.
+        assert_eq!(truncate("あいうえお", 2), "あい...");
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -22,7 +22,12 @@ pub struct CliArgs {
     pub chat_timeout_secs: Option<u64>,
     #[arg(long = "chat-retries")]
     pub chat_retries: Option<usize>,
-    #[arg(long = "debug")]
+    #[arg(long = "verbose")]
+    pub verbose: bool,
+    #[arg(long = "trace")]
+    pub trace: bool,
+    /// deprecated alias for `--trace` (hidden)
+    #[arg(long = "debug", hide = true)]
     pub debug: bool,
     #[arg(long = "stream")]
     pub stream: bool,

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,12 +1,134 @@
 use std::collections::BTreeMap;
 use std::env;
+use std::fmt;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::str::FromStr;
 
 use crate::cli::CliArgs;
 use crate::safety::host_validation::validate_localhost_url;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+/// `EnvFilter` directive that silences DEBUG/TRACE noise from hyper/reqwest/rustls.
+pub const NOISY_CRATES_FILTER: &str = "hyper_util=warn,reqwest=warn,hyper=warn,rustls=warn";
+
+/// 3-level log verbosity. The `Info < Verbose < Trace` ordering is part of the
+/// public contract (callers use comparisons like `log_level >= Verbose`) and
+/// must not be reordered.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, PartialOrd, Ord)]
+pub enum LogLevel {
+    #[default]
+    Info,
+    Verbose,
+    Trace,
+}
+
+impl LogLevel {
+    /// Build the `tracing_subscriber::EnvFilter` directive for this level.
+    pub fn env_filter(self) -> String {
+        match self {
+            LogLevel::Info => format!("info,{NOISY_CRATES_FILTER}"),
+            LogLevel::Verbose => format!("debug,{NOISY_CRATES_FILTER}"),
+            // Trace intentionally leaves noisy crates uncapped.
+            LogLevel::Trace => "trace".to_string(),
+        }
+    }
+
+    /// Map the legacy `debug=true/false` flag onto a `LogLevel`.
+    pub fn from_legacy_debug(debug: bool) -> Self {
+        if debug { Self::Trace } else { Self::Info }
+    }
+}
+
+impl fmt::Display for LogLevel {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            LogLevel::Info => "info",
+            LogLevel::Verbose => "verbose",
+            LogLevel::Trace => "trace",
+        };
+        write!(f, "{s}")
+    }
+}
+
+impl FromStr for LogLevel {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "info" => Ok(LogLevel::Info),
+            "verbose" => Ok(LogLevel::Verbose),
+            "trace" => Ok(LogLevel::Trace),
+            other => Err(format!("unknown log level: {other}")),
+        }
+    }
+}
+
+/// Identifies where a `log_level` / legacy `debug` setting was read from, so
+/// `resolve_log_level` can emit source-appropriate warning messages.
+#[derive(Debug, Clone, Copy)]
+enum LogLevelSource {
+    ConfigFile,
+    Env,
+}
+
+/// Resolve a log level from an optional primary value (`log_level=` /
+/// `ANVIL_LOG_LEVEL`) plus an optional legacy debug value (`debug=` /
+/// `ANVIL_DEBUG`). The primary value wins; invalid primaries fall back to
+/// `Info` with a warning, and consulting the legacy key emits a deprecation
+/// warning.
+fn resolve_log_level(
+    primary: Option<&str>,
+    legacy_debug: Option<&str>,
+    source: LogLevelSource,
+    warnings: &mut Vec<String>,
+) -> Option<LogLevel> {
+    if let Some(raw) = primary {
+        return Some(match raw.parse::<LogLevel>() {
+            Ok(level) => level,
+            Err(err) => {
+                warnings.push(match source {
+                    LogLevelSource::ConfigFile => {
+                        format!("invalid log_level={raw} in config file, using info: {err}")
+                    }
+                    LogLevelSource::Env => {
+                        format!("invalid ANVIL_LOG_LEVEL={raw}, using info: {err}")
+                    }
+                });
+                LogLevel::Info
+            }
+        });
+    }
+
+    let debug = legacy_debug.and_then(parse_bool)?;
+    warnings.push(
+        match source {
+            LogLevelSource::ConfigFile => {
+                "config file key 'debug' is deprecated, use 'log_level=info|verbose|trace'"
+            }
+            LogLevelSource::Env => {
+                "ANVIL_DEBUG is deprecated, use ANVIL_LOG_LEVEL=info|verbose|trace"
+            }
+        }
+        .to_string(),
+    );
+    Some(LogLevel::from_legacy_debug(debug))
+}
+
+/// Translate CLI log-level flags into an optional `LogLevel`.
+/// `--trace` and the deprecated `--debug` alias win over `--verbose`; when
+/// none are present the caller defers to env/config/defaults.
+fn cli_log_level_from_flags(trace: bool, debug: bool, verbose: bool) -> Option<LogLevel> {
+    if trace || debug {
+        Some(LogLevel::Trace)
+    } else if verbose {
+        Some(LogLevel::Verbose)
+    } else {
+        None
+    }
+}
+
+#[non_exhaustive]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct Config {
     pub cwd: PathBuf,
     pub requested_model: Option<String>,
@@ -16,7 +138,7 @@ pub struct Config {
     pub max_iterations: usize,
     pub chat_timeout_secs: u64,
     pub chat_retries: usize,
-    pub debug: bool,
+    pub log_level: LogLevel,
     pub stream: bool,
     pub yes_mode: bool,
     pub fresh_session: bool,
@@ -34,7 +156,7 @@ pub struct PartialConfig {
     pub max_iterations: Option<usize>,
     pub chat_timeout_secs: Option<u64>,
     pub chat_retries: Option<usize>,
-    pub debug: Option<bool>,
+    pub log_level: Option<LogLevel>,
     pub stream: Option<bool>,
     pub yes_mode: Option<bool>,
     pub fresh_session: Option<bool>,
@@ -42,14 +164,19 @@ pub struct PartialConfig {
 }
 
 impl Config {
-    pub fn load(args: CliArgs) -> Result<Self, String> {
-        let cwd = match args.cwd {
+    pub fn load(args: CliArgs) -> Result<(Self, Vec<String>), String> {
+        let cwd = match args.cwd.clone() {
             Some(path) => path,
             None => env::current_dir().map_err(|err| format!("failed to resolve cwd: {err}"))?,
         };
 
-        let file_config = load_config_file(&cwd.join(".anvil").join("config"))?;
-        let env_config = load_env_config();
+        let mut warnings: Vec<String> = Vec::new();
+
+        let file_config = load_config_file(&cwd.join(".anvil").join("config"), &mut warnings)?;
+        let env_config = load_env_config(&mut warnings);
+
+        let cli_log_level = cli_log_level_from_flags(args.trace, args.debug, args.verbose);
+
         let cli_config = PartialConfig {
             model: args.model.clone(),
             sidecar_model: args.sidecar_model.clone(),
@@ -58,7 +185,7 @@ impl Config {
             max_iterations: args.max_iterations,
             chat_timeout_secs: args.chat_timeout_secs,
             chat_retries: args.chat_retries,
-            debug: args.debug.then_some(true),
+            log_level: cli_log_level,
             stream: args.stream.then_some(true),
             yes_mode: args.yes.then_some(true),
             fresh_session: args.fresh_session.then_some(true),
@@ -71,7 +198,7 @@ impl Config {
                 .unwrap_or_else(|| "http://127.0.0.1:11434".to_string()),
         )?;
 
-        Ok(Self {
+        let config = Self {
             cwd,
             requested_model: merged.model,
             requested_sidecar_model: merged.sidecar_model,
@@ -80,14 +207,15 @@ impl Config {
             max_iterations: merged.max_iterations.unwrap_or(12),
             chat_timeout_secs: merged.chat_timeout_secs.unwrap_or(300),
             chat_retries: merged.chat_retries.unwrap_or(2),
-            debug: merged.debug.unwrap_or(false),
+            log_level: merged.log_level.unwrap_or_default(),
             stream: merged.stream.unwrap_or(false),
             yes_mode: merged.yes_mode.unwrap_or(false),
             fresh_session: merged.fresh_session.unwrap_or(false),
             oneshot: args.oneshot || args.prompt.is_some(),
             prompt: args.prompt,
             state_dir_override: merged.state_dir_override,
-        })
+        };
+        Ok((config, warnings))
     }
 }
 
@@ -115,8 +243,8 @@ pub fn merge_partial_configs(configs: &[PartialConfig]) -> PartialConfig {
         if config.chat_retries.is_some() {
             merged.chat_retries = config.chat_retries;
         }
-        if config.debug.is_some() {
-            merged.debug = config.debug;
+        if config.log_level.is_some() {
+            merged.log_level = config.log_level;
         }
         if config.stream.is_some() {
             merged.stream = config.stream;
@@ -134,7 +262,7 @@ pub fn merge_partial_configs(configs: &[PartialConfig]) -> PartialConfig {
     merged
 }
 
-pub fn load_config_file(path: &Path) -> Result<PartialConfig, String> {
+pub fn load_config_file(path: &Path, warnings: &mut Vec<String>) -> Result<PartialConfig, String> {
     if !path.exists() {
         return Ok(PartialConfig::default());
     }
@@ -142,6 +270,13 @@ pub fn load_config_file(path: &Path) -> Result<PartialConfig, String> {
     let contents = fs::read_to_string(path)
         .map_err(|err| format!("failed to read {}: {err}", path.display()))?;
     let map = parse_key_value_config(&contents);
+
+    let log_level = resolve_log_level(
+        map.get("log_level").map(String::as_str),
+        map.get("debug").map(String::as_str),
+        LogLevelSource::ConfigFile,
+        warnings,
+    );
 
     Ok(PartialConfig {
         model: map.get("model").cloned(),
@@ -160,7 +295,7 @@ pub fn load_config_file(path: &Path) -> Result<PartialConfig, String> {
             .get("chat_timeout_secs")
             .and_then(|value| value.parse().ok()),
         chat_retries: map.get("chat_retries").and_then(|value| value.parse().ok()),
-        debug: map.get("debug").and_then(|value| parse_bool(value)),
+        log_level,
         stream: map.get("stream").and_then(|value| parse_bool(value)),
         yes_mode: map.get("yes_mode").and_then(|value| parse_bool(value)),
         fresh_session: map.get("fresh_session").and_then(|value| parse_bool(value)),
@@ -168,7 +303,16 @@ pub fn load_config_file(path: &Path) -> Result<PartialConfig, String> {
     })
 }
 
-pub fn load_env_config() -> PartialConfig {
+pub fn load_env_config(warnings: &mut Vec<String>) -> PartialConfig {
+    let anvil_log_level = env::var("ANVIL_LOG_LEVEL").ok();
+    let anvil_debug = env::var("ANVIL_DEBUG").ok();
+    let log_level = resolve_log_level(
+        anvil_log_level.as_deref(),
+        anvil_debug.as_deref(),
+        LogLevelSource::Env,
+        warnings,
+    );
+
     PartialConfig {
         model: env::var("ANVIL_MODEL").ok(),
         sidecar_model: env::var("ANVIL_SIDECAR_MODEL").ok(),
@@ -187,9 +331,7 @@ pub fn load_env_config() -> PartialConfig {
         chat_retries: env::var("ANVIL_CHAT_RETRIES")
             .ok()
             .and_then(|value| value.parse().ok()),
-        debug: env::var("ANVIL_DEBUG")
-            .ok()
-            .and_then(|value| parse_bool(&value)),
+        log_level,
         stream: env::var("ANVIL_STREAM")
             .ok()
             .and_then(|value| parse_bool(&value)),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,18 @@ use ollama::client::OllamaClient;
 use session::store::SessionStore;
 
 pub fn run_cli(args: CliArgs) -> Result<(), String> {
-    let config = Config::load(args)?;
+    // --debug deprecation is emitted here because the flag only exists on the
+    // CLI; env/config deprecations are collected inside `Config::load`.
+    if args.debug {
+        eprintln!(
+            "warning: --debug is deprecated, use --trace (or --verbose for medium verbosity)"
+        );
+    }
+
+    let (config, warnings) = Config::load(args)?;
+    for warning in &warnings {
+        eprintln!("warning: {warning}");
+    }
 
     let state_root = resolve_state_root(&config)?;
     let workspace_key = compute_workspace_key(&config.cwd);
@@ -34,7 +45,7 @@ pub fn run_cli(args: CliArgs) -> Result<(), String> {
         .join(&session_id)
         .join("logs")
         .join("llm-io.jsonl");
-    logging::init_logging(config.debug, &log_path)?;
+    logging::init_logging(config.log_level, &log_path)?;
 
     let _ = symlink_anvil_dirs(&config.cwd, &state_root, &session_id);
 

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -7,15 +7,17 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use serde_json::{Value, json};
 use tracing_subscriber::EnvFilter;
 
+use crate::config::LogLevel;
+
 static LLM_IO_LOGGER: OnceLock<Mutex<File>> = OnceLock::new();
 static LLM_IO_LOG_PATH: OnceLock<PathBuf> = OnceLock::new();
 
-pub fn init_logging(debug: bool, log_path: &Path) -> Result<(), String> {
-    let filter = if debug {
-        EnvFilter::new("debug")
-    } else {
+pub fn init_logging(log_level: LogLevel, log_path: &Path) -> Result<(), String> {
+    let directive = log_level.env_filter();
+    let filter = EnvFilter::try_new(&directive).unwrap_or_else(|err| {
+        eprintln!("warning: invalid env filter '{directive}', falling back to info: {err}");
         EnvFilter::new("info")
-    };
+    });
 
     tracing_subscriber::fmt()
         .with_env_filter(filter)
@@ -24,21 +26,24 @@ pub fn init_logging(debug: bool, log_path: &Path) -> Result<(), String> {
         .try_init()
         .map_err(|err| format!("failed to initialize logging: {err}"))?;
 
-    if debug {
-        let file = OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(log_path)
-            .map_err(|err| format!("failed to open LLM I/O log {}: {err}", log_path.display()))?;
-
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            let _ = std::fs::set_permissions(log_path, std::fs::Permissions::from_mode(0o600));
+    // llm-io.jsonl is always opened regardless of log_level; a failure to open
+    // warns but does not abort the process.
+    match OpenOptions::new().create(true).append(true).open(log_path) {
+        Ok(file) => {
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                let _ = std::fs::set_permissions(log_path, std::fs::Permissions::from_mode(0o600));
+            }
+            let _ = LLM_IO_LOG_PATH.set(log_path.to_path_buf());
+            let _ = LLM_IO_LOGGER.set(Mutex::new(file));
         }
-
-        let _ = LLM_IO_LOG_PATH.set(log_path.to_path_buf());
-        let _ = LLM_IO_LOGGER.set(Mutex::new(file));
+        Err(err) => {
+            eprintln!(
+                "warning: failed to open LLM I/O log {}: {err}",
+                log_path.display()
+            );
+        }
     }
 
     Ok(())

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -1,6 +1,9 @@
 use std::path::PathBuf;
 
-use anvil::config::{PartialConfig, merge_partial_configs, parse_key_value_config};
+use anvil::config::{
+    LogLevel, PartialConfig, load_config_file, load_env_config, merge_partial_configs,
+    parse_key_value_config,
+};
 
 #[test]
 fn parses_key_value_config() {
@@ -67,4 +70,204 @@ fn merge_state_dir_override_falls_back_to_env_when_cli_missing() {
     let cli_config = PartialConfig::default();
     let merged = merge_partial_configs(&[env_config, cli_config]);
     assert_eq!(merged.state_dir_override, Some(PathBuf::from("/env/anvil")));
+}
+
+// --- LogLevel tests ---
+
+#[test]
+fn log_level_display_is_lowercase() {
+    assert_eq!(LogLevel::Info.to_string(), "info");
+    assert_eq!(LogLevel::Verbose.to_string(), "verbose");
+    assert_eq!(LogLevel::Trace.to_string(), "trace");
+}
+
+#[test]
+fn log_level_default_is_info() {
+    assert_eq!(LogLevel::default(), LogLevel::Info);
+}
+
+#[test]
+fn log_level_ordering_info_lt_verbose_lt_trace() {
+    assert!(LogLevel::Info < LogLevel::Verbose);
+    assert!(LogLevel::Verbose < LogLevel::Trace);
+}
+
+#[test]
+fn log_level_from_legacy_debug_true_is_trace() {
+    assert_eq!(LogLevel::from_legacy_debug(true), LogLevel::Trace);
+    assert_eq!(LogLevel::from_legacy_debug(false), LogLevel::Info);
+}
+
+#[test]
+fn log_level_from_str_case_insensitive() {
+    assert_eq!("INFO".parse::<LogLevel>().unwrap(), LogLevel::Info);
+    assert_eq!("Verbose".parse::<LogLevel>().unwrap(), LogLevel::Verbose);
+    assert_eq!("TRACE".parse::<LogLevel>().unwrap(), LogLevel::Trace);
+}
+
+#[test]
+fn log_level_from_str_rejects_unknown() {
+    assert!("quiet".parse::<LogLevel>().is_err());
+    assert!("".parse::<LogLevel>().is_err());
+}
+
+// --- env_config / config_file tests ---
+//
+// env var tests share process state, so we serialize via mutex.
+
+use std::sync::Mutex;
+static ENV_GUARD: Mutex<()> = Mutex::new(());
+
+fn with_env<F: FnOnce()>(vars: &[(&str, Option<&str>)], f: F) {
+    let _g = ENV_GUARD.lock().unwrap();
+    // snapshot
+    let prev: Vec<(String, Option<String>)> = vars
+        .iter()
+        .map(|(k, _)| ((*k).to_string(), std::env::var(*k).ok()))
+        .collect();
+    // apply
+    for (k, v) in vars {
+        match v {
+            Some(val) => unsafe { std::env::set_var(k, val) },
+            None => unsafe { std::env::remove_var(k) },
+        }
+    }
+    f();
+    // restore
+    for (k, v) in &prev {
+        match v {
+            Some(val) => unsafe { std::env::set_var(k, val) },
+            None => unsafe { std::env::remove_var(k) },
+        }
+    }
+}
+
+#[test]
+fn env_config_anvil_log_level_verbose_only() {
+    with_env(
+        &[("ANVIL_LOG_LEVEL", Some("verbose")), ("ANVIL_DEBUG", None)],
+        || {
+            let mut warnings: Vec<String> = Vec::new();
+            let cfg = load_env_config(&mut warnings);
+            assert_eq!(cfg.log_level, Some(LogLevel::Verbose));
+            assert!(warnings.is_empty(), "no warnings expected: {warnings:?}");
+        },
+    );
+}
+
+#[test]
+fn env_config_anvil_debug_true_only_maps_to_trace_with_warning() {
+    with_env(
+        &[("ANVIL_LOG_LEVEL", None), ("ANVIL_DEBUG", Some("true"))],
+        || {
+            let mut warnings: Vec<String> = Vec::new();
+            let cfg = load_env_config(&mut warnings);
+            assert_eq!(cfg.log_level, Some(LogLevel::Trace));
+            assert!(
+                warnings.iter().any(|w| w.contains("ANVIL_DEBUG")),
+                "expected deprecation warning for ANVIL_DEBUG: {warnings:?}"
+            );
+        },
+    );
+}
+
+#[test]
+fn env_config_anvil_log_level_beats_anvil_debug() {
+    with_env(
+        &[
+            ("ANVIL_LOG_LEVEL", Some("info")),
+            ("ANVIL_DEBUG", Some("true")),
+        ],
+        || {
+            let mut warnings: Vec<String> = Vec::new();
+            let cfg = load_env_config(&mut warnings);
+            // ANVIL_LOG_LEVEL wins → Info, no deprecation warning for ANVIL_DEBUG (not consulted)
+            assert_eq!(cfg.log_level, Some(LogLevel::Info));
+            assert!(
+                !warnings.iter().any(|w| w.contains("ANVIL_DEBUG")),
+                "unexpected ANVIL_DEBUG warning when ANVIL_LOG_LEVEL is set: {warnings:?}"
+            );
+        },
+    );
+}
+
+#[test]
+fn env_config_anvil_log_level_uppercase_trace() {
+    with_env(
+        &[("ANVIL_LOG_LEVEL", Some("TRACE")), ("ANVIL_DEBUG", None)],
+        || {
+            let mut warnings: Vec<String> = Vec::new();
+            let cfg = load_env_config(&mut warnings);
+            assert_eq!(cfg.log_level, Some(LogLevel::Trace));
+        },
+    );
+}
+
+#[test]
+fn env_config_invalid_log_level_warns_and_falls_back_to_info() {
+    with_env(
+        &[("ANVIL_LOG_LEVEL", Some("quiet")), ("ANVIL_DEBUG", None)],
+        || {
+            let mut warnings: Vec<String> = Vec::new();
+            let cfg = load_env_config(&mut warnings);
+            assert_eq!(cfg.log_level, Some(LogLevel::Info));
+            assert!(
+                warnings.iter().any(|w| w.contains("ANVIL_LOG_LEVEL")),
+                "expected warning for invalid ANVIL_LOG_LEVEL: {warnings:?}"
+            );
+        },
+    );
+}
+
+#[test]
+fn config_file_log_level_beats_legacy_debug() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().join("config");
+    std::fs::write(&path, "log_level=trace\ndebug=false\n").unwrap();
+    let mut warnings: Vec<String> = Vec::new();
+    let cfg = load_config_file(&path, &mut warnings).unwrap();
+    assert_eq!(cfg.log_level, Some(LogLevel::Trace));
+}
+
+#[test]
+fn config_file_invalid_log_level_warns_and_falls_back_to_info() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().join("config");
+    std::fs::write(&path, "log_level=quiet\n").unwrap();
+    let mut warnings: Vec<String> = Vec::new();
+    let cfg = load_config_file(&path, &mut warnings).unwrap();
+    assert_eq!(cfg.log_level, Some(LogLevel::Info));
+    assert!(
+        warnings.iter().any(|w| w.contains("log_level")),
+        "expected warning for invalid log_level: {warnings:?}"
+    );
+}
+
+#[test]
+fn config_file_legacy_debug_true_maps_to_trace_with_warning() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().join("config");
+    std::fs::write(&path, "debug=true\n").unwrap();
+    let mut warnings: Vec<String> = Vec::new();
+    let cfg = load_config_file(&path, &mut warnings).unwrap();
+    assert_eq!(cfg.log_level, Some(LogLevel::Trace));
+    assert!(
+        warnings.iter().any(|w| w.contains("debug")),
+        "expected deprecation warning for legacy debug key: {warnings:?}"
+    );
+}
+
+#[test]
+fn merge_log_level_prefers_later_source() {
+    let merged = merge_partial_configs(&[
+        PartialConfig {
+            log_level: Some(LogLevel::Verbose),
+            ..PartialConfig::default()
+        },
+        PartialConfig {
+            log_level: Some(LogLevel::Trace),
+            ..PartialConfig::default()
+        },
+    ]);
+    assert_eq!(merged.log_level, Some(LogLevel::Trace));
 }

--- a/tests/e2e_local_llm.rs
+++ b/tests/e2e_local_llm.rs
@@ -4,7 +4,7 @@ use std::process::Command;
 
 use anvil::agent::Agent;
 use anvil::agent::orchestration::{capture_repo_snapshot, verify_repo_progress};
-use anvil::config::Config;
+use anvil::config::{Config, LogLevel};
 use anvil::model_registry::RuntimeModels;
 use anvil::ollama::client::OllamaClient;
 use anvil::session::store::SessionStore;
@@ -138,7 +138,7 @@ fn live_ollama_reaches_first_write_on_scaffolded_nextjs() {
 
     let cwd = temp.path().join("app");
     let before = capture_repo_snapshot(&cwd);
-    let mut agent = new_agent_with_debug(&cwd, &host, &model, client, 10, true);
+    let mut agent = new_agent_with_log_level(&cwd, &host, &model, client, 10, LogLevel::Trace);
     let prompt = "Use the available tools to inspect the current app and make one concrete implementation code change. Stop after the first successful file change.";
     let _ = agent.run_oneshot(prompt);
 
@@ -168,38 +168,34 @@ fn new_agent(
     client: OllamaClient,
     max_iterations: usize,
 ) -> Agent {
-    new_agent_with_debug(cwd, host, model, client, max_iterations, false)
+    new_agent_with_log_level(cwd, host, model, client, max_iterations, LogLevel::Info)
 }
 
-fn new_agent_with_debug(
+fn new_agent_with_log_level(
     cwd: &Path,
     host: &str,
     model: &str,
     client: OllamaClient,
     max_iterations: usize,
-    debug: bool,
+    log_level: LogLevel,
 ) -> Agent {
     let state_root = cwd.join(".anvil-state");
     let workspace_key = compute_workspace_key(cwd);
     let session_id = resolve_session_id(&state_root, &workspace_key, true);
     ensure_state_dirs(&state_root, &session_id).unwrap();
-    let config = Config {
-        cwd: cwd.to_path_buf(),
-        requested_model: Some(model.to_string()),
-        requested_sidecar_model: None,
-        ollama_host: host.to_string(),
-        context_budget: 24_000,
-        max_iterations,
-        chat_timeout_secs: 300,
-        chat_retries: 1,
-        debug,
-        stream: false,
-        yes_mode: true,
-        fresh_session: true,
-        oneshot: true,
-        prompt: None,
-        state_dir_override: Some(state_root.clone()),
-    };
+    let mut config = Config::default();
+    config.cwd = cwd.to_path_buf();
+    config.requested_model = Some(model.to_string());
+    config.ollama_host = host.to_string();
+    config.context_budget = 24_000;
+    config.max_iterations = max_iterations;
+    config.chat_timeout_secs = 300;
+    config.chat_retries = 1;
+    config.log_level = log_level;
+    config.yes_mode = true;
+    config.fresh_session = true;
+    config.oneshot = true;
+    config.state_dir_override = Some(state_root.clone());
 
     Agent::new(
         config,


### PR DESCRIPTION
## 概要

default実行時に `DEBUG pooling idle connection` ノイズを抑制し、ログレベル体系を整備します。

## 変更内容

- `LogLevel` enum（Info/Verbose/Trace）を `Config` に追加
- `--verbose` / `--trace` CLI フラグ追加。`--debug` は hidden deprecated alias（起動時 warning）
- default: hyper/reqwest クレートを `warn` フィルタリングしてノイズ除去
- `llm-io.jsonl` はログレベル非依存で常時書き込み（open 失敗は non-fatal）
- tool dispatch・iter 境界に `tracing::debug!` 計装追加
- `/status` に現在の log_level 表示
- `scripts/bench.sh`: `--debug` → `--trace` 切り替え
- `ANVIL_LOG_LEVEL` 環境変数・`.anvil/config` の `log_level` キー対応
- config 優先順位: CLI > 環境変数 > config ファイル > デフォルト
- `README.md` 更新（新 log level 体系）

## テスト

- [x] `cargo test --all` パス（65テスト）
- [x] `cargo clippy --all-targets -- -D warnings` 警告ゼロ
- [x] `cargo fmt --all -- --check` パス
- [x] `bash tests/scripts/test_bench_smoke.sh` パス
- [x] 全15 Acceptance条件 PASS

## 関連Issue

Closes #408