### PR TITLE
feat(issue-407): final run summary line (changed files / time / iter count)

### DIFF
--- a/src/agent/loop_run.rs
+++ b/src/agent/loop_run.rs
@@ -22,6 +22,7 @@ use crate::tools::registry::{ToolContext, ToolRegistry};
 
 mod commands;
 mod lifecycle;
+mod summary;
 mod turn;
 
 const DEFAULT_KEEP_TAIL: usize = 24;

--- a/src/agent/loop_run/commands.rs
+++ b/src/agent/loop_run/commands.rs
@@ -1,3 +1,4 @@
+use super::summary::{ExitReason, format_run_summary};
 use super::*;
 use crate::config::LogLevel;
 
@@ -65,14 +66,21 @@ impl Agent {
             self.handle_command(input)
         } else {
             match self.handle_user_message(input, stream_output) {
-                Ok(reply) => {
-                    if stream_output {
-                        Ok(AgentEvent::Continue(None))
-                    } else {
-                        Ok(AgentEvent::Continue(Some(reply)))
+                Ok((prose, stats)) => {
+                    if !stream_output {
+                        println!("{prose}");
                     }
+                    let summary = format_run_summary(ExitReason::Done, &stats);
+                    println!();
+                    println!("{summary}");
+                    Ok(AgentEvent::Continue(None))
                 }
-                Err(err) => Err(err),
+                Err((reason, error_text, stats)) => {
+                    let summary = format_run_summary(reason, &stats);
+                    println!();
+                    println!("{summary}");
+                    Err(error_text)
+                }
             }
         };
 

--- a/src/agent/loop_run/summary.rs
+++ b/src/agent/loop_run/summary.rs
@@ -1,0 +1,190 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ExitReason {
+    Done,
+    MaxIterations,
+    EmptyResponses,
+    NoToolCalls,
+    MissingRepoEdits,
+    TransportError,
+}
+
+impl ExitReason {
+    pub(super) fn is_success(self) -> bool {
+        matches!(self, ExitReason::Done)
+    }
+
+    pub(super) fn label(self) -> &'static str {
+        match self {
+            ExitReason::Done => "done",
+            ExitReason::MaxIterations => "max_iterations",
+            ExitReason::EmptyResponses => "empty_responses",
+            ExitReason::NoToolCalls => "no_tool_calls",
+            ExitReason::MissingRepoEdits => "missing_repo_edits",
+            ExitReason::TransportError => "transport_error",
+        }
+    }
+
+    pub(super) fn default_error_text(self) -> &'static str {
+        match self {
+            ExitReason::Done => "",
+            ExitReason::MaxIterations => "assistant did not finish within max iterations",
+            ExitReason::EmptyResponses => "assistant returned empty responses repeatedly",
+            ExitReason::NoToolCalls => {
+                "assistant kept describing actions without using tools to perform them"
+            }
+            ExitReason::MissingRepoEdits => {
+                "assistant kept stopping before making the requested repository edits"
+            }
+            ExitReason::TransportError => "transport error: request failed after retries",
+        }
+    }
+}
+
+pub(super) struct LoopStats {
+    pub iter_used: usize,
+    pub iter_max: usize,
+    pub duration_secs: u64,
+    pub changed_files: Vec<String>,
+    pub total_changed: usize,
+}
+
+/// Ok((prose, stats)) on success; Err((reason, error_text, stats)) on failure.
+/// Stats are included in both arms so the caller can always emit a summary line.
+pub(super) type LoopResult = Result<(String, LoopStats), (ExitReason, String, LoopStats)>;
+
+fn sanitize_filename(name: &str) -> String {
+    const MAX_LEN: usize = 120;
+    let sanitized: String = name
+        .chars()
+        .map(|c| if c.is_control() { '?' } else { c })
+        .collect();
+    if sanitized.chars().count() > MAX_LEN {
+        let truncated: String = sanitized.chars().take(MAX_LEN).collect();
+        format!("{truncated}...")
+    } else {
+        sanitized
+    }
+}
+
+pub(super) fn format_run_summary(reason: ExitReason, stats: &LoopStats) -> String {
+    let mark = if reason.is_success() { "✔" } else { "✘" };
+    let label = reason.label();
+    let iter = format!("iter {}/{}", stats.iter_used, stats.iter_max);
+    let duration = format!("duration {}s", stats.duration_secs);
+
+    let total = stats.total_changed;
+    let file_part = if total == 0 {
+        "edited 0 files".to_string()
+    } else {
+        let shown: Vec<String> = stats
+            .changed_files
+            .iter()
+            .take(3)
+            .map(|f| sanitize_filename(f))
+            .collect();
+        let names = shown.join(", ");
+        if total > shown.len() {
+            let extra = total - shown.len();
+            format!("edited {total} files ({names}, +{extra} more)")
+        } else {
+            format!("edited {total} files ({names})")
+        }
+    };
+
+    format!("{mark} {label}  {iter}  {duration}  {file_part}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn stats(
+        iter_used: usize,
+        iter_max: usize,
+        duration_secs: u64,
+        files: Vec<&str>,
+        total_changed: usize,
+    ) -> LoopStats {
+        LoopStats {
+            iter_used,
+            iter_max,
+            duration_secs,
+            changed_files: files.into_iter().map(str::to_string).collect(),
+            total_changed,
+        }
+    }
+
+    #[test]
+    fn done_shows_checkmark_and_fields() {
+        let s = stats(
+            18,
+            40,
+            324,
+            vec!["page.tsx", "lib/game.ts", "lib/entities.ts"],
+            3,
+        );
+        let out = format_run_summary(ExitReason::Done, &s);
+        assert!(out.starts_with("✔ done"), "got: {out}");
+        assert!(out.contains("iter 18/40"), "got: {out}");
+        assert!(out.contains("duration 324s"), "got: {out}");
+        assert!(out.contains("edited 3 files"), "got: {out}");
+    }
+
+    #[test]
+    fn max_iterations_shows_cross() {
+        let s = stats(40, 40, 680, vec!["lib/game.ts", "tests/game.test.ts"], 2);
+        let out = format_run_summary(ExitReason::MaxIterations, &s);
+        assert!(out.starts_with("✘ max_iterations"), "got: {out}");
+        assert!(out.contains("iter 40/40"), "got: {out}");
+    }
+
+    #[test]
+    fn zero_files_shows_no_parentheses() {
+        let s = stats(5, 40, 10, vec![], 0);
+        let out = format_run_summary(ExitReason::Done, &s);
+        assert!(out.contains("edited 0 files"), "got: {out}");
+        assert!(!out.contains('('), "got: {out}");
+    }
+
+    #[test]
+    fn more_than_three_files_shows_plus_extra() {
+        // changed_files has 3 entries but total_changed is 5
+        let s = stats(10, 40, 50, vec!["a.rs", "b.rs", "c.rs"], 5);
+        let out = format_run_summary(ExitReason::Done, &s);
+        assert!(out.contains("+2 more"), "got: {out}");
+        assert!(out.contains("edited 5 files"), "got: {out}");
+    }
+
+    #[test]
+    fn control_chars_in_filename_are_sanitized() {
+        let s = stats(1, 10, 5, vec!["bad\nfile.rs", "ok.rs"], 2);
+        let out = format_run_summary(ExitReason::Done, &s);
+        assert!(!out.contains('\n'), "got: {out}");
+        assert!(out.contains('?'), "got: {out}");
+    }
+
+    #[test]
+    fn all_exit_reason_labels_are_distinct() {
+        let reasons = [
+            ExitReason::Done,
+            ExitReason::MaxIterations,
+            ExitReason::EmptyResponses,
+            ExitReason::NoToolCalls,
+            ExitReason::MissingRepoEdits,
+            ExitReason::TransportError,
+        ];
+        let labels: Vec<_> = reasons.iter().map(|r| r.label()).collect();
+        let unique: std::collections::HashSet<_> = labels.iter().collect();
+        assert_eq!(labels.len(), unique.len());
+    }
+
+    #[test]
+    fn success_only_for_done() {
+        assert!(ExitReason::Done.is_success());
+        assert!(!ExitReason::MaxIterations.is_success());
+        assert!(!ExitReason::EmptyResponses.is_success());
+        assert!(!ExitReason::NoToolCalls.is_success());
+        assert!(!ExitReason::MissingRepoEdits.is_success());
+        assert!(!ExitReason::TransportError.is_success());
+    }
+}

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -1,4 +1,8 @@
+use super::summary::{ExitReason, LoopResult, LoopStats};
 use super::*;
+use crate::agent::orchestration::{RepoVerification, capture_repo_snapshot, verify_repo_progress};
+use std::collections::HashSet;
+use std::time::Instant;
 
 /// Maximum number of characters of tool-call arguments retained in trace logs.
 const LOG_ARGS_MAX_CHARS: usize = 200;
@@ -17,12 +21,45 @@ fn truncate(s: &str, max: usize) -> String {
     }
 }
 
+fn build_stats(
+    accumulated: Vec<RepoVerification>,
+    final_verif: RepoVerification,
+    iter_used: usize,
+    iter_max: usize,
+    duration_secs: u64,
+) -> LoopStats {
+    let mut all_changed: HashSet<String> = HashSet::new();
+    let mut impl_changed = 0usize;
+    let mut test_changed = 0usize;
+    let mut setup_changed = 0usize;
+    let mut deleted_changed = 0usize;
+
+    for verif in accumulated.iter().chain(std::iter::once(&final_verif)) {
+        for f in &verif.changed_files {
+            all_changed.insert(f.clone());
+        }
+        impl_changed += verif.implementation_files_changed;
+        test_changed += verif.test_files_changed;
+        setup_changed += verif.setup_files_changed;
+        deleted_changed += verif.deleted_files_changed;
+    }
+
+    let total_changed = impl_changed + test_changed + setup_changed + deleted_changed;
+    let mut changed_files: Vec<String> = all_changed.into_iter().collect();
+    changed_files.sort();
+    changed_files.truncate(16);
+
+    LoopStats {
+        iter_used,
+        iter_max,
+        duration_secs,
+        changed_files,
+        total_changed,
+    }
+}
+
 impl Agent {
-    pub(super) fn handle_user_message(
-        &mut self,
-        input: &str,
-        stream_output: bool,
-    ) -> Result<String, String> {
+    pub(super) fn handle_user_message(&mut self, input: &str, stream_output: bool) -> LoopResult {
         self.push_user_message(input.to_string());
         self.maybe_compact_session(DEFAULT_KEEP_TAIL);
 
@@ -39,8 +76,13 @@ impl Agent {
         requires_action: bool,
         stream_output: bool,
         restart_convergence_mode: bool,
-    ) -> Result<String, String> {
+    ) -> LoopResult {
         let use_color = io::stdout().is_terminal() && !no_color_requested();
+        let start = Instant::now();
+        let mut before_snapshot = capture_repo_snapshot(&self.work_root);
+        let mut accumulated: Vec<RepoVerification> = Vec::new();
+        let mut last_known_root = self.work_root.clone();
+
         let mut tool_calls_made_this_turn = 0usize;
         let mut repo_edit_calls_made_this_turn = 0usize;
         let mut empty_retries = 0usize;
@@ -49,10 +91,25 @@ impl Agent {
         let mut recent_bash_commands = Vec::<String>::new();
         let mut install_commands_seen = 0usize;
 
-        for iter_count in 0..self.config.max_iterations {
+        let mut exit_reason = ExitReason::MaxIterations;
+        let mut error_text = String::new();
+        let mut last_iter = 0usize;
+        let mut final_prose = String::new();
+
+        'outer: for iter_count in 0..self.config.max_iterations {
+            last_iter = iter_count + 1;
             let approx_tokens = approximate_token_count(&self.session.messages);
             tracing::debug!(iter = iter_count, tokens = approx_tokens, "iter");
-            let reply = self.request_assistant_reply_with_retry(stream_output)?;
+
+            let reply = match self.request_assistant_reply_with_retry(stream_output) {
+                Ok(r) => r,
+                Err(err) => {
+                    exit_reason = ExitReason::TransportError;
+                    error_text = err;
+                    break 'outer;
+                }
+            };
+
             let prepared_tool_calls = reply
                 .tool_calls
                 .into_iter()
@@ -124,6 +181,15 @@ impl Agent {
                     } else {
                         self.execute_tool_call(&tool_name, &tool_call.arguments)
                     };
+
+                    // detect work_root change after each tool execution
+                    if self.work_root != last_known_root {
+                        let verif = verify_repo_progress(&before_snapshot, &last_known_root);
+                        accumulated.push(verif);
+                        before_snapshot = capture_repo_snapshot(&self.work_root);
+                        last_known_root = self.work_root.clone();
+                    }
+
                     let compact_result = prompting::compact_tool_result(&tool_name, raw_result);
                     self.session
                         .messages
@@ -147,16 +213,17 @@ impl Agent {
                 if action_expectation == recovery::ActionExpectation::RepoChange {
                     repo_change_retries += 1;
                     if repo_change_retries >= 3 {
-                        return Err(
-                            "assistant kept stopping before making the requested repository edits"
-                                .to_string(),
-                        );
+                        exit_reason = ExitReason::MissingRepoEdits;
+                        error_text = exit_reason.default_error_text().to_string();
+                        break 'outer;
                     }
                     self.push_system_note(recovery::repo_change_recovery_note(repo_change_retries));
                 } else {
                     empty_retries += 1;
                     if empty_retries >= 3 {
-                        return Err("assistant returned empty responses repeatedly".to_string());
+                        exit_reason = ExitReason::EmptyResponses;
+                        error_text = exit_reason.default_error_text().to_string();
+                        break 'outer;
                     }
                     self.push_system_note(recovery::empty_response_recovery_note(
                         empty_retries,
@@ -170,19 +237,17 @@ impl Agent {
                 if action_expectation == recovery::ActionExpectation::RepoChange {
                     repo_change_retries += 1;
                     if repo_change_retries >= 3 {
-                        return Err(
-                            "assistant kept stopping before making the requested repository edits"
-                                .to_string(),
-                        );
+                        exit_reason = ExitReason::MissingRepoEdits;
+                        error_text = exit_reason.default_error_text().to_string();
+                        break 'outer;
                     }
                     self.push_system_note(recovery::repo_change_recovery_note(repo_change_retries));
                 } else {
                     no_tool_retries += 1;
                     if no_tool_retries >= 3 {
-                        return Err(
-                            "assistant kept describing actions without using tools to perform them"
-                                .to_string(),
-                        );
+                        exit_reason = ExitReason::NoToolCalls;
+                        error_text = exit_reason.default_error_text().to_string();
+                        break 'outer;
                     }
                     self.push_system_note(recovery::no_tool_recovery_note(no_tool_retries));
                 }
@@ -194,23 +259,43 @@ impl Agent {
             {
                 repo_change_retries += 1;
                 if repo_change_retries >= 3 {
-                    return Err(
-                        "assistant kept stopping before making the requested repository edits"
-                            .to_string(),
-                    );
+                    exit_reason = ExitReason::MissingRepoEdits;
+                    error_text = exit_reason.default_error_text().to_string();
+                    break 'outer;
                 }
                 self.push_system_note(recovery::repo_change_recovery_note(repo_change_retries));
                 continue;
             }
 
-            self.session.messages.push(ConversationMessage::assistant(
-                final_reply.clone(),
-                Vec::new(),
-            ));
-            return Ok(final_reply);
+            // Done
+            final_prose = final_reply;
+            exit_reason = ExitReason::Done;
+            break 'outer;
         }
 
-        Err("assistant did not finish within max iterations".to_string())
+        // Single exit point: compute stats and return LoopResult
+        let duration_secs = start.elapsed().as_secs();
+        let final_verif = verify_repo_progress(&before_snapshot, &self.work_root);
+        let stats = build_stats(
+            accumulated,
+            final_verif,
+            last_iter.min(self.config.max_iterations),
+            self.config.max_iterations,
+            duration_secs,
+        );
+
+        if exit_reason.is_success() {
+            self.session.messages.push(ConversationMessage::assistant(
+                final_prose.clone(),
+                Vec::new(),
+            ));
+            Ok((final_prose, stats))
+        } else {
+            if error_text.is_empty() {
+                error_text = exit_reason.default_error_text().to_string();
+            }
+            Err((exit_reason, error_text, stats))
+        }
     }
 
     fn request_assistant_reply_with_retry(

--- a/src/agent/orchestration.rs
+++ b/src/agent/orchestration.rs
@@ -16,6 +16,7 @@ pub struct RepoVerification {
     pub implementation_files_changed: usize,
     pub test_files_changed: usize,
     pub setup_files_changed: usize,
+    pub deleted_files_changed: usize,
 }
 
 impl RepoVerification {
@@ -23,6 +24,13 @@ impl RepoVerification {
         self.implementation_files_changed > 0
             || self.test_files_changed > 0
             || self.setup_files_changed > 0
+    }
+
+    pub fn total_changed_files(&self) -> usize {
+        self.implementation_files_changed
+            + self.test_files_changed
+            + self.setup_files_changed
+            + self.deleted_files_changed
     }
 }
 
@@ -60,23 +68,37 @@ pub fn verify_repo_progress(before: &RepoSnapshot, root: &Path) -> RepoVerificat
     let mut implementation_files_changed = 0usize;
     let mut test_files_changed = 0usize;
     let mut setup_files_changed = 0usize;
+    let mut deleted_files_changed = 0usize;
 
-    for (path, after_hash) in after.files {
-        let changed = before.files.get(&path) != Some(&after_hash);
+    // modified or created files
+    for (path, after_hash) in &after.files {
+        let changed = before.files.get(path) != Some(after_hash);
         if !changed {
             continue;
         }
         let display = path.display().to_string();
-        if changed_files.len() < 4 {
+        if changed_files.len() < 16 {
             changed_files.push(display.clone());
         }
-        if is_test_file(&path) {
+        if is_test_file(path) {
             test_files_changed += 1;
-        } else if is_setup_file(&path) {
+        } else if is_setup_file(path) {
             setup_files_changed += 1;
-        } else if is_implementation_file(&path) {
+        } else if is_implementation_file(path) {
             implementation_files_changed += 1;
         }
+    }
+
+    // deleted files (present before but absent after)
+    for path in before.files.keys() {
+        if after.files.contains_key(path) {
+            continue;
+        }
+        let display = format!("{} (deleted)", path.display());
+        if changed_files.len() < 16 {
+            changed_files.push(display);
+        }
+        deleted_files_changed += 1;
     }
 
     RepoVerification {
@@ -84,6 +106,7 @@ pub fn verify_repo_progress(before: &RepoSnapshot, root: &Path) -> RepoVerificat
         implementation_files_changed,
         test_files_changed,
         setup_files_changed,
+        deleted_files_changed,
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,9 @@ pub fn run_cli(args: CliArgs) -> Result<(), String> {
 
     if let Some(prompt) = agent.initial_prompt_from_cli_or_stdin()? {
         let reply = agent.run_oneshot(&prompt)?;
-        println!("{reply}");
+        if !reply.is_empty() {
+            println!("{reply}");
+        }
         return Ok(());
     }
 

--- a/tests/orchestration_tests.rs
+++ b/tests/orchestration_tests.rs
@@ -20,6 +20,71 @@ fn deterministic_verifier_reports_changed_file_categories() {
     assert_eq!(verification.setup_files_changed, 1);
     assert_eq!(verification.implementation_files_changed, 1);
     assert_eq!(verification.test_files_changed, 1);
+    assert_eq!(verification.deleted_files_changed, 0);
     assert!(verification.made_any_progress());
     assert_eq!(verification.changed_files.len(), 3);
+    assert_eq!(verification.total_changed_files(), 3);
+}
+
+#[test]
+fn deleted_files_are_counted_with_suffix() {
+    let temp = tempdir().unwrap();
+    std::fs::write(temp.path().join("remove_me.rs"), "fn x() {}").unwrap();
+    std::fs::write(temp.path().join("keep.rs"), "fn y() {}").unwrap();
+    let before = capture_repo_snapshot(temp.path());
+
+    std::fs::remove_file(temp.path().join("remove_me.rs")).unwrap();
+
+    let verification = verify_repo_progress(&before, temp.path());
+    assert_eq!(verification.deleted_files_changed, 1);
+    assert!(
+        verification
+            .changed_files
+            .iter()
+            .any(|f| f.contains("(deleted)")),
+        "expected (deleted) suffix, got: {:?}",
+        verification.changed_files
+    );
+}
+
+#[test]
+fn total_changed_files_sums_all_categories() {
+    let temp = tempdir().unwrap();
+    std::fs::create_dir_all(temp.path().join("src")).unwrap();
+    std::fs::write(temp.path().join("delete_me.rs"), "fn a() {}").unwrap();
+    let before = capture_repo_snapshot(temp.path());
+
+    // create impl + test files, delete one
+    std::fs::write(temp.path().join("src/main.rs"), "fn main() {}").unwrap();
+    std::fs::write(temp.path().join("src/main.test.ts"), "test('x', () => {})").unwrap();
+    std::fs::remove_file(temp.path().join("delete_me.rs")).unwrap();
+
+    let v = verify_repo_progress(&before, temp.path());
+    assert_eq!(v.implementation_files_changed, 1);
+    assert_eq!(v.test_files_changed, 1);
+    assert_eq!(v.deleted_files_changed, 1);
+    assert_eq!(v.total_changed_files(), 3);
+}
+
+#[test]
+fn changed_files_capped_at_sixteen() {
+    let temp = tempdir().unwrap();
+    let before = capture_repo_snapshot(temp.path());
+
+    for i in 0..20 {
+        std::fs::write(
+            temp.path().join(format!("file{i}.rs")),
+            format!("fn f{i}() {{}}"),
+        )
+        .unwrap();
+    }
+
+    let v = verify_repo_progress(&before, temp.path());
+    assert!(
+        v.changed_files.len() <= 16,
+        "cap exceeded: {}",
+        v.changed_files.len()
+    );
+    assert_eq!(v.implementation_files_changed, 20);
+    assert_eq!(v.total_changed_files(), 20);
 }


### PR DESCRIPTION
## 概要

run終了時に結果サマリーを1行で出力します。成功・失敗・max_iter到達に関わらず必ず表示されます。

## 変更内容

- `summary.rs` 追加: `LoopStats` / `LoopResult` / `ExitReason` 型定義
- run開始時に `Instant::now()` で時間計測開始
- 全終了経路（done / max_iter / empty / error）でサマリー出力
- 出力例: `✔ done  iter 18/40  duration 324s  edited 3 files (page.tsx, lib/game.ts, lib/entities.ts)`
- 失敗時: `✘ max_iterations  iter 40/40  duration 680s  edited 2 files`
- `orchestration.rs` の `verify_repo_progress` を活用してchanged files追跡

## テスト

- [x] `cargo test` パス（orchestration_tests.rs に新規統合テスト追加）
- [x] `cargo clippy --all-targets -- -D warnings` 警告ゼロ
- [x] `cargo fmt --check` パス
- [x] `cargo build` パス

## 備考

`turn.rs` の変更は PR #422（#406）とは別箇所ですが、マージ順は #422 → 本PR を推奨します。

## 関連Issue

Closes #407