### PR TITLE
feat(issue-432): add terminal resize handling (SIGWINCH) for TUI layout

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,8 @@
   - 推論 / ツール実行中のスピナー（stderr, 80ms, TTY / `NO_COLOR` / `ANVIL_NO_SPINNER` / UTF-8 分岐）
 - `src/agent/loop_run/interrupt.rs`
   - ESC 割り込み monitor（stdin raw mode + daemon thread、`ANVIL_NO_INTERRUPT` / 非TTY / approve prompt で自動無効化）
+- `src/agent/loop_run/footer.rs`
+  - 固定フッター daemon (stdout, 200ms, DECSTBM 再適用、token / mode / log / yes 表示、current_cols broadcast for turn.rs progress line)
 - `src/modes/plan_act.rs`
   - Plan / Act の単純な状態
 - `src/session/*`

--- a/src/agent/loop_run/footer.rs
+++ b/src/agent/loop_run/footer.rs
@@ -153,10 +153,32 @@ pub(super) struct FooterStateInner {
     /// resolved at acquire time so the worker can keep rendering through the
     /// captured writer even when the live terminal size is unavailable.
     pub fallback_rows: AtomicU16,
+    /// Whether DECSTBM install + footer line rendering are active. `false`
+    /// means "probe-only lease": the daemon keeps polling / storing
+    /// `current_cols`, but does not install DECSTBM, chain a panic hook, or
+    /// write footer lines (issue #432 §4.4.2).
+    pub draw_enabled: bool,
+    /// Broadcast channel for the current terminal width. Updated every `TICK`
+    /// (200ms) by `render_loop`. A value of `0` means "not yet probed" (first
+    /// tick hasn't run, `terminal::size()` failed at acquire, or the daemon
+    /// permanently self-disabled). Readers (progress line) observe this via
+    /// `FooterHandle::current_cols()` and treat `0` as "width unknown; use
+    /// fallback".
+    pub current_cols: AtomicU16,
+    /// `ANVIL_NO_RESIZE` opt-out flag decided once at `FooterLease::acquire`
+    /// time (issue #432 §4.4.1). When true, `render_loop` skips `current_cols`
+    /// store and `FooterHandle::current_cols()` returns `None` regardless of
+    /// stored value. Immutable after construction.
+    pub resize_opt_out: bool,
 }
 
 impl FooterStateInner {
-    pub(super) fn new(budget: usize, flags: FooterFlags) -> Arc<Self> {
+    pub(super) fn new(
+        budget: usize,
+        flags: FooterFlags,
+        draw_enabled: bool,
+        resize_opt_out: bool,
+    ) -> Arc<Self> {
         Arc::new(Self {
             tokens: AtomicUsize::new(0),
             budget,
@@ -165,7 +187,18 @@ impl FooterStateInner {
             self_disabled: AtomicBool::new(false),
             wake: (Mutex::new(()), Condvar::new()),
             fallback_rows: AtomicU16::new(0),
+            draw_enabled,
+            current_cols: AtomicU16::new(0),
+            resize_opt_out,
         })
+    }
+
+    /// Permanently self-disable the footer daemon. Zeroes `current_cols` so
+    /// readers stop receiving the last-known-good value after disable. This
+    /// is the only code path that should set `self_disabled = true`.
+    pub(super) fn mark_self_disabled(&self) {
+        self.self_disabled.store(true, Ordering::SeqCst);
+        self.current_cols.store(0, Ordering::Relaxed);
     }
 
     /// Compute the current footer snapshot. Pure read; safe to call from the
@@ -456,12 +489,18 @@ impl FooterLease {
 
         #[cfg(not(windows))]
         {
-            if !config.footer {
+            let is_terminal = io::stdout().is_terminal();
+            // Non-TTY: fully disabled regardless of config (issue #430 / #432).
+            if !is_terminal {
                 return Self::disabled_lease();
             }
-            if !io::stdout().is_terminal() {
-                return Self::disabled_lease();
-            }
+
+            // Determine draw vs. probe-only (issue #432 §4.4.2). On a TTY with
+            // `config.footer == false` we still spawn the daemon for cols
+            // broadcast; DECSTBM / footer line writes are suppressed.
+            let draw_enabled = config.footer;
+            // ANVIL_NO_RESIZE opt-out decided once at acquire time.
+            let resize_opt_out = std::env::var_os("ANVIL_NO_RESIZE").is_some_and(|v| !v.is_empty());
 
             // Single-instance gate (AC15). Acquired here and held until `Drop`.
             // We don't keep the guard alive across the whole acquire path — we
@@ -510,7 +549,15 @@ impl FooterLease {
                 yes: config.yes_mode,
             };
             let writer: FooterWriter = Box::new(io::stdout());
-            match install_active(rows, budget, initial_flags, writer, bit_guard) {
+            match install_active(
+                rows,
+                budget,
+                initial_flags,
+                writer,
+                bit_guard,
+                draw_enabled,
+                resize_opt_out,
+            ) {
                 Ok(lease) => lease,
                 Err(()) => {
                     // install_active already released the bit and logged on
@@ -546,8 +593,19 @@ impl FooterLease {
     /// contract as `acquire`).
     #[cfg(test)]
     pub(super) fn acquire_for_test(rows: u16, writer: FooterWriter) -> Self {
-        // Claim the bit (or refuse, returning a disabled lease for parity
-        // with the public path). Tests serialise via a test-local mutex.
+        Self::acquire_for_test_with(rows, writer, /* draw_enabled */ true, false)
+    }
+
+    /// Test-only: `acquire_for_test` with explicit `draw_enabled` and
+    /// `resize_opt_out` flags, letting probe-only / no-resize contracts be
+    /// exercised without mutating real env vars.
+    #[cfg(test)]
+    pub(super) fn acquire_for_test_with(
+        rows: u16,
+        writer: FooterWriter,
+        draw_enabled: bool,
+        resize_opt_out: bool,
+    ) -> Self {
         {
             let mut held = lock_lease_bit_or_recover();
             if *held {
@@ -557,7 +615,15 @@ impl FooterLease {
             *held = true;
         }
         let bit_guard = LeaseBitGuard::new();
-        match install_active(rows, 24_000, FooterFlags::default(), writer, bit_guard) {
+        match install_active(
+            rows,
+            24_000,
+            FooterFlags::default(),
+            writer,
+            bit_guard,
+            draw_enabled,
+            resize_opt_out,
+        ) {
             Ok(lease) => lease,
             Err(()) => Self::disabled_lease(),
         }
@@ -569,36 +635,46 @@ impl FooterLease {
 /// bit through `bit_guard.release()` and returns `Err(())`; on success the
 /// guard is consumed and ownership of the bit transfers to the returned
 /// `FooterLease`.
+///
+/// When `draw_enabled == false` the lease becomes "probe-only" (issue #432):
+/// the daemon still runs and updates `current_cols` every tick, but DECSTBM
+/// install, panic hook chain, and footer line writes are skipped. The
+/// resulting `FooterHandle` has `enabled == false` but carries live state so
+/// `current_cols()` can return `Some(_)`.
 fn install_active(
     rows: u16,
     budget: usize,
     initial_flags: FooterFlags,
     writer: FooterWriter,
     bit_guard: LeaseBitGuard,
+    draw_enabled: bool,
+    resize_opt_out: bool,
 ) -> Result<FooterLease, ()> {
     // 1. Build the shared state and synchronisation primitives up front.
     //    The wake `Condvar` lives inside `FooterStateInner` (Phase D) so
     //    `FreezeGuard::Drop` can wake the worker through the handle.
-    let state = FooterStateInner::new(budget, initial_flags);
+    let state = FooterStateInner::new(budget, initial_flags, draw_enabled, resize_opt_out);
     state.fallback_rows.store(rows, Ordering::Relaxed);
     let stop = Arc::new(AtomicBool::new(false));
     let writer = Arc::new(Mutex::new(writer));
 
     // 2. Set DECSTBM (Task C.4). Failure → release bit and disable.
-    let decstbm = match ansi::build_decstbm(rows) {
-        Some(s) => s,
-        None => {
-            tracing::warn!("anvil footer: build_decstbm returned None; disabling");
-            bit_guard.release();
-            return Err(());
-        }
-    };
-    {
+    //    Skipped entirely for probe-only leases (issue #432 §4.4.2).
+    if draw_enabled {
+        let decstbm = match ansi::build_decstbm(rows) {
+            Some(s) => s,
+            None => {
+                tracing::warn!("anvil footer: build_decstbm returned None; disabling");
+                bit_guard.release();
+                return Err(());
+            }
+        };
         let mut w = writer
             .lock()
             .expect("footer writer mutex never poisoned at install");
         if let Err(err) = w.write_all(decstbm.as_bytes()) {
             tracing::warn!(?err, "anvil footer: failed to write DECSTBM; disabling");
+            drop(w);
             bit_guard.release();
             return Err(());
         }
@@ -608,18 +684,24 @@ fn install_active(
     // 3. Install panic hook chain (Task C.2). The custom hook sends the
     //    DECSTBM reset to stdout (best-effort, broken pipes ignored) and then
     //    delegates to `prev` so backtraces and tracing-subscriber's own hook
-    //    keep working (AC10).
-    let prev_panic_hook: PanicHook = std::panic::take_hook();
-    let prev_arc = Arc::new(prev_panic_hook);
-    let prev_for_hook = prev_arc.clone();
-    std::panic::set_hook(Box::new(move |info| {
-        // Best-effort DECSTBM reset directly to raw stdout. We intentionally
-        // do NOT touch the FOOTER_LEASE_HELD mutex here (DR2-012 invariant)
-        // to avoid deadlocking with the Drop path that may also be running.
-        let _ = io::stdout().write_all(b"\x1b[r");
-        let _ = io::stdout().flush();
-        prev_for_hook(info);
-    }));
+    //    keep working (AC10). Skipped for probe-only leases — there is no
+    //    DECSTBM to reset in that path.
+    let prev_panic_hook_arc: Option<Arc<PanicHook>> = if draw_enabled {
+        let prev_panic_hook: PanicHook = std::panic::take_hook();
+        let prev_arc = Arc::new(prev_panic_hook);
+        let prev_for_hook = prev_arc.clone();
+        std::panic::set_hook(Box::new(move |info| {
+            // Best-effort DECSTBM reset directly to raw stdout. We intentionally
+            // do NOT touch the FOOTER_LEASE_HELD mutex here (DR2-012 invariant)
+            // to avoid deadlocking with the Drop path that may also be running.
+            let _ = io::stdout().write_all(b"\x1b[r");
+            let _ = io::stdout().flush();
+            prev_for_hook(info);
+        }));
+        Some(prev_arc)
+    } else {
+        None
+    };
 
     // 4. Spawn the worker thread (Task C.3).
     let state_for_thread = state.clone();
@@ -641,10 +723,12 @@ fn install_active(
         Ok(h) => h,
         Err(err) => {
             tracing::warn!(?err, "anvil footer: failed to spawn worker; disabling");
-            // Reverse panic hook install before bailing.
-            std::panic::set_hook(panic_hook_from_arc(prev_arc));
-            // Best-effort DECSTBM reset.
-            if let Ok(mut w) = writer.lock() {
+            // Reverse panic hook install before bailing (only if we installed).
+            if let Some(prev_arc) = prev_panic_hook_arc {
+                std::panic::set_hook(panic_hook_from_arc(prev_arc));
+            }
+            // Best-effort DECSTBM reset (only if we installed DECSTBM).
+            if draw_enabled && let Ok(mut w) = writer.lock() {
                 let _ = w.write_all(ansi::build_decstbm_reset().as_bytes());
                 let _ = w.flush();
             }
@@ -657,7 +741,7 @@ fn install_active(
     //    into `holds_lease_bit = true` here.
     bit_guard.into_owned();
     let handle = FooterHandle {
-        enabled: true,
+        enabled: draw_enabled,
         state: Some(state.clone()),
     };
     Ok(FooterLease {
@@ -666,7 +750,7 @@ fn install_active(
             state,
             stop,
             worker: Some(worker),
-            prev_panic_hook: Some(prev_arc),
+            prev_panic_hook: prev_panic_hook_arc,
             decstbm_rows: rows,
             writer,
         }),
@@ -742,8 +826,11 @@ impl Drop for FooterLease {
                 tracing::warn!(?e, "anvil footer: worker thread join failed");
             }
             // 3. DECSTBM reset + cursor restore. Best-effort: broken pipes
-            //    after the worker disabled itself are ignored.
-            if let Ok(mut w) = active.writer.lock() {
+            //    after the worker disabled itself are ignored. Skipped for
+            //    probe-only leases (issue #432): we never wrote DECSTBM set.
+            if active.state.draw_enabled
+                && let Ok(mut w) = active.writer.lock()
+            {
                 let _ = w.write_all(ansi::build_decstbm_reset().as_bytes());
                 let cursor_home = ansi::move_to(active.decstbm_rows, 1);
                 let _ = w.write_all(cursor_home.as_bytes());
@@ -780,6 +867,28 @@ impl FooterHandle {
     /// call sites can do cheap early-returns when constructing argument lists.
     pub fn is_enabled(&self) -> bool {
         self.enabled
+    }
+
+    /// Current terminal width in columns as observed by the footer render loop.
+    ///
+    /// Returns `Some(cols)` when the handle carries shared state (even if
+    /// visual footer rendering is disabled, i.e. `is_enabled() == false`) and
+    /// `render_loop` has written at least one non-zero probe.
+    ///
+    /// Returns `None` when the handle is fully detached (`FooterHandle::disabled()`
+    /// / non-TTY at acquire time), when `ANVIL_NO_RESIZE` is set, or when
+    /// `render_loop` has never recorded a live size (first-tick race).
+    ///
+    /// Readers MUST fall back to a fixed default on `None`.
+    pub fn current_cols(&self) -> Option<u16> {
+        let state = self.state.as_ref()?;
+        if state.resize_opt_out {
+            return None;
+        }
+        match state.current_cols.load(Ordering::Relaxed) {
+            0 => None,
+            cols => Some(cols),
+        }
     }
 
     /// Publish the per-turn token count.
@@ -913,18 +1022,47 @@ fn render_loop(
             let _ = cvar.wait_timeout(g, TICK);
             continue;
         }
+
+        // Issue #432: probe terminal size exactly once per tick. Distinguish
+        // transient ioctl failures (Err) from anomalous live sizes (rows<2 ||
+        // cols==0). Transient failures fall back to `fallback_rows`; anomalous
+        // sizes trigger permanent self-disable so readers stop receiving stale
+        // values (CB-002 / issue #432 §6.2).
+        enum Probe {
+            Live { cols: u16, rows: u16 },
+            Err,
+            Anomalous,
+        }
+        let probe = match crossterm::terminal::size() {
+            Ok((c, r)) if c >= 1 && r >= 2 => Probe::Live { cols: c, rows: r },
+            Ok(_) => Probe::Anomalous,
+            Err(_) => Probe::Err,
+        };
+        if matches!(probe, Probe::Anomalous) {
+            // Anomalous in any lease (probe-only or draw-enabled): permanently
+            // self-disable. `mark_self_disabled()` also zeroes current_cols
+            // so readers stop receiving stale values.
+            state.mark_self_disabled();
+            continue;
+        }
+        if !state.resize_opt_out
+            && let Probe::Live { cols, .. } = probe
+        {
+            // Keep current_cols fresh for progress_line readers even while
+            // frozen. Reader has its own opt-out guard; this is defence-in-depth.
+            state.current_cols.store(cols, Ordering::Relaxed);
+        }
+
         let frozen = state.freeze.load(Ordering::SeqCst);
-        if !frozen {
-            // 3. terminal::size() — fall back to the rows captured at acquire
-            // time when the live probe fails (CI / non-TTY harness writers).
-            // Anomalous values still flip permanent self-disable below.
-            let size = crossterm::terminal::size();
-            let (cols, rows) = match size {
-                Ok((c, r)) => (c, r),
-                Err(_) => {
+        if state.draw_enabled && !frozen {
+            // Reuse the probe above — fall back to rows captured at acquire
+            // time when the live probe failed (CI / non-TTY harness writers).
+            let rows = match probe {
+                Probe::Live { rows, .. } => rows,
+                Probe::Err => {
                     let fallback = state.fallback_rows.load(Ordering::Relaxed);
                     if fallback > 0 {
-                        (80, fallback)
+                        fallback
                     } else {
                         // No fallback recorded — wait and retry next tick;
                         // transient ioctl errors must not self-disable.
@@ -933,13 +1071,8 @@ fn render_loop(
                         continue;
                     }
                 }
+                Probe::Anomalous => unreachable!("handled above"),
             };
-            if rows < 2 || cols == 0 {
-                // Anomalous size while running — self-disable to avoid
-                // emitting garbage. (DR4-001)
-                state.self_disabled.store(true, Ordering::SeqCst);
-                continue;
-            }
 
             // AC3: when the row count changed, re-emit DECSTBM so the scroll
             // region still leaves the bottom row free.
@@ -970,7 +1103,7 @@ fn render_loop(
             if write_result.is_err() {
                 // AC17: write failure → permanent self-disable. Phase E
                 // refines the warning text and metrics.
-                state.self_disabled.store(true, Ordering::SeqCst);
+                state.mark_self_disabled();
                 tracing::warn!("anvil footer: write failed; self-disabling");
                 continue;
             }
@@ -1358,7 +1491,7 @@ mod tests {
 
     #[test]
     fn publish_tokens_writes_through_state() {
-        let state = FooterStateInner::new(24_000, FooterFlags::default());
+        let state = FooterStateInner::new(24_000, FooterFlags::default(), true, false);
         let h = FooterHandle::with_state(state.clone());
         h.publish_tokens(12_345);
         assert_eq!(state.tokens.load(Ordering::Relaxed), 12_345);
@@ -1366,7 +1499,7 @@ mod tests {
 
     #[test]
     fn publish_flags_writes_through_state() {
-        let state = FooterStateInner::new(24_000, FooterFlags::default());
+        let state = FooterStateInner::new(24_000, FooterFlags::default(), true, false);
         let h = FooterHandle::with_state(state.clone());
         h.publish_flags(ExecutionMode::Plan, LogLevel::Trace, true);
         let flags = *state.flags.lock().unwrap();
@@ -1385,7 +1518,7 @@ mod tests {
 
     #[test]
     fn snapshot_reads_back_published_values() {
-        let state = FooterStateInner::new(24_000, FooterFlags::default());
+        let state = FooterStateInner::new(24_000, FooterFlags::default(), true, false);
         let h = FooterHandle::with_state(state.clone());
         h.publish_tokens(10_100);
         h.publish_flags(ExecutionMode::Plan, LogLevel::Verbose, true);
@@ -1401,7 +1534,7 @@ mod tests {
 
     #[test]
     fn snapshot_zero_budget_yields_zero_ratio() {
-        let state = FooterStateInner::new(0, FooterFlags::default());
+        let state = FooterStateInner::new(0, FooterFlags::default(), true, false);
         let s = state.snapshot();
         assert_eq!(s.ratio, 0.0);
     }
@@ -1537,7 +1670,7 @@ mod tests {
         let buf = Arc::new(Mutex::new(Vec::<u8>::new()));
         let writer: Arc<Mutex<FooterWriter>> =
             Arc::new(Mutex::new(Box::new(CaptureWriter::new(buf.clone()))));
-        let state = FooterStateInner::new(24_000, FooterFlags::default());
+        let state = FooterStateInner::new(24_000, FooterFlags::default(), true, false);
         let stop = Arc::new(AtomicBool::new(false));
 
         let state_t = state.clone();
@@ -1570,7 +1703,7 @@ mod tests {
         let buf = Arc::new(Mutex::new(Vec::<u8>::new()));
         let writer: Arc<Mutex<FooterWriter>> =
             Arc::new(Mutex::new(Box::new(CaptureWriter::new(buf.clone()))));
-        let state = FooterStateInner::new(24_000, FooterFlags::default());
+        let state = FooterStateInner::new(24_000, FooterFlags::default(), true, false);
         // Pre-set self_disabled before the worker starts.
         state.self_disabled.store(true, Ordering::SeqCst);
         let stop = Arc::new(AtomicBool::new(false));
@@ -1723,5 +1856,105 @@ mod tests {
             "worker must resume rendering after FreezeGuard drop"
         );
         drop(lease);
+    }
+
+    // ===== Issue #432: cols broadcaster / probe-only lease ==================
+
+    #[test]
+    fn current_cols_returns_none_after_mark_self_disabled() {
+        let state = FooterStateInner::new(24_000, FooterFlags::default(), true, false);
+        // Simulate a post-tick probe result by storing a live width.
+        state.current_cols.store(120, Ordering::Relaxed);
+        let handle = FooterHandle::with_state(state.clone());
+        assert_eq!(handle.current_cols(), Some(120));
+
+        state.mark_self_disabled();
+        assert!(state.self_disabled.load(Ordering::SeqCst));
+        assert_eq!(
+            handle.current_cols(),
+            None,
+            "mark_self_disabled must zero current_cols"
+        );
+    }
+
+    #[test]
+    fn current_cols_returns_none_when_resize_opt_out() {
+        // resize_opt_out=true: reader-side guard returns None regardless of
+        // any stored value.
+        let state = FooterStateInner::new(24_000, FooterFlags::default(), true, true);
+        state.current_cols.store(120, Ordering::Relaxed);
+        let handle = FooterHandle::with_state(state);
+        assert_eq!(handle.current_cols(), None);
+    }
+
+    #[test]
+    fn visuals_disabled_handle_can_still_report_current_cols() {
+        // Probe-only lease contract: draw_enabled=false + state=Some(_) means
+        // `is_enabled() == false` yet `current_cols()` still broadcasts.
+        let state = FooterStateInner::new(24_000, FooterFlags::default(), false, false);
+        state.current_cols.store(120, Ordering::Relaxed);
+        let handle = FooterHandle::with_state(state);
+        assert!(!handle.is_enabled());
+        assert_eq!(handle.current_cols(), Some(120));
+    }
+
+    #[test]
+    fn mark_self_disabled_zeros_current_cols() {
+        let state = FooterStateInner::new(24_000, FooterFlags::default(), true, false);
+        state.current_cols.store(80, Ordering::Relaxed);
+        state.mark_self_disabled();
+        assert_eq!(state.current_cols.load(Ordering::Relaxed), 0);
+        assert!(state.self_disabled.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn acquire_with_footer_disabled_yields_probe_only_lease() {
+        // Directly construct a probe-only lease via `acquire_for_test_with`
+        // (the real `FooterLease::acquire` path requires a TTY, which cargo's
+        // test harness does not provide). This asserts the contract:
+        // handle.is_enabled() == false but state is attached so current_cols()
+        // can return Some(_).
+        let _g = PhaseCTestGuard::acquire();
+        let buf = Arc::new(Mutex::new(Vec::<u8>::new()));
+        let lease = FooterLease::acquire_for_test_with(
+            24,
+            Box::new(CaptureWriter::new(buf.clone())),
+            /* draw_enabled */ false,
+            /* resize_opt_out */ false,
+        );
+        let handle = lease.handle_clone();
+        assert!(
+            !handle.is_enabled(),
+            "probe-only lease must report is_enabled() == false"
+        );
+        // Wait a couple of ticks for the worker to probe and store cols.
+        let deadline = std::time::Instant::now() + Duration::from_millis(2000);
+        let mut saw_cols = false;
+        while std::time::Instant::now() < deadline {
+            if handle.current_cols().is_some() {
+                saw_cols = true;
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        }
+        // When cargo test runs on a non-TTY, `crossterm::terminal::size()`
+        // may still return Ok (as is common on macOS / Linux with a pty
+        // wrapper) or Err. Only assert that the probe-only lease itself does
+        // not panic and keeps `is_enabled()` false. `saw_cols` is allowed to
+        // be either true or false depending on the harness.
+        let _ = saw_cols;
+
+        // Probe-only lease must NOT write DECSTBM.
+        drop(lease);
+        let captured = buf.lock().unwrap();
+        let s = String::from_utf8_lossy(&captured);
+        assert!(
+            !s.contains("\x1b[1;"),
+            "probe-only lease must not write DECSTBM set: {s:?}"
+        );
+        assert!(
+            !s.contains("\x1b[r"),
+            "probe-only lease must not write DECSTBM reset: {s:?}"
+        );
     }
 }

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -200,6 +200,7 @@ impl Agent {
                         &self.work_root,
                         use_color,
                         use_unicode,
+                        self.footer.current_cols(),
                     );
                     println!("{progress}");
                     let _ = io::stdout().flush();
@@ -638,10 +639,15 @@ fn paint(s: &str, color: &str, use_color: bool) -> String {
 /// optional parenthesized suffix (e.g. `"5B"` for Write byte count). Paths are
 /// made relative to `work_root` when possible. All model-derived strings pass
 /// through `sanitize_for_progress` to prevent terminal injection.
+///
+/// `arg_budget` caps the Bash command display length (issue #432). Other tool
+/// arms currently ignore this budget; the uniform signature lets the caller
+/// compute the budget once via `progress_available_width`.
 fn tool_display(
     tool_name: &str,
     arguments: &serde_json::Value,
     work_root: &std::path::Path,
+    arg_budget: usize,
 ) -> (String, Option<String>) {
     let str_arg = |key: &str| -> &str {
         arguments
@@ -668,16 +674,60 @@ fn tool_display(
         "Edit" | "Read" => (sanitize_for_progress(&relativize(str_arg("path"))), None),
         "Bash" => {
             let sanitized = sanitize_for_progress(str_arg("command"));
-            (truncate(&sanitized, 57), None)
+            (truncate(&sanitized, arg_budget), None)
         }
         "Glob" | "Grep" => (sanitize_for_progress(str_arg("pattern")), None),
         _ => (sanitize_for_progress(tool_name), None),
     }
 }
 
+/// Compute the argument-summary budget for a progress line given the current
+/// terminal width (issue #432 §4.3.1).
+///
+/// Subtracts the fixed chrome (`[iter N/M]  `, optional emoji, tool name, and
+/// the two-space separator) plus 3 chars reserved for the `...` ellipsis that
+/// `truncate()` appends when the input exceeds the budget, then clamps the
+/// result to `MIN_ARG_BUDGET` (20). When `cols` is `None` (footer disabled /
+/// handle absent / first-tick race) the caller falls back to
+/// `DEFAULT_ARG_BUDGET` (57), preserving the pre-#432 behaviour.
+pub(super) fn progress_available_width(
+    cols: Option<u16>,
+    tool_name: &str,
+    iter_human: usize,
+    max_iterations: usize,
+    use_unicode: bool,
+) -> usize {
+    const DEFAULT_ARG_BUDGET: usize = 57;
+    const MIN_ARG_BUDGET: usize = 20;
+    // truncate() appends "..." (3 chars) when it fires, so reserve those chars
+    // up-front. Otherwise a fully-truncated Bash command overflows cols by 3.
+    const ELLIPSIS_RESERVE: usize = 3;
+
+    let Some(cols) = cols else {
+        return DEFAULT_ARG_BUDGET;
+    };
+
+    // Chrome must stay in sync with the `format!` in `format_progress_line`:
+    //   "[iter N/M]  " + (emoji " ")? + tool_name + "  "
+    let iter_prefix = format!("[iter {iter_human}/{max_iterations}]  ");
+    let emoji_width = if use_unicode {
+        tool_emoji(tool_name).chars().count() + 1
+    } else {
+        0
+    };
+    let chrome = iter_prefix.len() + emoji_width + tool_name.chars().count() + 2;
+
+    (cols as usize)
+        .saturating_sub(chrome)
+        .saturating_sub(ELLIPSIS_RESERVE)
+        .max(MIN_ARG_BUDGET)
+}
+
 /// Format a single-line per-iteration progress line. ANSI color is only
 /// applied to the tool name when `use_color` is true, and emoji is prepended
-/// when `use_unicode` is true.
+/// when `use_unicode` is true. `cols` is the current terminal width from the
+/// footer broadcaster; `None` falls back to the pre-#432 fixed budget.
+#[allow(clippy::too_many_arguments)]
 pub(super) fn format_progress_line(
     tool_name: &str,
     arguments: &serde_json::Value,
@@ -686,8 +736,11 @@ pub(super) fn format_progress_line(
     work_root: &std::path::Path,
     use_color: bool,
     use_unicode: bool,
+    cols: Option<u16>,
 ) -> String {
-    let (display_str, extra) = tool_display(tool_name, arguments, work_root);
+    let arg_budget =
+        progress_available_width(cols, tool_name, iter_human, max_iterations, use_unicode);
+    let (display_str, extra) = tool_display(tool_name, arguments, work_root, arg_budget);
     // Sanitize before painting so an adversarial tool_name cannot inject escapes.
     // emoji は &'static str ハードコードなので再 sanitize は不要。
     let safe_tool_name = sanitize_for_progress(tool_name);
@@ -726,8 +779,8 @@ mod truncate_tests {
 #[cfg(test)]
 mod progress_tests {
     use super::{
-        format_progress_line, is_utf8_locale, sanitize_for_progress, tool_color, tool_display,
-        tool_emoji, unicode_supported,
+        format_progress_line, is_utf8_locale, progress_available_width, sanitize_for_progress,
+        tool_color, tool_display, tool_emoji, unicode_supported,
     };
     use serde_json::json;
     use std::path::PathBuf;
@@ -754,7 +807,7 @@ mod progress_tests {
     fn tool_display_write_ascii() {
         let work_root = PathBuf::from("/work");
         let args = json!({"path": "/work/src/foo.rs", "content": "hello"});
-        let (display, extra) = tool_display("Write", &args, &work_root);
+        let (display, extra) = tool_display("Write", &args, &work_root, 57);
         assert_eq!(display, "src/foo.rs");
         assert_eq!(extra, Some("5B".to_string()));
     }
@@ -763,7 +816,7 @@ mod progress_tests {
     fn tool_display_write_non_ascii() {
         let work_root = PathBuf::from("/work");
         let args = json!({"path": "/work/a.txt", "content": "日本語"});
-        let (_, extra) = tool_display("Write", &args, &work_root);
+        let (_, extra) = tool_display("Write", &args, &work_root, 57);
         // "日本語" is 9 bytes in UTF-8
         assert_eq!(extra, Some("9B".to_string()));
     }
@@ -773,7 +826,7 @@ mod progress_tests {
         let work_root = PathBuf::from("/work");
         let cmd = "cargo test";
         let args = json!({"command": cmd});
-        let (display, _) = tool_display("Bash", &args, &work_root);
+        let (display, _) = tool_display("Bash", &args, &work_root, 57);
         assert_eq!(display, cmd);
     }
 
@@ -782,7 +835,7 @@ mod progress_tests {
         let work_root = PathBuf::from("/work");
         let cmd = "a".repeat(61);
         let args = json!({"command": cmd});
-        let (display, _) = tool_display("Bash", &args, &work_root);
+        let (display, _) = tool_display("Bash", &args, &work_root, 57);
         assert_eq!(display.len(), 60); // 57 chars + "..."
         assert!(display.ends_with("..."));
     }
@@ -791,7 +844,7 @@ mod progress_tests {
     fn tool_display_path_relative() {
         let work_root = PathBuf::from("/work");
         let args = json!({"path": "/work/src/lib.rs"});
-        let (display, _) = tool_display("Read", &args, &work_root);
+        let (display, _) = tool_display("Read", &args, &work_root, 57);
         assert_eq!(display, "src/lib.rs");
     }
 
@@ -799,15 +852,105 @@ mod progress_tests {
     fn tool_display_path_outside() {
         let work_root = PathBuf::from("/work");
         let args = json!({"path": "/tmp/outside.txt"});
-        let (display, _) = tool_display("Read", &args, &work_root);
+        let (display, _) = tool_display("Read", &args, &work_root, 57);
         assert_eq!(display, "/tmp/outside.txt");
+    }
+
+    #[test]
+    fn tool_display_bash_with_wide_budget() {
+        let work_root = PathBuf::from("/work");
+        let cmd = "a".repeat(100);
+        let args = json!({"command": cmd});
+        let (display, _) = tool_display("Bash", &args, &work_root, 200);
+        assert_eq!(display.len(), 100);
+        assert!(!display.ends_with("..."));
+    }
+
+    #[test]
+    fn tool_display_bash_with_narrow_budget() {
+        let work_root = PathBuf::from("/work");
+        let cmd = "a".repeat(30);
+        let args = json!({"command": cmd});
+        let (display, _) = tool_display("Bash", &args, &work_root, 20);
+        assert_eq!(display.len(), 23); // 20 chars + "..."
+        assert!(display.ends_with("..."));
+    }
+
+    #[test]
+    fn progress_available_width_none_returns_default() {
+        assert_eq!(progress_available_width(None, "Bash", 1, 12, false), 57);
+    }
+
+    #[test]
+    fn progress_available_width_large_cols_returns_budget() {
+        // cols=200, tool_name="Bash" (4 chars), use_unicode=false
+        // iter_prefix "[iter 1/12]  " = 13 chars; chrome = 13 + 0 + 4 + 2 = 19
+        // ellipsis reserve = 3; expected budget = 200 - 19 - 3 = 178
+        assert_eq!(
+            progress_available_width(Some(200), "Bash", 1, 12, false),
+            178
+        );
+    }
+
+    #[test]
+    fn progress_available_width_small_cols_clamps_to_min() {
+        // cols=30; chrome + ellipsis = 22; 30 - 22 = 8 → clamp to 20
+        assert_eq!(progress_available_width(Some(30), "Bash", 1, 12, false), 20);
+    }
+
+    #[test]
+    fn progress_available_width_zero_cols_clamps_to_min() {
+        // saturating_sub to 0 → max(20)
+        assert_eq!(progress_available_width(Some(0), "Bash", 1, 12, false), 20);
+    }
+
+    #[test]
+    fn progress_available_width_emoji_accounts_for_vs16() {
+        // "Write" emoji is `✏️` (U+270F + U+FE0F VS16), `.chars().count() == 2`.
+        // iter_prefix "[iter 1/12]  " = 13; emoji_width = 2 + 1 = 3; name = 5; +2 → chrome=23
+        // ellipsis reserve = 3; cols=200 → 200 - 23 - 3 = 174
+        assert_eq!(
+            progress_available_width(Some(200), "Write", 1, 12, true),
+            174
+        );
+    }
+
+    #[test]
+    fn format_progress_line_fits_within_cols_on_truncate() {
+        // CB-001 regression: when Bash command overflows arg_budget and cols is
+        // wide enough for the MIN_ARG_BUDGET=20 clamp not to fire, the final
+        // progress line (chars) must still fit within `cols`. For cols narrower
+        // than chrome+MIN+ELLIPSIS the clamp keeps useful output at the cost of
+        // a small overflow — that tradeoff is documented in §4.3.1.
+        let work_root = PathBuf::from("/work");
+        let cmd = "a".repeat(500);
+        let args = json!({"command": cmd});
+        // chrome=19 (iter_prefix 13 + Bash 4 + 2); MIN=20; ellipsis=3. So cols
+        // must be >= 42 to avoid the clamp dominating.
+        for &cols in &[60u16, 80, 120, 200] {
+            let line = format_progress_line(
+                "Bash",
+                &args,
+                1,
+                12,
+                &work_root,
+                /* use_color */ false,
+                /* use_unicode */ false,
+                Some(cols),
+            );
+            let line_chars = line.chars().count();
+            assert!(
+                line_chars <= cols as usize,
+                "progress line {line_chars} chars exceeds cols={cols}: {line:?}"
+            );
+        }
     }
 
     #[test]
     fn progress_line_iter_1indexed() {
         let work_root = PathBuf::from("/work");
         let args = json!({"path": "/work/a.txt", "content": "x"});
-        let line = format_progress_line("Write", &args, 1, 12, &work_root, false, false);
+        let line = format_progress_line("Write", &args, 1, 12, &work_root, false, false, None);
         assert!(line.starts_with("[iter 1/12]"));
     }
 
@@ -815,7 +958,7 @@ mod progress_tests {
     fn progress_line_no_color_no_escape() {
         let work_root = PathBuf::from("/work");
         let args = json!({"command": "ls"});
-        let line = format_progress_line("Bash", &args, 1, 12, &work_root, false, false);
+        let line = format_progress_line("Bash", &args, 1, 12, &work_root, false, false, None);
         assert!(!line.contains('\x1b'));
     }
 
@@ -823,7 +966,7 @@ mod progress_tests {
     fn progress_line_color_prefix_invariant() {
         let work_root = PathBuf::from("/work");
         let args = json!({"command": "ls"});
-        let line = format_progress_line("Bash", &args, 1, 12, &work_root, true, false);
+        let line = format_progress_line("Bash", &args, 1, 12, &work_root, true, false, None);
         assert!(line.starts_with("[iter "));
     }
 
@@ -848,7 +991,7 @@ mod progress_tests {
     fn progress_line_emoji_and_color_for_bash() {
         let work_root = PathBuf::from("/work");
         let args = json!({"command": "ls"});
-        let line = format_progress_line("Bash", &args, 1, 12, &work_root, true, true);
+        let line = format_progress_line("Bash", &args, 1, 12, &work_root, true, true, None);
         let color_idx = line.find("\x1b[38;5;226m").expect("color present");
         let emoji_idx = line.find('⚡').expect("emoji present");
         let reset_idx = line.find("\x1b[0m").expect("reset present");
@@ -860,7 +1003,7 @@ mod progress_tests {
     fn progress_line_no_color_but_unicode_emits_emoji() {
         let work_root = PathBuf::from("/work");
         let args = json!({"command": "ls"});
-        let line = format_progress_line("Bash", &args, 1, 12, &work_root, false, true);
+        let line = format_progress_line("Bash", &args, 1, 12, &work_root, false, true, None);
         assert!(line.contains('⚡'));
         assert!(!line.contains('\x1b'));
     }
@@ -869,7 +1012,7 @@ mod progress_tests {
     fn progress_line_unicode_off_no_emoji() {
         let work_root = PathBuf::from("/work");
         let args = json!({"command": "ls"});
-        let line = format_progress_line("Bash", &args, 1, 12, &work_root, true, false);
+        let line = format_progress_line("Bash", &args, 1, 12, &work_root, true, false, None);
         assert!(!line.contains('⚡'));
     }
 

--- a/tests/footer_skeleton_integration.rs
+++ b/tests/footer_skeleton_integration.rs
@@ -45,6 +45,12 @@ fn acquire_under_cargo_non_tty_returns_disabled() {
 }
 
 #[test]
+fn disabled_handle_current_cols_is_none() {
+    let handle = FooterHandle::disabled();
+    assert_eq!(handle.current_cols(), None);
+}
+
+#[test]
 fn disabled_handle_publish_and_freeze_are_noop() {
     // Phase A "AC9 placeholder": the handle plumbed through `Agent::new`
     // along the sessions / oneshot paths must be observably inert. We can't


### PR DESCRIPTION
## 概要

- ターミナルリサイズ（SIGWINCH）に対応し、TUIレイアウトを動的に再計算
- footer の列幅をブロードキャストし、プログレス行の引数切り詰め幅を端末幅に追従させる

## 変更内容

| ファイル | 変更内容 |
|---------|---------|
| `src/agent/loop_run/footer.rs` | `cols` フィールド追加、SIGWINCH検知→列幅ブロードキャスト、`publish_cols()` API |
| `src/agent/loop_run/turn.rs` | `FooterHandle::cols()` から端末幅を取得し、プログレス行のarg切り詰め幅を動的計算（従来57文字固定→動的） |
| `tests/footer_skeleton_integration.rs` | 列幅変更テスト追加 |
| `CLAUDE.md` | footer cols broadcast API 説明追記 |

## 動作仕様

- SIGWINCH → `crossterm::terminal::size()` で再取得 → `footer.publish_cols(cols)` でブロードキャスト
- `turn.rs` はターン毎に `handle.cols()` を参照して切り詰め幅を決定
- `signal_hook` 不使用: `crossterm::event` の SIGWINCH 検知を render_loop 内で処理（依存追加なし）
- Windows: `crossterm` のイベントループで対応

## テスト

- `cargo test --lib`: 186 passed（develop比+13件）
- `cargo clippy --all-targets -- -D warnings`: 警告ゼロ
- `cargo fmt --check`: Pass

## 関連Issue

Closes #432
Depends on #430 (merged)