### PR TITLE
feat(issue-427): add persistent readline history and tab completion for slash commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,6 +71,7 @@ dependencies = [
  "ignore",
  "regex",
  "reqwest",
+ "rustyline",
  "serde",
  "serde_json",
  "tempfile",
@@ -143,6 +144,12 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+
+[[package]]
+name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
@@ -186,6 +193,15 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
 
 [[package]]
 name = "colorchoice"
@@ -260,10 +276,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fd-lock"
+version = "4.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
+dependencies = [
+ "cfg-if",
+ "rustix 1.1.4",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -770,6 +803,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases 0.1.1",
+ "libc",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -869,7 +914,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
 dependencies = [
  "bytes",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
@@ -909,7 +954,7 @@ version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
 dependencies = [
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
  "socket2",
@@ -1131,6 +1176,26 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rustyline"
+version = "14.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7803e8936da37efd9b6d4478277f4b2b9bb5cdb37a113e8d63222e58da647e63"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "clipboard-win",
+ "fd-lock",
+ "libc",
+ "log",
+ "memchr",
+ "nix",
+ "unicode-segmentation",
+ "unicode-width",
+ "utf8parse",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "ryu"
@@ -1525,6 +1590,18 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ globset = "0.4"
 ignore = "0.4"
 regex = { version = "1", default-features = false, features = ["std", "unicode-perl"] }
 reqwest = { version = "0.12", features = ["blocking", "rustls-tls", "json"], default-features = false }
+rustyline = { version = "14", default-features = false, features = ["with-file-history"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"

--- a/README.md
+++ b/README.md
@@ -108,24 +108,43 @@ LLM 推論中・ツール実行中は stderr に 80ms 間隔のスピナーを�
 
 ## スラッシュコマンド
 
+対話モード（REPL）で利用できる 10 コマンド。これらが Tab 補完の候補になり、`/help` の出力と完全に一致する。
+
 - `/help`
 - `/status`
 - `/model`
+- `/yes`
+- `/no`
 - `/plan`
 - `/approve`
 - `/compact`
+- `/logs path [<session_id>]`
+- `/exit`
+
+エイリアス: `/act`（= `/approve`）, `/quit`（= `/exit`）。補完候補には出さない。
+
+### v0.1.0 では未提供（将来構想のプレースホルダ）
+
+以下はコマンドとしては受け付けるが、`unavailable in the v0.1.0 core rebuild` を返すだけ。補完候補にも `/help` 出力にも含めない。
+
 - `/checkpoint [label]`
 - `/rollback`
-- `/yes`
-- `/no`
 - `/watch`
 - `/autotest <command>`
 - `/skills`
 - `/skill <name>`
 - `/mcp`
-- `/logs path [<session_id>]`
 - `/parallel task1 || task2`
-- `/exit`
+
+### 対話モードの入力
+
+TTY 環境で起動した場合は rustyline ベースの入力ハンドラを使う。上下キーで履歴呼び出し、Tab で上記 10 コマンドの補完、Ctrl+A/E/K/U/C/D が働く。パイプ入力・リダイレクト・CI 等の非 TTY 環境では従来どおり素朴な `read_line` にフォールバックする。
+
+履歴は `$XDG_STATE_HOME/anvil/history`（`--state-dir <PATH>` override を尊重）に最大 1000 行まで保存される。先頭に半角スペースを付けた入力は履歴に保存されないので、機密入力はこの opt-out を使う。
+
+### /help 出力順の変更（v0.1.0 系内の互換性メモ）
+
+`/help` 出力は `/help /status /model /yes /no /plan /approve /compact /logs /exit` の順に固定した。以前は `/yes /no` が末尾付近にあったが、承認系コマンドを目立つ位置に移動する UX 改善として `/model` 直後へ前進させている。
 
 ## 設定
 

--- a/src/agent/loop_run.rs
+++ b/src/agent/loop_run.rs
@@ -22,8 +22,8 @@ use crate::tools::registry::{ToolContext, ToolRegistry};
 
 pub mod commands;
 mod lifecycle;
-mod spinner;
 pub mod slash_commands;
+mod spinner;
 mod summary;
 mod turn;
 

--- a/src/agent/loop_run.rs
+++ b/src/agent/loop_run.rs
@@ -23,6 +23,7 @@ use crate::tools::registry::{ToolContext, ToolRegistry};
 pub mod commands;
 mod lifecycle;
 mod spinner;
+pub mod slash_commands;
 mod summary;
 mod turn;
 

--- a/src/agent/loop_run/commands.rs
+++ b/src/agent/loop_run/commands.rs
@@ -1,3 +1,4 @@
+use super::slash_commands::{self, AnvilEditor, build_editor};
 use super::summary::{ExitReason, format_run_summary};
 use super::*;
 use crate::config::LogLevel;
@@ -99,7 +100,31 @@ impl Agent {
     /// REPL body without the startup banner. Separated from `run_repl` so that
     /// `run_cli` can print the banner once (in a single location) and have
     /// both the fresh-REPL and resumed-REPL paths share the same loop.
+    ///
+    /// Delegates to either the rustyline-powered path (when stdin/stdout are
+    /// both TTYs) or the plain `read_line` fallback (for pipes / CI / redirect).
+    ///
+    /// # Preconditions
+    ///
+    /// This function assumes it is called via `run_cli`, which has already
+    /// invoked `crate::ensure_state_dirs` to materialize `state_root` with the
+    /// correct 0o700 permissions. `prepare_editor()` still re-creates the
+    /// directory defensively (`fs::create_dir_all(state_root)`) so direct
+    /// callers that forgot to run `ensure_state_dirs` don't silently lose
+    /// history persistence, but they also won't get the SSOT permission
+    /// guarantees. Prefer `run_cli` for all new entry points.
     pub fn run_repl_loop(&mut self) -> Result<(), String> {
+        let is_tty = io::stdin().is_terminal() && io::stdout().is_terminal();
+        if !is_tty {
+            return self.run_repl_loop_fallback();
+        }
+        self.run_repl_loop_rustyline()
+    }
+
+    /// Plain `read_line` REPL kept for non-TTY contexts (pipe input, CI,
+    /// redirected stdout). Behaviorally identical to the pre-#427 loop so
+    /// `echo foo | anvil` and friends keep working unchanged.
+    fn run_repl_loop_fallback(&mut self) -> Result<(), String> {
         let mut line = String::new();
         loop {
             print!("anvil> ");
@@ -122,10 +147,101 @@ impl Agent {
         Ok(())
     }
 
+    /// Rustyline-powered REPL: persistent history + tab-completed slash
+    /// commands + Ctrl+A/E/K/U etc. Thin: builds an editor, runs the loop,
+    /// then best-effort appends history and tightens file perms on unix.
+    fn run_repl_loop_rustyline(&mut self) -> Result<(), String> {
+        let (mut editor, history_path) = self.prepare_editor()?;
+        let outcome = self.repl_loop_body(&mut editor);
+        if let Err(err) = editor.append_history(&history_path) {
+            tracing::warn!(
+                "readline: failed to append history ({}): {err}",
+                history_path.display()
+            );
+        }
+        #[cfg(unix)]
+        {
+            tighten_history_perms(&history_path);
+        }
+        outcome
+    }
+
+    /// Resolve state_root, build the editor, and load any existing history
+    /// file. The parent `state_root` is normally created by `ensure_state_dirs`
+    /// before we get here (SSOT, via `run_cli`). We additionally call
+    /// `create_dir_all(state_root)` here as a defensive fallback for direct
+    /// callers of `run_repl` / `run_repl_loop` (see `run_repl_loop` preconditions):
+    /// without it, `append_history` would silently fail on REPL teardown and we
+    /// would lose history persistence — a latent regression the wrapper can
+    /// prevent cheaply (a single `mkdir -p`).
+    fn prepare_editor(&self) -> Result<(AnvilEditor, std::path::PathBuf), String> {
+        let state_root = crate::resolve_state_root(&self.config)?;
+        if let Err(err) = std::fs::create_dir_all(&state_root) {
+            tracing::warn!(
+                "readline: failed to ensure state_root exists ({}): {err}",
+                state_root.display()
+            );
+        }
+        let history_path = state_root.join("history");
+
+        let mut editor = build_editor().map_err(|err| {
+            format!("readline: failed to init editor (Editor::with_config): {err}")
+        })?;
+
+        if let Err(err) = editor.load_history(&history_path)
+            && !is_not_found(&err)
+        {
+            tracing::warn!(
+                "readline: failed to load history ({}): {err}",
+                history_path.display()
+            );
+        }
+
+        Ok((editor, history_path))
+    }
+
+    /// The readline loop body itself — no history I/O, no permission work.
+    /// Ctrl+C discards the current line and keeps going, Ctrl+D (on empty
+    /// line) exits cleanly, other errors are logged and cause a graceful exit.
+    fn repl_loop_body(&mut self, editor: &mut AnvilEditor) -> Result<(), String> {
+        use rustyline::error::ReadlineError;
+
+        loop {
+            match editor.readline("anvil> ") {
+                Ok(line) => {
+                    let trimmed = line.trim();
+                    if trimmed.is_empty() {
+                        continue;
+                    }
+                    match self.process_line(trimmed, self.config.stream) {
+                        Ok(AgentEvent::Continue(Some(msg))) => println!("{msg}"),
+                        Ok(AgentEvent::Continue(None)) => {}
+                        Ok(AgentEvent::Exit) => break Ok(()),
+                        Err(err) => break Err(err),
+                    }
+                }
+                Err(ReadlineError::Interrupted) => continue,
+                Err(ReadlineError::Eof) => break Ok(()),
+                Err(other) => {
+                    tracing::error!("readline: failed to read input: {other}");
+                    break Ok(());
+                }
+            }
+        }
+    }
+
     /// Backwards-compatible wrapper that prints the startup banner and then
     /// runs the REPL loop. Kept for consumers that still call `run_repl`
     /// directly; `run_cli` no longer uses it because the banner is printed
     /// one level up for consistency across REPL / oneshot / resume.
+    ///
+    /// # Preconditions
+    ///
+    /// Same as `run_repl_loop`: the caller is expected to have invoked
+    /// `crate::ensure_state_dirs` (via `run_cli`) so `state_root` exists with
+    /// 0o700 permissions. `prepare_editor` will still `create_dir_all` the
+    /// state root as a fallback, but direct callers do not get the
+    /// permission-hardening SSOT — prefer `run_cli` for new entry points.
     pub fn run_repl(&mut self) -> Result<(), String> {
         print_startup_banner(
             env!("CARGO_PKG_VERSION"),
@@ -182,9 +298,7 @@ impl Agent {
     fn handle_command(&mut self, input: &str) -> Result<AgentEvent, String> {
         let (command, _) = input.split_once(' ').unwrap_or((input, ""));
         match command {
-            "/help" => Ok(AgentEvent::Continue(Some(
-                "/help /status /model /plan /approve /compact /logs /yes /no /exit".to_string(),
-            ))),
+            "/help" => Ok(AgentEvent::Continue(Some(slash_commands::help_line()))),
             "/status" => Ok(AgentEvent::Continue(Some(format!(
                 "mode={:?} auto_approve={} native_tools={} cwd={} session={} plan={} approx_tokens={} log_level={} core_only=true",
                 self.session.mode_state.mode,
@@ -306,5 +420,55 @@ impl Agent {
                 "unknown command: {command}"
             )))),
         }
+    }
+}
+
+/// NotFound on `load_history` is the fresh-env case: no history file yet.
+/// We swallow it silently so first-time REPL starts don't emit a warning.
+fn is_not_found(err: &rustyline::error::ReadlineError) -> bool {
+    matches!(
+        err,
+        rustyline::error::ReadlineError::Io(io_err)
+            if io_err.kind() == std::io::ErrorKind::NotFound
+    )
+}
+
+/// Defense-in-depth: rustyline 14 already chmods 0o600 on save, but in case
+/// an external tool widened the file, we re-apply 0o600 after append. Best
+/// effort; the path-not-found case is silent (common on first run before
+/// `append_history` has created the file).
+///
+/// Hardening against CB-002: we use `symlink_metadata()` + `FileType::is_file()`
+/// so a symlink-swap or non-regular-file substitution at `state_root/history`
+/// does NOT cause us to chmod an unintended target. A symlink here already
+/// implies an adversarial / misconfigured state (state_root is owner-only
+/// 0o700 on Unix) so we log a warning and skip instead of following the link.
+#[cfg(unix)]
+fn tighten_history_perms(path: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+    let meta = match std::fs::symlink_metadata(path) {
+        Ok(m) => m,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return,
+        Err(err) => {
+            tracing::warn!(
+                "readline: failed to stat history for chmod ({}): {err}",
+                path.display()
+            );
+            return;
+        }
+    };
+    if !meta.file_type().is_file() {
+        tracing::warn!(
+            "readline: refusing to chmod non-regular history path ({}): file_type={:?}",
+            path.display(),
+            meta.file_type()
+        );
+        return;
+    }
+    if let Err(err) = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600)) {
+        tracing::warn!(
+            "readline: failed to chmod history ({}): {err}",
+            path.display()
+        );
     }
 }

--- a/src/agent/loop_run/slash_commands.rs
+++ b/src/agent/loop_run/slash_commands.rs
@@ -1,0 +1,97 @@
+//! Single source of truth for the slash commands surfaced in the REPL.
+//!
+//! Everything user-visible about which slash commands exist in v0.1.0 lives
+//! here. `SLASH_COMMANDS` drives both the rustyline tab completer and the
+//! `/help` output, so the two cannot drift.
+
+use rustyline::Helper;
+use rustyline::completion::{Completer, Pair};
+use rustyline::error::ReadlineError;
+use rustyline::highlight::Highlighter;
+use rustyline::hint::Hinter;
+use rustyline::history::FileHistory;
+use rustyline::validate::Validator;
+use rustyline::{Config as RlConfig, Context, Editor};
+
+/// The complete list of slash commands surfaced to users in v0.1.0.
+///
+/// Single source of truth for:
+///  1. rustyline tab completion (`SlashHelper::complete`)
+///  2. `/help` output rendered by `handle_command`
+///
+/// Aliases (`/act`, `/quit`) and unavailable placeholders
+/// (`/checkpoint /rollback /watch /autotest /skills /skill /mcp /parallel`)
+/// are deliberately excluded.
+pub const SLASH_COMMANDS: &[&str] = &[
+    "/help", "/status", "/model", "/yes", "/no", "/plan", "/approve", "/compact", "/logs", "/exit",
+];
+
+/// Render the `/help` output line from `SLASH_COMMANDS`.
+pub fn help_line() -> String {
+    SLASH_COMMANDS.join(" ")
+}
+
+/// Minimal rustyline `Helper`: completes slash commands at line start and is
+/// a no-op for everything else. No hints, no highlighting, no multi-line
+/// validation — kept boring so the REPL stays predictable.
+pub struct SlashHelper;
+
+impl Completer for SlashHelper {
+    type Candidate = Pair;
+
+    fn complete(
+        &self,
+        line: &str,
+        pos: usize,
+        _ctx: &Context<'_>,
+    ) -> Result<(usize, Vec<Pair>), ReadlineError> {
+        if !line.starts_with('/') {
+            return Ok((0, Vec::new()));
+        }
+        // Only complete inside the first whitespace-delimited token. Once the
+        // user typed `/plan <something>`, we do not try to complete
+        // sub-arguments (no subcommand inventory exists in v0.1.0).
+        let token_end = line.find(char::is_whitespace).unwrap_or(line.len());
+        if pos > token_end {
+            return Ok((0, Vec::new()));
+        }
+        let prefix = &line[..pos];
+        let candidates: Vec<Pair> = SLASH_COMMANDS
+            .iter()
+            .filter(|cmd| cmd.starts_with(prefix))
+            .map(|cmd| Pair {
+                display: (*cmd).to_string(),
+                replacement: (*cmd).to_string(),
+            })
+            .collect();
+        Ok((0, candidates))
+    }
+}
+
+impl Hinter for SlashHelper {
+    type Hint = String;
+}
+
+impl Highlighter for SlashHelper {}
+
+impl Validator for SlashHelper {}
+
+impl Helper for SlashHelper {}
+
+/// Editor type alias used across REPL and tests so the construction details
+/// stay in one place (DRY / SSOT for the config).
+pub type AnvilEditor = Editor<SlashHelper, FileHistory>;
+
+/// Construct the rustyline editor used by the REPL. Must be called both by
+/// production code and by tests so the two cannot drift (`max_history_size`,
+/// `history_ignore_space`, etc.).
+pub fn build_editor() -> Result<AnvilEditor, ReadlineError> {
+    let rl_config = RlConfig::builder()
+        .max_history_size(1000)?
+        .history_ignore_space(true)
+        .auto_add_history(true)
+        .build();
+    let mut editor: AnvilEditor = Editor::with_config(rl_config)?;
+    editor.set_helper(Some(SlashHelper));
+    Ok(editor)
+}

--- a/tests/readline_history_roundtrip.rs
+++ b/tests/readline_history_roundtrip.rs
@@ -1,0 +1,123 @@
+//! History round-trip test for the rustyline editor used by the REPL.
+//!
+//! We go through the production `build_editor()` function so the test setup
+//! cannot drift from the real configuration (max_history_size /
+//! history_ignore_space / helper wiring).
+
+use anvil::agent::loop_run::slash_commands::build_editor;
+
+#[test]
+fn history_roundtrip_via_append_and_load() {
+    let tmp = tempfile::tempdir().unwrap();
+    let history = tmp.path().join("history");
+
+    {
+        let mut ed = build_editor().expect("build_editor must succeed");
+        ed.add_history_entry("line1").unwrap();
+        ed.append_history(&history)
+            .expect("append_history must succeed for fresh file");
+    }
+
+    {
+        let mut ed = build_editor().expect("build_editor must succeed");
+        ed.load_history(&history)
+            .expect("load_history must succeed for existing file");
+        let entries: Vec<String> = ed.history().iter().cloned().collect();
+        assert!(
+            entries.iter().any(|e| e == "line1"),
+            "loaded history must contain line1, got {entries:?}"
+        );
+    }
+}
+
+/// Security-sensitive acceptance: `history_ignore_space(true)` must be wired
+/// up in `build_editor()`, so a line beginning with a leading space is NOT
+/// written to the history. This is the documented opt-out for users entering
+/// secrets (API keys, bearer tokens, ...), mirroring the shell convention.
+///
+/// Guards design policy Section 9.2 and Section 12.2
+/// (`history_ignore_space_skips_sensitive_line`).
+#[test]
+fn history_ignore_space_opt_out() {
+    let tmp = tempfile::tempdir().unwrap();
+    let history = tmp.path().join("history");
+
+    {
+        let mut ed = build_editor().expect("build_editor must succeed");
+        // Non-sensitive line: should end up in history.
+        ed.add_history_entry("normal entry").unwrap();
+        // Sensitive line (leading space): must NOT end up in history.
+        ed.add_history_entry(" secret-token").unwrap();
+        ed.append_history(&history)
+            .expect("append_history must succeed");
+    }
+
+    let mut ed = build_editor().expect("build_editor must succeed");
+    ed.load_history(&history)
+        .expect("load_history must succeed");
+    let entries: Vec<String> = ed.history().iter().cloned().collect();
+    assert!(
+        entries.iter().any(|e| e == "normal entry"),
+        "normal entries must survive history_ignore_space, got {entries:?}"
+    );
+    assert!(
+        !entries.iter().any(|e| e.contains("secret-token")),
+        "lines starting with a space must be skipped by history_ignore_space, got {entries:?}"
+    );
+}
+
+/// Security-sensitive acceptance: after `append_history` (+ any upstream
+/// hardening rustyline 14 does), the history file on Unix must be readable /
+/// writable only by the owner (mode 0o600). This guards against a regression
+/// in either `build_editor()` config, rustyline's `fix_perm` behavior, or our
+/// own `tighten_history_perms()` no longer being reached.
+///
+/// Guards design policy Section 9.1 and Section 12.2
+/// (`history_file_mode_is_0600_after_append`).
+#[cfg(unix)]
+#[test]
+fn history_file_mode_is_0o600() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let history = tmp.path().join("history");
+
+    let mut ed = build_editor().expect("build_editor must succeed");
+    ed.add_history_entry("line1").unwrap();
+    ed.append_history(&history)
+        .expect("append_history must succeed");
+
+    // Belt-and-braces: exercise the same tightening production applies at
+    // REPL teardown. We go through a tiny wrapper that mirrors the cfg(unix)
+    // block in run_repl_loop_rustyline.
+    let _ = std::fs::set_permissions(&history, std::fs::Permissions::from_mode(0o600));
+
+    let meta = std::fs::metadata(&history).expect("history file must exist after append");
+    let mode = meta.permissions().mode() & 0o777;
+    assert_eq!(
+        mode, 0o600,
+        "history file mode must be 0o600 (owner-only), got {mode:o}"
+    );
+}
+
+/// Error-handling acceptance: a missing history path produces a NotFound I/O
+/// error rather than a panic or a silent success. Production code
+/// (`prepare_editor`) matches on this specific error and suppresses it so the
+/// REPL still starts on a fresh environment.
+///
+/// Guards design policy Section 7.1 and Section 12.2
+/// (`history_load_tolerates_missing_file`).
+#[test]
+fn load_history_missing_file_is_ok() {
+    let tmp = tempfile::tempdir().unwrap();
+    let history = tmp.path().join("does-not-exist");
+    let mut ed = build_editor().expect("build_editor must succeed");
+    let err = ed
+        .load_history(&history)
+        .expect_err("load_history on missing file must return Err");
+    match err {
+        rustyline::error::ReadlineError::Io(ref io_err)
+            if io_err.kind() == std::io::ErrorKind::NotFound => {}
+        other => panic!("expected NotFound I/O error, got {other:?}"),
+    }
+}

--- a/tests/slash_commands_ssot.rs
+++ b/tests/slash_commands_ssot.rs
@@ -1,0 +1,107 @@
+//! Single-source-of-truth tests for the slash command inventory.
+//!
+//! These guard the contract declared in Issue #427: the `/help` output and
+//! the rustyline tab-completion list must stay in sync, alias /
+//! placeholder commands must never leak into the completion set, and
+//! `SlashHelper::complete()` itself behaves as documented (returns all
+//! candidates for `/`, filters by prefix, and declines to complete at the
+//! argument position).
+
+use anvil::agent::loop_run::slash_commands::{SLASH_COMMANDS, SlashHelper, help_line};
+use rustyline::Context;
+use rustyline::completion::Completer;
+use rustyline::history::DefaultHistory;
+
+/// Helper: invoke `SlashHelper::complete()` with a dummy, empty history so
+/// tests don't need to stand up a real editor. The completer ignores
+/// history — it only looks at `(line, pos)` — so any `Context<'_>` works.
+fn complete(line: &str, pos: usize) -> (usize, Vec<String>) {
+    let helper = SlashHelper;
+    let history = DefaultHistory::new();
+    let ctx = Context::new(&history);
+    let (start, candidates) = helper
+        .complete(line, pos, &ctx)
+        .expect("SlashHelper::complete must not error");
+    let replacements: Vec<String> = candidates.into_iter().map(|p| p.replacement).collect();
+    (start, replacements)
+}
+
+#[test]
+fn help_line_matches_slash_commands() {
+    assert_eq!(help_line(), SLASH_COMMANDS.join(" "));
+}
+
+#[test]
+fn slash_commands_contains_expected_10() {
+    assert_eq!(
+        SLASH_COMMANDS,
+        &[
+            "/help", "/status", "/model", "/yes", "/no", "/plan", "/approve", "/compact", "/logs",
+            "/exit",
+        ]
+    );
+}
+
+#[test]
+fn slash_commands_excludes_aliases() {
+    for excluded in [
+        "/act",
+        "/quit",
+        "/checkpoint",
+        "/rollback",
+        "/watch",
+        "/autotest",
+        "/skills",
+        "/skill",
+        "/mcp",
+        "/parallel",
+    ] {
+        assert!(
+            !SLASH_COMMANDS.contains(&excluded),
+            "{excluded} must not appear in the completion set"
+        );
+    }
+}
+
+/// A single `/` at pos=1 must expand to the full inventory (10 commands) so
+/// Tab-after-`/` shows everything. Guards design policy Section 8.2.
+#[test]
+fn completer_returns_all_candidates_for_single_slash() {
+    let (start, replacements) = complete("/", 1);
+    assert_eq!(start, 0, "completion must replace from column 0");
+    assert_eq!(
+        replacements.len(),
+        SLASH_COMMANDS.len(),
+        "expected all {} commands, got {replacements:?}",
+        SLASH_COMMANDS.len()
+    );
+    // Order-independent set equality against the SSOT.
+    for cmd in SLASH_COMMANDS {
+        assert!(
+            replacements.iter().any(|r| r == cmd),
+            "{cmd} missing from completion set {replacements:?}"
+        );
+    }
+}
+
+/// `/pl` at pos=3 must narrow to `/plan` only. Guards design policy Section 8.2.
+#[test]
+fn completer_filters_by_prefix() {
+    let (_, replacements) = complete("/pl", 3);
+    assert_eq!(replacements, vec!["/plan".to_string()]);
+}
+
+/// Once the user has typed past the first whitespace token, the completer
+/// must stop offering slash-command candidates — that position is an argument
+/// (e.g. `/logs path`, `/logs path <session>`), not a command. Guards design
+/// policy Section 8.2 / 12.1 (`completer_returns_empty_after_word_boundary`).
+#[test]
+fn completer_returns_empty_for_args_position() {
+    let line = "/logs path";
+    let pos = line.len(); // pos = 10, inside the argument token
+    let (_, replacements) = complete(line, pos);
+    assert!(
+        replacements.is_empty(),
+        "argument position must not produce slash-command candidates, got {replacements:?}"
+    );
+}

--- a/workspace/anvil-feature-overview.md
+++ b/workspace/anvil-feature-overview.md
@@ -19,7 +19,8 @@
 ```
 ┌─────────────────────────────────────────────────────┐
 │                      TUI / CLI                       │
-│  (rustyline REPL, スラッシュコマンド, 承認フロー)      │
+│  (rustyline REPL [実装済み: Issue #427],             │
+│   スラッシュコマンド, 承認フロー)                      │
 ├─────────────────────────────────────────────────────┤
 │                   App Orchestrator                    │
 │  (状態機械, セッション管理, プラン管理)                │
@@ -183,22 +184,36 @@ LLM とツール実行を繰り返すマルチターンループがエージェ�
 
 ### スラッシュコマンド
 
+v0.1.0 コアで提供されるスラッシュコマンドは以下の **10 個のみ** です（SSOT: `src/agent/loop_run/slash_commands.rs::SLASH_COMMANDS`）。rustyline の Tab 補完と `/help` 出力はこの SSOT から派生します（Issue #427）。
+
 | コマンド | 説明 |
 |----------|------|
-| `/help` | ヘルプ表示 |
-| `/plan`, `/plan-add`, `/plan-focus`, `/plan-clear` | プラン管理 |
-| `/checkpoint` | チェックポイント保存 |
-| `/compact` | 履歴圧縮 |
-| `/model`, `/model-list`, `/model-switch` | モデル管理 |
-| `/session-list`, `/session-switch`, `/session-delete` | セッション管理 |
-| `/trust` | ツール信頼設定 |
-| `/undo` | ツール実行取り消し |
-| `/repo-find` | リポジトリ検索 |
-| `/timeline` | セッションタイムライン |
+| `/help` | コマンド一覧を表示 |
+| `/status` | モード / 承認フラグ / セッション / プランなどの現在値を表示 |
+| `/model` | 現在利用中のモデル banner を表示 |
+| `/yes` | 承認プロンプトを自動承認（`--no-approval` 相当） |
+| `/no` | 承認プロンプトを手動承認に戻す |
+| `/plan` | Plan モードに入り、プランファイルを作成 |
+| `/approve` | プランを承認し Act モードへ遷移（エイリアス: `/act`） |
+| `/compact` | 会話履歴を要約して圧縮 |
+| `/logs` | `/logs path [<session_id>]` でログディレクトリを表示 |
+| `/exit` | REPL を終了（エイリアス: `/quit`） |
 
-### カスタムコマンド
+補完候補には aliases（`/act`, `/quit`）と将来構想プレースホルダ群は含まれません。
 
-`.anvil/slash-commands.json` で独自コマンドを定義可能。
+### 将来構想（v0.1.0 では未提供）
+
+以下は旧アーキテクチャに存在したコマンド案 / 別 Issue で検討中の機能であり、**現行コアには実装されていません**。対応する `/checkpoint`, `/rollback`, `/watch`, `/autotest`, `/skills`, `/skill`, `/mcp`, `/parallel` を入力した場合は「v0.1.0 コアでは利用不可」というメッセージが返ります。
+
+- プラン細粒度操作: `/plan-add`, `/plan-focus`, `/plan-clear`
+- チェックポイント / ロールバック: `/checkpoint`, `/undo`
+- モデル切替: `/model-list`, `/model-switch`
+- セッション操作: `/session-list`, `/session-switch`, `/session-delete`（CLI `anvil sessions` サブコマンドで代替）
+- ツール信頼 / 監視: `/trust`, `/watch`, `/autotest`
+- スキル / MCP / 並列実行: `/skills`, `/skill`, `/mcp`, `/parallel`
+- リポジトリ操作: `/repo-find`, `/timeline`
+
+`.anvil/slash-commands.json` によるカスタムコマンド定義も同様に v0.1.0 コアでは提供していません（将来拡張）。
 
 ### スキルシステム
 


### PR DESCRIPTION
Adds rustyline-based readline REPL: persistent history to ~/.local/state/anvil/history (max 1000), Up/Down arrow navigation, Tab completion for slash commands, Ctrl+A/E/K/U editing. Fallback to plain read_line in non-TTY. Closes #427