### PR TITLE
feat(eval): add multilingual scenarios for cross-lingual photon path

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ workdir 側の `.anvil/logs/` `.anvil/sessions/` `.anvil/plans/` は上記への
 
 `scripts/` 配下のハーネス群で 5-run ベンチマークと集計レポートを生成できる。
 実践的な E2E/UAT の評価設計は `docs/e2e-uat-evaluation.md` にまとめている。
+Photon の cross-lingual 効果を測る場合は `--scenario-set cross_lingual`（日本語/英語ペア 6 シナリオ）と `photon_warning_blocked_count` 列を併用する（詳細: [docs/e2e-uat-evaluation.md](docs/e2e-uat-evaluation.md#cross-lingual-eval-run)）。
 CI / release confidence checks は [docs/ci.md](docs/ci.md) にまとめている。
 Git 管理に含める artifacts の方針は [docs/repository-hygiene.md](docs/repository-hygiene.md) にまとめている。
 

--- a/docs/e2e-uat-evaluation.md
+++ b/docs/e2e-uat-evaluation.md
@@ -249,7 +249,7 @@ For release-quality validation, use the expanded strict rule:
 `workspace/eval/runs/<run-id>/results.csv` should use this header:
 
 ```csv
-run_id,commit,scenario_id,model,sidecar_model,rep,photon_on,photon_context_injected,pass,high_quality,protocol_complete,verification_pass,fallback_used,fallback_level,fallback_completed,mode,mode_confidence,mode_alternative_gap,mode_ambiguity,mode_override_count,verifier_source,verifier_candidate_count,repo_context_seed_source,repo_context_candidate_count,repo_context_no_candidates,first_success_iter,total_iter,duration_sec,changed_files_count,unrelated_change_count,tool_failure_count,read_before_edit,real_entry_file_touched,safe_fail,safety_violation,browser_smoke_pass,resume_pass,dirty_worktree_preserved,notes
+run_id,commit,scenario_id,model,sidecar_model,rep,photon_on,photon_context_injected,photon_warning_blocked_count,pass,high_quality,protocol_complete,verification_pass,fallback_used,fallback_level,fallback_completed,mode,mode_confidence,mode_alternative_gap,mode_ambiguity,mode_override_count,verifier_source,verifier_candidate_count,repo_context_seed_source,repo_context_candidate_count,repo_context_no_candidates,first_success_iter,total_iter,duration_sec,changed_files_count,unrelated_change_count,tool_failure_count,read_before_edit,real_entry_file_touched,safe_fail,safety_violation,browser_smoke_pass,resume_pass,dirty_worktree_preserved,notes
 ```
 
 `photon_on`: `true` when the run was invoked with `--photon-on`; `false`
@@ -258,6 +258,12 @@ otherwise. Leave empty for legacy runs predating this field.
 `photon_context_injected`: `true` when the `agent.photon_context_pack.completed`
 event reports `injected=true` or `items_adopted>0` for that turn; `false`
 otherwise.
+
+`photon_warning_blocked_count`: cumulative sum of `total_blocked` from all
+`agent.photon_context_pack.warning_blocked` events across all turns in the
+session. Empty string (`""`) when `photon_on=false`. `"0"` when
+`photon_on=true` but no warnings fired. A value `> 0` indicates the
+warning_filter was active for at least one turn.
 
 Boolean fields must be `true` or `false`. Unknown values should be empty rather
 than guessed.
@@ -323,6 +329,33 @@ Anvil; dry-run rows leave pass/fail fields blank and exit `0`. Real runs exit
 `0` only when every row is `high_quality=true`; otherwise they exit `2` after
 writing the artifacts for inspection. Per-scenario timeouts are recorded as
 failed rows with `notes=timeout`; they must not abort the rest of the matrix.
+
+## Cross-Lingual Eval Run
+
+To measure photon's cross-lingual effect, use the `cross_lingual` scenario set
+which pairs each Japanese scenario with an English variant:
+
+```bash
+python3 scripts/e2e_uat_matrix.py \
+  --scenario-set cross_lingual \
+  --models qwen3.6:27b-coding-nvfp4 \
+  --sidecar-model qwen3-coder:30b \
+  --reps 1 \
+  --photon-on
+```
+
+`--scenario-set cross_lingual` covers:
+
+- S2-03 existing SvelteKit route edit (Japanese)
+- S2-03-en existing SvelteKit route edit (English)
+- S3-01 Python bug fix with self-test (Japanese)
+- S3-01-en Python bug fix with self-test (English)
+- S5-01 ANVIL.md preferred verifier (Japanese)
+- S5-01-en ANVIL.md preferred verifier (English)
+
+Compare `photon_warning_blocked_count` between Japanese and English rows to
+quantify the cross-lingual effect. A value `> 0` in English rows confirms
+that the warning_filter is active for cross-lingual sessions.
 
 ## Photon Memory Comparison Run
 

--- a/scripts/e2e_uat_matrix.py
+++ b/scripts/e2e_uat_matrix.py
@@ -19,7 +19,6 @@ import os
 import re
 import shutil
 import subprocess
-import sys
 import textwrap
 import time
 from collections import Counter
@@ -34,6 +33,7 @@ DEFAULT_SIDECAR = "qwen3-coder:30b"
 DEFAULT_REPS = 3
 DEFAULT_MAX_ITERATIONS = 50
 DEFAULT_TIMEOUT_SECS = 420
+DEFAULT_PHOTON_URL = "http://127.0.0.1:18765"
 
 RESULT_FIELDS = [
     "run_id",
@@ -44,6 +44,7 @@ RESULT_FIELDS = [
     "rep",
     "photon_on",
     "photon_context_injected",
+    "photon_warning_blocked_count",
     "pass",
     "high_quality",
     "protocol_complete",
@@ -205,6 +206,23 @@ def load_llm_events(state_dir: Path) -> list[dict[str, object]]:
 def event_payload(event: dict[str, object]) -> dict[str, object]:
     payload = event.get("payload")
     return payload if isinstance(payload, dict) else {}
+
+
+def safe_non_negative_int(value: object) -> int:
+    """Coerce an untrusted log payload value into a non-negative int.
+
+    Used by photon observability extraction where payload fields may be missing,
+    of unexpected type, or out of range. Returns 0 for any non-coercible or
+    negative value (including bool, which is intentionally rejected to avoid
+    `True -> 1` surprises in counters).
+    """
+    if isinstance(value, bool):
+        return 0
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError, OverflowError):
+        return 0
+    return parsed if parsed >= 0 else 0
 
 
 def format_metric_float(value: object) -> str:
@@ -753,14 +771,25 @@ def grade_sp_01(root: Path, output: str, _err: str, rc: int, changed: set[str]) 
 
 
 def extract_photon_observability(events: list[dict[str, object]]) -> dict[str, object]:
+    # Walk every event (no early break): warning_blocked events may appear after
+    # the completed event in the same session, and we need to accumulate
+    # total_blocked across all turns. Payload fields are treated as untrusted
+    # input via safe_non_negative_int() as defense-in-depth.
     injected = False
+    warning_blocked_count = 0
     for event in events:
-        if event.get("event") == "agent.photon_context_pack.completed":
+        name = event.get("event")
+        if name == "agent.photon_context_pack.completed":
             payload = event_payload(event)
-            if payload.get("injected") is True or int(payload.get("items_adopted", 0)) > 0:
+            if payload.get("injected") is True or safe_non_negative_int(payload.get("items_adopted")) > 0:
                 injected = True
-                break
-    return {"photon_context_injected": injected}
+        elif name == "agent.photon_context_pack.warning_blocked":
+            payload = event_payload(event)
+            warning_blocked_count += safe_non_negative_int(payload.get("total_blocked"))
+    return {
+        "photon_context_injected": injected,
+        "photon_warning_blocked_count": warning_blocked_count,
+    }
 
 
 def scenario_map() -> dict[str, Scenario]:
@@ -806,6 +835,15 @@ def scenario_map() -> dict[str, Scenario]:
             grade_s2_03,
         ),
         Scenario(
+            "S2-03-en",
+            "ui-framework",
+            "Existing SvelteKit route edit (English)",
+            "Read the existing SvelteKit page and add status toggle UI to Operations Console. "
+            "Do not replace with React/Next.js. Verify with npm run build.",
+            setup_s2_03,
+            grade_s2_03,
+        ),
+        Scenario(
             "S2-06",
             "ui-framework",
             "Unknown UI framework safe fail",
@@ -818,6 +856,14 @@ def scenario_map() -> dict[str, Scenario]:
             "existing-code",
             "Python bug fix with self-test",
             "calculator.pyのバグを修正し、ANVIL.mdのPreferred verifierで確認してください。",
+            setup_s3_01,
+            grade_s3_01,
+        ),
+        Scenario(
+            "S3-01-en",
+            "existing-code",
+            "Python bug fix with self-test (English)",
+            "Fix the bug in calculator.py and verify using the Preferred verifier listed in ANVIL.md.",
             setup_s3_01,
             grade_s3_01,
         ),
@@ -854,6 +900,14 @@ def scenario_map() -> dict[str, Scenario]:
             grade_s5_01,
         ),
         Scenario(
+            "S5-01-en",
+            "harness",
+            "ANVIL.md preferred verifier (English)",
+            "Fix the bug in tool.py and verify using the Preferred verifier listed in ANVIL.md.",
+            setup_s5_01,
+            grade_s5_01,
+        ),
+        Scenario(
             "S6-04",
             "observability-safety",
             "Secret-looking value redaction",
@@ -878,6 +932,7 @@ SCENARIO_SETS = {
     "strict": ["S0-01", "S1-02", "S2-03", "S3-01"],
     "expanded": ["S0-01", "S1-01", "S1-02", "S2-02", "S2-03", "S2-06", "S3-01", "S3-03", "S3-04", "S4-02", "S5-01", "S6-04"],
     "photon": ["SP-01"],
+    "cross_lingual": ["S2-03", "S2-03-en", "S3-01", "S3-01-en", "S5-01", "S5-01-en"],
 }
 
 
@@ -905,7 +960,7 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--photon-url",
-        default="http://127.0.0.1:18765",
+        default=DEFAULT_PHOTON_URL,
         help="Photon sidecar URL. Used only when --photon-on is set. Default: %(default)s",
     )
     return parser.parse_args()
@@ -985,7 +1040,7 @@ def run_one(
     timeout_secs: int,
     dry_run: bool,
     photon_on: bool = False,
-    photon_url: str = "http://127.0.0.1:18765",
+    photon_url: str = DEFAULT_PHOTON_URL,
 ) -> dict[str, str]:
     model_slug = model.replace(":", "_").replace("/", "_")
     workdir = run_dir / "workdirs" / model_slug / f"r{rep}" / scenario.id
@@ -1063,7 +1118,7 @@ def run_one(
     output = stdout + "\n" + stderr
     if dry_run:
         first_iter, total_iter = count_iters(output)
-        return {
+        dry_run_row = {
             "run_id": run_dir.name,
             "commit": commit,
             "scenario_id": scenario.id,
@@ -1072,6 +1127,7 @@ def run_one(
             "rep": str(rep),
             "photon_on": bool_s(photon_on),
             "photon_context_injected": "",
+            "photon_warning_blocked_count": "",
             "pass": "",
             "high_quality": "",
             "protocol_complete": "",
@@ -1104,6 +1160,12 @@ def run_one(
             "dirty_worktree_preserved": "",
             "notes": "dry-run",
         }
+        assert set(dry_run_row) == set(RESULT_FIELDS), (
+            f"dry_run_row keys mismatch RESULT_FIELDS: "
+            f"extra={set(dry_run_row)-set(RESULT_FIELDS)}, "
+            f"missing={set(RESULT_FIELDS)-set(dry_run_row)}"
+        )
+        return dry_run_row
     llm_events = load_llm_events(state_dir)
     grade = scenario.grade(workdir, output, stderr, rc, changed)
     grade.setdefault("pass", rc == 0)
@@ -1116,6 +1178,8 @@ def run_one(
     grade.update(extract_observability(llm_events))
     grade.update(extract_photon_observability(llm_events))
     grade["photon_on"] = photon_on
+    if not photon_on:
+        grade["photon_warning_blocked_count"] = ""
     grade.setdefault("fallback_level", "minimal-patch")
     if grade.get("verification_pass") != "" and not grade.get("verifier_source"):
         grade["verifier_source"] = "e2e_scenario_grader"
@@ -1255,6 +1319,8 @@ def main() -> int:
         reps=args.reps,
         scenarios=scenarios,
         max_iterations=args.max_iterations,
+        photon_on=args.photon_on,
+        photon_url=args.photon_url,
     )
 
     rows: list[dict[str, str]] = []


### PR DESCRIPTION
## Summary

Add English variants of 3 evaluation scenarios to enable direct measurement of photon's cross-lingual code path (Issue #97 / photon-action-memory) and warning_filter (#583/PR #584).

- 3 new scenarios: `S2-03-en`, `S3-01-en`, `S5-01-en` (reuse existing setup/grade with English fixtures)
- New scenario set: `cross_lingual` (6 IDs in JP/EN pair order)
- New CSV column: `photon_warning_blocked_count` (right after `photon_context_injected`)
- Defensive helper `safe_non_negative_int()` for JSONL event parsing
- Manifest now records `photon_on` / `photon_url`

## Background

The β+γ-light evaluation (n=240, post-#584) showed that Anvil's warning_filter is implemented but never fires because:
- Anvil task = Japanese
- photon seed = English
- photon's quality_gate uses ASCII-only token overlap detector

Result: 0/280 warning_blocked events observed. With this PR, we can:
1. Run `--scenario-set cross_lingual` to A/B compare JP vs EN scenarios
2. Measure `photon_warning_blocked_count` per row
3. Validate photon Issue #97 (multilingual detector) effect after implementation

## Test Plan

- [x] ruff check: clean (incidentally fixed pre-existing `import sys` F401)
- [x] `tests/scripts/test_e2e_uat_matrix_metrics.sh`: PASS
- [x] `--scenario-set cross_lingual --dry-run`: 6 rows in correct JP/EN pair order
- [x] CSV column position: `photon_warning_blocked_count` at idx 9 (after `photon_context_injected` at idx 8)
- [x] `safe_non_negative_int` handles bool/None/str/negative/float defensively

## Related

- Issue: #585
- photon Issue #97: multilingual overlap detector
- photon Issue #98: multilingual seeds
- evaluation context: `workspace/orchestration/runs/2026-05-14/eval-results-post584.md`

Closes #585

🤖 Generated with [Claude Code](https://claude.com/claude-code)