### PR TITLE
feat(photon-config): add photon-action-memory config fields to RunConfig (#553)

### DIFF
--- a/src/agent/loop_run/footer.rs
+++ b/src/agent/loop_run/footer.rs
@@ -1226,6 +1226,11 @@ mod tests {
             state_dir_override: None,
             resume: Default::default(),
             footer: enabled,
+            photon_enabled: false,
+            photon_url: "http://127.0.0.1:3030".to_string(),
+            photon_shadow_mode: true,
+            photon_canary: 0,
+            photon_timeout_ms: 200,
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -237,6 +237,11 @@ pub struct Config {
     /// disabled by `--no-footer`, `ANVIL_NO_FOOTER` (non-empty), or
     /// `.anvil/config` `footer=false`. See issue #430 §5.
     pub footer: bool,
+    pub photon_enabled: bool,
+    pub photon_url: String,
+    pub photon_shadow_mode: bool,
+    pub photon_canary: u16,
+    pub photon_timeout_ms: u64,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -260,6 +265,11 @@ pub struct PartialConfig {
     /// (`--no-footer` / non-empty `ANVIL_NO_FOOTER` / `.anvil/config` `footer=false`).
     /// `None` means "no opinion" so default (`true`) wins.
     pub footer: Option<bool>,
+    pub photon_enabled: Option<bool>,
+    pub photon_url: Option<String>,
+    pub photon_shadow_mode: Option<bool>,
+    pub photon_canary: Option<u16>,
+    pub photon_timeout_ms: Option<u64>,
 }
 
 impl Config {
@@ -295,13 +305,30 @@ impl Config {
             // CLI footer flag is "disable-only": `--no-footer` emits Some(false),
             // omission emits None so file/env/default can still apply.
             footer: args.no_footer.then_some(false),
+            // photon settings are not configurable via CLI flags in A1
+            photon_enabled: None,
+            photon_url: None,
+            photon_shadow_mode: None,
+            photon_canary: None,
+            photon_timeout_ms: None,
         };
         let merged = merge_partial_configs(&[file_config, env_config, cli_config]);
         let ollama_host = validate_localhost_url(
             merged
                 .ollama_host
                 .unwrap_or_else(|| "http://127.0.0.1:11434".to_string()),
+            "ollama host",
         )?;
+        let photon_url_raw = merged
+            .photon_url
+            .unwrap_or_else(|| "http://127.0.0.1:3030".to_string());
+        let photon_url = validate_localhost_url(photon_url_raw, "photon_url")?;
+
+        let offline = merged.offline.unwrap_or(false);
+        if offline && merged.photon_enabled.unwrap_or(false) {
+            warnings.push("photon_enabled is forced false because offline=true".to_string());
+        }
+        let photon_enabled = !offline && merged.photon_enabled.unwrap_or(false);
 
         let config = Self {
             cwd,
@@ -318,13 +345,18 @@ impl Config {
             fresh_session: merged.fresh_session.unwrap_or(false),
             oneshot: args.oneshot || args.prompt.is_some(),
             auto_plan: merged.auto_plan.unwrap_or(false),
-            offline: merged.offline.unwrap_or(false),
+            offline,
             deterministic_fallback: merged.deterministic_fallback.unwrap_or_default(),
             prompt: args.prompt,
             state_dir_override: merged.state_dir_override,
             resume: ResumeRequest::from_flag(args.resume),
             // Default true; any disable signal (file/env/CLI) lands as Some(false).
             footer: merged.footer.unwrap_or(true),
+            photon_enabled,
+            photon_url,
+            photon_shadow_mode: merged.photon_shadow_mode.unwrap_or(true),
+            photon_canary: merged.photon_canary.unwrap_or(0),
+            photon_timeout_ms: merged.photon_timeout_ms.unwrap_or(200),
         };
         Ok((config, warnings))
     }
@@ -381,6 +413,21 @@ pub fn merge_partial_configs(configs: &[PartialConfig]) -> PartialConfig {
         if config.footer.is_some() {
             merged.footer = config.footer;
         }
+        if config.photon_enabled.is_some() {
+            merged.photon_enabled = config.photon_enabled;
+        }
+        if config.photon_url.is_some() {
+            merged.photon_url = config.photon_url.clone();
+        }
+        if config.photon_shadow_mode.is_some() {
+            merged.photon_shadow_mode = config.photon_shadow_mode;
+        }
+        if config.photon_canary.is_some() {
+            merged.photon_canary = config.photon_canary;
+        }
+        if config.photon_timeout_ms.is_some() {
+            merged.photon_timeout_ms = config.photon_timeout_ms;
+        }
     }
     merged
 }
@@ -434,6 +481,16 @@ pub fn load_config_file(path: &Path, warnings: &mut Vec<String>) -> Result<Parti
             .get("footer")
             .and_then(|value| parse_bool(value))
             .and_then(|enabled| (!enabled).then_some(false)),
+        photon_enabled: map.get("photon_enabled").and_then(|v| parse_bool(v)),
+        // photon_url empty string is skipped by parse_key_value_config, so None means unset
+        photon_url: map.get("photon_url").cloned(),
+        photon_shadow_mode: map.get("photon_shadow_mode").and_then(|v| parse_bool(v)),
+        photon_canary: map
+            .get("photon_canary")
+            .and_then(|v| parse_photon_canary(v, warnings)),
+        photon_timeout_ms: map
+            .get("photon_timeout_ms")
+            .and_then(|v| parse_photon_timeout_ms(v, warnings)),
     })
 }
 
@@ -490,6 +547,43 @@ pub fn load_env_config(warnings: &mut Vec<String>) -> PartialConfig {
         footer: env::var("ANVIL_NO_FOOTER")
             .ok()
             .and_then(|value| (!value.is_empty()).then_some(false)),
+        photon_enabled: env::var("ANVIL_PHOTON_ENABLED")
+            .ok()
+            .and_then(|v| parse_bool(&v)),
+        photon_url: env::var("ANVIL_PHOTON_URL").ok(),
+        photon_shadow_mode: env::var("ANVIL_PHOTON_SHADOW_MODE")
+            .ok()
+            .and_then(|v| parse_bool(&v)),
+        photon_canary: env::var("ANVIL_PHOTON_CANARY")
+            .ok()
+            .and_then(|v| parse_photon_canary(&v, warnings)),
+        photon_timeout_ms: env::var("ANVIL_PHOTON_TIMEOUT_MS")
+            .ok()
+            .and_then(|v| parse_photon_timeout_ms(&v, warnings)),
+    }
+}
+
+fn parse_photon_canary(s: &str, warnings: &mut Vec<String>) -> Option<u16> {
+    match s.trim().parse::<u16>() {
+        Ok(n) if n <= 1000 => Some(n),
+        _ => {
+            warnings.push(format!(
+                "invalid ANVIL_PHOTON_CANARY={s}, must be 0-1000, using default (0)"
+            ));
+            None
+        }
+    }
+}
+
+fn parse_photon_timeout_ms(s: &str, warnings: &mut Vec<String>) -> Option<u64> {
+    match s.trim().parse::<u64>() {
+        Ok(n) if (1..=60_000).contains(&n) => Some(n),
+        _ => {
+            warnings.push(format!(
+                "invalid ANVIL_PHOTON_TIMEOUT_MS={s}, must be 1-60000, using default (200)"
+            ));
+            None
+        }
     }
 }
 

--- a/src/safety/host_validation.rs
+++ b/src/safety/host_validation.rs
@@ -1,20 +1,20 @@
 use reqwest::Url;
 
-pub fn validate_localhost_url(raw: String) -> Result<String, String> {
-    let url = Url::parse(&raw).map_err(|err| format!("invalid ollama host: {err}"))?;
+pub fn validate_localhost_url(raw: String, label: &str) -> Result<String, String> {
+    let url = Url::parse(&raw).map_err(|err| format!("invalid {label}: {err}"))?;
     if url.username() != "" || url.password().is_some() {
-        return Err("ollama host must not include credentials".to_string());
+        return Err(format!("{label} must not include credentials"));
     }
     let host = url
         .host_str()
-        .ok_or_else(|| "ollama host must include a host".to_string())?;
+        .ok_or_else(|| format!("{label} must include a host"))?;
     let allowed = matches!(host, "localhost" | "127.0.0.1" | "::1" | "[::1]");
     if !allowed {
-        return Err("ollama host must point to localhost".to_string());
+        return Err(format!("{label} must point to localhost"));
     }
     match url.scheme() {
         "http" | "https" => {}
-        _ => return Err("ollama host must use http or https".to_string()),
+        _ => return Err(format!("{label} must use http or https")),
     }
     Ok(raw.trim_end_matches('/').to_string())
 }

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -1,7 +1,8 @@
 use std::path::PathBuf;
 
+use anvil::cli::CliArgs;
 use anvil::config::{
-    DeterministicFallbackMode, LogLevel, PartialConfig, load_config_file, load_env_config,
+    Config, DeterministicFallbackMode, LogLevel, PartialConfig, load_config_file, load_env_config,
     merge_partial_configs, parse_key_value_config,
 };
 
@@ -482,4 +483,215 @@ fn merge_log_level_prefers_later_source() {
         },
     ]);
     assert_eq!(merged.log_level, Some(LogLevel::Trace));
+}
+
+// --- photon config (issue #553) ---
+
+fn minimal_args(cwd: &std::path::Path) -> CliArgs {
+    CliArgs {
+        cwd: Some(cwd.to_path_buf()),
+        prompt: None,
+        model: None,
+        sidecar_model: None,
+        ollama_host: None,
+        context_budget: None,
+        max_iterations: None,
+        chat_timeout_secs: None,
+        chat_retries: None,
+        verbose: false,
+        trace: false,
+        debug: false,
+        stream: false,
+        yes: false,
+        fresh_session: false,
+        oneshot: false,
+        auto_plan: false,
+        offline: false,
+        deterministic_fallback: None,
+        no_footer: false,
+        resume: None,
+        state_dir: None,
+        command: None,
+    }
+}
+
+const PHOTON_ENV_VARS: &[(&str, Option<&str>)] = &[
+    ("ANVIL_PHOTON_ENABLED", None),
+    ("ANVIL_PHOTON_URL", None),
+    ("ANVIL_PHOTON_SHADOW_MODE", None),
+    ("ANVIL_PHOTON_CANARY", None),
+    ("ANVIL_PHOTON_TIMEOUT_MS", None),
+    ("ANVIL_OFFLINE", None),
+];
+
+#[test]
+fn photon_disabled_by_default() {
+    let tmp = tempfile::tempdir().unwrap();
+    with_env(PHOTON_ENV_VARS, || {
+        let (cfg, _warnings) = Config::load(minimal_args(tmp.path())).unwrap();
+        assert!(!cfg.photon_enabled);
+        assert_eq!(cfg.photon_canary, 0);
+        assert_eq!(cfg.photon_timeout_ms, 200);
+        assert_eq!(cfg.photon_url, "http://127.0.0.1:3030");
+    });
+}
+
+#[test]
+fn photon_shadow_mode_default_true() {
+    let tmp = tempfile::tempdir().unwrap();
+    with_env(PHOTON_ENV_VARS, || {
+        let (cfg, _) = Config::load(minimal_args(tmp.path())).unwrap();
+        assert!(cfg.photon_shadow_mode);
+    });
+}
+
+#[test]
+fn env_photon_enabled_true() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut vars: Vec<(&str, Option<&str>)> = PHOTON_ENV_VARS.to_vec();
+    vars[0] = ("ANVIL_PHOTON_ENABLED", Some("true"));
+    with_env(&vars, || {
+        let (cfg, warnings) = Config::load(minimal_args(tmp.path())).unwrap();
+        assert!(cfg.photon_enabled);
+        assert!(warnings.is_empty(), "unexpected warnings: {warnings:?}");
+    });
+}
+
+#[test]
+fn env_photon_url_invalid_returns_err() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut vars: Vec<(&str, Option<&str>)> = PHOTON_ENV_VARS.to_vec();
+    vars[1] = ("ANVIL_PHOTON_URL", Some("not-a-url"));
+    with_env(&vars, || {
+        let result = Config::load(minimal_args(tmp.path()));
+        assert!(result.is_err(), "expected Err for invalid URL");
+    });
+}
+
+#[test]
+fn env_photon_url_external_returns_err() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut vars: Vec<(&str, Option<&str>)> = PHOTON_ENV_VARS.to_vec();
+    vars[1] = ("ANVIL_PHOTON_URL", Some("http://example.com:3030"));
+    with_env(&vars, || {
+        let result = Config::load(minimal_args(tmp.path()));
+        assert!(result.is_err(), "expected Err for external URL");
+        let err = result.unwrap_err();
+        assert!(
+            err.contains("photon_url"),
+            "expected 'photon_url' in error, got: {err}"
+        );
+    });
+}
+
+#[test]
+fn env_photon_canary_out_of_range_warns_and_defaults() {
+    with_env(&[("ANVIL_PHOTON_CANARY", Some("1001"))], || {
+        let mut warnings = Vec::new();
+        let cfg = load_env_config(&mut warnings);
+        assert_eq!(cfg.photon_canary, None, "out-of-range should be None");
+        assert!(
+            warnings.iter().any(|w| w.contains("ANVIL_PHOTON_CANARY")),
+            "expected ANVIL_PHOTON_CANARY warning: {warnings:?}"
+        );
+        assert!(
+            warnings.iter().any(|w| w.contains("using default (0)")),
+            "expected default value in warning: {warnings:?}"
+        );
+    });
+}
+
+#[test]
+fn env_photon_timeout_zero_warns_and_defaults() {
+    with_env(&[("ANVIL_PHOTON_TIMEOUT_MS", Some("0"))], || {
+        let mut warnings = Vec::new();
+        let cfg = load_env_config(&mut warnings);
+        assert_eq!(cfg.photon_timeout_ms, None);
+        assert!(
+            warnings
+                .iter()
+                .any(|w| w.contains("ANVIL_PHOTON_TIMEOUT_MS")),
+            "expected ANVIL_PHOTON_TIMEOUT_MS warning: {warnings:?}"
+        );
+        assert!(
+            warnings.iter().any(|w| w.contains("using default (200)")),
+            "expected default value in warning: {warnings:?}"
+        );
+    });
+}
+
+#[test]
+fn env_photon_timeout_too_large_warns_and_defaults() {
+    with_env(&[("ANVIL_PHOTON_TIMEOUT_MS", Some("60001"))], || {
+        let mut warnings = Vec::new();
+        let cfg = load_env_config(&mut warnings);
+        assert_eq!(cfg.photon_timeout_ms, None);
+        assert!(
+            warnings
+                .iter()
+                .any(|w| w.contains("ANVIL_PHOTON_TIMEOUT_MS")),
+            "expected ANVIL_PHOTON_TIMEOUT_MS warning: {warnings:?}"
+        );
+    });
+}
+
+#[test]
+fn config_file_photon_enabled() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().join("config");
+    std::fs::write(&path, "photon_enabled=true\n").unwrap();
+    let mut warnings = Vec::new();
+    let cfg = load_config_file(&path, &mut warnings).unwrap();
+    assert_eq!(cfg.photon_enabled, Some(true));
+    assert!(warnings.is_empty());
+}
+
+#[test]
+fn merge_photon_env_overrides_file() {
+    let file_config = PartialConfig {
+        photon_enabled: Some(false),
+        ..PartialConfig::default()
+    };
+    let env_config = PartialConfig {
+        photon_enabled: Some(true),
+        ..PartialConfig::default()
+    };
+    let merged = merge_partial_configs(&[file_config, env_config]);
+    assert_eq!(merged.photon_enabled, Some(true));
+}
+
+#[test]
+fn merge_photon_invalid_higher_priority_leaves_lower() {
+    // env has invalid canary (→ None from load_env_config); file has valid 500
+    // After merge, the file's valid value should win because env contributed None
+    let file_config = PartialConfig {
+        photon_canary: Some(500),
+        ..PartialConfig::default()
+    };
+    // simulate env producing None for invalid canary
+    let env_config = PartialConfig {
+        photon_canary: None,
+        ..PartialConfig::default()
+    };
+    let merged = merge_partial_configs(&[file_config, env_config]);
+    assert_eq!(merged.photon_canary, Some(500));
+}
+
+#[test]
+fn offline_forces_photon_disabled() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut vars: Vec<(&str, Option<&str>)> = PHOTON_ENV_VARS.to_vec();
+    vars[0] = ("ANVIL_PHOTON_ENABLED", Some("true"));
+    vars.push(("ANVIL_OFFLINE", Some("true")));
+    with_env(&vars, || {
+        let (cfg, warnings) = Config::load(minimal_args(tmp.path())).unwrap();
+        assert!(
+            !cfg.photon_enabled,
+            "offline should force photon_enabled=false"
+        );
+        assert!(
+            warnings.iter().any(|w| w.contains("photon_enabled")),
+            "expected offline override warning: {warnings:?}"
+        );
+    });
 }


### PR DESCRIPTION
## Summary

- `RunConfig` に photon-action-memory sidecar 連携用の 5 設定フィールドを追加
- デフォルトでは `photon_enabled=false` で無効。`ANVIL_PHOTON_ENABLED=true` で有効化
- `offline=true` 時は photon を強制無効化（warning を出力）
- `validate_localhost_url` を 2 引数化してエラーメッセージにラベルを付与

## 追加した設定

| フィールド | 環境変数 | デフォルト |
|-----------|---------|----------|
| `photon_enabled: bool` | `ANVIL_PHOTON_ENABLED` | `false` |
| `photon_url: String` | `ANVIL_PHOTON_URL` | `http://127.0.0.1:3030` |
| `photon_shadow_mode: bool` | `ANVIL_PHOTON_SHADOW_MODE` | `true` |
| `photon_canary: u16` | `ANVIL_PHOTON_CANARY` | `0` (0-1000) |
| `photon_timeout_ms: u64` | `ANVIL_PHOTON_TIMEOUT_MS` | `200` |

## 変更ファイル

- `src/config.rs`: 5 フィールド追加、`validate_localhost_url` 2 引数化
- `src/safety/host_validation.rs`: `validate_localhost_url(url, label)` にラベル引数追加
- `tests/config_tests.rs`: photon 設定の単体テスト追加
- `src/agent/loop_run/footer.rs`: テストフィクスチャ更新

## Test plan

- [x] `cargo fmt --check` PASS
- [x] `cargo clippy --all-targets -- -D warnings` PASS (0 errors, 0 warnings)
- [x] `cargo test` PASS (全テスト)

**Note**: #554 (A2: HTTP client) は本 PR マージ後に rebase して config フィールドを統合する必要があります。

Closes #553

🤖 Generated with [Claude Code](https://claude.com/claude-code)