### PR TITLE
feat(precaution): add /precautions slash command (#454)

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ LLM 推論中・ツール実行中は stderr に 80ms 間隔のスピナーを�
 
 ## スラッシュコマンド
 
-対話モード（REPL）で利用できる 10 コマンド。これらが Tab 補完の候補になり、`/help` の出力と完全に一致する。
+対話モード（REPL）で利用できる 11 コマンド。これらが Tab 補完の候補になり、`/help` の出力と完全に一致する。
 
 - `/help`
 - `/status`
@@ -135,6 +135,7 @@ LLM 推論中・ツール実行中は stderr に 80ms 間隔のスピナーを�
 - `/approve`
 - `/compact`
 - `/logs path [<session_id>]`
+- `/precautions [add <text>|retire <id>|clear]`
 - `/exit`
 
 エイリアス: `/act`（= `/approve`）, `/quit`（= `/exit`）。補完候補には出さない。
@@ -154,13 +155,13 @@ LLM 推論中・ツール実行中は stderr に 80ms 間隔のスピナーを�
 
 ### 対話モードの入力
 
-TTY 環境で起動した場合は rustyline ベースの入力ハンドラを使う。上下キーで履歴呼び出し、Tab で上記 10 コマンドの補完、Ctrl+A/E/K/U/C/D が働く。パイプ入力・リダイレクト・CI 等の非 TTY 環境では従来どおり素朴な `read_line` にフォールバックする。
+TTY 環境で起動した場合は rustyline ベースの入力ハンドラを使う。上下キーで履歴呼び出し、Tab で上記 11 コマンドの補完、Ctrl+A/E/K/U/C/D が働く。パイプ入力・リダイレクト・CI 等の非 TTY 環境では従来どおり素朴な `read_line` にフォールバックする。
 
 履歴は `$XDG_STATE_HOME/anvil/history`（`--state-dir <PATH>` override を尊重）に最大 1000 行まで保存される。先頭に半角スペースを付けた入力は履歴に保存されないので、機密入力はこの opt-out を使う。
 
 ### /help 出力順の変更（v0.1.0 系内の互換性メモ）
 
-`/help` 出力は `/help /status /model /yes /no /plan /approve /compact /logs /exit` の順に固定した。以前は `/yes /no` が末尾付近にあったが、承認系コマンドを目立つ位置に移動する UX 改善として `/model` 直後へ前進させている。
+`/help` 出力は `/help /status /model /yes /no /plan /approve /compact /logs /precautions /exit` の順に固定した。以前は `/yes /no` が末尾付近にあったが、承認系コマンドを目立つ位置に移動する UX 改善として `/model` 直後へ前進させている。
 
 ## 設定
 

--- a/src/agent/loop_run/commands.rs
+++ b/src/agent/loop_run/commands.rs
@@ -10,7 +10,10 @@ use crate::config::LogLevel;
 use crate::logging::log_llm_event;
 use crate::modes::plan_act::{PlanStage, TaskProfile, infer_work_mode_from_text};
 use crate::ollama::xml_fallback::strip_think_tags;
-use crate::session::store::ConversationMessage;
+use crate::session::precaution::{
+    AddPrecautionOutcome, Precaution, PrecautionSource, PrecautionStatus, Severity,
+};
+use crate::session::store::{ConversationMessage, WorkingMemory};
 use crossterm::event::{self, Event, KeyCode};
 use crossterm::terminal::{disable_raw_mode, enable_raw_mode};
 use serde::Deserialize;
@@ -1422,8 +1425,159 @@ The plan must still define: (1) the first shippable vertical slice, (2) concrete
         }
     }
 
+    fn handle_precautions_command(&mut self, args: &str) -> Result<AgentEvent, String> {
+        let args = args.trim();
+        let (subcommand, rest) = args
+            .split_once(' ')
+            .map(|(command, rest)| (command, rest.trim()))
+            .unwrap_or((args, ""));
+
+        match subcommand {
+            "" => self.precautions_list(),
+            "add" if rest.is_empty() => Ok(AgentEvent::Continue(Some(
+                "usage: /precautions add <text>".to_string(),
+            ))),
+            "add" => self.precautions_add(rest),
+            "retire" if rest.is_empty() => Ok(AgentEvent::Continue(Some(
+                "usage: /precautions retire <id>".to_string(),
+            ))),
+            "retire" => self.precautions_retire(rest),
+            "clear" if rest.is_empty() => self.precautions_clear(),
+            "clear" => Ok(AgentEvent::Continue(Some(precautions_usage().to_string()))),
+            _ => Ok(AgentEvent::Continue(Some(precautions_usage().to_string()))),
+        }
+    }
+
+    fn precautions_list(&self) -> Result<AgentEvent, String> {
+        let lines: Vec<String> = self
+            .session
+            .working_memory
+            .active_precautions
+            .iter()
+            .filter(|precaution| precaution.status == PrecautionStatus::Active)
+            .map(|precaution| {
+                format!(
+                    "{}  [{}]  [{}]  {}",
+                    precaution_id12(&precaution.id),
+                    precaution.severity.as_label(),
+                    precaution.source.as_label(),
+                    precaution.text
+                )
+            })
+            .collect();
+
+        let message = if lines.is_empty() {
+            "(no active precautions)".to_string()
+        } else {
+            lines.join("\n")
+        };
+        Ok(AgentEvent::Continue(Some(message)))
+    }
+
+    fn precautions_add(&mut self, text: &str) -> Result<AgentEvent, String> {
+        let precaution = Precaution {
+            id: String::new(),
+            source: PrecautionSource::Manual,
+            severity: Severity::Medium,
+            text: text.to_string(),
+            applies_to: Vec::new(),
+            status: PrecautionStatus::Active,
+            retired_reason: None,
+        };
+
+        let canonical = canonical_preview_precaution(precaution.clone(), &self.work_root)?;
+        let outcome = self
+            .session
+            .working_memory
+            .add_precaution(precaution, &self.work_root);
+        let id12 = precaution_id12(&canonical.id);
+
+        let message = match outcome {
+            AddPrecautionOutcome::Added => {
+                format!("added precaution: {id12}  {}", canonical.text)
+            }
+            AddPrecautionOutcome::DuplicateIgnored => format!("duplicate ignored: {id12}"),
+            AddPrecautionOutcome::Truncated => format!(
+                "added precaution (truncated to {} chars): {id12}  {}",
+                WorkingMemory::MAX_PRECAUTION_TEXT,
+                canonical.text
+            ),
+        };
+        Ok(AgentEvent::Continue(Some(message)))
+    }
+
+    fn precautions_retire(&mut self, id_prefix: &str) -> Result<AgentEvent, String> {
+        let given = id_prefix.to_ascii_lowercase();
+        if !is_valid_precaution_id_prefix(&given) {
+            return Ok(AgentEvent::Continue(Some(format!(
+                "precaution not found: {given}"
+            ))));
+        }
+
+        let matches: Vec<String> = self
+            .session
+            .working_memory
+            .active_precautions
+            .iter()
+            .filter(|precaution| {
+                matches!(
+                    precaution.status,
+                    PrecautionStatus::Active | PrecautionStatus::Resolved
+                ) && precaution.id.starts_with(&given)
+            })
+            .map(|precaution| precaution.id.clone())
+            .collect();
+
+        match matches.as_slice() {
+            [] => Ok(AgentEvent::Continue(Some(format!(
+                "precaution not found: {given}"
+            )))),
+            [_, _, ..] => Ok(AgentEvent::Continue(Some(format!(
+                "ambiguous id prefix: {given}; matches {} entries",
+                matches.len()
+            )))),
+            [id] => {
+                if self.session.working_memory.retire_precaution(id) {
+                    Ok(AgentEvent::Continue(Some(format!(
+                        "retired: {}",
+                        precaution_id12(id)
+                    ))))
+                } else {
+                    Ok(AgentEvent::Continue(Some(format!(
+                        "precaution not found: {given}"
+                    ))))
+                }
+            }
+        }
+    }
+
+    fn precautions_clear(&mut self) -> Result<AgentEvent, String> {
+        if !self.config.yes_mode {
+            return Ok(AgentEvent::Continue(Some(
+                "refused: enable /yes or retire individually".to_string(),
+            )));
+        }
+
+        let ids: Vec<String> = self
+            .session
+            .working_memory
+            .active_precautions
+            .iter()
+            .filter(|precaution| precaution.status == PrecautionStatus::Active)
+            .map(|precaution| precaution.id.clone())
+            .collect();
+        let retired = ids
+            .iter()
+            .filter(|id| self.session.working_memory.retire_precaution(id))
+            .count();
+
+        Ok(AgentEvent::Continue(Some(format!(
+            "retired {retired} precautions"
+        ))))
+    }
+
     fn handle_command(&mut self, input: &str) -> Result<AgentEvent, String> {
-        let (command, _) = input.split_once(' ').unwrap_or((input, ""));
+        let (command, rest) = input.split_once(' ').unwrap_or((input, ""));
         match command {
             "/help" => Ok(AgentEvent::Continue(Some(slash_commands::help_line()))),
             "/status" => Ok(AgentEvent::Continue(Some(format!(
@@ -1513,6 +1667,7 @@ The plan must still define: (1) the first shippable vertical slice, (2) concrete
                     ))),
                 }
             }
+            "/precautions" => self.handle_precautions_command(rest),
             "/checkpoint" | "/rollback" | "/watch" | "/autotest" | "/skills" | "/skill"
             | "/mcp" | "/parallel" => Ok(AgentEvent::Continue(Some(format!(
                 "{command} is unavailable in the v0.1.0 core rebuild"
@@ -1523,6 +1678,31 @@ The plan must still define: (1) the first shippable vertical slice, (2) concrete
             )))),
         }
     }
+}
+
+fn precautions_usage() -> &'static str {
+    "usage: /precautions [add <text>|retire <id>|clear]"
+}
+
+fn precaution_id12(id: &str) -> String {
+    id.get(..12).unwrap_or(id).to_string()
+}
+
+fn is_valid_precaution_id_prefix(id: &str) -> bool {
+    id.len() == 12 && id.chars().all(|c| c.is_ascii_hexdigit())
+}
+
+fn canonical_preview_precaution(
+    precaution: Precaution,
+    work_root: &Path,
+) -> Result<Precaution, String> {
+    let mut preview = WorkingMemory::default();
+    let _ = preview.add_precaution(precaution, work_root);
+    preview
+        .active_precautions
+        .into_iter()
+        .next()
+        .ok_or_else(|| "failed to canonicalize precaution".to_string())
 }
 
 fn should_render_fallback_prompt(stdout_is_tty: bool) -> bool {
@@ -1584,9 +1764,15 @@ fn tighten_history_perms(path: &Path) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::agent::loop_run::FooterHandle;
+    use crate::config::Config;
+    use crate::model_registry::RuntimeModels;
     use crate::modes::plan_act::ExecutionMode;
+    use crate::ollama::client::OllamaClient;
+    use crate::session::store::{SessionSnapshot, SessionStore};
     use std::path::{Path, PathBuf};
     use std::sync::Mutex;
+    use tempfile::{TempDir, tempdir};
 
     /// Serialize env-mutating tests within this module so `cargo test`'s
     /// default parallel runner cannot race on `NO_COLOR`.
@@ -1641,6 +1827,212 @@ mod tests {
 
     fn sample_mode() -> ExecutionMode {
         ExecutionMode::Act
+    }
+
+    fn test_agent(yes_mode: bool) -> (Agent, TempDir) {
+        let temp = tempdir().unwrap();
+        let state_root = temp.path().join(".anvil-state");
+        let session_id = "0199fe00-0000-7000-8000-000000000454";
+        let workspace_key = "test-workspace";
+        let config = Config {
+            cwd: temp.path().to_path_buf(),
+            requested_model: Some("test-model".to_string()),
+            ollama_host: "http://127.0.0.1:11434".to_string(),
+            yes_mode,
+            state_dir_override: Some(state_root.clone()),
+            ..Config::default()
+        };
+        let client = OllamaClient::new(config.ollama_host.clone()).unwrap();
+        let session = SessionSnapshot {
+            id: session_id.to_string(),
+            workspace_key: workspace_key.to_string(),
+            ..SessionSnapshot::default()
+        };
+        let agent = Agent::new(
+            config,
+            RuntimeModels {
+                main: "test-model".to_string(),
+                sidecar: None,
+            },
+            client,
+            SessionStore::new(&state_root, session_id, workspace_key),
+            session,
+            FooterHandle::disabled(),
+        );
+        (agent, temp)
+    }
+
+    fn continue_message(event: AgentEvent) -> String {
+        match event {
+            AgentEvent::Continue(Some(message)) => message,
+            AgentEvent::Continue(None) => panic!("expected message, got Continue(None)"),
+            AgentEvent::Exit => panic!("expected Continue, got Exit"),
+        }
+    }
+
+    fn active_precautions_prompt(agent: &Agent) -> Option<String> {
+        let selected = select_precautions_for_prompt(
+            &agent.session.working_memory.active_precautions,
+            ExecutionMode::Act,
+            &agent.session.working_memory.touched_files,
+            None,
+        );
+        agent
+            .session
+            .working_memory
+            .format_for_prompt_with_precautions(&selected)
+    }
+
+    #[test]
+    fn precautions_command_add_list_retire_updates_prompt() {
+        let (mut agent, _temp) = test_agent(false);
+        let add = continue_message(
+            agent
+                .handle_precautions_command("add Do not modify generated files")
+                .unwrap(),
+        );
+        let id12 = precaution_id12(&agent.session.working_memory.active_precautions[0].id);
+        assert!(add.contains("added precaution"));
+        assert!(add.contains(&id12));
+        assert!(add.contains("Do not modify generated files"));
+
+        let list = continue_message(agent.handle_precautions_command("").unwrap());
+        assert!(list.contains(&id12), "{list}");
+        assert!(list.contains("[medium]"), "{list}");
+        assert!(list.contains("[manual]"), "{list}");
+        assert!(list.contains("Do not modify generated files"), "{list}");
+
+        let prompt = active_precautions_prompt(&agent).expect("prompt should render");
+        assert!(prompt.contains("Active Precautions:"), "{prompt}");
+        assert!(
+            prompt.contains("- [medium] Do not modify generated files"),
+            "{prompt}"
+        );
+
+        let retire = continue_message(
+            agent
+                .handle_precautions_command(&format!("retire {id12}"))
+                .unwrap(),
+        );
+        assert_eq!(retire, format!("retired: {id12}"));
+        let prompt_after = active_precautions_prompt(&agent);
+        assert!(
+            prompt_after
+                .as_deref()
+                .is_none_or(|body| !body.contains("Active Precautions:")),
+            "{prompt_after:?}"
+        );
+    }
+
+    #[test]
+    fn precautions_add_message_uses_canonicalized_text() {
+        let (mut agent, _temp) = test_agent(false);
+        let raw = "Do not leak AKIAIOSFODNN7EXAMPLE\u{1b}[31m";
+
+        let message = continue_message(
+            agent
+                .handle_precautions_command(&format!("add {raw}"))
+                .unwrap(),
+        );
+
+        assert!(!message.contains("AKIAIOSFODNN7EXAMPLE"), "{message}");
+        assert!(!message.contains('\u{1b}'), "{message:?}");
+        assert!(message.contains("***"), "{message}");
+    }
+
+    #[test]
+    fn precautions_retire_rejects_invalid_prefixes() {
+        let (mut agent, _temp) = test_agent(false);
+        continue_message(agent.handle_precautions_command("add keep this").unwrap());
+        let id = agent.session.working_memory.active_precautions[0]
+            .id
+            .clone();
+
+        let full_hash = continue_message(
+            agent
+                .handle_precautions_command(&format!("retire {id}"))
+                .unwrap(),
+        );
+        assert_eq!(full_hash, format!("precaution not found: {id}"));
+
+        let invalid = continue_message(
+            agent
+                .handle_precautions_command("retire not-hex-id!")
+                .unwrap(),
+        );
+        assert_eq!(invalid, "precaution not found: not-hex-id!");
+        assert_eq!(
+            agent.session.working_memory.active_precautions[0].status,
+            PrecautionStatus::Active
+        );
+    }
+
+    #[test]
+    fn precautions_clear_requires_yes_and_rejects_extra_args() {
+        let (mut agent, _temp) = test_agent(false);
+        continue_message(agent.handle_precautions_command("add clear me").unwrap());
+
+        let refused = continue_message(agent.handle_precautions_command("clear").unwrap());
+        assert_eq!(refused, "refused: enable /yes or retire individually");
+        assert_eq!(
+            agent.session.working_memory.active_precautions[0].status,
+            PrecautionStatus::Active
+        );
+
+        agent.config.yes_mode = true;
+        let usage = continue_message(agent.handle_precautions_command("clear now").unwrap());
+        assert_eq!(usage, precautions_usage());
+        assert_eq!(
+            agent.session.working_memory.active_precautions[0].status,
+            PrecautionStatus::Active
+        );
+
+        let cleared = continue_message(agent.handle_precautions_command("clear").unwrap());
+        assert_eq!(cleared, "retired 1 precautions");
+        assert_eq!(
+            agent.session.working_memory.active_precautions[0].status,
+            PrecautionStatus::Retired
+        );
+    }
+
+    #[test]
+    fn precautions_retire_ambiguous_prefix_does_not_change_entries() {
+        let (mut agent, _temp) = test_agent(false);
+        let prefix = "abcdef123456";
+        for suffix in ["0000", "1111"] {
+            agent
+                .session
+                .working_memory
+                .active_precautions
+                .push(Precaution {
+                    id: format!("{prefix}{suffix}7890abcdef1234567890abcdef1234567890abcdef123456"),
+                    source: PrecautionSource::Manual,
+                    severity: Severity::Medium,
+                    text: format!("entry {suffix}"),
+                    applies_to: Vec::new(),
+                    status: PrecautionStatus::Active,
+                    retired_reason: None,
+                });
+        }
+
+        let message = continue_message(
+            agent
+                .handle_precautions_command(&format!("retire {prefix}"))
+                .unwrap(),
+        );
+
+        assert_eq!(
+            message,
+            "ambiguous id prefix: abcdef123456; matches 2 entries"
+        );
+        assert!(
+            agent
+                .session
+                .working_memory
+                .active_precautions
+                .iter()
+                .all(|precaution| precaution.status == PrecautionStatus::Active)
+        );
     }
 
     fn build_inputs<'a>(

--- a/src/agent/loop_run/slash_commands.rs
+++ b/src/agent/loop_run/slash_commands.rs
@@ -23,7 +23,18 @@ use rustyline::{Config as RlConfig, Context, Editor};
 /// (`/checkpoint /rollback /watch /autotest /skills /skill /mcp /parallel`)
 /// are deliberately excluded.
 pub const SLASH_COMMANDS: &[&str] = &[
-    "/help", "/status", "/model", "/yes", "/no", "/plan", "/approve", "/compact", "/logs", "/exit",
+    "/help",
+    "/status",
+    "/model",
+    "/yes",
+    "/no",
+    "/plan",
+    "/approve",
+    "/compact",
+    // IO/状態確認カテゴリ: /logs と /precautions は機能カテゴリで隣接させる
+    "/logs",
+    "/precautions",
+    "/exit",
 ];
 
 /// Render the `/help` output line from `SLASH_COMMANDS`.

--- a/src/session/precaution.rs
+++ b/src/session/precaution.rs
@@ -72,6 +72,25 @@ pub enum PrecautionSource {
     Unknown,
 }
 
+impl PrecautionSource {
+    /// Stable snake_case label for id derivation, command output, and logs.
+    /// Matches `#[serde(rename_all = "snake_case")]` so session.json and
+    /// runtime labels stay aligned.
+    pub fn as_label(&self) -> &'static str {
+        match self {
+            PrecautionSource::UserRequirement => "user_requirement",
+            PrecautionSource::PlanConstraint => "plan_constraint",
+            PrecautionSource::BuildFailure => "build_failure",
+            PrecautionSource::TestFailure => "test_failure",
+            PrecautionSource::ToolFailure => "tool_failure",
+            PrecautionSource::NoProgress => "no_progress",
+            PrecautionSource::SafetyPolicy => "safety_policy",
+            PrecautionSource::Manual => "manual",
+            PrecautionSource::Unknown => "unknown",
+        }
+    }
+}
+
 /// Lifecycle state of a precaution.
 ///
 /// `Unknown` is a forward-compat fallback (DR4-002). After session load,
@@ -172,7 +191,7 @@ pub(crate) fn severity_order(s: Severity) -> u8 {
 
 #[cfg(test)]
 mod tests {
-    use super::{Severity, severity_order};
+    use super::{PrecautionSource, Severity, severity_order};
 
     #[test]
     fn severity_order_high_lowest_low_highest() {
@@ -180,5 +199,30 @@ mod tests {
         assert_eq!(severity_order(Severity::Medium), 1);
         assert_eq!(severity_order(Severity::Unknown), 1);
         assert_eq!(severity_order(Severity::Low), 2);
+    }
+
+    #[test]
+    fn precaution_source_as_label_matches_serde_rename() {
+        let cases = [
+            (PrecautionSource::UserRequirement, "user_requirement"),
+            (PrecautionSource::PlanConstraint, "plan_constraint"),
+            (PrecautionSource::BuildFailure, "build_failure"),
+            (PrecautionSource::TestFailure, "test_failure"),
+            (PrecautionSource::ToolFailure, "tool_failure"),
+            (PrecautionSource::NoProgress, "no_progress"),
+            (PrecautionSource::SafetyPolicy, "safety_policy"),
+            (PrecautionSource::Manual, "manual"),
+            (PrecautionSource::Unknown, "unknown"),
+        ];
+
+        for (source, expected) in cases {
+            let serialized = serde_json::to_value(source)
+                .unwrap()
+                .as_str()
+                .unwrap()
+                .to_string();
+            assert_eq!(serialized, expected);
+            assert_eq!(source.as_label(), expected);
+        }
     }
 }

--- a/src/session/store.rs
+++ b/src/session/store.rs
@@ -7,7 +7,7 @@ use crate::modes::plan_act::{ExecutionMode, ModeState};
 use crate::ollama::xml_fallback::ToolCall;
 use crate::session::feedback::{FeedbackFrame, mask_secrets, normalize_path_to_workspace};
 use crate::session::precaution::{
-    AddPrecautionOutcome, Precaution, PrecautionSource, PrecautionStatus, RetiredReason, Severity,
+    AddPrecautionOutcome, Precaution, PrecautionStatus, RetiredReason, Severity,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, Default)]
@@ -451,7 +451,7 @@ fn compute_precaution_id(p: &Precaution) -> String {
     let mut hasher = Sha256::new();
     hasher.update(p.text.as_bytes());
     hasher.update(b"\x00");
-    hasher.update(precaution_source_tag(p.source).as_bytes());
+    hasher.update(p.source.as_label().as_bytes());
     hasher.update(b"\x00");
     for path in &p.applies_to {
         if let Some(key) = path_to_canonical_string(path) {
@@ -460,22 +460,6 @@ fn compute_precaution_id(p: &Precaution) -> String {
         }
     }
     format!("{:x}", hasher.finalize())
-}
-
-/// Deterministic snake_case tag for `PrecautionSource`, independent of
-/// serde_json version (DR1-013).
-fn precaution_source_tag(s: PrecautionSource) -> &'static str {
-    match s {
-        PrecautionSource::UserRequirement => "user_requirement",
-        PrecautionSource::PlanConstraint => "plan_constraint",
-        PrecautionSource::BuildFailure => "build_failure",
-        PrecautionSource::TestFailure => "test_failure",
-        PrecautionSource::ToolFailure => "tool_failure",
-        PrecautionSource::NoProgress => "no_progress",
-        PrecautionSource::SafetyPolicy => "safety_policy",
-        PrecautionSource::Manual => "manual",
-        PrecautionSource::Unknown => "unknown",
-    }
 }
 
 /// Canonical "/"-joined UTF-8 string of a path, OR None if any component is
@@ -804,7 +788,9 @@ pub fn reconcile_resume_state(session: &mut SessionSnapshot, _cwd: &Path) {
 
 #[cfg(test)]
 mod tests {
-    use super::{Precaution, PrecautionSource, PrecautionStatus, Severity, WorkingMemory};
+    use crate::session::precaution::PrecautionSource;
+
+    use super::{Precaution, PrecautionStatus, Severity, WorkingMemory, compute_precaution_id};
     use tempfile::tempdir;
 
     fn make_precaution(text: &str, severity: Severity, status: PrecautionStatus) -> Precaution {
@@ -817,6 +803,24 @@ mod tests {
             status,
             retired_reason: None,
         }
+    }
+
+    #[test]
+    fn compute_precaution_id_uses_stable_source_label() {
+        let precaution = Precaution {
+            id: String::new(),
+            source: PrecautionSource::ToolFailure,
+            severity: Severity::Medium,
+            text: "legacy-id-fixture".to_string(),
+            applies_to: Vec::new(),
+            status: PrecautionStatus::Active,
+            retired_reason: None,
+        };
+
+        assert_eq!(
+            compute_precaution_id(&precaution),
+            "672e482bcd99c2d07445e5acce743b3ec669b2e7916e0af59c9ef6a668e4e573"
+        );
     }
 
     #[test]

--- a/tests/precautions_repl.rs
+++ b/tests/precautions_repl.rs
@@ -1,0 +1,134 @@
+use std::path::Path;
+
+use anvil::agent::Agent;
+use anvil::agent::loop_run::{AgentEvent, FooterHandle, select_precautions_for_prompt};
+use anvil::config::Config;
+use anvil::model_registry::RuntimeModels;
+use anvil::modes::plan_act::ExecutionMode;
+use anvil::ollama::client::OllamaClient;
+use anvil::session::precaution::PrecautionStatus;
+use anvil::session::store::{SessionSnapshot, SessionStore};
+use tempfile::tempdir;
+
+fn build_agent(
+    cwd: &Path,
+    state_root: &Path,
+    session_id: &str,
+    workspace_key: &str,
+    session: SessionSnapshot,
+) -> Agent {
+    let mut config = Config::default();
+    config.cwd = cwd.to_path_buf();
+    config.requested_model = Some("test-model".to_string());
+    config.ollama_host = "http://127.0.0.1:11434".to_string();
+    config.state_dir_override = Some(state_root.to_path_buf());
+
+    Agent::new(
+        config,
+        RuntimeModels {
+            main: "test-model".to_string(),
+            sidecar: None,
+        },
+        OllamaClient::new("http://127.0.0.1:11434".to_string()).unwrap(),
+        SessionStore::new(state_root, session_id, workspace_key),
+        session,
+        FooterHandle::disabled(),
+    )
+}
+
+fn continue_message(event: AgentEvent) -> String {
+    match event {
+        AgentEvent::Continue(Some(message)) => message,
+        AgentEvent::Continue(None) => panic!("expected Continue(Some), got Continue(None)"),
+        AgentEvent::Exit => panic!("expected Continue, got Exit"),
+    }
+}
+
+#[test]
+fn precautions_add_resume_list_prompt_and_retire_via_repl() {
+    let temp = tempdir().unwrap();
+    let state_root = temp.path().join(".anvil-state");
+    let session_id = "0199fe00-0000-7000-8000-000000000454";
+    let workspace_key = "test-workspace";
+    let store = SessionStore::new(&state_root, session_id, workspace_key);
+    let session = SessionSnapshot {
+        id: session_id.to_string(),
+        workspace_key: workspace_key.to_string(),
+        ..SessionSnapshot::default()
+    };
+    let mut agent = build_agent(temp.path(), &state_root, session_id, workspace_key, session);
+
+    let add = continue_message(
+        agent
+            .process_line("/precautions add Do not modify generated files", false)
+            .unwrap(),
+    );
+    assert!(add.contains("added precaution"), "{add}");
+
+    let mut loaded = store.load_or_new(false).unwrap();
+    loaded
+        .working_memory
+        .sanitize_active_precautions_after_load(temp.path());
+    let precaution = loaded
+        .working_memory
+        .active_precautions
+        .iter()
+        .find(|precaution| precaution.status == PrecautionStatus::Active)
+        .expect("active precaution persisted");
+    let id12 = precaution.id[..12].to_string();
+    assert_eq!(precaution.text, "Do not modify generated files");
+
+    let mut resumed = build_agent(
+        temp.path(),
+        &state_root,
+        session_id,
+        workspace_key,
+        loaded.clone(),
+    );
+    let list = continue_message(resumed.process_line("/precautions", false).unwrap());
+    assert!(list.contains(&id12), "{list}");
+    assert!(list.contains("Do not modify generated files"), "{list}");
+
+    let selected = select_precautions_for_prompt(
+        &loaded.working_memory.active_precautions,
+        ExecutionMode::Act,
+        &loaded.working_memory.touched_files,
+        None,
+    );
+    let prompt = loaded
+        .working_memory
+        .format_for_prompt_with_precautions(&selected)
+        .expect("active precaution should render");
+    assert!(prompt.contains("Active Precautions:"), "{prompt}");
+    assert!(
+        prompt.contains("- [medium] Do not modify generated files"),
+        "{prompt}"
+    );
+
+    let retire = continue_message(
+        resumed
+            .process_line(&format!("/precautions retire {id12}"), false)
+            .unwrap(),
+    );
+    assert_eq!(retire, format!("retired: {id12}"));
+
+    let mut retired = store.load_or_new(false).unwrap();
+    retired
+        .working_memory
+        .sanitize_active_precautions_after_load(temp.path());
+    let selected_after = select_precautions_for_prompt(
+        &retired.working_memory.active_precautions,
+        ExecutionMode::Act,
+        &retired.working_memory.touched_files,
+        None,
+    );
+    let prompt_after = retired
+        .working_memory
+        .format_for_prompt_with_precautions(&selected_after);
+    assert!(
+        prompt_after
+            .as_deref()
+            .is_none_or(|body| !body.contains("Active Precautions:")),
+        "{prompt_after:?}"
+    );
+}

--- a/tests/session_tests.rs
+++ b/tests/session_tests.rs
@@ -91,6 +91,36 @@ fn session_store_fills_in_empty_id_on_load() {
 }
 
 #[test]
+fn manual_precaution_survives_session_store_load_and_sanitize() {
+    let dir = tempdir().unwrap();
+    let session_id = "0199fe00-0000-7000-8000-000000000454";
+    let workspace_key = "ws-key";
+    let store = SessionStore::new(dir.path(), session_id, workspace_key);
+    let mut snapshot = SessionSnapshot {
+        id: session_id.to_string(),
+        workspace_key: workspace_key.to_string(),
+        ..SessionSnapshot::default()
+    };
+    snapshot
+        .working_memory
+        .add_precaution(sample_precaution("preserve manual precaution"), dir.path());
+    let original_id = snapshot.working_memory.active_precautions[0].id.clone();
+
+    store.save(&snapshot).unwrap();
+    let mut loaded = store.load_or_new(false).unwrap();
+    loaded
+        .working_memory
+        .sanitize_active_precautions_after_load(dir.path());
+
+    assert_eq!(loaded.working_memory.active_precautions.len(), 1);
+    let restored = &loaded.working_memory.active_precautions[0];
+    assert_eq!(restored.id, original_id);
+    assert_eq!(restored.source, PrecautionSource::Manual);
+    assert_eq!(restored.status, PrecautionStatus::Active);
+    assert_eq!(restored.text, "preserve manual precaution");
+}
+
+#[test]
 fn compaction_keeps_recent_tail() {
     let mut messages = (0..40)
         .map(|index| ConversationMessage::user(format!("message {index}")))

--- a/tests/slash_commands_ssot.rs
+++ b/tests/slash_commands_ssot.rs
@@ -32,11 +32,20 @@ fn help_line_matches_slash_commands() {
 }
 
 #[test]
-fn slash_commands_contains_expected_10() {
+fn slash_commands_contains_expected_11() {
     assert_eq!(
         SLASH_COMMANDS,
         &[
-            "/help", "/status", "/model", "/yes", "/no", "/plan", "/approve", "/compact", "/logs",
+            "/help",
+            "/status",
+            "/model",
+            "/yes",
+            "/no",
+            "/plan",
+            "/approve",
+            "/compact",
+            "/logs",
+            "/precautions",
             "/exit",
         ]
     );
@@ -63,7 +72,7 @@ fn slash_commands_excludes_aliases() {
     }
 }
 
-/// A single `/` at pos=1 must expand to the full inventory (10 commands) so
+/// A single `/` at pos=1 must expand to the full inventory (11 commands) so
 /// Tab-after-`/` shows everything. Guards design policy Section 8.2.
 #[test]
 fn completer_returns_all_candidates_for_single_slash() {


### PR DESCRIPTION
## Summary

Issue #454 (Epic A: Dynamic Precaution Runtime / 論理 #5) — REPL から active precautions を確認・追加・retire・clear できる slash command を追加。

## Operations

- \`/precautions\` — active precautions 一覧表示
- \`/precautions add \"text\"\` — 手動追加 (source = Manual)
- \`/precautions retire <id>\` — Retired にする
- \`/precautions clear\` — 一括 retire/削除（confirmation または yes mode）

## 受入条件

- [x] AC1: /precautions で active precautions が表示される
- [x] AC2: /precautions add した内容が session に保存される
- [x] AC3: 手動追加した precaution が次の Act prompt に入る
- [x] AC4: /precautions retire <id> 後、その precaution は prompt に入らない
- [x] AC5: resume 後も manual precaution が残る
- [x] AC6: 不正 ID 指定で runtime が落ちない

## Test plan

- [x] cargo fmt --all -- --check
- [x] cargo clippy --all-targets -- -D warnings
- [x] cargo test --all
- [ ] CI green

## Refs

- Parent Epic: #444
- Depends on: #450, #451, #452, #453 (merged)
- workspace/v0.1.1/feature.md (Issue #5, 論理番号)

Closes #454

🤖 Generated with [Claude Code](https://claude.com/claude-code)