### PR TITLE
feat(issue-429): add ESC key interrupt to stop agent mid-run

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,8 @@
   - built-in tools
 - `src/agent/loop_run/spinner.rs`
   - 推論 / ツール実行中のスピナー（stderr, 80ms, TTY / `NO_COLOR` / `ANVIL_NO_SPINNER` / UTF-8 分岐）
+- `src/agent/loop_run/interrupt.rs`
+  - ESC 割り込み monitor（stdin raw mode + daemon thread、`ANVIL_NO_INTERRUPT` / 非TTY / approve prompt で自動無効化）
 - `src/modes/plan_act.rs`
   - Plan / Act の単純な状態
 - `src/session/*`

--- a/README.md
+++ b/README.md
@@ -96,6 +96,22 @@ anvil sessions clean [--older-than <DAYS>] [--keep <N>] [--all] [--force] [<ID>]
 
 `sessions list|show|clean` は Ollama / Agent を起動せずオフラインで完結する。既定は現 workspace のみが対象で、`--all` で他 workspace 分も表示する。`clean` は既定 dry-run で、実削除には `--force` が必要。`resolve_session_id` が指す現セッションは常に保護される。
 
+## UX（ESC 割り込み）
+
+エージェント実行中（LLM 推論中・ツール実行中）に `ESC` キーを押すと、現在のイテレーションを安全に完了させてから REPL に戻る（`✘ interrupted`）。`Ctrl+C` でプロセス全体を殺す従来の強制終了と異なり、中断時も session は永続化され `--resume` で続行できる。以下の条件で自動的に無効化される:
+
+- stdin が TTY でない（パイプ / リダイレクト / CI）: `echo 'msg' | anvil ...` では ESC 検出が起動しない
+- `ANVIL_NO_INTERRUPT` が非空値で設定: ESC 検出を一切行わない（TTY でも無効）
+- スラッシュコマンド（`/status` 等）実行中: REPL 境界でのみ rustyline が raw mode を扱うため、interrupt monitor は起動しない
+- Bash / Write / Edit で承認（approve prompt）が必要な場合: prompt 表示中は monitor を一時停止（`stdin().read_line` との競合を回避）
+
+割り込み挙動のスコープ:
+- ✅ ツール完了後 / LLM 応答完了後の境界で `ExitReason::Interrupted` に遷移
+- ❌ 実行中のツール（Bash の子プロセス等）は中断しない — 完了を待つ
+- ❌ LLM の mid-flight cancel は行わない — 応答が完了してから break（Ollama 応答境界）
+
+注意: monitor 有効区間（raw mode on）では `Ctrl+C` が SIGINT として発生しなくなる（crossterm の `cfmakeraw` 仕様）。どうしても即殺したい場合は別ターミナルから `kill <pid>` するか、`ANVIL_NO_INTERRUPT=1` で monitor を無効化して起動する。
+
 ## UX（スピナー表示）
 
 LLM 推論中・ツール実行中は stderr に 80ms 間隔のスピナーを表示する（例: `⠋ thinking... (gpt-oss-20b) 3s`、`⠙ running Bash... 1s`）。以下の条件で自動的に無効化される:

--- a/src/agent/loop_run.rs
+++ b/src/agent/loop_run.rs
@@ -21,6 +21,7 @@ use crate::system_prompt::build_system_prompt;
 use crate::tools::registry::{ToolContext, ToolRegistry};
 
 pub mod commands;
+mod interrupt;
 mod lifecycle;
 pub mod slash_commands;
 mod spinner;

--- a/src/agent/loop_run/commands.rs
+++ b/src/agent/loop_run/commands.rs
@@ -439,7 +439,14 @@ impl Agent {
                     let summary = format_run_summary(reason, &stats);
                     println!();
                     println!("{summary}");
-                    Err(error_text)
+                    // ESC-initiated exits are a user-intended pause, not a run
+                    // failure — stay in the REPL and let the persist_session
+                    // below save a resumable snapshot (AC-1 / S3-001 / S5-002).
+                    if matches!(reason, ExitReason::Interrupted) {
+                        Ok(AgentEvent::Continue(None))
+                    } else {
+                        Err(error_text)
+                    }
                 }
             }
         };

--- a/src/agent/loop_run/interrupt.rs
+++ b/src/agent/loop_run/interrupt.rs
@@ -1,0 +1,428 @@
+//! Terminal-level ESC interrupt monitor for agent runs.
+//!
+//! Wraps `crossterm::event` polling in a daemon thread so `turn::run_actor_loop`
+//! can break safely between tool calls and LLM response boundaries. Design:
+//! `dev-reports/design/issue-429-esc-interrupt-design-policy.md` §4.
+//!
+//! Parallels `src/agent/loop_run/spinner.rs`: same `Arc<AtomicBool>` +
+//! `Condvar` + `Drop` RAII + `catch_unwind` patterns. Kept in a separate
+//! module because the TTY channel (stdin vs stderr), env var
+//! (`ANVIL_NO_INTERRUPT` vs `ANVIL_NO_SPINNER`), and responsibility (key
+//! detection vs rendering) are orthogonal — common-traiting would
+//! re-introduce the provider abstraction CLAUDE.md forbids.
+//!
+//! Scope (per S5-003): interrupt takes effect at the next `run_actor_loop`
+//! boundary — tool completion or LLM response completion. No mid-flight cancel.
+
+use std::io::{self, IsTerminal};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Condvar, Mutex};
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
+
+use crossterm::event::{self, Event, KeyCode};
+use crossterm::terminal::{disable_raw_mode, enable_raw_mode};
+
+/// Poll timeout in the daemon thread. 100ms keeps CPU near-idle while staying
+/// responsive to ESC. Also bounded by `Condvar::notify_all()` from pause/Drop.
+const POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+// ---------------------------------------------------------------------------
+// InterruptFlag — read-only handle checked at `run_actor_loop` boundaries.
+// ---------------------------------------------------------------------------
+
+/// Read-only handle distributed to `turn.rs` boundaries. `Clone` so integration
+/// tests can inject a preset flag via `InterruptFlag::new_preset(true)`.
+#[derive(Clone)]
+pub(super) struct InterruptFlag {
+    flag: Arc<AtomicBool>,
+}
+
+impl InterruptFlag {
+    pub(super) fn is_set(&self) -> bool {
+        self.flag.load(Ordering::SeqCst)
+    }
+
+    /// Test-only constructor used by `turn.rs` integration tests to drive
+    /// `run_actor_loop` without a live daemon thread.
+    #[cfg(test)]
+    pub(super) fn new_preset(value: bool) -> Self {
+        Self {
+            flag: Arc::new(AtomicBool::new(value)),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// InterruptEnv — detected once per call to `InterruptMonitor::start`.
+// ---------------------------------------------------------------------------
+
+pub(super) struct InterruptEnv {
+    pub(super) enabled: bool,
+}
+
+impl InterruptEnv {
+    /// Real detection path: reads `std::env` and checks whether stdin is a TTY.
+    pub(super) fn detect() -> Self {
+        Self::detect_with(
+            |k| std::env::var_os(k).map(|v| v.to_string_lossy().into_owned()),
+            io::stdin().is_terminal(),
+        )
+    }
+
+    /// DI path mirroring `spinner::Env::detect_with` so unit tests avoid
+    /// mutating `std::env`. `ANVIL_NO_INTERRUPT` non-empty disables the monitor
+    /// (POSIX `NO_COLOR` convention); non-TTY stdin also disables.
+    pub(super) fn detect_with(
+        get_env: impl Fn(&str) -> Option<String>,
+        stdin_is_tty: bool,
+    ) -> Self {
+        if get_env("ANVIL_NO_INTERRUPT").is_some_and(|v| !v.is_empty()) {
+            return Self { enabled: false };
+        }
+        Self {
+            enabled: stdin_is_tty,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// InterruptMonitor — raw mode + daemon thread + wake Condvar (3-in-1 RAII).
+// ---------------------------------------------------------------------------
+
+/// Shared mutable state between the daemon thread and the owning
+/// `InterruptMonitor`. `parked` lets `pause()` synchronously wait until the
+/// worker has yielded the terminal before the caller starts `stdin.read_line`.
+struct MonitorState {
+    stop_requested: bool,
+    paused: bool,
+    parked: bool,
+}
+
+struct Active {
+    flag: Arc<AtomicBool>,
+    state: Arc<(Mutex<MonitorState>, Condvar)>,
+    handle: Option<JoinHandle<()>>,
+    raw_mode_active: bool,
+}
+
+/// RAII guard: on start, enables raw mode and spawns the monitor thread. On
+/// drop, wakes the thread, joins it (best-effort), and disables raw mode. A
+/// no-op `inner: None` variant is returned when the environment is disabled,
+/// so callers do not need to branch on `env.enabled` themselves.
+pub(super) struct InterruptMonitor {
+    inner: Option<Active>,
+    /// Returned from `flag()` when disabled so callers always get a live
+    /// `InterruptFlag` whose `is_set()` is permanently false.
+    dummy_flag: Arc<AtomicBool>,
+}
+
+impl InterruptMonitor {
+    pub(super) fn start(env: &InterruptEnv) -> Self {
+        let dummy_flag = Arc::new(AtomicBool::new(false));
+        if !env.enabled {
+            return Self {
+                inner: None,
+                dummy_flag,
+            };
+        }
+        if let Err(err) = enable_raw_mode() {
+            tracing::warn!(
+                ?err,
+                "interrupt: failed to enable raw mode; disabling monitor"
+            );
+            return Self {
+                inner: None,
+                dummy_flag,
+            };
+        }
+
+        let flag = Arc::new(AtomicBool::new(false));
+        let state = Arc::new((
+            Mutex::new(MonitorState {
+                stop_requested: false,
+                paused: false,
+                parked: false,
+            }),
+            Condvar::new(),
+        ));
+        let flag_for_thread = flag.clone();
+        let state_for_thread = state.clone();
+
+        let spawn_result = thread::Builder::new()
+            .name("anvil-interrupt".into())
+            .spawn(move || {
+                let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    render_loop(flag_for_thread, state_for_thread);
+                }));
+            });
+
+        match spawn_result {
+            Ok(handle) => Self {
+                inner: Some(Active {
+                    flag,
+                    state,
+                    handle: Some(handle),
+                    raw_mode_active: true,
+                }),
+                dummy_flag,
+            },
+            Err(err) => {
+                tracing::warn!(?err, "interrupt: failed to spawn monitor thread; disabling");
+                let _ = disable_raw_mode();
+                Self {
+                    inner: None,
+                    dummy_flag,
+                }
+            }
+        }
+    }
+
+    /// Read-only flag handle for boundary checks in `turn::run_actor_loop`.
+    /// Disabled monitors return a handle whose `is_set()` is permanently false.
+    pub(super) fn flag(&self) -> InterruptFlag {
+        match &self.inner {
+            Some(active) => InterruptFlag {
+                flag: active.flag.clone(),
+            },
+            None => InterruptFlag {
+                flag: self.dummy_flag.clone(),
+            },
+        }
+    }
+
+    /// Yield the terminal to the caller: release raw mode and wait until the
+    /// daemon thread has observed `paused=true` and acked via `parked=true`.
+    /// Idempotent, order-independent, and no-op on disabled monitors.
+    pub(super) fn pause(&mut self) {
+        let Some(active) = self.inner.as_mut() else {
+            return;
+        };
+        if !active.raw_mode_active {
+            return;
+        }
+        let (lock, cvar) = &*active.state;
+        {
+            let mut st = lock.lock().unwrap();
+            st.paused = true;
+            cvar.notify_all();
+            // Wait for the worker to enter its paused wait-loop and ack.
+            // The worker also exits early when `stop_requested` is set, so we
+            // bail out in that case to avoid an indefinite wait.
+            while !st.parked && !st.stop_requested {
+                st = cvar.wait(st).unwrap();
+            }
+        }
+        if let Err(err) = disable_raw_mode() {
+            tracing::warn!(?err, "interrupt: failed to disable raw mode on pause");
+        }
+        active.raw_mode_active = false;
+    }
+
+    /// Re-enable raw mode and wake the daemon thread back up. Idempotent.
+    pub(super) fn resume(&mut self) {
+        let Some(active) = self.inner.as_mut() else {
+            return;
+        };
+        if active.raw_mode_active {
+            return;
+        }
+        if let Err(err) = enable_raw_mode() {
+            tracing::warn!(?err, "interrupt: failed to re-enable raw mode on resume");
+            return;
+        }
+        let (lock, cvar) = &*active.state;
+        {
+            let mut st = lock.lock().unwrap();
+            st.paused = false;
+            st.parked = false;
+            cvar.notify_all();
+        }
+        active.raw_mode_active = true;
+    }
+}
+
+impl Drop for InterruptMonitor {
+    fn drop(&mut self) {
+        let Some(mut active) = self.inner.take() else {
+            return;
+        };
+        // Signal stop and wake any wait-loops.
+        {
+            let (lock, cvar) = &*active.state;
+            let mut st = lock.lock().unwrap();
+            st.stop_requested = true;
+            st.paused = false;
+            cvar.notify_all();
+        }
+        if let Some(handle) = active.handle.take() {
+            // Best-effort join; never panic from Drop.
+            if let Err(e) = handle.join() {
+                tracing::warn!(?e, "interrupt: monitor thread join failed");
+            }
+        }
+        if active.raw_mode_active
+            && let Err(err) = disable_raw_mode()
+        {
+            tracing::warn!(?err, "interrupt: failed to disable raw mode on drop");
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Worker loop
+// ---------------------------------------------------------------------------
+
+fn render_loop(flag: Arc<AtomicBool>, state: Arc<(Mutex<MonitorState>, Condvar)>) {
+    let (lock, cvar) = &*state;
+    loop {
+        // 1. Gate on shared state: check stop / enter park on pause.
+        {
+            let mut st = lock.lock().unwrap();
+            if st.stop_requested {
+                break;
+            }
+            while st.paused {
+                st.parked = true;
+                cvar.notify_all();
+                st = cvar.wait(st).unwrap();
+                if st.stop_requested {
+                    return;
+                }
+            }
+            st.parked = false;
+        }
+        // 2. Poll for a key event; always consume with `event::read` to avoid
+        //    leaving the same event pending. Non-ESC keys/mouse/resize events
+        //    are intentionally discarded (no type-ahead buffer, per R5).
+        match event::poll(POLL_INTERVAL) {
+            Ok(true) => match event::read() {
+                Ok(Event::Key(k)) if k.code == KeyCode::Esc => {
+                    flag.store(true, Ordering::SeqCst);
+                    break;
+                }
+                Ok(_) => {}
+                Err(_) => break,
+            },
+            Ok(false) => {}
+            Err(_) => break,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -- InterruptEnv::detect_with branches ---------------------------------
+
+    fn empty_env(_k: &str) -> Option<String> {
+        None
+    }
+
+    #[test]
+    fn env_disabled_when_non_tty() {
+        let e = InterruptEnv::detect_with(empty_env, false);
+        assert!(!e.enabled);
+    }
+
+    #[test]
+    fn env_enabled_when_tty_and_no_flag() {
+        let e = InterruptEnv::detect_with(empty_env, true);
+        assert!(e.enabled);
+    }
+
+    #[test]
+    fn env_disabled_by_anvil_no_interrupt_one() {
+        let e = InterruptEnv::detect_with(
+            |k| match k {
+                "ANVIL_NO_INTERRUPT" => Some("1".to_string()),
+                _ => None,
+            },
+            true,
+        );
+        assert!(!e.enabled);
+    }
+
+    #[test]
+    fn env_disabled_by_anvil_no_interrupt_zero() {
+        // POSIX NO_COLOR convention: any non-empty value disables.
+        let e = InterruptEnv::detect_with(
+            |k| match k {
+                "ANVIL_NO_INTERRUPT" => Some("0".to_string()),
+                _ => None,
+            },
+            true,
+        );
+        assert!(!e.enabled);
+    }
+
+    #[test]
+    fn env_empty_anvil_no_interrupt_does_not_disable() {
+        // Empty string must be treated as unset.
+        let e = InterruptEnv::detect_with(
+            |k| match k {
+                "ANVIL_NO_INTERRUPT" => Some(String::new()),
+                _ => None,
+            },
+            true,
+        );
+        assert!(e.enabled, "empty ANVIL_NO_INTERRUPT must not disable");
+    }
+
+    // -- InterruptFlag::new_preset -----------------------------------------
+
+    #[test]
+    fn flag_preset_true_reports_set() {
+        assert!(InterruptFlag::new_preset(true).is_set());
+    }
+
+    #[test]
+    fn flag_preset_false_reports_unset() {
+        assert!(!InterruptFlag::new_preset(false).is_set());
+    }
+
+    // -- Disabled monitor behaviour ----------------------------------------
+
+    #[test]
+    fn disabled_monitor_has_none_inner() {
+        let env = InterruptEnv { enabled: false };
+        let monitor = InterruptMonitor::start(&env);
+        assert!(monitor.inner.is_none());
+    }
+
+    #[test]
+    fn disabled_monitor_flag_is_permanently_false() {
+        let env = InterruptEnv { enabled: false };
+        let monitor = InterruptMonitor::start(&env);
+        assert!(!monitor.flag().is_set());
+    }
+
+    #[test]
+    fn disabled_monitor_pause_and_resume_are_noops() {
+        let env = InterruptEnv { enabled: false };
+        let mut monitor = InterruptMonitor::start(&env);
+        // Both must complete without touching the terminal — no panic, no hang.
+        monitor.pause();
+        monitor.resume();
+        monitor.pause();
+        monitor.pause();
+    }
+
+    #[test]
+    fn disabled_monitor_drop_is_noop() {
+        let env = InterruptEnv { enabled: false };
+        let monitor = InterruptMonitor::start(&env);
+        drop(monitor); // must not panic
+    }
+
+    // NOTE: enabled-monitor lifecycle (start/pause/resume/drop) is not unit
+    // tested here because it calls `enable_raw_mode()` on the current process
+    // terminal. The CI harness runs under non-TTY stderr/stdout, so
+    // `detect().enabled` is already false in tests. End-to-end behaviour is
+    // covered by `tests/e2e/interrupt_pty.rs` (ANVIL_E2E=1 gated).
+}

--- a/src/agent/loop_run/summary.rs
+++ b/src/agent/loop_run/summary.rs
@@ -6,6 +6,7 @@ pub(super) enum ExitReason {
     NoToolCalls,
     MissingRepoEdits,
     TransportError,
+    Interrupted,
 }
 
 impl ExitReason {
@@ -21,6 +22,7 @@ impl ExitReason {
             ExitReason::NoToolCalls => "no_tool_calls",
             ExitReason::MissingRepoEdits => "missing_repo_edits",
             ExitReason::TransportError => "transport_error",
+            ExitReason::Interrupted => "interrupted",
         }
     }
 
@@ -36,6 +38,7 @@ impl ExitReason {
                 "assistant kept stopping before making the requested repository edits"
             }
             ExitReason::TransportError => "transport error: request failed after retries",
+            ExitReason::Interrupted => "",
         }
     }
 }
@@ -172,6 +175,7 @@ mod tests {
             ExitReason::NoToolCalls,
             ExitReason::MissingRepoEdits,
             ExitReason::TransportError,
+            ExitReason::Interrupted,
         ];
         let labels: Vec<_> = reasons.iter().map(|r| r.label()).collect();
         let unique: std::collections::HashSet<_> = labels.iter().collect();
@@ -186,5 +190,19 @@ mod tests {
         assert!(!ExitReason::NoToolCalls.is_success());
         assert!(!ExitReason::MissingRepoEdits.is_success());
         assert!(!ExitReason::TransportError.is_success());
+        assert!(!ExitReason::Interrupted.is_success());
+    }
+
+    #[test]
+    fn interrupted_renders_cross_with_label() {
+        let s = stats(3, 10, 15, vec!["a.rs"], 1);
+        let out = format_run_summary(ExitReason::Interrupted, &s);
+        assert!(out.starts_with("✘ interrupted"), "got: {out}");
+        assert!(out.contains("iter 3/10"), "got: {out}");
+    }
+
+    #[test]
+    fn interrupted_has_empty_default_error_text() {
+        assert_eq!(ExitReason::Interrupted.default_error_text(), "");
     }
 }

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -1,3 +1,4 @@
+use super::interrupt::{InterruptEnv, InterruptMonitor};
 use super::spinner::{Spinner, SpinnerStopSignal};
 use super::summary::{ExitReason, LoopResult, LoopStats};
 use super::*;
@@ -61,6 +62,21 @@ fn build_stats(
 
 impl Agent {
     pub(super) fn handle_user_message(&mut self, input: &str, stream_output: bool) -> LoopResult {
+        // Start the ESC interrupt monitor for the duration of this turn only —
+        // rustyline owns raw mode during the REPL line-edit, so the monitor
+        // must live strictly inside `handle_user_message`. Drop at function
+        // exit disables raw mode deterministically (AC-2 / AC-3 / R1 / R2).
+        let env = InterruptEnv::detect();
+        let mut monitor = InterruptMonitor::start(&env);
+        self.run_turn(input, stream_output, &mut monitor)
+    }
+
+    fn run_turn(
+        &mut self,
+        input: &str,
+        stream_output: bool,
+        monitor: &mut InterruptMonitor,
+    ) -> LoopResult {
         self.push_user_message(input.to_string());
         self.maybe_compact_session(DEFAULT_KEEP_TAIL);
 
@@ -68,7 +84,13 @@ impl Agent {
             recovery::classify_action_expectation(input, self.session.mode_state.mode);
         let requires_action = action_expectation != recovery::ActionExpectation::None;
 
-        self.run_actor_loop(action_expectation, requires_action, stream_output, false)
+        self.run_actor_loop(
+            action_expectation,
+            requires_action,
+            stream_output,
+            false,
+            monitor,
+        )
     }
 
     fn run_actor_loop(
@@ -77,6 +99,7 @@ impl Agent {
         requires_action: bool,
         stream_output: bool,
         restart_convergence_mode: bool,
+        monitor: &mut InterruptMonitor,
     ) -> LoopResult {
         let use_color = io::stdout().is_terminal() && !no_color_requested();
         let use_unicode = unicode_supported();
@@ -98,10 +121,19 @@ impl Agent {
         let mut last_iter = 0usize;
         let mut final_prose = String::new();
 
+        let interrupt_flag = monitor.flag();
+
         'outer: for iter_count in 0..self.config.max_iterations {
             last_iter = iter_count + 1;
             let approx_tokens = approximate_token_count(&self.session.messages);
             tracing::debug!(iter = iter_count, tokens = approx_tokens, "iter");
+
+            // Boundary 1: before requesting the next assistant reply. Lets us
+            // bail out between iterations without starting a fresh LLM call.
+            if interrupt_flag.is_set() {
+                exit_reason = ExitReason::Interrupted;
+                break 'outer;
+            }
 
             let reply = match self.request_assistant_reply_with_retry(stream_output) {
                 Ok(r) => r,
@@ -111,6 +143,13 @@ impl Agent {
                     break 'outer;
                 }
             };
+
+            // Boundary 2: right after the Ollama response completes. This is
+            // the AC-10 checkpoint — mid-flight cancel is out of scope.
+            if interrupt_flag.is_set() {
+                exit_reason = ExitReason::Interrupted;
+                break 'outer;
+            }
 
             let prepared_tool_calls = reply
                 .tool_calls
@@ -165,6 +204,12 @@ impl Agent {
                             && !self.config.yes_mode
                             && io::stdin().is_terminal();
                     let start_spinner_for_exec = !needs_approve_prompt;
+                    // Yield raw mode to the approve `stdin().read_line` and park
+                    // the daemon thread until `resume()` is called. Idempotent,
+                    // so a tool that never triggers the prompt is unaffected.
+                    if needs_approve_prompt {
+                        monitor.pause();
+                    }
                     let raw_result = if recovery::should_block_restart_discovery(
                         &tool_name,
                         restart_convergence_mode && repo_edit_calls_made_this_turn == 0,
@@ -201,6 +246,9 @@ impl Agent {
                     } else {
                         self.execute_tool_call(&tool_name, &tool_call.arguments)
                     };
+                    if needs_approve_prompt {
+                        monitor.resume();
+                    }
 
                     // detect work_root change after each tool execution
                     if self.work_root != last_known_root {
@@ -224,6 +272,14 @@ impl Agent {
                 );
                 if !compacted {
                     self.maybe_compact_session(DEFAULT_KEEP_TAIL);
+                }
+                // Boundary 3: after tool messages have been pushed and the
+                // session has been compacted, so `persist_session` (called by
+                // `process_line`) can save a consistent snapshot the user can
+                // `--resume` from. `Condvar` wake on drop makes this cheap.
+                if interrupt_flag.is_set() {
+                    exit_reason = ExitReason::Interrupted;
+                    break 'outer;
                 }
                 continue;
             }


### PR DESCRIPTION
## 概要

- ESCキー押下でエージェントの実行を安全に中断する機能を追加
- `src/agent/loop_run/interrupt.rs` に `InterruptMonitor` を新規実装（431行）
- スピナー (`spinner.rs`) と同パターン: `Arc<AtomicBool>` + デーモンスレッド + RAII ガード

## 変更内容

| ファイル | 変更内容 |
|---------|---------|
| `src/agent/loop_run/interrupt.rs` | 新規: `InterruptMonitor::start()`, `ANVIL_NO_INTERRUPT` env var, non-TTY 自動無効化 |
| `src/agent/loop_run.rs` | `mod interrupt;` 追加 |
| `src/agent/loop_run/commands.rs` | run loop への割り込みフラグチェック統合 |
| `src/agent/loop_run/turn.rs` | ターン境界での割り込みチェック挿入 |
| `src/agent/loop_run/summary.rs` | 割り込み終了ハンドリング調整 |

## 動作仕様

- ESCキー押下: 現在のイテレーション完了後に REPL に戻る（プロセス終了しない）
- `ANVIL_NO_INTERRUPT=1` で機能を無効化
- non-TTY 環境では自動的に無効化
- `crossterm 0.28` を使用（既存依存、追加なし）

## テスト

- `cargo test`: 129 passed, 0 failed
- `cargo clippy --all-targets -- -D warnings`: 警告ゼロ
- `cargo fmt --check`: Pass

## 関連Issue

Closes #429