### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [Unreleased]
+
+## [0.2.0] - 2026-04-28
+
+Epic A: Dynamic Precaution Runtime — runtime feedback の正規化、Active Precaution の永続化、Reminder Sidecar による自動生成、Act-mode prompt への注入、`/precautions` REPL コマンド、ランタイム回復経路との接続を一通り入れた。
+
+### Added
+
+- `FeedbackFrame` / `FeedbackKind` runtime feedback 値型 (#450)。Bash / auto_test / tool parser failure / unsafe command block / no-progress / edit failure を共通 shape に正規化し、`SessionSnapshot.last_feedback` に保存。secret mask（token prefix / kv secret / URL credential）と head+tail 8 KiB excerpt cap、PathBuf workspace 相対化を含む。
+- `WorkingMemory.active_precautions` と `Precaution` 型 (#451)。SHA-256 deterministic id、FIFO eviction、bounded caps（active 16 / total 64 / text 240）、untrusted-load sanitizer、`format_for_prompt` での Active Precautions セクション出力。
+- Reminder Sidecar (#452)。`FeedbackFrame` の失敗系 kind を sidecar Ollama に渡して `Precaution` を自動生成（per-turn cap = 1、`tools=None`、JSON-only、`<think>` strip + first JSON object 抽出、`ANVIL_NO_REMINDER` で disable 可）。`agent.reminder.{completed,failed,skipped}` ログ出力。
+- Active Precautions の Act-mode prompt 注入 (#453)。`select_precautions_for_prompt` で severity sort、touched/suspected ファイル相対の relevance scoring、token budget cap（`MAX_ACTIVE_PRECAUTIONS_PROMPT=8` / `MAX_ACTIVE_PRECAUTIONS_CHARS=1024`）、Plan-mode 抑止を適用。
+- `/precautions [add <text>|retire <id>|clear]` REPL コマンド (#454)。Active precautions を一覧 / 追加 / retire / clear。`PrecautionSource::as_label` で表示と `compute_precaution_id` の source label を共有。
+- Runtime recovery と precaution の接続 (#455)。`FeedbackKind::NoToolCall` (D1) と deterministic content fallback (D2) を追加し、no-tool-call exhaustion / 5 つの in-loop fallback success / 2 つの timeout wrapper / 3 つの post-loop site で feedback を記録。`eligible_feedback_recorded_this_turn` flag で first-eligible-failure-wins を保証。
+
+### Fixed
+
+- `history_roundtrip_via_append_and_load` ほか rustyline history テストの flaky を解消 (#443)。rustyline 14 の `History::save()` が umask を非アトミックに反転する race を、test ファイル全体を process-wide Mutex で直列化することで回避。
+- `non_utf8_stdout_does_not_panic_or_error` テストを CI の dash で安定化。`printf '\xff\xfe\xfd'` を POSIX 互換の `printf '\377\376\375'` に置換し、escape が展開されなかった場合の guard assertion を追加。
+
 ## [0.1.0] - 2026-04-16
 
 - Rebuilt Anvil from scratch as an Ollama-first local coding agent.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "anvil"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "clap",
  "crossterm",
@@ -102,9 +102,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block-buffer"
@@ -139,9 +139,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -167,9 +167,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -189,9 +189,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -335,7 +335,7 @@ checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -553,15 +553,14 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http",
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -692,9 +691,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -782,9 +781,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1035,9 +1034,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core",
@@ -1170,7 +1169,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1188,9 +1187,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
 dependencies = [
  "once_cell",
  "ring",
@@ -1202,9 +1201,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "web-time",
  "zeroize",
@@ -1212,9 +1211,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.11"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -1526,9 +1525,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.51.1"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",
@@ -1750,11 +1749,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -1763,7 +1762,7 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -1877,9 +1876,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -1904,6 +1903,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -2063,6 +2071,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anvil"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 
 [dependencies]


### PR DESCRIPTION
## Summary

v0.2.0 リリース。Epic A (Dynamic Precaution Runtime) の全 6 issue (#450 / #451 / #452 / #453 / #454 / #455) と #443 の history-flaky 修正を含む。

## CHANGELOG

### Added

- `FeedbackFrame` / `FeedbackKind` runtime feedback 値型 (#450)。Bash / auto_test / tool parser failure / unsafe command block / no-progress / edit failure を共通 shape に正規化し、`SessionSnapshot.last_feedback` に保存。secret mask（token prefix / kv secret / URL credential）と head+tail 8 KiB excerpt cap、PathBuf workspace 相対化を含む。
- `WorkingMemory.active_precautions` と `Precaution` 型 (#451)。SHA-256 deterministic id、FIFO eviction、bounded caps（active 16 / total 64 / text 240）、untrusted-load sanitizer、`format_for_prompt` での Active Precautions セクション出力。
- Reminder Sidecar (#452)。`FeedbackFrame` の失敗系 kind を sidecar Ollama に渡して `Precaution` を自動生成（per-turn cap = 1、`tools=None`、JSON-only、`<think>` strip + first JSON object 抽出、`ANVIL_NO_REMINDER` で disable 可）。`agent.reminder.{completed,failed,skipped}` ログ出力。
- Active Precautions の Act-mode prompt 注入 (#453)。`select_precautions_for_prompt` で severity sort、touched/suspected ファイル相対の relevance scoring、token budget cap (`MAX_ACTIVE_PRECAUTIONS_PROMPT=8` / `MAX_ACTIVE_PRECAUTIONS_CHARS=1024`)、Plan-mode 抑止を適用。
- `/precautions [add <text>|retire <id>|clear]` REPL コマンド (#454)。Active precautions を一覧 / 追加 / retire / clear。
- Runtime recovery と precaution の接続 (#455)。`FeedbackKind::NoToolCall` (D1) と deterministic content fallback (D2) を追加し、in-loop fallback success / no-tool-call exhaustion / post-loop site で feedback を記録。`eligible_feedback_recorded_this_turn` flag で first-eligible-failure-wins を保証。

### Fixed

- `history_roundtrip_via_append_and_load` ほか rustyline history テストの flaky を解消 (#443)。
- `non_utf8_stdout_does_not_panic_or_error` テストを CI の dash で安定化（POSIX 互換 octal escape に置換）。

## Quality Checks

- [x] `cargo build` — clean
- [x] `cargo test` — 616 lib + integration suites all pass
- [x] `cargo clippy --all-targets` — clean
- [x] Cargo.toml version 0.1.0 → 0.2.0
- [x] Cargo.lock regenerated
- [x] CHANGELOG.md updated with [0.2.0] - 2026-04-28 section

## Test Plan

- [ ] CI workflows (`fmt` / `clippy` / `test` / `build`) all green
- [ ] After merge: tag `v0.2.0` and confirm release.yml produces `anvil-linux-*` / `anvil-darwin-*` gzip artifacts on GitHub Releases

🤖 Generated with [Claude Code](https://claude.com/claude-code)