### PR TITLE
feat(issue-409): add --resume flag and sessions subcommand

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,8 @@
   - Plan / Act の単純な状態
 - `src/session/*`
   - セッション保存と compaction
+  - `discovery.rs`: `iter_session_dirs` 共有イテレータ（UUID/symlink/size/parse 防御）
+  - `sessions_cli.rs`: `anvil sessions list|show|clean` と `--resume <ID>` の path confinement / plan / I/O
 - `src/git/checkpoint.rs`
   - checkpoint / rollback
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,16 @@ anvil [OPTIONS]
       --fresh-session                ignore saved session, start new session_id
       --state-dir <PATH>             override XDG state root (default: $XDG_STATE_HOME/anvil)
       --oneshot                      read one prompt from CLI or stdin
+      --resume [<ID>]                replay the last user message; no arg = latest workspace session
+
+anvil sessions list  [--all] [--json]
+anvil sessions show  <ID> [--all] [--json]
+anvil sessions clean [--older-than <DAYS>] [--keep <N>] [--all] [--force] [<ID>]
 ```
+
+`--resume` は直近の `user` メッセージを自動で再投入し、履歴のまま会話を継続する。`--resume <ID>` で UUID v7 を明示指定でき、現在の workspace と一致しない session はエラーになる（他 workspace の閲覧は後述 `sessions show --all` 経由）。`--resume` は `--fresh-session` / `--prompt` / `--oneshot` と排他。
+
+`sessions list|show|clean` は Ollama / Agent を起動せずオフラインで完結する。既定は現 workspace のみが対象で、`--all` で他 workspace 分も表示する。`clean` は既定 dry-run で、実削除には `--force` が必要。`resolve_session_id` が指す現セッションは常に保護される。
 
 ## スラッシュコマンド
 
@@ -163,6 +172,15 @@ $XDG_STATE_HOME/anvil/           (未設定時: ~/.local/state/anvil)
 workdir 側の `.anvil/logs/` `.anvil/sessions/` `.anvil/plans/` は上記へのベストエフォート symlink（削除されても次回起動時に再作成）。
 
 `--state-dir <PATH>` または `ANVIL_STATE_DIR=<PATH>` で保存先を上書きできる。テストでは `ANVIL_STATE_DIR` を tempdir に設定することで実 `$HOME` を汚染しない。
+
+### Session 継続と検査
+
+- `anvil` を引数なしで起動すると、現 workspace 直下にある最新の session を自動復元する（暗黙リストア）。
+- `--resume` は復元に加え、**最後の `user` メッセージを自動で再投入** して run を再開する。500 / max_iter で中断した直近ターンの続きを流し直したいときに使う。
+- `--resume <UUID>` で session を明示指定できる。UUID v7 以外・symlink・`state_root/sessions/` 外を指すものは拒否され、他 workspace の session もエラーになる。
+- `anvil sessions list` で現 workspace の session 一覧（`ID / updated_at / messages / last_tool / mode`）を更新日降順で表示する。`--all` で他 workspace 分も一覧に含め、`workspace_key` 空の古い session は `unassigned` として表示される。
+- `anvil sessions show <ID>` は 1 session の概要（`id / workspace_key / active_root / messages 件数 / 先頭 user prompt / 最終 assistant or tool / checkpoints 件数 / mode_state`）を出す。`--json` で機械可読出力（transcript 本体は含まない）。
+- `anvil sessions clean` は既定 dry-run。`--older-than 30d` で 30 日超、`--keep 5` で直近 5 件以外を候補にする。`<UUID>` 直接指定も可能。`--force` を付けたときのみ削除する。**現在 `resolve_session_id` が解決する session は常に保護**される。
 
 ## 安全性
 

--- a/src/agent/loop_run.rs
+++ b/src/agent/loop_run.rs
@@ -20,7 +20,7 @@ use crate::stdin_prompt;
 use crate::system_prompt::build_system_prompt;
 use crate::tools::registry::{ToolContext, ToolRegistry};
 
-mod commands;
+pub mod commands;
 mod lifecycle;
 mod summary;
 mod turn;

--- a/src/agent/loop_run/commands.rs
+++ b/src/agent/loop_run/commands.rs
@@ -2,6 +2,64 @@ use super::summary::{ExitReason, format_run_summary};
 use super::*;
 use crate::config::LogLevel;
 
+/// First 8 characters of a session id, or the full id if shorter. Used for
+/// banner display so users get a stable short handle without exposing the
+/// whole UUID.
+pub fn short_id(id: &str) -> &str {
+    id.get(..8).unwrap_or(id)
+}
+
+/// Print the REPL / resume startup banner to stdout. The `fresh` and
+/// `resumed` flags drive the `[state]` suffix so users can tell at a glance
+/// which session they are in.
+#[allow(clippy::too_many_arguments)]
+pub fn print_startup_banner(
+    version: &str,
+    model_banner: &str,
+    mode: &crate::modes::plan_act::ExecutionMode,
+    work_root: &std::path::Path,
+    session_id_short: &str,
+    message_count: usize,
+    fresh: bool,
+    resumed: bool,
+    log_level: LogLevel,
+) {
+    println!("anvil {version}");
+    println!("{model_banner}");
+    println!("mode={mode:?} cwd={}", work_root.display());
+    let state = if fresh {
+        "fresh"
+    } else if resumed {
+        "resumed"
+    } else {
+        "continued"
+    };
+    println!("session={session_id_short} messages={message_count} [{state}]");
+    if log_level >= LogLevel::Verbose
+        && let Some(path) = crate::logging::llm_io_log_path()
+    {
+        println!("llm log={}", path.display());
+    }
+}
+
+/// Oneshot startup banner: single stderr line so script output on stdout stays
+/// clean.
+pub fn print_startup_banner_stderr_oneshot(
+    session_id_short: &str,
+    message_count: usize,
+    fresh: bool,
+    resumed: bool,
+) {
+    let state = if fresh {
+        "fresh"
+    } else if resumed {
+        "resumed"
+    } else {
+        "continued"
+    };
+    eprintln!("anvil session={session_id_short} messages={message_count} [{state}]");
+}
+
 impl Agent {
     pub fn initial_prompt_from_cli_or_stdin(&self) -> Result<Option<String>, String> {
         if let Some(prompt) = &self.config.prompt {
@@ -21,20 +79,27 @@ impl Agent {
         }
     }
 
-    pub fn run_repl(&mut self) -> Result<(), String> {
-        println!("anvil {}", env!("CARGO_PKG_VERSION"));
-        println!("{}", format_model_banner(&self.models));
-        println!(
-            "mode={:?} cwd={}",
-            self.session.mode_state.mode,
-            self.work_root.display()
-        );
-        if self.config.log_level >= LogLevel::Verbose
-            && let Some(path) = crate::logging::llm_io_log_path()
-        {
-            println!("llm log={}", path.display());
+    /// Replay the last user turn and then continue in the REPL loop.
+    /// Used by `--resume` / `--resume <ID>` after the session has been loaded
+    /// and reconciled. The caller is responsible for printing the startup
+    /// banner; this method does not re-print it.
+    pub fn run_resume(&mut self, replay_prompt: &str) -> Result<(), String> {
+        match self.process_line(replay_prompt, self.config.stream)? {
+            AgentEvent::Continue(Some(message)) => {
+                if !self.config.stream {
+                    println!("{message}");
+                }
+            }
+            AgentEvent::Continue(None) => {}
+            AgentEvent::Exit => return Ok(()),
         }
+        self.run_repl_loop()
+    }
 
+    /// REPL body without the startup banner. Separated from `run_repl` so that
+    /// `run_cli` can print the banner once (in a single location) and have
+    /// both the fresh-REPL and resumed-REPL paths share the same loop.
+    pub fn run_repl_loop(&mut self) -> Result<(), String> {
         let mut line = String::new();
         loop {
             print!("anvil> ");
@@ -55,6 +120,25 @@ impl Agent {
             }
         }
         Ok(())
+    }
+
+    /// Backwards-compatible wrapper that prints the startup banner and then
+    /// runs the REPL loop. Kept for consumers that still call `run_repl`
+    /// directly; `run_cli` no longer uses it because the banner is printed
+    /// one level up for consistency across REPL / oneshot / resume.
+    pub fn run_repl(&mut self) -> Result<(), String> {
+        print_startup_banner(
+            env!("CARGO_PKG_VERSION"),
+            &format_model_banner(&self.models),
+            &self.session.mode_state.mode,
+            &self.work_root,
+            short_id(&self.session.id),
+            self.session.messages.len(),
+            self.config.fresh_session,
+            false,
+            self.config.log_level,
+        );
+        self.run_repl_loop()
     }
 
     pub fn process_line(&mut self, input: &str, stream_output: bool) -> Result<AgentEvent, String> {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use clap::Parser;
+use clap::{Parser, Subcommand};
 
 #[derive(Debug, Clone, Parser)]
 #[command(name = "anvil")]
@@ -37,8 +37,192 @@ pub struct CliArgs {
     pub fresh_session: bool,
     #[arg(long = "oneshot")]
     pub oneshot: bool,
+    /// Resume the most recent workspace session (`--resume`) or a specific
+    /// session id (`--resume <ID>`). The empty string sentinel (produced by
+    /// clap's `default_missing_value`) means "latest workspace session".
+    #[arg(long = "resume", num_args = 0..=1, default_missing_value = "", value_name = "ID")]
+    pub resume: Option<String>,
     #[arg(long = "cwd", hide = true)]
     pub cwd: Option<PathBuf>,
     #[arg(long = "state-dir")]
     pub state_dir: Option<PathBuf>,
+
+    /// `anvil sessions ...` subcommands. None → REPL / oneshot (従来動作).
+    #[command(subcommand)]
+    pub command: Option<Command>,
+}
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum Command {
+    /// Inspect / clean stored sessions.
+    Sessions {
+        #[command(subcommand)]
+        action: SessionsAction,
+    },
+}
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum SessionsAction {
+    /// List sessions in the current workspace (or all workspaces with --all).
+    List {
+        #[arg(long)]
+        all: bool,
+        #[arg(long)]
+        json: bool,
+    },
+    /// Show a single session's metadata by id.
+    Show {
+        id: String,
+        #[arg(long)]
+        all: bool,
+        #[arg(long)]
+        json: bool,
+    },
+    /// Delete old session directories. Defaults to dry-run.
+    Clean {
+        /// Delete this specific session id (mutually exclusive with --older-than / --keep).
+        id: Option<String>,
+        /// Delete sessions older than N days (by session.json mtime).
+        #[arg(long = "older-than", value_name = "DAYS")]
+        older_than_days: Option<u32>,
+        /// Keep the newest N sessions and delete the rest.
+        #[arg(long, value_name = "N")]
+        keep: Option<usize>,
+        /// Include sessions from other workspaces.
+        #[arg(long)]
+        all: bool,
+        /// Actually delete (required; otherwise dry-run).
+        #[arg(long)]
+        force: bool,
+    },
+}
+
+impl CliArgs {
+    /// Validate CLI-level mutual-exclusion constraints that clap cannot express
+    /// declaratively. Returns `Err` with a user-facing message if violated.
+    pub fn validate(&self) -> Result<(), String> {
+        let resume_on = self.resume.is_some();
+        if resume_on && self.fresh_session {
+            return Err("--resume and --fresh-session are mutually exclusive".to_string());
+        }
+        if resume_on && (self.prompt.is_some() || self.oneshot) {
+            return Err("--resume cannot be combined with --prompt / --oneshot".to_string());
+        }
+        Ok(())
+    }
+}
+
+/// Describes how the caller asked the agent to pick up a prior session.
+/// Converted from the raw `--resume` flag value at the CLI boundary.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub enum ResumeRequest {
+    /// No resume requested.
+    #[default]
+    None,
+    /// Resume the most recent workspace session.
+    Latest,
+    /// Resume an explicitly named session id.
+    WithId(String),
+}
+
+impl ResumeRequest {
+    pub fn from_flag(value: Option<String>) -> Self {
+        match value {
+            None => Self::None,
+            Some(s) if s.is_empty() => Self::Latest,
+            Some(s) => Self::WithId(s),
+        }
+    }
+
+    pub fn is_some(&self) -> bool {
+        !matches!(self, Self::None)
+    }
+
+    pub fn explicit_id(&self) -> Option<&str> {
+        if let Self::WithId(id) = self {
+            Some(id)
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base_args() -> CliArgs {
+        CliArgs {
+            prompt: None,
+            model: None,
+            sidecar_model: None,
+            ollama_host: None,
+            context_budget: None,
+            max_iterations: None,
+            chat_timeout_secs: None,
+            chat_retries: None,
+            verbose: false,
+            trace: false,
+            debug: false,
+            stream: false,
+            yes: false,
+            fresh_session: false,
+            oneshot: false,
+            resume: None,
+            cwd: None,
+            state_dir: None,
+            command: None,
+        }
+    }
+
+    #[test]
+    fn validate_accepts_default() {
+        assert!(base_args().validate().is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_resume_with_fresh_session() {
+        let mut args = base_args();
+        args.resume = Some(String::new());
+        args.fresh_session = true;
+        assert!(args.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_resume_with_prompt() {
+        let mut args = base_args();
+        args.resume = Some("abc".to_string());
+        args.prompt = Some("hello".to_string());
+        assert!(args.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_resume_with_oneshot() {
+        let mut args = base_args();
+        args.resume = Some(String::new());
+        args.oneshot = true;
+        assert!(args.validate().is_err());
+    }
+
+    #[test]
+    fn resume_request_conversion() {
+        assert_eq!(ResumeRequest::from_flag(None), ResumeRequest::None);
+        assert_eq!(
+            ResumeRequest::from_flag(Some(String::new())),
+            ResumeRequest::Latest
+        );
+        assert_eq!(
+            ResumeRequest::from_flag(Some("abc".into())),
+            ResumeRequest::WithId("abc".into())
+        );
+    }
+
+    #[test]
+    fn resume_request_helpers() {
+        assert!(!ResumeRequest::None.is_some());
+        assert!(ResumeRequest::Latest.is_some());
+        let r = ResumeRequest::WithId("x".to_string());
+        assert_eq!(r.explicit_id(), Some("x"));
+        assert!(r.is_some());
+    }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,7 +5,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
-use crate::cli::CliArgs;
+use crate::cli::{CliArgs, ResumeRequest};
 use crate::safety::host_validation::validate_localhost_url;
 
 /// `EnvFilter` directive that silences DEBUG/TRACE noise from hyper/reqwest/rustls.
@@ -145,6 +145,7 @@ pub struct Config {
     pub oneshot: bool,
     pub prompt: Option<String>,
     pub state_dir_override: Option<PathBuf>,
+    pub resume: ResumeRequest,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -214,6 +215,7 @@ impl Config {
             oneshot: args.oneshot || args.prompt.is_some(),
             prompt: args.prompt,
             state_dir_override: merged.state_dir_override,
+            resume: ResumeRequest::from_flag(args.resume),
         };
         Ok((config, warnings))
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,11 +14,16 @@ use std::io::{self, IsTerminal, Read};
 use std::path::{Path, PathBuf};
 
 use agent::Agent;
-use cli::CliArgs;
+use agent::loop_run::commands::{
+    print_startup_banner, print_startup_banner_stderr_oneshot, short_id,
+};
+use cli::{CliArgs, Command};
 use config::Config;
 use model_registry::{RuntimeModels, select_models};
 use ollama::client::OllamaClient;
-use session::store::SessionStore;
+use session::compact::find_last_user_prompt;
+use session::sessions_cli;
+use session::store::{SessionStore, reconcile_resume_state};
 
 pub fn run_cli(args: CliArgs) -> Result<(), String> {
     // --debug deprecation is emitted here because the flag only exists on the
@@ -29,6 +34,26 @@ pub fn run_cli(args: CliArgs) -> Result<(), String> {
         );
     }
 
+    // CLI-level mutual-exclusion checks that clap cannot express declaratively.
+    args.validate()?;
+
+    // Short-circuit for `anvil sessions ...` BEFORE loading Ollama / Agent so
+    // session inspection works offline and without an LLM running.
+    if let Some(Command::Sessions { action }) = args.command.clone() {
+        // We still need cwd-derived state_root + workspace_key to scope the
+        // sessions view; log level / model / Ollama host are deliberately
+        // not consulted.
+        let cwd = match args.cwd.clone() {
+            Some(path) => path,
+            None => {
+                std::env::current_dir().map_err(|err| format!("failed to resolve cwd: {err}"))?
+            }
+        };
+        let state_root = resolve_state_root_from_parts(args.state_dir.as_deref())?;
+        let workspace_key = compute_workspace_key(&cwd);
+        return sessions_cli::dispatch(&state_root, &workspace_key, action);
+    }
+
     let (config, warnings) = Config::load(args)?;
     for warning in &warnings {
         eprintln!("warning: {warning}");
@@ -36,7 +61,16 @@ pub fn run_cli(args: CliArgs) -> Result<(), String> {
 
     let state_root = resolve_state_root(&config)?;
     let workspace_key = compute_workspace_key(&config.cwd);
-    let session_id = resolve_session_id(&state_root, &workspace_key, config.fresh_session);
+
+    // Explicit `--resume <ID>` takes a different code path that refuses
+    // anything that is not a UUID v7 directory under state_root/sessions.
+    let session_id = match config.resume.explicit_id() {
+        Some(id) => {
+            sessions_cli::validate_explicit_session_id(&state_root, id)?;
+            id.to_string()
+        }
+        None => resolve_session_id(&state_root, &workspace_key, config.fresh_session),
+    };
 
     ensure_state_dirs(&state_root, &session_id)?;
 
@@ -64,8 +98,75 @@ pub fn run_cli(args: CliArgs) -> Result<(), String> {
     );
 
     let session_store = SessionStore::new(&state_root, &session_id, &workspace_key);
-    let session = session_store.load_or_new(config.fresh_session)?;
+    let mut session = session_store.load_or_new(config.fresh_session)?;
+
+    // Explicit --resume <ID>: refuse foreign workspace sessions. We only
+    // check here, after the snapshot is loaded, because workspace_key lives
+    // inside the snapshot (not the path).
+    if config.resume.explicit_id().is_some()
+        && !session.workspace_key.is_empty()
+        && session.workspace_key != workspace_key
+    {
+        return Err(format!(
+            "session {session_id} belongs to a different workspace; --resume cannot cross workspace"
+        ));
+    }
+
+    // Clean up broken references so the agent does not try to cd into a
+    // missing active_root or resume a deleted plan.md.
+    reconcile_resume_state(&mut session, &config.cwd);
+
+    let is_resume = config.resume.is_some();
+    let is_oneshot = config.oneshot;
+    let model_banner = format_model_banner(&models);
+    let version = env!("CARGO_PKG_VERSION");
+    let session_short = short_id(&session.id).to_string();
+    let messages_count = session.messages.len();
+    let work_root_for_banner = session
+        .active_root
+        .clone()
+        .unwrap_or_else(|| config.cwd.clone());
+    let mode_for_banner = session.mode_state.mode;
+    let fresh = config.fresh_session;
+    let log_level = config.log_level;
+
+    // Resume path has to read the last user prompt before we hand the
+    // snapshot to Agent::new (which consumes it by value).
+    let resume_prompt: Option<String> = if is_resume {
+        Some(find_last_user_prompt(&session.messages).ok_or_else(|| {
+            "cannot resume: the last user message has already been collapsed into a \
+             compaction summary. Start a new prompt instead."
+                .to_string()
+        })?)
+    } else {
+        None
+    };
+
     let mut agent = Agent::new(config, models, client, session_store, session);
+
+    // Banner: REPL / resume get stdout; oneshot gets stderr so stdout stays
+    // clean for script consumers.
+    if is_oneshot {
+        print_startup_banner_stderr_oneshot(&session_short, messages_count, fresh, is_resume);
+    } else {
+        print_startup_banner(
+            version,
+            &model_banner,
+            &mode_for_banner,
+            &work_root_for_banner,
+            &session_short,
+            messages_count,
+            fresh,
+            is_resume,
+            log_level,
+        );
+    }
+
+    if let Some(prompt) = resume_prompt {
+        // Resume: replay the last user turn, then fall into the REPL loop
+        // (banner has already been printed above).
+        return agent.run_resume(&prompt);
+    }
 
     if let Some(prompt) = agent.initial_prompt_from_cli_or_stdin()? {
         let reply = agent.run_oneshot(&prompt)?;
@@ -75,7 +176,39 @@ pub fn run_cli(args: CliArgs) -> Result<(), String> {
         return Ok(());
     }
 
-    agent.run_repl()
+    agent.run_repl_loop()
+}
+
+/// Lightweight state-root resolver for the `sessions` subcommand path, where
+/// we don't construct a full `Config`. Mirrors `resolve_state_root` but takes
+/// just the CLI override so sessions commands can run without Ollama/Agent.
+fn resolve_state_root_from_parts(state_dir_override: Option<&Path>) -> Result<PathBuf, String> {
+    if let Some(override_path) = state_dir_override {
+        if !override_path.is_absolute() {
+            return Err(format!(
+                "state-dir must be absolute: {}",
+                override_path.display()
+            ));
+        }
+        if override_path
+            .components()
+            .any(|c| c == std::path::Component::ParentDir)
+        {
+            return Err(format!(
+                "state-dir must not contain '..': {}",
+                override_path.display()
+            ));
+        }
+        return Ok(override_path.to_path_buf());
+    }
+    if let Ok(env_dir) = std::env::var("ANVIL_STATE_DIR") {
+        let p = PathBuf::from(env_dir);
+        if !p.is_absolute() || p.components().any(|c| c == std::path::Component::ParentDir) {
+            return Err("ANVIL_STATE_DIR must be an absolute path without '..'".to_string());
+        }
+        return Ok(p);
+    }
+    Ok(xdg_state_home().join("anvil"))
 }
 
 pub fn stdin_prompt() -> Result<Option<String>, String> {
@@ -149,54 +282,16 @@ pub fn resolve_session_id(state_root: &Path, workspace_key: &str, fresh: bool) -
         return uuid::Uuid::now_v7().to_string();
     }
 
-    let sessions_dir = state_root.join("sessions");
-    let mut candidates: Vec<String> = Vec::new();
+    // iter_session_dirs centralizes UUID/symlink/size/parse defenses;
+    // here we only keep entries whose persisted workspace_key matches.
+    let latest = session::discovery::iter_session_dirs(state_root)
+        .into_iter()
+        .filter(|entry| entry.snapshot.workspace_key == workspace_key)
+        .map(|entry| entry.id)
+        // UUID v7 strings are lexicographically time-ordered; take the max.
+        .max();
 
-    if let Ok(entries) = std::fs::read_dir(&sessions_dir) {
-        for entry in entries.flatten() {
-            let path = entry.path();
-            // use directory name as session_id — never trust session.json content for path construction
-            let dir_name = match entry.file_name().into_string() {
-                Ok(n) => n,
-                Err(_) => continue,
-            };
-            // validate directory name is a well-formed UUID
-            if uuid::Uuid::parse_str(&dir_name).is_err() {
-                continue;
-            }
-            // skip symlinks
-            let Ok(meta) = path.symlink_metadata() else {
-                continue;
-            };
-            if meta.file_type().is_symlink() || !meta.is_dir() {
-                continue;
-            }
-            let session_json = path.join("session.json");
-            if !session_json.exists() {
-                continue;
-            }
-            if let Ok(meta) = std::fs::metadata(&session_json)
-                && meta.len() > 10 * 1024 * 1024
-            {
-                continue;
-            }
-            let Ok(data) = std::fs::read_to_string(&session_json) else {
-                continue;
-            };
-            let Ok(snap) = serde_json::from_str::<session::store::SessionSnapshot>(&data) else {
-                continue;
-            };
-            if snap.workspace_key == workspace_key {
-                candidates.push(dir_name);
-            }
-        }
-    }
-
-    // UUID v7 strings are lexicographically time-ordered; pick the most recent
-    if let Some(latest) = candidates.into_iter().max() {
-        return latest;
-    }
-    uuid::Uuid::now_v7().to_string()
+    latest.unwrap_or_else(|| uuid::Uuid::now_v7().to_string())
 }
 
 pub fn ensure_state_dirs(state_root: &Path, session_id: &str) -> Result<(), String> {

--- a/src/session/compact.rs
+++ b/src/session/compact.rs
@@ -76,6 +76,21 @@ pub fn is_compact_summary(message: &ConversationMessage) -> bool {
     message.role == "system" && message.content.starts_with(COMPACT_SUMMARY_PREFIX)
 }
 
+/// Walk the message history from the tail toward the head and return the
+/// content of the most recent `role=user` message, skipping compaction
+/// summaries. Used by `--resume` to replay the last user turn.
+///
+/// Returns `None` when the tail (or the entire history) has been collapsed
+/// into a summary by `compact_messages` — callers should surface a specific
+/// error telling the user the last prompt is no longer replayable.
+pub fn find_last_user_prompt(messages: &[ConversationMessage]) -> Option<String> {
+    messages
+        .iter()
+        .rev()
+        .find(|m| m.role == "user" && !is_compact_summary(m))
+        .map(|m| m.content.clone())
+}
+
 fn summarize_messages(messages: &[ConversationMessage]) -> String {
     let mut lines = Vec::new();
     let recent = messages

--- a/src/session/discovery.rs
+++ b/src/session/discovery.rs
@@ -1,0 +1,179 @@
+//! Shared iterator that walks `state_root/sessions/*` and yields parsed
+//! session snapshots with their on-disk metadata.
+//!
+//! The defensive checks (UUID v7 directory names only, skip symlinks, skip
+//! non-directories, skip missing / oversized / broken `session.json`) are
+//! centralized here so that `resolve_session_id`, `sessions list`, and
+//! `sessions clean` all share one implementation.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+use crate::session::store::SessionSnapshot;
+
+/// Maximum on-disk size of `session.json` that the iterator is willing to
+/// read. Larger files are treated as corrupted and skipped; this mirrors the
+/// defense that `resolve_session_id` used to apply inline.
+pub const MAX_SESSION_JSON_BYTES: u64 = 10 * 1024 * 1024;
+
+/// One `sessions/<uuid>/session.json` entry that survived all defensive
+/// checks. `updated_at` is the filesystem mtime of `session.json`; the
+/// iterator deliberately does not fall back to directory mtime (which would
+/// drift under symlink manipulation).
+#[derive(Debug, Clone)]
+pub struct SessionDirEntry {
+    pub id: String,
+    pub dir: PathBuf,
+    pub session_json: PathBuf,
+    pub updated_at: SystemTime,
+    pub snapshot: SessionSnapshot,
+}
+
+/// Walk `state_root/sessions/*` and yield one `SessionDirEntry` per
+/// well-formed session directory. Entries that fail any defensive check are
+/// silently skipped; callers that need visibility into skip reasons should
+/// implement their own loop.
+///
+/// Order is undefined (filesystem order); callers that care about ordering
+/// should sort by `updated_at` / `id`.
+pub fn iter_session_dirs(state_root: &Path) -> Vec<SessionDirEntry> {
+    let sessions_dir = state_root.join("sessions");
+    let mut out = Vec::new();
+    let Ok(entries) = fs::read_dir(&sessions_dir) else {
+        return out;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Ok(dir_name) = entry.file_name().into_string() else {
+            continue;
+        };
+        // Directory name must be a UUID (any version accepted here; the
+        // explicit-id path enforces v7 separately via
+        // `sessions_cli::validate_session_id_format`).
+        if uuid::Uuid::parse_str(&dir_name).is_err() {
+            continue;
+        }
+        let Ok(meta) = path.symlink_metadata() else {
+            continue;
+        };
+        if meta.file_type().is_symlink() || !meta.is_dir() {
+            continue;
+        }
+        let session_json = path.join("session.json");
+        if !session_json.exists() {
+            continue;
+        }
+        let Ok(file_meta) = fs::metadata(&session_json) else {
+            continue;
+        };
+        if file_meta.len() > MAX_SESSION_JSON_BYTES {
+            continue;
+        }
+        let updated_at = file_meta.modified().unwrap_or(SystemTime::UNIX_EPOCH);
+        let Ok(data) = fs::read_to_string(&session_json) else {
+            continue;
+        };
+        let Ok(snapshot) = serde_json::from_str::<SessionSnapshot>(&data) else {
+            continue;
+        };
+        out.push(SessionDirEntry {
+            id: dir_name,
+            dir: path,
+            session_json,
+            updated_at,
+            snapshot,
+        });
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::File;
+    use std::io::Write;
+    use tempfile::TempDir;
+
+    fn write_session(dir: &Path, id: &str, workspace_key: &str) -> PathBuf {
+        let session_dir = dir.join("sessions").join(id);
+        fs::create_dir_all(&session_dir).unwrap();
+        let snap = SessionSnapshot {
+            id: id.to_string(),
+            workspace_key: workspace_key.to_string(),
+            ..Default::default()
+        };
+        let path = session_dir.join("session.json");
+        fs::write(&path, serde_json::to_string_pretty(&snap).unwrap()).unwrap();
+        path
+    }
+
+    #[test]
+    fn iter_returns_valid_sessions() {
+        let tmp = TempDir::new().unwrap();
+        let id1 = uuid::Uuid::now_v7().to_string();
+        let id2 = uuid::Uuid::now_v7().to_string();
+        write_session(tmp.path(), &id1, "ws-a");
+        write_session(tmp.path(), &id2, "ws-b");
+        let entries = iter_session_dirs(tmp.path());
+        assert_eq!(entries.len(), 2);
+    }
+
+    #[test]
+    fn iter_skips_non_uuid_directory_names() {
+        let tmp = TempDir::new().unwrap();
+        let bad = tmp.path().join("sessions").join("not-a-uuid");
+        fs::create_dir_all(&bad).unwrap();
+        File::create(bad.join("session.json"))
+            .unwrap()
+            .write_all(b"{}")
+            .unwrap();
+        let entries = iter_session_dirs(tmp.path());
+        assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn iter_skips_broken_json() {
+        let tmp = TempDir::new().unwrap();
+        let id = uuid::Uuid::now_v7().to_string();
+        let session_dir = tmp.path().join("sessions").join(&id);
+        fs::create_dir_all(&session_dir).unwrap();
+        fs::write(session_dir.join("session.json"), b"{not json").unwrap();
+        let entries = iter_session_dirs(tmp.path());
+        assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn iter_skips_oversized_json() {
+        let tmp = TempDir::new().unwrap();
+        let id = uuid::Uuid::now_v7().to_string();
+        let session_dir = tmp.path().join("sessions").join(&id);
+        fs::create_dir_all(&session_dir).unwrap();
+        // Write > 10 MiB
+        let path = session_dir.join("session.json");
+        let mut f = File::create(&path).unwrap();
+        f.write_all(&vec![b'a'; (MAX_SESSION_JSON_BYTES + 1) as usize])
+            .unwrap();
+        drop(f);
+        let entries = iter_session_dirs(tmp.path());
+        assert!(entries.is_empty());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn iter_skips_symlinks() {
+        let tmp = TempDir::new().unwrap();
+        let sessions = tmp.path().join("sessions");
+        fs::create_dir_all(&sessions).unwrap();
+
+        let real_id = uuid::Uuid::now_v7().to_string();
+        write_session(tmp.path(), &real_id, "ws-a");
+
+        let link_id = uuid::Uuid::now_v7().to_string();
+        std::os::unix::fs::symlink(sessions.join(&real_id), sessions.join(&link_id)).unwrap();
+
+        let entries = iter_session_dirs(tmp.path());
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].id, real_id);
+    }
+}

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -1,2 +1,4 @@
 pub mod compact;
+pub mod discovery;
+pub mod sessions_cli;
 pub mod store;

--- a/src/session/sessions_cli.rs
+++ b/src/session/sessions_cli.rs
@@ -1,0 +1,899 @@
+//! `anvil sessions {list,show,clean}` subcommand implementation.
+//!
+//! This module is split into a pure-data layer (metadata scanning, validation,
+//! list/clean planning) and a thin I/O layer (`run_list` / `run_show` /
+//! `run_clean` / `dispatch`) that formats the planned result to stdout and
+//! performs deletions. The pure layer is exhaustively unit-tested; the I/O
+//! layer is covered by integration tests in `tests/session_cli_tests.rs`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+use crate::cli::SessionsAction;
+use crate::modes::plan_act::ExecutionMode;
+use crate::session::compact::is_compact_summary;
+use crate::session::discovery::{SessionDirEntry, iter_session_dirs};
+use crate::session::store::{ConversationMessage, SessionSnapshot};
+
+pub const UNASSIGNED_WORKSPACE: &str = "unassigned";
+
+// ---------------------------------------------------------------------------
+// Data model
+// ---------------------------------------------------------------------------
+
+/// Display-only summary of a single session. Built from a `SessionDirEntry`
+/// via `SessionMeta::from_entry`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SessionMeta {
+    pub id: String,
+    pub workspace_key: String,
+    pub updated_at: SystemTime,
+    pub message_count: usize,
+    pub last_tool_name: Option<String>,
+    pub mode: ExecutionMode,
+}
+
+impl SessionMeta {
+    pub fn from_entry(entry: &SessionDirEntry) -> Self {
+        Self {
+            id: entry.id.clone(),
+            workspace_key: entry.snapshot.workspace_key.clone(),
+            updated_at: entry.updated_at,
+            message_count: entry.snapshot.messages.len(),
+            last_tool_name: last_tool_name(&entry.snapshot.messages, 20),
+            mode: entry.snapshot.mode_state.mode,
+        }
+    }
+}
+
+fn last_tool_name(messages: &[ConversationMessage], tail_limit: usize) -> Option<String> {
+    for message in messages.iter().rev().take(tail_limit) {
+        if message.role == "assistant"
+            && let Some(tc) = message.tool_calls.first()
+        {
+            return Some(tc.name.clone());
+        }
+        if message.role == "tool"
+            && let Some(name) = &message.name
+        {
+            return Some(name.clone());
+        }
+    }
+    None
+}
+
+pub fn scan_session_meta(state_root: &Path) -> Vec<SessionMeta> {
+    iter_session_dirs(state_root)
+        .iter()
+        .map(SessionMeta::from_entry)
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Path confinement helpers
+// ---------------------------------------------------------------------------
+
+/// Pure-function check: the caller's id is a UUID v7 literal.
+///
+/// Rejects non-UUID strings and any UUID version != 7. This mirrors the
+/// resolver's "directory name must be a UUID" guard while refusing v4/v1 ids
+/// that could be synthesized to point at externally-prepared directories.
+pub fn validate_session_id_format(id: &str) -> Result<(), String> {
+    let Ok(uuid) = uuid::Uuid::parse_str(id) else {
+        return Err(format!("session id must be a UUID v7 string: {id}"));
+    };
+    if uuid.get_version_num() != 7 {
+        return Err(format!("session id must be a UUID v7 string: {id}"));
+    }
+    Ok(())
+}
+
+/// Filesystem-layer check: `state_root/sessions/<id>` exists, is a real
+/// directory (not a symlink), and `session.json` resolves inside
+/// `state_root/sessions/` after canonicalization.
+///
+/// Callers must run `validate_session_id_format` before this function. The
+/// returned path is the validated session directory (not the `session.json`
+/// file) so callers can re-use it for `fs::read_dir` / `fs::remove_dir_all`.
+pub fn validate_session_dir(state_root: &Path, id: &str) -> Result<PathBuf, String> {
+    let session_dir = state_root.join("sessions").join(id);
+    let meta =
+        fs::symlink_metadata(&session_dir).map_err(|e| format!("session not found ({id}): {e}"))?;
+    if meta.file_type().is_symlink() {
+        return Err(format!("session id refers to a symlink: {id}"));
+    }
+    if !meta.is_dir() {
+        return Err(format!("session id is not a directory: {id}"));
+    }
+
+    let session_json = session_dir.join("session.json");
+    let canon_json = session_json
+        .canonicalize()
+        .map_err(|e| format!("cannot canonicalize session.json for {id}: {e}"))?;
+    let canon_sessions_root = state_root
+        .join("sessions")
+        .canonicalize()
+        .map_err(|e| format!("cannot canonicalize state_root/sessions: {e}"))?;
+    if !canon_json.starts_with(&canon_sessions_root) {
+        return Err(format!("session path escapes state_root/sessions: {id}"));
+    }
+    Ok(session_dir)
+}
+
+/// Convenience wrapper used by `--resume <ID>` and `sessions show <ID>`.
+pub fn validate_explicit_session_id(state_root: &Path, id: &str) -> Result<PathBuf, String> {
+    validate_session_id_format(id)?;
+    validate_session_dir(state_root, id)
+}
+
+// ---------------------------------------------------------------------------
+// List planning (pure)
+// ---------------------------------------------------------------------------
+
+/// Where a row came from, used to tag output when `--all` includes foreign
+/// workspaces.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WorkspaceScope {
+    Current,
+    Other,
+    /// `workspace_key` was empty in the snapshot (very old sessions).
+    Unassigned,
+}
+
+/// One list-view row; human and `--json` formatters both read this.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ListRow {
+    pub id: String,
+    pub workspace_key: String,
+    pub scope: WorkspaceScope,
+    pub updated_at: SystemTime,
+    pub message_count: usize,
+    pub last_tool_name: Option<String>,
+    pub mode: ExecutionMode,
+}
+
+pub fn compute_list_rows(metas: &[SessionMeta], current_ws: &str, all: bool) -> Vec<ListRow> {
+    let mut rows: Vec<ListRow> = metas
+        .iter()
+        .filter_map(|m| {
+            let scope = if m.workspace_key.is_empty() {
+                WorkspaceScope::Unassigned
+            } else if m.workspace_key == current_ws {
+                WorkspaceScope::Current
+            } else {
+                WorkspaceScope::Other
+            };
+            if !all && scope != WorkspaceScope::Current {
+                return None;
+            }
+            Some(ListRow {
+                id: m.id.clone(),
+                workspace_key: m.workspace_key.clone(),
+                scope,
+                updated_at: m.updated_at,
+                message_count: m.message_count,
+                last_tool_name: m.last_tool_name.clone(),
+                mode: m.mode,
+            })
+        })
+        .collect();
+
+    // Sort newest first. For equal mtimes, break ties by UUID descending so
+    // output is deterministic across platforms (mtime precision varies).
+    rows.sort_by(|a, b| {
+        b.updated_at
+            .cmp(&a.updated_at)
+            .then_with(|| b.id.cmp(&a.id))
+    });
+    rows
+}
+
+// ---------------------------------------------------------------------------
+// Clean planning (pure)
+// ---------------------------------------------------------------------------
+
+/// Normalized `sessions clean` arguments used by `plan_clean`.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct CleanArgs {
+    pub id: Option<String>,
+    pub older_than_days: Option<u32>,
+    pub keep: Option<usize>,
+    pub all: bool,
+}
+
+/// The set of sessions that `sessions clean` intends to delete, plus the one
+/// that is being explicitly protected (the resolver's current winner).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CleanPlan {
+    pub to_delete: Vec<SessionMeta>,
+    pub protected_id: Option<String>,
+    pub scope_hint: CleanScopeHint,
+}
+
+/// Describes which subset of sessions the plan considered. Used by the I/O
+/// layer to render dry-run output.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CleanScopeHint {
+    CurrentWorkspace,
+    AllWorkspaces,
+    SingleId,
+}
+
+pub fn plan_clean(
+    metas: &[SessionMeta],
+    current_ws: &str,
+    args: &CleanArgs,
+    protected_id: Option<&str>,
+    now: SystemTime,
+) -> Result<CleanPlan, String> {
+    // Single-id path: caller has already run validate_session_id_format on
+    // args.id, we only need to check workspace and protection.
+    if let Some(id) = &args.id {
+        if args.older_than_days.is_some() || args.keep.is_some() {
+            return Err(
+                "--older-than and --keep cannot be combined with an explicit session id"
+                    .to_string(),
+            );
+        }
+        let Some(meta) = metas.iter().find(|m| &m.id == id) else {
+            return Err(format!("session not found: {id}"));
+        };
+        if !args.all && meta.workspace_key != current_ws {
+            return Err(format!(
+                "session {id} belongs to a different workspace; pass --all to clean it"
+            ));
+        }
+        if protected_id == Some(id.as_str()) {
+            return Err(format!(
+                "refusing to delete the session currently selected by resolve_session_id: {id}"
+            ));
+        }
+        return Ok(CleanPlan {
+            to_delete: vec![meta.clone()],
+            protected_id: protected_id.map(str::to_string),
+            scope_hint: CleanScopeHint::SingleId,
+        });
+    }
+
+    // Bulk path: workspace filter first.
+    let scope_hint = if args.all {
+        CleanScopeHint::AllWorkspaces
+    } else {
+        CleanScopeHint::CurrentWorkspace
+    };
+    let mut pool: Vec<SessionMeta> = metas
+        .iter()
+        .filter(|m| args.all || m.workspace_key == current_ws)
+        .cloned()
+        .collect();
+
+    // Newest first, tie-break by id descending for determinism.
+    pool.sort_by(|a, b| {
+        b.updated_at
+            .cmp(&a.updated_at)
+            .then_with(|| b.id.cmp(&a.id))
+    });
+
+    let mut to_delete: Vec<SessionMeta> = Vec::new();
+
+    if let Some(days) = args.older_than_days {
+        let cutoff = now
+            .checked_sub(std::time::Duration::from_secs(days as u64 * 24 * 60 * 60))
+            .unwrap_or(SystemTime::UNIX_EPOCH);
+        to_delete.extend(pool.iter().filter(|m| m.updated_at < cutoff).cloned());
+    }
+
+    if let Some(keep) = args.keep {
+        // Pool is already newest-first; anything past index `keep` is dropped.
+        to_delete.extend(pool.iter().skip(keep).cloned());
+    }
+
+    if args.older_than_days.is_none() && args.keep.is_none() {
+        return Err(
+            "sessions clean requires --older-than <DAYS>, --keep <N>, or an explicit id"
+                .to_string(),
+        );
+    }
+
+    // Deduplicate by id (in case --older-than and --keep overlap).
+    to_delete.sort_by(|a, b| a.id.cmp(&b.id));
+    to_delete.dedup_by(|a, b| a.id == b.id);
+
+    // Never remove the currently-resolved session.
+    if let Some(pid) = protected_id {
+        to_delete.retain(|m| m.id != pid);
+    }
+
+    // Re-sort deletion order newest-first for human-readable dry-run output.
+    to_delete.sort_by(|a, b| {
+        b.updated_at
+            .cmp(&a.updated_at)
+            .then_with(|| b.id.cmp(&a.id))
+    });
+
+    Ok(CleanPlan {
+        to_delete,
+        protected_id: protected_id.map(str::to_string),
+        scope_hint,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Show helpers (pure)
+// ---------------------------------------------------------------------------
+
+/// Short, non-secret preview fields derived from a `SessionSnapshot`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ShowView {
+    pub id: String,
+    pub workspace_key: String,
+    pub active_root: Option<PathBuf>,
+    pub message_count: usize,
+    pub first_user_preview: Option<String>,
+    pub last_assistant_or_tool_preview: Option<String>,
+    pub checkpoint_count: usize,
+    pub mode: ExecutionMode,
+    pub active_plan_path: Option<PathBuf>,
+}
+
+const SHOW_PREVIEW_CHARS: usize = 200;
+
+impl ShowView {
+    pub fn from_snapshot(snap: &SessionSnapshot) -> Self {
+        Self {
+            id: snap.id.clone(),
+            workspace_key: snap.workspace_key.clone(),
+            active_root: snap.active_root.clone(),
+            message_count: snap.messages.len(),
+            first_user_preview: first_user_preview(&snap.messages),
+            last_assistant_or_tool_preview: last_assistant_or_tool_preview(&snap.messages),
+            checkpoint_count: snap.checkpoints.len(),
+            mode: snap.mode_state.mode,
+            active_plan_path: snap.mode_state.active_plan_path.clone(),
+        }
+    }
+}
+
+fn first_user_preview(messages: &[ConversationMessage]) -> Option<String> {
+    messages
+        .iter()
+        .find(|m| m.role == "user" && !is_compact_summary(m))
+        .map(|m| preview(&m.content))
+}
+
+fn last_assistant_or_tool_preview(messages: &[ConversationMessage]) -> Option<String> {
+    for m in messages.iter().rev() {
+        if m.role == "assistant" && !m.content.is_empty() {
+            return Some(preview(&m.content));
+        }
+        if m.role == "assistant"
+            && let Some(tc) = m.tool_calls.first()
+        {
+            return Some(format!("tool_call:{}", tc.name));
+        }
+        if m.role == "tool" {
+            let label = m.name.as_deref().unwrap_or("tool");
+            return Some(format!("{label}:{}", preview(&m.content)));
+        }
+    }
+    None
+}
+
+fn preview(s: &str) -> String {
+    let collapsed: String = s.chars().filter(|c| *c != '\n').collect();
+    collapsed.chars().take(SHOW_PREVIEW_CHARS).collect()
+}
+
+// ---------------------------------------------------------------------------
+// Dispatch and I/O layer
+// ---------------------------------------------------------------------------
+
+pub fn dispatch(state_root: &Path, current_ws: &str, action: SessionsAction) -> Result<(), String> {
+    match action {
+        SessionsAction::List { all, json } => run_list(state_root, current_ws, all, json),
+        SessionsAction::Show { id, all, json } => run_show(state_root, current_ws, &id, all, json),
+        SessionsAction::Clean {
+            id,
+            older_than_days,
+            keep,
+            all,
+            force,
+        } => {
+            if let Some(ref explicit) = id {
+                validate_session_id_format(explicit)?;
+            }
+            let args = CleanArgs {
+                id,
+                older_than_days,
+                keep,
+                all,
+            };
+            run_clean(state_root, current_ws, args, force)
+        }
+    }
+}
+
+pub fn run_list(state_root: &Path, current_ws: &str, all: bool, json: bool) -> Result<(), String> {
+    let metas = scan_session_meta(state_root);
+    let rows = compute_list_rows(&metas, current_ws, all);
+    if json {
+        println!("{}", render_list_json(&rows));
+    } else {
+        print_list_human(&rows, all);
+    }
+    Ok(())
+}
+
+pub fn run_show(
+    state_root: &Path,
+    current_ws: &str,
+    id: &str,
+    all: bool,
+    json: bool,
+) -> Result<(), String> {
+    let session_dir = validate_explicit_session_id(state_root, id)?;
+    let session_json = session_dir.join("session.json");
+    let data = fs::read_to_string(&session_json)
+        .map_err(|e| format!("failed to read session.json for {id}: {e}"))?;
+    let snap: SessionSnapshot = serde_json::from_str(&data)
+        .map_err(|e| format!("failed to parse session.json for {id}: {e}"))?;
+
+    if !all && !snap.workspace_key.is_empty() && snap.workspace_key != current_ws {
+        return Err(format!(
+            "session {id} belongs to a different workspace; pass --all to view it"
+        ));
+    }
+
+    let view = ShowView::from_snapshot(&snap);
+    if json {
+        println!("{}", render_show_json(&view));
+    } else {
+        print_show_human(&view);
+    }
+    Ok(())
+}
+
+pub fn run_clean(
+    state_root: &Path,
+    current_ws: &str,
+    args: CleanArgs,
+    force: bool,
+) -> Result<(), String> {
+    let metas = scan_session_meta(state_root);
+    let protected = crate::resolve_session_id(state_root, current_ws, false);
+    let plan = plan_clean(
+        &metas,
+        current_ws,
+        &args,
+        Some(&protected),
+        SystemTime::now(),
+    )?;
+    execute_clean_plan(state_root, &plan, force)
+}
+
+pub fn execute_clean_plan(state_root: &Path, plan: &CleanPlan, force: bool) -> Result<(), String> {
+    if plan.to_delete.is_empty() {
+        println!("no sessions match the cleanup criteria");
+        if let Some(pid) = &plan.protected_id {
+            println!("(protected current session: {pid})");
+        }
+        return Ok(());
+    }
+
+    if !force {
+        println!("dry-run: would delete {} session(s):", plan.to_delete.len());
+        for m in &plan.to_delete {
+            println!(
+                "  - {id}  ws={ws}  messages={n}  mode={mode:?}",
+                id = m.id,
+                ws = if m.workspace_key.is_empty() {
+                    UNASSIGNED_WORKSPACE
+                } else {
+                    &m.workspace_key
+                },
+                n = m.message_count,
+                mode = m.mode
+            );
+        }
+        if let Some(pid) = &plan.protected_id {
+            println!("(protected current session: {pid})");
+        }
+        println!("pass --force to actually delete.");
+        return Ok(());
+    }
+
+    let mut deleted = 0usize;
+    for m in &plan.to_delete {
+        // TOCTOU guard: re-validate filesystem state right before rm.
+        let path = validate_session_dir(state_root, &m.id)?;
+        fs::remove_dir_all(&path).map_err(|e| format!("failed to remove {}: {e}", m.id))?;
+        println!("deleted {}", m.id);
+        deleted += 1;
+    }
+    println!("removed {deleted} session(s)");
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Rendering helpers (kept inline; they're straightforward enough that a
+// separate module would just add indirection).
+// ---------------------------------------------------------------------------
+
+fn print_list_human(rows: &[ListRow], include_ws: bool) {
+    if rows.is_empty() {
+        println!("no sessions found");
+        return;
+    }
+    if include_ws {
+        println!(
+            "ID                                    UPDATED_AT       MESSAGES  LAST_TOOL           MODE     WORKSPACE"
+        );
+        for r in rows {
+            println!(
+                "{id:38} {ts:16} {n:>8}  {tool:<18}  {mode:<8} {ws}",
+                id = r.id,
+                ts = fmt_mtime(r.updated_at),
+                n = r.message_count,
+                tool = r.last_tool_name.as_deref().unwrap_or("-"),
+                mode = format!("{:?}", r.mode),
+                ws = workspace_label(&r.workspace_key, r.scope),
+            );
+        }
+    } else {
+        println!(
+            "ID                                    UPDATED_AT       MESSAGES  LAST_TOOL           MODE"
+        );
+        for r in rows {
+            println!(
+                "{id:38} {ts:16} {n:>8}  {tool:<18}  {mode:?}",
+                id = r.id,
+                ts = fmt_mtime(r.updated_at),
+                n = r.message_count,
+                tool = r.last_tool_name.as_deref().unwrap_or("-"),
+                mode = r.mode,
+            );
+        }
+    }
+}
+
+fn workspace_label(key: &str, scope: WorkspaceScope) -> String {
+    match scope {
+        WorkspaceScope::Unassigned => UNASSIGNED_WORKSPACE.to_string(),
+        WorkspaceScope::Current | WorkspaceScope::Other => key.to_string(),
+    }
+}
+
+fn fmt_mtime(t: SystemTime) -> String {
+    match t.duration_since(SystemTime::UNIX_EPOCH) {
+        Ok(dur) => dur.as_secs().to_string(),
+        Err(_) => "?".to_string(),
+    }
+}
+
+fn print_show_human(v: &ShowView) {
+    println!("id:             {}", v.id);
+    println!(
+        "workspace_key:  {}",
+        if v.workspace_key.is_empty() {
+            UNASSIGNED_WORKSPACE
+        } else {
+            &v.workspace_key
+        }
+    );
+    println!(
+        "active_root:    {}",
+        v.active_root
+            .as_ref()
+            .map(|p| p.display().to_string())
+            .unwrap_or_else(|| "-".to_string())
+    );
+    println!("messages:       {}", v.message_count);
+    println!(
+        "first_user:     {}",
+        v.first_user_preview.as_deref().unwrap_or("-")
+    );
+    println!(
+        "last_turn:      {}",
+        v.last_assistant_or_tool_preview.as_deref().unwrap_or("-")
+    );
+    println!("checkpoints:    {}", v.checkpoint_count);
+    println!("mode:           {:?}", v.mode);
+    println!(
+        "active_plan:    {}",
+        v.active_plan_path
+            .as_ref()
+            .map(|p| p.display().to_string())
+            .unwrap_or_else(|| "-".to_string())
+    );
+}
+
+fn render_list_json(rows: &[ListRow]) -> String {
+    let arr: Vec<serde_json::Value> = rows
+        .iter()
+        .map(|r| {
+            serde_json::json!({
+                "id": r.id,
+                "workspace_key": r.workspace_key,
+                "workspace_scope": match r.scope {
+                    WorkspaceScope::Current => "current",
+                    WorkspaceScope::Other => "other",
+                    WorkspaceScope::Unassigned => "unassigned",
+                },
+                "updated_at_unix": match r.updated_at.duration_since(SystemTime::UNIX_EPOCH) {
+                    Ok(d) => d.as_secs(),
+                    Err(_) => 0,
+                },
+                "messages": r.message_count,
+                "last_tool": r.last_tool_name,
+                "mode": format!("{:?}", r.mode),
+            })
+        })
+        .collect();
+    serde_json::to_string_pretty(&serde_json::Value::Array(arr)).unwrap_or_else(|_| "[]".into())
+}
+
+fn render_show_json(v: &ShowView) -> String {
+    let value = serde_json::json!({
+        "id": v.id,
+        "workspace_key": v.workspace_key,
+        "active_root": v.active_root.as_ref().map(|p| p.display().to_string()),
+        "messages": v.message_count,
+        "first_user_preview": v.first_user_preview,
+        "last_turn_preview": v.last_assistant_or_tool_preview,
+        "checkpoints": v.checkpoint_count,
+        "mode": format!("{:?}", v.mode),
+        "active_plan_path": v.active_plan_path.as_ref().map(|p| p.display().to_string()),
+    });
+    serde_json::to_string_pretty(&value).unwrap_or_else(|_| "{}".into())
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::modes::plan_act::ModeState;
+    use std::time::Duration;
+    use tempfile::TempDir;
+
+    fn meta(id: &str, ws: &str, age_secs: u64, now: SystemTime, messages: usize) -> SessionMeta {
+        SessionMeta {
+            id: id.to_string(),
+            workspace_key: ws.to_string(),
+            updated_at: now
+                .checked_sub(Duration::from_secs(age_secs))
+                .unwrap_or(SystemTime::UNIX_EPOCH),
+            message_count: messages,
+            last_tool_name: None,
+            mode: ExecutionMode::Act,
+        }
+    }
+
+    fn v7() -> String {
+        uuid::Uuid::now_v7().to_string()
+    }
+
+    #[test]
+    fn validate_format_accepts_v7() {
+        assert!(validate_session_id_format(&v7()).is_ok());
+    }
+
+    #[test]
+    fn validate_format_rejects_v4() {
+        // Hardcoded UUID v4 literal (version nibble 4). The uuid crate's
+        // v4 feature is not enabled in this workspace, so we cannot call
+        // `Uuid::new_v4()` — a literal is equivalent for this assertion.
+        let v4 = "0190f3c0-1111-4a00-8000-000000000000";
+        assert!(validate_session_id_format(v4).is_err());
+    }
+
+    #[test]
+    fn validate_format_rejects_junk() {
+        assert!(validate_session_id_format("").is_err());
+        assert!(validate_session_id_format("not-a-uuid").is_err());
+        assert!(validate_session_id_format("../evil").is_err());
+    }
+
+    #[test]
+    fn validate_dir_rejects_missing() {
+        let tmp = TempDir::new().unwrap();
+        let id = v7();
+        assert!(validate_session_dir(tmp.path(), &id).is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn validate_dir_rejects_symlink() {
+        let tmp = TempDir::new().unwrap();
+        let sessions = tmp.path().join("sessions");
+        std::fs::create_dir_all(&sessions).unwrap();
+
+        let real_id = v7();
+        let real_dir = sessions.join(&real_id);
+        std::fs::create_dir_all(&real_dir).unwrap();
+        std::fs::write(real_dir.join("session.json"), "{}").unwrap();
+
+        let link_id = v7();
+        std::os::unix::fs::symlink(&real_dir, sessions.join(&link_id)).unwrap();
+
+        let err = validate_session_dir(tmp.path(), &link_id).unwrap_err();
+        assert!(err.contains("symlink"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn compute_list_filters_current_workspace() {
+        let now = SystemTime::now();
+        let metas = vec![
+            meta("id-a", "ws-x", 100, now, 3),
+            meta("id-b", "ws-y", 50, now, 2),
+        ];
+        let rows = compute_list_rows(&metas, "ws-x", false);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].id, "id-a");
+    }
+
+    #[test]
+    fn compute_list_all_includes_unassigned() {
+        let now = SystemTime::now();
+        let metas = vec![
+            meta("id-a", "ws-x", 100, now, 3),
+            meta("id-b", "", 50, now, 2),
+        ];
+        let rows = compute_list_rows(&metas, "ws-x", true);
+        assert_eq!(rows.len(), 2);
+        let unassigned = rows
+            .iter()
+            .find(|r| r.scope == WorkspaceScope::Unassigned)
+            .unwrap();
+        assert_eq!(unassigned.id, "id-b");
+    }
+
+    #[test]
+    fn compute_list_sort_newest_first_tiebreak_uuid_desc() {
+        let now = SystemTime::now();
+        // equal mtime -> uuid desc
+        let metas = vec![
+            meta("aaaa", "ws-x", 10, now, 1),
+            meta("bbbb", "ws-x", 10, now, 1),
+        ];
+        let rows = compute_list_rows(&metas, "ws-x", false);
+        assert_eq!(rows[0].id, "bbbb");
+        assert_eq!(rows[1].id, "aaaa");
+    }
+
+    #[test]
+    fn plan_clean_rejects_bulk_without_criteria() {
+        let now = SystemTime::now();
+        let metas = vec![meta("id-a", "ws-x", 10, now, 1)];
+        let args = CleanArgs::default();
+        assert!(plan_clean(&metas, "ws-x", &args, None, now).is_err());
+    }
+
+    #[test]
+    fn plan_clean_older_than_selects_stale() {
+        let now = SystemTime::now();
+        let metas = vec![
+            meta("young", "ws-x", 60, now, 1),              // 1 min old
+            meta("old", "ws-x", 60 * 60 * 24 * 40, now, 1), // 40 days
+        ];
+        let args = CleanArgs {
+            older_than_days: Some(30),
+            ..Default::default()
+        };
+        let plan = plan_clean(&metas, "ws-x", &args, None, now).unwrap();
+        assert_eq!(plan.to_delete.len(), 1);
+        assert_eq!(plan.to_delete[0].id, "old");
+    }
+
+    #[test]
+    fn plan_clean_keep_n_retains_newest() {
+        let now = SystemTime::now();
+        let metas = vec![
+            meta("new1", "ws-x", 10, now, 1),
+            meta("new2", "ws-x", 20, now, 1),
+            meta("old1", "ws-x", 1000, now, 1),
+            meta("old2", "ws-x", 2000, now, 1),
+        ];
+        let args = CleanArgs {
+            keep: Some(2),
+            ..Default::default()
+        };
+        let plan = plan_clean(&metas, "ws-x", &args, None, now).unwrap();
+        let ids: Vec<&str> = plan.to_delete.iter().map(|m| m.id.as_str()).collect();
+        assert_eq!(ids, vec!["old1", "old2"]);
+    }
+
+    #[test]
+    fn plan_clean_excludes_protected() {
+        let now = SystemTime::now();
+        let metas = vec![
+            meta("latest", "ws-x", 10, now, 1),
+            meta("old", "ws-x", 60 * 60 * 24 * 40, now, 1),
+        ];
+        let args = CleanArgs {
+            keep: Some(0),
+            ..Default::default()
+        };
+        let plan = plan_clean(&metas, "ws-x", &args, Some("latest"), now).unwrap();
+        assert_eq!(plan.to_delete.len(), 1);
+        assert_eq!(plan.to_delete[0].id, "old");
+    }
+
+    #[test]
+    fn plan_clean_single_id_rejects_cross_workspace() {
+        let now = SystemTime::now();
+        let metas = vec![meta("id-a", "ws-other", 10, now, 1)];
+        let args = CleanArgs {
+            id: Some("id-a".to_string()),
+            all: false,
+            ..Default::default()
+        };
+        assert!(plan_clean(&metas, "ws-x", &args, None, now).is_err());
+    }
+
+    #[test]
+    fn plan_clean_single_id_requires_no_combos() {
+        let now = SystemTime::now();
+        let metas = vec![meta("id-a", "ws-x", 10, now, 1)];
+        let args = CleanArgs {
+            id: Some("id-a".to_string()),
+            older_than_days: Some(1),
+            ..Default::default()
+        };
+        assert!(plan_clean(&metas, "ws-x", &args, None, now).is_err());
+    }
+
+    #[test]
+    fn plan_clean_single_id_all_allows_cross_workspace() {
+        let now = SystemTime::now();
+        let metas = vec![meta("id-a", "ws-other", 10, now, 1)];
+        let args = CleanArgs {
+            id: Some("id-a".to_string()),
+            all: true,
+            ..Default::default()
+        };
+        let plan = plan_clean(&metas, "ws-x", &args, None, now).unwrap();
+        assert_eq!(plan.to_delete.len(), 1);
+    }
+
+    #[test]
+    fn plan_clean_refuses_to_delete_protected_single_id() {
+        let now = SystemTime::now();
+        let metas = vec![meta("id-a", "ws-x", 10, now, 1)];
+        let args = CleanArgs {
+            id: Some("id-a".to_string()),
+            ..Default::default()
+        };
+        assert!(plan_clean(&metas, "ws-x", &args, Some("id-a"), now).is_err());
+    }
+
+    #[test]
+    fn show_view_builds_from_snapshot() {
+        let snap = SessionSnapshot {
+            id: "sid".into(),
+            workspace_key: "ws-x".into(),
+            active_root: Some(PathBuf::from("/tmp/work")),
+            mode_state: ModeState {
+                mode: ExecutionMode::Plan,
+                active_plan_path: Some(PathBuf::from("/tmp/work/.anvil/plan.md")),
+            },
+            messages: vec![
+                ConversationMessage::system("sys".into()),
+                ConversationMessage::user("hello world\nextra".into()),
+                ConversationMessage::assistant("hi".into(), vec![]),
+            ],
+            checkpoints: vec!["cp1".into()],
+            native_tools_disabled: false,
+        };
+        let v = ShowView::from_snapshot(&snap);
+        assert_eq!(v.id, "sid");
+        assert_eq!(v.workspace_key, "ws-x");
+        assert_eq!(v.message_count, 3);
+        assert_eq!(v.first_user_preview.as_deref(), Some("hello worldextra"));
+        assert_eq!(v.checkpoint_count, 1);
+        assert_eq!(v.mode, ExecutionMode::Plan);
+    }
+}

--- a/src/session/store.rs
+++ b/src/session/store.rs
@@ -1,7 +1,7 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use crate::modes::plan_act::ModeState;
+use crate::modes::plan_act::{ExecutionMode, ModeState};
 use crate::ollama::xml_fallback::ToolCall;
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -175,6 +175,47 @@ impl SessionStore {
             Some(candidate)
         } else {
             None
+        }
+    }
+}
+
+/// Bring a restored `SessionSnapshot` back to a runnable state before it is
+/// handed to `Agent::new`:
+///   (1) If `active_root` points at a directory that no longer exists,
+///       clear it so the agent falls back to the current cwd.
+///   (2) If the session is mid-Plan but its `active_plan_path` file is gone,
+///       downgrade to Act so the agent does not try to open a missing plan.
+///
+/// Emits a `warn:` line to stderr for each reconciliation. Idempotent.
+pub fn reconcile_resume_state(session: &mut SessionSnapshot, _cwd: &Path) {
+    if let Some(root) = &session.active_root
+        && !root.is_dir()
+    {
+        eprintln!(
+            "warn: session.active_root no longer exists ({}); falling back to cwd",
+            root.display()
+        );
+        session.active_root = None;
+    }
+
+    if session.mode_state.mode == ExecutionMode::Plan {
+        let missing_plan = session
+            .mode_state
+            .active_plan_path
+            .as_ref()
+            .is_some_and(|p| !p.exists());
+        if missing_plan {
+            eprintln!(
+                "warn: plan file missing ({}); downgrading to Act mode",
+                session
+                    .mode_state
+                    .active_plan_path
+                    .as_ref()
+                    .map(|p| p.display().to_string())
+                    .unwrap_or_default()
+            );
+            session.mode_state.mode = ExecutionMode::Act;
+            session.mode_state.active_plan_path = None;
         }
     }
 }

--- a/tests/session_cli_tests.rs
+++ b/tests/session_cli_tests.rs
@@ -1,0 +1,448 @@
+//! Integration tests for Issue #409: `--resume` and `sessions` subcommand.
+//!
+//! These exercise the public helpers that the `run_cli` wiring layers on top
+//! of. The tests deliberately avoid spawning the `anvil` binary so they run
+//! offline (no Ollama, no network) and stay deterministic.
+
+use anvil::cli::{CliArgs, Command, ResumeRequest, SessionsAction};
+use anvil::modes::plan_act::{ExecutionMode, ModeState};
+use anvil::session::compact::{COMPACT_SUMMARY_PREFIX, compact_messages, find_last_user_prompt};
+use anvil::session::sessions_cli::{
+    CleanArgs, ShowView, compute_list_rows, plan_clean, scan_session_meta,
+    validate_explicit_session_id, validate_session_dir, validate_session_id_format,
+};
+use anvil::session::store::{
+    ConversationMessage, SessionSnapshot, SessionStore, reconcile_resume_state,
+};
+use clap::Parser;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
+use tempfile::TempDir;
+
+// --------------------------------------------------------------------------
+// Helpers
+// --------------------------------------------------------------------------
+
+fn v7_id() -> String {
+    uuid::Uuid::now_v7().to_string()
+}
+
+fn write_session(
+    state_root: &Path,
+    id: &str,
+    workspace_key: &str,
+    messages: Vec<ConversationMessage>,
+    mode: ExecutionMode,
+    active_plan_path: Option<PathBuf>,
+    active_root: Option<PathBuf>,
+) -> PathBuf {
+    let session_dir = state_root.join("sessions").join(id);
+    fs::create_dir_all(&session_dir).unwrap();
+    let snap = SessionSnapshot {
+        id: id.to_string(),
+        workspace_key: workspace_key.to_string(),
+        messages,
+        mode_state: ModeState {
+            mode,
+            active_plan_path,
+        },
+        active_root,
+        ..Default::default()
+    };
+    let path = session_dir.join("session.json");
+    fs::write(&path, serde_json::to_string_pretty(&snap).unwrap()).unwrap();
+    path
+}
+
+fn simple_user_only(id: &str, ws: &str, state_root: &Path, text: &str) -> PathBuf {
+    write_session(
+        state_root,
+        id,
+        ws,
+        vec![ConversationMessage::user(text.into())],
+        ExecutionMode::Act,
+        None,
+        None,
+    )
+}
+
+// --------------------------------------------------------------------------
+// 1 & 2: CLI exclusivity
+// --------------------------------------------------------------------------
+
+#[test]
+fn resume_and_fresh_session_are_exclusive() {
+    let args = CliArgs::try_parse_from(["anvil", "--resume", "--fresh-session"]).expect("parse");
+    let err = args.validate().expect_err("must reject");
+    assert!(err.contains("--resume"), "got: {err}");
+    assert!(err.contains("--fresh-session"), "got: {err}");
+}
+
+#[test]
+fn resume_and_prompt_are_exclusive() {
+    let args = CliArgs::try_parse_from(["anvil", "--resume", "--prompt", "hi"]).expect("parse");
+    let err = args.validate().expect_err("must reject");
+    assert!(err.contains("--resume"), "got: {err}");
+}
+
+#[test]
+fn resume_and_oneshot_are_exclusive() {
+    let args = CliArgs::try_parse_from(["anvil", "--resume", "--oneshot"]).expect("parse");
+    let err = args.validate().expect_err("must reject");
+    assert!(err.contains("--resume"), "got: {err}");
+}
+
+// --------------------------------------------------------------------------
+// Task 2.2 / 15: existing CLI surface remains backward compatible
+// --------------------------------------------------------------------------
+
+#[test]
+fn existing_prompt_flow_still_parses_after_subcommand_introduction() {
+    let args = CliArgs::try_parse_from(["anvil", "--prompt", "hello world"]).expect("parse");
+    assert!(args.command.is_none());
+    assert_eq!(args.prompt.as_deref(), Some("hello world"));
+    assert!(args.validate().is_ok());
+}
+
+#[test]
+fn sessions_subcommand_parses() {
+    let args = CliArgs::try_parse_from(["anvil", "sessions", "list", "--json"]).expect("parse");
+    match args.command {
+        Some(Command::Sessions {
+            action: SessionsAction::List { all, json },
+        }) => {
+            assert!(!all);
+            assert!(json);
+        }
+        _ => panic!("expected Sessions::List"),
+    }
+}
+
+#[test]
+fn resume_with_id_parses() {
+    let id = v7_id();
+    let argv = ["anvil", "--resume", id.as_str()];
+    let args = CliArgs::try_parse_from(argv).expect("parse");
+    assert_eq!(
+        ResumeRequest::from_flag(args.resume.clone()),
+        ResumeRequest::WithId(id)
+    );
+    assert!(args.validate().is_ok());
+}
+
+#[test]
+fn resume_without_id_parses_as_latest() {
+    let args = CliArgs::try_parse_from(["anvil", "--resume"]).expect("parse");
+    assert_eq!(
+        ResumeRequest::from_flag(args.resume.clone()),
+        ResumeRequest::Latest
+    );
+}
+
+// --------------------------------------------------------------------------
+// 3 & 10 & 4: find_last_user_prompt + compaction behavior
+// --------------------------------------------------------------------------
+
+#[test]
+fn find_last_user_with_tail_assistant() {
+    let msgs = vec![
+        ConversationMessage::user("hello".into()),
+        ConversationMessage::assistant("hi".into(), vec![]),
+    ];
+    assert_eq!(find_last_user_prompt(&msgs).as_deref(), Some("hello"));
+}
+
+#[test]
+fn find_last_user_with_tail_tool() {
+    let msgs = vec![
+        ConversationMessage::user("do something".into()),
+        ConversationMessage::assistant("".into(), vec![]),
+        ConversationMessage::tool("read".into(), "contents".into()),
+    ];
+    assert_eq!(
+        find_last_user_prompt(&msgs).as_deref(),
+        Some("do something")
+    );
+}
+
+#[test]
+fn find_last_user_returns_none_when_compaction_removed_all_users() {
+    let mut messages = (0..30)
+        .map(|i| ConversationMessage::assistant(format!("reply-{i}"), vec![]))
+        .collect::<Vec<_>>();
+    messages.push(ConversationMessage::system(format!(
+        "{COMPACT_SUMMARY_PREFIX}\nsummary"
+    )));
+    assert!(find_last_user_prompt(&messages).is_none());
+}
+
+#[test]
+fn find_last_user_skips_compaction_summary_prefix() {
+    let msgs = vec![
+        ConversationMessage::user("original".into()),
+        ConversationMessage::system(format!("{COMPACT_SUMMARY_PREFIX}\nuser: old prompt")),
+    ];
+    assert_eq!(
+        find_last_user_prompt(&msgs).as_deref(),
+        Some("original"),
+        "compaction summary should be skipped"
+    );
+}
+
+#[test]
+fn compaction_then_find_last_user_still_works_when_tail_keeps_user() {
+    let mut messages: Vec<ConversationMessage> = (0..40)
+        .map(|i| {
+            if i % 3 == 0 {
+                ConversationMessage::user(format!("prompt-{i}"))
+            } else {
+                ConversationMessage::assistant(format!("reply-{i}"), vec![])
+            }
+        })
+        .collect();
+    compact_messages(&mut messages, 10);
+    let got = find_last_user_prompt(&messages);
+    assert!(got.is_some(), "tail should still contain a user message");
+}
+
+// --------------------------------------------------------------------------
+// 5 / 6 / 7: list filtering and JSON-ish scope tagging
+// --------------------------------------------------------------------------
+
+#[test]
+fn list_filters_current_workspace_only_by_default() {
+    let tmp = TempDir::new().unwrap();
+    simple_user_only(&v7_id(), "ws-current", tmp.path(), "A");
+    simple_user_only(&v7_id(), "ws-other", tmp.path(), "B");
+    let metas = scan_session_meta(tmp.path());
+    let rows = compute_list_rows(&metas, "ws-current", false);
+    assert_eq!(rows.len(), 1);
+}
+
+#[test]
+fn list_all_includes_unassigned_and_foreign() {
+    let tmp = TempDir::new().unwrap();
+    simple_user_only(&v7_id(), "ws-current", tmp.path(), "A");
+    simple_user_only(&v7_id(), "", tmp.path(), "B"); // unassigned
+    simple_user_only(&v7_id(), "ws-other", tmp.path(), "C");
+    let metas = scan_session_meta(tmp.path());
+    let rows = compute_list_rows(&metas, "ws-current", true);
+    assert_eq!(rows.len(), 3);
+    assert!(rows.iter().any(|r| matches!(
+        r.scope,
+        anvil::session::sessions_cli::WorkspaceScope::Unassigned
+    )));
+}
+
+// --------------------------------------------------------------------------
+// 8 & 19: show fields + explicit-id rejection
+// --------------------------------------------------------------------------
+
+#[test]
+fn show_view_contains_acceptance_fields() {
+    let tmp = TempDir::new().unwrap();
+    let id = v7_id();
+    let plan_path = tmp.path().join("plan.md");
+    fs::write(&plan_path, "plan").unwrap();
+    write_session(
+        tmp.path(),
+        &id,
+        "ws-a",
+        vec![
+            ConversationMessage::user("first user".into()),
+            ConversationMessage::assistant("ok".into(), vec![]),
+        ],
+        ExecutionMode::Plan,
+        Some(plan_path),
+        Some(tmp.path().to_path_buf()),
+    );
+    let session_json = tmp.path().join("sessions").join(&id).join("session.json");
+    let data = fs::read_to_string(&session_json).unwrap();
+    let snap: SessionSnapshot = serde_json::from_str(&data).unwrap();
+
+    let view = ShowView::from_snapshot(&snap);
+    assert_eq!(view.id, id);
+    assert_eq!(view.workspace_key, "ws-a");
+    assert_eq!(view.message_count, 2);
+    assert_eq!(view.first_user_preview.as_deref(), Some("first user"));
+    assert!(view.last_assistant_or_tool_preview.is_some());
+    assert_eq!(view.mode, ExecutionMode::Plan);
+}
+
+#[test]
+fn validate_explicit_rejects_non_v7_ids() {
+    assert!(validate_session_id_format("not-a-uuid").is_err());
+    assert!(validate_session_id_format("0190f3c0-1111-4a00-8000-000000000000").is_err());
+}
+
+#[test]
+fn validate_explicit_rejects_missing_directory() {
+    let tmp = TempDir::new().unwrap();
+    let err = validate_explicit_session_id(tmp.path(), &v7_id()).unwrap_err();
+    assert!(err.contains("session"), "unexpected: {err}");
+}
+
+#[cfg(unix)]
+#[test]
+fn validate_explicit_rejects_symlink() {
+    let tmp = TempDir::new().unwrap();
+    let sessions = tmp.path().join("sessions");
+    fs::create_dir_all(&sessions).unwrap();
+
+    let real_id = v7_id();
+    let real_dir = sessions.join(&real_id);
+    fs::create_dir_all(&real_dir).unwrap();
+    fs::write(real_dir.join("session.json"), "{}").unwrap();
+
+    let link_id = v7_id();
+    std::os::unix::fs::symlink(&real_dir, sessions.join(&link_id)).unwrap();
+
+    let err = validate_explicit_session_id(tmp.path(), &link_id).unwrap_err();
+    assert!(err.contains("symlink"), "unexpected: {err}");
+}
+
+#[test]
+fn validate_session_dir_rejects_path_traversal_attempt() {
+    let tmp = TempDir::new().unwrap();
+    // An id that happens to parse as UUID v7 but references something that
+    // does not exist in state_root/sessions/ — format check is upstream.
+    let err = validate_session_dir(tmp.path(), "0199fe00-0000-7000-8000-aaaaaaaaaaaa").unwrap_err();
+    assert!(err.contains("session"), "unexpected: {err}");
+}
+
+// --------------------------------------------------------------------------
+// 9 / 10 / 12: clean dry-run, protection, sort stability
+// --------------------------------------------------------------------------
+
+#[test]
+fn plan_clean_older_than_matches_list_order_desc() {
+    let tmp = TempDir::new().unwrap();
+    let now = SystemTime::now();
+
+    let fresh_id = v7_id();
+    simple_user_only(&fresh_id, "ws", tmp.path(), "fresh");
+
+    let old_id = v7_id();
+    let old_path = simple_user_only(&old_id, "ws", tmp.path(), "old");
+    // Drive session.json mtime 40 days into the past so --older-than 30 trips.
+    let old_mtime = now - Duration::from_secs(60 * 60 * 24 * 40);
+    let f = fs::File::options().write(true).open(&old_path).unwrap();
+    f.set_modified(old_mtime).unwrap();
+    drop(f);
+
+    let metas = scan_session_meta(tmp.path());
+    // list view comes out newest-first
+    let list_rows = compute_list_rows(&metas, "ws", false);
+    assert_eq!(
+        list_rows.first().map(|r| r.id.as_str()),
+        Some(fresh_id.as_str())
+    );
+
+    let args = CleanArgs {
+        older_than_days: Some(30),
+        ..Default::default()
+    };
+    let plan = plan_clean(&metas, "ws", &args, Some(&fresh_id), now).unwrap();
+    assert_eq!(plan.to_delete.len(), 1);
+    assert_eq!(plan.to_delete[0].id, old_id);
+}
+
+#[test]
+fn plan_clean_protects_resolver_winner() {
+    let tmp = TempDir::new().unwrap();
+    let winner = v7_id();
+    simple_user_only(&winner, "ws", tmp.path(), "winner");
+    simple_user_only(&v7_id(), "ws", tmp.path(), "loser");
+
+    let metas = scan_session_meta(tmp.path());
+    let args = CleanArgs {
+        keep: Some(0),
+        ..Default::default()
+    };
+    let plan = plan_clean(&metas, "ws", &args, Some(&winner), SystemTime::now()).unwrap();
+    assert!(plan.to_delete.iter().all(|m| m.id != winner));
+}
+
+#[cfg(unix)]
+#[test]
+fn plan_clean_ignores_symlinked_session_dirs() {
+    // iter_session_dirs (used by scan_session_meta) already skips symlinks,
+    // so clean never even sees them as candidates.
+    let tmp = TempDir::new().unwrap();
+    let sessions = tmp.path().join("sessions");
+    fs::create_dir_all(&sessions).unwrap();
+
+    let real_id = v7_id();
+    let real_dir = sessions.join(&real_id);
+    fs::create_dir_all(&real_dir).unwrap();
+    fs::write(
+        real_dir.join("session.json"),
+        r#"{"mode_state":{"mode":"Act","active_plan_path":null},"messages":[],"checkpoints":[]}"#,
+    )
+    .unwrap();
+
+    let link_id = v7_id();
+    std::os::unix::fs::symlink(&real_dir, sessions.join(&link_id)).unwrap();
+
+    let metas = scan_session_meta(tmp.path());
+    assert_eq!(metas.len(), 1);
+    assert_eq!(metas[0].id, real_id);
+}
+
+// --------------------------------------------------------------------------
+// 13 / 14: reconcile_resume_state
+// --------------------------------------------------------------------------
+
+#[test]
+fn reconcile_clears_missing_active_root() {
+    let tmp = TempDir::new().unwrap();
+    let id = v7_id();
+    let store = SessionStore::new(tmp.path(), &id, "ws");
+    let mut snap = SessionSnapshot {
+        id: id.clone(),
+        workspace_key: "ws".into(),
+        active_root: Some(PathBuf::from("/definitely-not-a-dir-xyz")),
+        ..Default::default()
+    };
+    reconcile_resume_state(&mut snap, tmp.path());
+    assert!(snap.active_root.is_none());
+    // store is unused but we built it to ensure the helper compiles
+    // against the public API.
+    let _ = store;
+}
+
+#[test]
+fn reconcile_downgrades_plan_when_plan_file_missing() {
+    let tmp = TempDir::new().unwrap();
+    let mut snap = SessionSnapshot {
+        mode_state: ModeState {
+            mode: ExecutionMode::Plan,
+            active_plan_path: Some(PathBuf::from("/definitely-not-a-file-xyz")),
+        },
+        ..Default::default()
+    };
+    reconcile_resume_state(&mut snap, tmp.path());
+    assert_eq!(snap.mode_state.mode, ExecutionMode::Act);
+    assert!(snap.mode_state.active_plan_path.is_none());
+}
+
+#[test]
+fn reconcile_is_noop_when_everything_is_valid() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().to_path_buf();
+    let plan = tmp.path().join("plan.md");
+    fs::write(&plan, "plan").unwrap();
+    let mut snap = SessionSnapshot {
+        active_root: Some(root.clone()),
+        mode_state: ModeState {
+            mode: ExecutionMode::Plan,
+            active_plan_path: Some(plan.clone()),
+        },
+        ..Default::default()
+    };
+    reconcile_resume_state(&mut snap, tmp.path());
+    assert_eq!(snap.active_root.as_deref(), Some(root.as_path()));
+    assert_eq!(snap.mode_state.mode, ExecutionMode::Plan);
+    assert_eq!(snap.mode_state.active_plan_path.as_ref(), Some(&plan));
+}


### PR DESCRIPTION
## 概要
- `anvil --resume` で最後のセッションから継続可能
- `anvil sessions list` で過去のセッション一覧表示（メッセージ数・最終ツール）
- `anvil sessions show <ID>` でセッション詳細サマリー
- `anvil sessions clean` で古いセッション削除
- マルチセッションストレージ対応（UUID v7ベースのファイル名）

## 変更内容
- `src/session/discovery.rs` — セッション探索モジュール新規
- `src/session/sessions_cli.rs` — sessions サブコマンドハンドラ新規
- `src/session/store.rs` — マルチセッション対応・メタデータ追跡拡張
- `src/session/mod.rs` — 新モジュール公開
- `src/cli.rs` — `--resume` フラグ・`sessions` サブコマンド追加
- `src/config.rs` — resume 設定対応
- `src/agent/loop_run.rs` — resume セッション読み込みパス追加
- `tests/session_cli_tests.rs` — 統合テスト追加

## テスト
- [x] `cargo test --all` パス
- [x] `cargo clippy --all-targets` 警告ゼロ
- [x] `cargo fmt --all -- --check` パス

## 関連Issue
Closes #409