### PR TITLE
fix(photon): extract_blocked_summary_ids reads context_pack.warnings (#587)

### DIFF
--- a/src/photon/prompt.rs
+++ b/src/photon/prompt.rs
@@ -433,13 +433,23 @@ fn parse_warning_message(msg: &str) -> Option<(&str, &str)> {
 /// Extract the set of summary IDs that the photon sidecar has flagged with
 /// `summary_quality_gate` / `premature_termination_risk` (Issue #583).
 ///
+/// Accepts the v0.2 sidecar layout (`context_pack.warnings`) first, then
+/// falls back to legacy top-level `warnings` for test fixtures — mirrors
+/// `parse_items_with_total` (Issue #587).
+///
 /// Fail-open: malformed responses, missing fields, and unexpected types yield
 /// an empty set rather than blocking everything. Returns the set together with
 /// stats describing which DoS caps fired.
 pub(crate) fn extract_blocked_summary_ids(
     resp: &ContextPackResponse,
 ) -> (HashSet<String>, BlockedIdsStats) {
-    let warnings = match resp.0.get("warnings").and_then(|v| v.as_array()) {
+    let warnings = match resp
+        .0
+        .get("context_pack")
+        .and_then(|cp| cp.get("warnings"))
+        .and_then(|v| v.as_array())
+        .or_else(|| resp.0.get("warnings").and_then(|v| v.as_array()))
+    {
         Some(arr) => arr,
         None => return (HashSet::new(), BlockedIdsStats::default()),
     };
@@ -954,6 +964,35 @@ mod tests {
         let section = section.expect("item lacking id must survive (fail-open)");
         assert!(section.contains("summary without id"));
         assert_eq!(render_stats.items_blocked, 0);
+        assert_eq!(render_stats.items_adopted, 1);
+    }
+
+    // WF-14 (Issue #587): warnings nested under `context_pack` (real photon
+    // v0.2 sidecar layout) are extracted; previously they were silently
+    // ignored because the function only looked at the top-level key.
+    #[test]
+    fn wf14_v0_2_nested_warnings_layout() {
+        let resp = mk_resp(json!({
+            "schema_version": "action-memory.v0.2",
+            "context_pack": {
+                "items": [
+                    { "kind": "summary", "id": "seed_a", "summary": "a" },
+                    { "kind": "summary", "id": "seed_b", "summary": "b" },
+                ],
+                "warnings": [
+                    { "kind": "summary_quality_gate", "message": "seed_a: premature_termination_risk" }
+                ]
+            }
+        }));
+        let (blocked, stats) = extract_blocked_summary_ids(&resp);
+        assert_eq!(stats.total_warnings, 1);
+        assert!(blocked.contains("seed_a"));
+        assert!(!blocked.contains("seed_b"));
+        let (section, render_stats) = render_context_pack(&resp, &blocked);
+        let section = section.expect("non-blocked item must survive");
+        assert!(section.contains("b"));
+        assert!(!section.contains("seed_a"));
+        assert_eq!(render_stats.items_blocked, 1);
         assert_eq!(render_stats.items_adopted, 1);
     }
 

--- a/tests/photon_warning_filter_smoke.rs
+++ b/tests/photon_warning_filter_smoke.rs
@@ -108,7 +108,8 @@ fn find_first_event(session_id: &str, event_name: &str) -> Option<serde_json::Va
 
 /// Build a mockito body for `/v1/context/pack` with the given items and
 /// optional warnings. Items each carry `id=seed_<i>` so we can flag specific
-/// entries by ID.
+/// entries by ID. Uses the real photon v0.2 sidecar layout where items and
+/// warnings are nested under `context_pack` (Issue #587).
 fn mock_context_pack_body(num_items: usize, warnings: serde_json::Value) -> String {
     let items: Vec<serde_json::Value> = (0..num_items)
         .map(|i| {
@@ -120,8 +121,11 @@ fn mock_context_pack_body(num_items: usize, warnings: serde_json::Value) -> Stri
         })
         .collect();
     serde_json::json!({
-        "items": items,
-        "warnings": warnings,
+        "schema_version": "action-memory.v0.2",
+        "context_pack": {
+            "items": items,
+            "warnings": warnings,
+        }
     })
     .to_string()
 }


### PR DESCRIPTION
## Summary

Bug fix: `extract_blocked_summary_ids` in `src/photon/prompt.rs:442` was reading `warnings` from the top level of the photon response, but the actual v0.2 sidecar layout nests warnings under `context_pack.warnings`. This caused **all photon-side quality_gate features (#85, #97, #103) to be silently dormant** because Anvil's warning_filter never received warnings.

## Observed bug

cross_lingual evaluation (post-#103/#104, n=60):
- Direct curl to `/v1/context/pack` (JP S2-03 task) → warning emitted ✅
- Same task via Anvil binary → `items_blocked: 0`, `photon_warning_blocked_count: 0` ❌

After verifying photon's actual response shape:
```json
{
  "schema_version": "...",
  "context_pack": {
    "items": [...],
    "warnings": [...]   ← here, NESTED
  }
}
```

And Anvil's code (`src/photon/prompt.rs:442`):
```rust
let warnings = match resp.0.get("warnings")  // ← reads TOP LEVEL!
```

## Fix

```rust
let warnings = match resp.0
    .get("context_pack")
    .and_then(|cp| cp.get("warnings"))
    .and_then(|v| v.as_array())
    .or_else(|| resp.0.get("warnings").and_then(|v| v.as_array()))
{
    Some(arr) => arr,
    None => return (HashSet::new(), BlockedIdsStats::default()),
};
```

Primary path: `context_pack.warnings` (real layout)
Fallback: top-level `warnings` (legacy/test fixtures, backward compat)

## Test Plan

- [x] `cargo fmt --check` — pass
- [x] `cargo clippy --all-targets -- -D warnings` — pass
- [x] `cargo test` — all pass
- [x] **New regression test** `wf14_v0_2_nested_warnings_layout`: verifies `context_pack.warnings` is read correctly
- [x] **Updated fixture** `mock_context_pack_body()`: now produces real v0.2 nested layout (regression prevention)

## Expected Impact

After this fix, the previously dormant photon features become active:

| photon feature | Before | After |
|---|---|---|
| #85 quality_gate | ✅ implemented, ❌ ignored | ✅ active |
| #97 multilingual detector | ✅ implemented, ❌ ignored | ✅ active |
| #103 threshold tuning | ✅ implemented, ❌ ignored | ✅ active |

Expected cross_lingual eval uplift:
- S2-03 JP: 70% → **80-90%** (warning-driven seed skip)
- Overall: 88% → **92-95%**

## Related

- Anvil PR #584 (originally introduced the bug)
- photon Issues #85, #97, #103: all functional but Anvil receive layer broken
- Root cause analysis (Opus 4.7) added to Issue body
- Evaluation evidence: `workspace/eval/runs/crosslang-post103104-20260515-094249/`

Closes #587

🤖 Generated with [Claude Code](https://claude.com/claude-code)