### PR TITLE
fix: serialize readline history tests to dodge rustyline 14 umask race

### DIFF
--- a/tests/readline_history_roundtrip.rs
+++ b/tests/readline_history_roundtrip.rs
@@ -5,9 +5,26 @@
 //! history_ignore_space / helper wiring).
 
 use anvil::agent::loop_run::slash_commands::build_editor;
+use std::sync::{Mutex, MutexGuard, PoisonError};
+
+/// Serialize every test in this binary that touches `append_history` /
+/// `tempfile::tempdir()`. rustyline 14's `History::save()`
+/// (`rustyline-14.0.0/src/history.rs:685-697`) flips the **process-global**
+/// umask to `0o0177` non-atomically around `File::create`. If a parallel test
+/// thread runs `tempdir()` (which `mkdir`s with mode `0o700`) inside that
+/// window, the new directory ends up `0o0700 & ~0o0177 == 0o0600` — missing
+/// the user execute bit — and any subsequent file open inside it fails with
+/// `EACCES`. See Issue #443.
+static UMASK_SERIAL: Mutex<()> = Mutex::new(());
+
+fn serial_lock() -> MutexGuard<'static, ()> {
+    // Recover from a prior test's panic so one failure doesn't cascade.
+    UMASK_SERIAL.lock().unwrap_or_else(PoisonError::into_inner)
+}
 
 #[test]
 fn history_roundtrip_via_append_and_load() {
+    let _serial = serial_lock();
     let tmp = tempfile::tempdir().unwrap();
     let history = tmp.path().join("history");
 
@@ -39,6 +56,7 @@ fn history_roundtrip_via_append_and_load() {
 /// (`history_ignore_space_skips_sensitive_line`).
 #[test]
 fn history_ignore_space_opt_out() {
+    let _serial = serial_lock();
     let tmp = tempfile::tempdir().unwrap();
     let history = tmp.path().join("history");
 
@@ -79,6 +97,7 @@ fn history_ignore_space_opt_out() {
 fn history_file_mode_is_0o600() {
     use std::os::unix::fs::PermissionsExt;
 
+    let _serial = serial_lock();
     let tmp = tempfile::tempdir().unwrap();
     let history = tmp.path().join("history");
 
@@ -109,6 +128,7 @@ fn history_file_mode_is_0o600() {
 /// (`history_load_tolerates_missing_file`).
 #[test]
 fn load_history_missing_file_is_ok() {
+    let _serial = serial_lock();
     let tmp = tempfile::tempdir().unwrap();
     let history = tmp.path().join("does-not-exist");
     let mut ed = build_editor().expect("build_editor must succeed");


### PR DESCRIPTION
## Summary

- `tests/readline_history_roundtrip.rs` の 4 テストを **process-wide な `Mutex<()>` で直列化** し、rustyline 14 の `History::save()` が引き起こす umask レース (#443) を回避
- レース原因: `History::save()` が `umask(0o0177)` → `File::create` → `restore_umask()` の間にある非アトミックな poisoned umask 期間に、並列テストの `tempfile::tempdir()` (`mkdir(path, 0o700)`) が走ると、新規ディレクトリが `0o0600` (user execute なし) になり、以降の file open が `EACCES` で失敗する

## Test plan

- [x] `cargo test --test readline_history_roundtrip -- --test-threads=4` を 100 連続実行で 100/100 pass
- [x] `cargo test --all` で 457 unit + integration テスト全て pass
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [ ] CI (`.github/workflows/ci.yml`) が green

Closes #443

🤖 Generated with [Claude Code](https://claude.com/claude-code)