### PR TITLE
feat(tests): add /tests promote/discard slash commands (#460)

### DIFF
--- a/src/agent/loop_run/commands.rs
+++ b/src/agent/loop_run/commands.rs
@@ -1576,6 +1576,92 @@ The plan must still define: (1) the first shippable vertical slice, (2) concrete
         ))))
     }
 
+    /// Resolve the per-session `tmp-tests/` directory under `state_root`.
+    /// `session_store.path()` points at `<state_root>/sessions/<id>/session.json`,
+    /// so the parent directory is the session root.
+    fn tmp_tests_root(&self) -> Result<PathBuf, String> {
+        self.session_store
+            .path()
+            .parent()
+            .map(|dir| dir.join("tmp-tests"))
+            .ok_or_else(|| "session path has no parent directory".to_string())
+    }
+
+    /// Dispatch `/tests` and its subcommands. Mirrors the
+    /// `anvil sessions tmp-tests {list,promote,discard}` CLI but calls the
+    /// `tmp_tests::*` lifecycle helpers directly so REPL operations bypass
+    /// the `ToolRegistry` `Write` path (and its `tester_active=true`
+    /// confinement) — see `src/session/tmp_tests.rs` for the SSOT.
+    fn handle_tests_command(&mut self, rest: &str) -> Result<AgentEvent, String> {
+        use crate::session::tmp_tests;
+
+        let tmp_tests_root = match self.tmp_tests_root() {
+            Ok(p) => p,
+            Err(err) => return Ok(AgentEvent::Continue(Some(format!("error: {err}")))),
+        };
+
+        let args: Vec<&str> = rest.split_whitespace().collect();
+        match args.as_slice() {
+            [] | ["list"] => {
+                let tests = match tmp_tests::list_tmp_tests(&tmp_tests_root) {
+                    Ok(v) => v,
+                    Err(err) => {
+                        return Ok(AgentEvent::Continue(Some(format!("error: {err}"))));
+                    }
+                };
+                Ok(AgentEvent::Continue(Some(render_tests_list(&tests))))
+            }
+            ["promote", test_id] => self.run_tests_promote(&tmp_tests_root, test_id, false),
+            ["promote", test_id, "--force"] => {
+                self.run_tests_promote(&tmp_tests_root, test_id, true)
+            }
+            ["discard", test_id] => match tmp_tests::discard_tmp_test(&tmp_tests_root, test_id) {
+                Ok(()) => Ok(AgentEvent::Continue(Some(format!("discarded {test_id}")))),
+                Err(err) => Ok(AgentEvent::Continue(Some(format!("error: {err}")))),
+            },
+            _ => Ok(AgentEvent::Continue(Some(tests_usage().to_string()))),
+        }
+    }
+
+    /// Promote a tmp-test to the workspace tree. Plan mode is rejected up
+    /// front because promote writes a regular file to `work_root`.
+    /// `auto_approve` follows `config.yes_mode` (matches the `/yes` UX);
+    /// `interactive_approval=true` is fixed because the REPL is always
+    /// interactive when this code runs.
+    fn run_tests_promote(
+        &self,
+        tmp_tests_root: &Path,
+        test_id: &str,
+        force: bool,
+    ) -> Result<AgentEvent, String> {
+        use crate::session::tmp_tests;
+
+        if self.session.mode_state.mode == ExecutionMode::Plan {
+            return Ok(AgentEvent::Continue(Some(
+                "Plan mode disallows /tests promote (use /approve to enter Act mode first)"
+                    .to_string(),
+            )));
+        }
+
+        let auto_approve = self.config.yes_mode;
+        let interactive_approval = true;
+
+        match tmp_tests::promote_tmp_test(
+            &self.work_root,
+            tmp_tests_root,
+            test_id,
+            force,
+            auto_approve,
+            interactive_approval,
+        ) {
+            Ok(dst) => Ok(AgentEvent::Continue(Some(format!(
+                "promoted {test_id} -> {}",
+                dst.display()
+            )))),
+            Err(err) => Ok(AgentEvent::Continue(Some(format!("error: {err}")))),
+        }
+    }
+
     fn handle_command(&mut self, input: &str) -> Result<AgentEvent, String> {
         let (command, rest) = input.split_once(' ').unwrap_or((input, ""));
         match command {
@@ -1668,6 +1754,7 @@ The plan must still define: (1) the first shippable vertical slice, (2) concrete
                 }
             }
             "/precautions" => self.handle_precautions_command(rest),
+            "/tests" => self.handle_tests_command(rest),
             "/checkpoint" | "/rollback" | "/watch" | "/autotest" | "/skills" | "/skill"
             | "/mcp" | "/parallel" => Ok(AgentEvent::Continue(Some(format!(
                 "{command} is unavailable in the v0.1.0 core rebuild"
@@ -1682,6 +1769,43 @@ The plan must still define: (1) the first shippable vertical slice, (2) concrete
 
 fn precautions_usage() -> &'static str {
     "usage: /precautions [add <text>|retire <id>|clear]"
+}
+
+fn tests_usage() -> &'static str {
+    "usage: /tests [list] | /tests promote <id> [--force] | /tests discard <id>"
+}
+
+/// Format the result of `tmp_tests::list_tmp_tests` for REPL display. The
+/// header / column layout is byte-identical to the
+/// `anvil sessions tmp-tests list` CLI handler (see
+/// `src/session/sessions_cli.rs::run_tmp_tests_list`) so muscle memory carries
+/// across the two surfaces.
+fn render_tests_list(tests: &[crate::session::tmp_tests::TmpTest]) -> String {
+    use crate::session::tmp_tests::TmpTestStatus;
+
+    if tests.is_empty() {
+        return "no tmp-tests found".to_string();
+    }
+
+    let mut output = String::from(
+        "ID                                              STATUS     CREATED_AT  RELATIVE_PATH",
+    );
+    for t in tests {
+        let status = match t.status {
+            TmpTestStatus::Draft => "draft",
+            TmpTestStatus::Promoted => "promoted",
+            TmpTestStatus::Discarded => "discarded",
+        };
+        output.push('\n');
+        output.push_str(&format!(
+            "{id:48} {status:<10} {ts:<10} {rel}",
+            id = t.id,
+            status = status,
+            ts = t.created_at,
+            rel = t.relative_path.display(),
+        ));
+    }
+    output
 }
 
 fn precaution_id12(id: &str) -> String {

--- a/src/agent/loop_run/slash_commands.rs
+++ b/src/agent/loop_run/slash_commands.rs
@@ -34,6 +34,7 @@ pub const SLASH_COMMANDS: &[&str] = &[
     // IO/状態確認カテゴリ: /logs と /precautions は機能カテゴリで隣接させる
     "/logs",
     "/precautions",
+    "/tests",
     "/exit",
 ];
 

--- a/tests/slash_commands_ssot.rs
+++ b/tests/slash_commands_ssot.rs
@@ -32,7 +32,7 @@ fn help_line_matches_slash_commands() {
 }
 
 #[test]
-fn slash_commands_contains_expected_11() {
+fn slash_commands_contains_expected_12() {
     assert_eq!(
         SLASH_COMMANDS,
         &[
@@ -46,6 +46,7 @@ fn slash_commands_contains_expected_11() {
             "/compact",
             "/logs",
             "/precautions",
+            "/tests",
             "/exit",
         ]
     );

--- a/tests/tests_slash_command.rs
+++ b/tests/tests_slash_command.rs
@@ -1,0 +1,299 @@
+//! E2E coverage for the `/tests` slash command (Issue #460).
+//!
+//! These exercise the public REPL surface (`Agent::process_line`) end-to-end
+//! against a real on-disk tmp-tests directory, so the dispatcher, the
+//! `tmp_tests::*` lifecycle helpers, and the rendering helper stay wired
+//! together. They share the same fixture pattern as `tests/precautions_repl.rs`
+//! and `tests/tmp_tests_e2e.rs` (no Ollama, no network).
+
+use std::fs;
+use std::path::Path;
+
+use anvil::agent::Agent;
+use anvil::agent::loop_run::{AgentEvent, FooterHandle};
+use anvil::config::Config;
+use anvil::model_registry::RuntimeModels;
+use anvil::modes::plan_act::ExecutionMode;
+use anvil::ollama::client::OllamaClient;
+use anvil::session::store::{SessionSnapshot, SessionStore};
+use anvil::session::tmp_tests;
+use tempfile::tempdir;
+
+const SESSION_ID: &str = "0199fe00-0000-7000-8000-000000000460";
+const WORKSPACE_KEY: &str = "anvil-460-tests";
+
+fn build_agent(cwd: &Path, state_root: &Path, session: SessionSnapshot, yes_mode: bool) -> Agent {
+    let mut config = Config::default();
+    config.cwd = cwd.to_path_buf();
+    config.requested_model = Some("test-model".to_string());
+    config.ollama_host = "http://127.0.0.1:11434".to_string();
+    config.state_dir_override = Some(state_root.to_path_buf());
+    config.yes_mode = yes_mode;
+
+    Agent::new(
+        config,
+        RuntimeModels {
+            main: "test-model".to_string(),
+            sidecar: None,
+        },
+        OllamaClient::new("http://127.0.0.1:11434".to_string()).unwrap(),
+        SessionStore::new(state_root, SESSION_ID, WORKSPACE_KEY),
+        session,
+        FooterHandle::disabled(),
+    )
+}
+
+fn continue_message(event: AgentEvent) -> String {
+    match event {
+        AgentEvent::Continue(Some(message)) => message,
+        AgentEvent::Continue(None) => panic!("expected Continue(Some), got Continue(None)"),
+        AgentEvent::Exit => panic!("expected Continue, got Exit"),
+    }
+}
+
+/// Lay out `state_root/sessions/<id>/` so `session_store.path()` resolves and
+/// `tmp_tests_root` / `session.json` siblings match production.
+fn prepare_session_dir(state_root: &Path) -> std::path::PathBuf {
+    let session_dir = state_root.join("sessions").join(SESSION_ID);
+    fs::create_dir_all(&session_dir).unwrap();
+    session_dir
+}
+
+fn act_session() -> SessionSnapshot {
+    SessionSnapshot {
+        id: SESSION_ID.to_string(),
+        workspace_key: WORKSPACE_KEY.to_string(),
+        ..SessionSnapshot::default()
+    }
+}
+
+#[test]
+fn tests_list_on_fresh_session_reports_empty() {
+    let temp = tempdir().unwrap();
+    let state_root = temp.path().join(".anvil-state");
+    prepare_session_dir(&state_root);
+
+    let mut agent = build_agent(temp.path(), &state_root, act_session(), false);
+    let out = continue_message(agent.process_line("/tests", false).unwrap());
+    assert_eq!(out, "no tmp-tests found");
+
+    let out = continue_message(agent.process_line("/tests list", false).unwrap());
+    assert_eq!(out, "no tmp-tests found");
+}
+
+#[test]
+fn tests_list_renders_existing_tmp_tests() {
+    let temp = tempdir().unwrap();
+    let state_root = temp.path().join(".anvil-state");
+    let session_dir = prepare_session_dir(&state_root);
+    let tmp_tests_root = session_dir.join("tmp-tests");
+
+    let tt = tmp_tests::create_generated_test(
+        &tmp_tests_root,
+        "tests/smoke_460.rs",
+        b"#[test]\nfn smoke() {}\n",
+    )
+    .unwrap();
+
+    let mut agent = build_agent(temp.path(), &state_root, act_session(), false);
+    let out = continue_message(agent.process_line("/tests", false).unwrap());
+
+    assert!(
+        out.starts_with("ID                                              STATUS"),
+        "expected header, got: {out}"
+    );
+    assert!(out.contains(&tt.id), "list missing test id: {out}");
+    assert!(out.contains("draft"), "list missing draft status: {out}");
+    assert!(
+        out.contains("tests/smoke_460.rs"),
+        "list missing rel path: {out}"
+    );
+}
+
+#[test]
+fn tests_promote_writes_workspace_file_and_marks_promoted() {
+    let temp = tempdir().unwrap();
+    let cwd = temp.path().join("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let state_root = temp.path().join(".anvil-state");
+    let session_dir = prepare_session_dir(&state_root);
+    let tmp_tests_root = session_dir.join("tmp-tests");
+
+    let tt = tmp_tests::create_generated_test(
+        &tmp_tests_root,
+        "tests/promoted_460.rs",
+        b"#[test]\nfn ok() {}\n",
+    )
+    .unwrap();
+
+    let mut agent = build_agent(&cwd, &state_root, act_session(), false);
+    let out = continue_message(
+        agent
+            .process_line(&format!("/tests promote {}", tt.id), false)
+            .unwrap(),
+    );
+    assert!(out.starts_with("promoted "), "{out}");
+
+    let dst = cwd.join("tests/promoted_460.rs");
+    assert!(dst.exists(), "promote did not write workspace file");
+    let body = fs::read_to_string(&dst).unwrap();
+    assert!(body.contains("fn ok()"), "wrong contents: {body}");
+
+    let listed = tmp_tests::list_tmp_tests(&tmp_tests_root).unwrap();
+    let found = listed.iter().find(|t| t.id == tt.id).expect("metadata");
+    assert!(matches!(found.status, tmp_tests::TmpTestStatus::Promoted));
+}
+
+#[test]
+fn tests_promote_collision_without_force_surfaces_lifecycle_error() {
+    let temp = tempdir().unwrap();
+    let cwd = temp.path().join("workspace");
+    fs::create_dir_all(cwd.join("tests")).unwrap();
+    fs::write(cwd.join("tests/collide.rs"), b"existing").unwrap();
+    let state_root = temp.path().join(".anvil-state");
+    let session_dir = prepare_session_dir(&state_root);
+    let tmp_tests_root = session_dir.join("tmp-tests");
+
+    let tt =
+        tmp_tests::create_generated_test(&tmp_tests_root, "tests/collide.rs", b"new body").unwrap();
+
+    let mut agent = build_agent(&cwd, &state_root, act_session(), false);
+    let out = continue_message(
+        agent
+            .process_line(&format!("/tests promote {}", tt.id), false)
+            .unwrap(),
+    );
+    assert!(
+        out.contains("failed to create promote target") && out.contains("use --force to overwrite"),
+        "expected lifecycle collision error, got: {out}"
+    );
+
+    // Original workspace file must remain untouched (TOCTOU guarantee).
+    assert_eq!(
+        fs::read_to_string(cwd.join("tests/collide.rs")).unwrap(),
+        "existing"
+    );
+}
+
+#[test]
+fn tests_promote_with_force_overwrites_regular_file() {
+    let temp = tempdir().unwrap();
+    let cwd = temp.path().join("workspace");
+    fs::create_dir_all(cwd.join("tests")).unwrap();
+    fs::write(cwd.join("tests/over.rs"), b"old").unwrap();
+    let state_root = temp.path().join(".anvil-state");
+    let session_dir = prepare_session_dir(&state_root);
+    let tmp_tests_root = session_dir.join("tmp-tests");
+
+    let tt =
+        tmp_tests::create_generated_test(&tmp_tests_root, "tests/over.rs", b"replacement").unwrap();
+
+    let mut agent = build_agent(&cwd, &state_root, act_session(), false);
+    let out = continue_message(
+        agent
+            .process_line(&format!("/tests promote {} --force", tt.id), false)
+            .unwrap(),
+    );
+    assert!(out.starts_with("promoted "), "{out}");
+    assert_eq!(
+        fs::read_to_string(cwd.join("tests/over.rs")).unwrap(),
+        "replacement"
+    );
+}
+
+#[test]
+fn tests_promote_in_plan_mode_is_rejected_without_touching_workspace() {
+    let temp = tempdir().unwrap();
+    let cwd = temp.path().join("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let state_root = temp.path().join(".anvil-state");
+    let session_dir = prepare_session_dir(&state_root);
+    let tmp_tests_root = session_dir.join("tmp-tests");
+
+    let tt = tmp_tests::create_generated_test(&tmp_tests_root, "tests/plan.rs", b"x").unwrap();
+
+    let mut session = act_session();
+    session.mode_state.mode = ExecutionMode::Plan;
+    let mut agent = build_agent(&cwd, &state_root, session, false);
+    let out = continue_message(
+        agent
+            .process_line(&format!("/tests promote {}", tt.id), false)
+            .unwrap(),
+    );
+    assert!(
+        out.starts_with("Plan mode disallows /tests promote"),
+        "expected Plan-mode rejection, got: {out}"
+    );
+    assert!(
+        !cwd.join("tests/plan.rs").exists(),
+        "promote in Plan mode must not write to workspace"
+    );
+
+    // List and discard remain available in Plan mode.
+    let list = continue_message(agent.process_line("/tests", false).unwrap());
+    assert!(
+        list.contains(&tt.id),
+        "list should work in Plan mode: {list}"
+    );
+    let discarded = continue_message(
+        agent
+            .process_line(&format!("/tests discard {}", tt.id), false)
+            .unwrap(),
+    );
+    assert_eq!(discarded, format!("discarded {}", tt.id));
+}
+
+#[test]
+fn tests_discard_removes_body_and_metadata() {
+    let temp = tempdir().unwrap();
+    let state_root = temp.path().join(".anvil-state");
+    let session_dir = prepare_session_dir(&state_root);
+    let tmp_tests_root = session_dir.join("tmp-tests");
+    let tt = tmp_tests::create_generated_test(&tmp_tests_root, "tests/d.rs", b"x").unwrap();
+
+    let mut agent = build_agent(temp.path(), &state_root, act_session(), false);
+    let out = continue_message(
+        agent
+            .process_line(&format!("/tests discard {}", tt.id), false)
+            .unwrap(),
+    );
+    assert_eq!(out, format!("discarded {}", tt.id));
+
+    let after = tmp_tests::list_tmp_tests(&tmp_tests_root).unwrap();
+    assert!(after.iter().all(|t| t.id != tt.id));
+    assert!(!tmp_tests_root.join("files/tests/d.rs").exists());
+}
+
+#[test]
+fn tests_invalid_id_does_not_panic() {
+    let temp = tempdir().unwrap();
+    let state_root = temp.path().join(".anvil-state");
+    prepare_session_dir(&state_root);
+
+    let mut agent = build_agent(temp.path(), &state_root, act_session(), false);
+
+    let promote_out = continue_message(
+        agent
+            .process_line("/tests promote not-an-id", false)
+            .unwrap(),
+    );
+    assert!(promote_out.starts_with("error: "), "{promote_out}");
+
+    let discard_out = continue_message(
+        agent
+            .process_line("/tests discard not-an-id", false)
+            .unwrap(),
+    );
+    assert!(discard_out.starts_with("error: "), "{discard_out}");
+}
+
+#[test]
+fn tests_unknown_subcommand_prints_usage() {
+    let temp = tempdir().unwrap();
+    let state_root = temp.path().join(".anvil-state");
+    prepare_session_dir(&state_root);
+
+    let mut agent = build_agent(temp.path(), &state_root, act_session(), false);
+    let out = continue_message(agent.process_line("/tests bogus", false).unwrap());
+    assert!(out.starts_with("usage: /tests"), "{out}");
+}


### PR DESCRIPTION
## Summary

Issue #460 (Epic B / 論理 #11, **Epic B 最後の Issue**) — `/tests` slash command を追加。tmp_tests ライフサイクル (#458) を REPL から直接操作可能に。

## Operations

- `/tests` — tmp-tests 一覧（既存 `anvil sessions tmp-tests list` と同じ表示）
- `/tests promote <id>` — repo path に書き込み (Write approval 経由)、Plan mode では拒否
- `/tests discard <id>` — tmp-test 削除

## Implementation

- dispatcher は `tmp_tests::{promote_tmp_test, discard_tmp_test, list_tmp_tests}` を直接呼び出し、`ToolRegistry::Write` を通さない → #459 の `tester_active=true` path confinement に引っかからない
- `auto_approve` は `config.yes_mode` を踏襲（`/yes` UX 整合）
- `interactive_approval = true`（REPL は対話前提）

## 受入条件

- [x] AC1: /tests で generated tests が表示される
- [x] AC2: /tests promote <id> で repo に書き込まれる
- [x] AC3: promote 時に approval が発生する
- [x] AC4: overwrite 時に明示 confirmation が出る
- [x] AC5: /tests discard <id> で temporary test が削除される
- [x] AC6: 不正 ID で runtime が落ちない

## Test plan

- [x] cargo fmt / clippy / test --all
- [ ] CI green

## Refs

- Parent Epic: #445 (Epic B: Verification & Temporary Testing — **完了**)
- Depends on: #458 (Temp Workspace), #459 (Tester Skill) — both merged
- workspace/v0.1.1/feature.md (Issue #11, 論理番号)

Closes #460

🤖 Generated with [Claude Code](https://claude.com/claude-code)