### PR TITLE
feat(eval): add --photon-repo-prefix flag for A-0 measurement (photon ON / no seed match)

### DIFF
--- a/scripts/e2e_uat_matrix.py
+++ b/scripts/e2e_uat_matrix.py
@@ -963,6 +963,16 @@ def parse_args() -> argparse.Namespace:
         default=DEFAULT_PHOTON_URL,
         help="Photon sidecar URL. Used only when --photon-on is set. Default: %(default)s",
     )
+    parser.add_argument(
+        "--photon-repo-prefix",
+        default="",
+        help=(
+            "Prefix to prepend to scenario id when naming the workdir. "
+            "Anvil sends the workdir basename as the photon repo name; "
+            "use a non-empty prefix to bypass seeded photon memories "
+            "(A-0 measurement: photon ON, no seed match)."
+        ),
+    )
     return parser.parse_args()
 
 
@@ -1041,10 +1051,14 @@ def run_one(
     dry_run: bool,
     photon_on: bool = False,
     photon_url: str = DEFAULT_PHOTON_URL,
+    photon_repo_prefix: str = "",
 ) -> dict[str, str]:
     model_slug = model.replace(":", "_").replace("/", "_")
-    workdir = run_dir / "workdirs" / model_slug / f"r{rep}" / scenario.id
-    state_dir = run_dir / "state" / model_slug / f"r{rep}" / scenario.id
+    # photon_repo_prefix lets caller bypass seeded photon memories by changing
+    # the workdir basename (which Anvil sends as photon repo name).
+    scenario_dir_name = f"{photon_repo_prefix}{scenario.id}" if photon_repo_prefix else scenario.id
+    workdir = run_dir / "workdirs" / model_slug / f"r{rep}" / scenario_dir_name
+    state_dir = run_dir / "state" / model_slug / f"r{rep}" / scenario_dir_name
     log_dir = run_dir / "raw" / model_slug / f"r{rep}"
     shutil.rmtree(workdir, ignore_errors=True)
     shutil.rmtree(state_dir, ignore_errors=True)
@@ -1342,6 +1356,7 @@ def main() -> int:
                         dry_run=args.dry_run,
                         photon_on=args.photon_on,
                         photon_url=args.photon_url,
+                        photon_repo_prefix=args.photon_repo_prefix,
                     )
                 )
 


### PR DESCRIPTION
## Summary

Photon eval matrix で「photon ON だが photon DB に seed が無い状態」(A-0 計測) を smoke / expanded で取りたい場合に、workdir basename を別の prefix 付きに変えて photon の repo_id 一致を外す機能を追加。

- `--photon-repo-prefix <STR>`: 空でない値を渡すと workdir basename が `<prefix><scenario_id>` になり、Anvil が photon に送る repo_id が seed の repo_id と不一致になる
- 後方互換: prefix 未指定時は従来通り `workdirs/<model>/r<N>/<scenario_id>` のまま

## 使い分け

| 計測アーム | 起動例 |
|----------|--------|
| baseline (photon OFF) | `python3 scripts/e2e_uat_matrix.py --scenario-set smoke` |
| A-1 (photon ON / seed match) | `... --photon-on` |
| A-0 (photon ON / no seed match) | `... --photon-on --photon-repo-prefix nomatch-` |

## Test plan

- [x] `python3 scripts/e2e_uat_matrix.py --help` で `--photon-repo-prefix` の help 文確認
- [x] prefix 未指定時の workdir basename が従来通り `<scenario_id>` のまま（regression なし）
- [x] prefix=`nomatch-` 指定時に workdir basename が `nomatch-S0-01` 等に変わる

## 背景

2026-05-16 の Anvil A/B 評価で photon ON arm (`smoke` scenario × seed 投入済) は成功シナリオで -40% 高速化を確認したが、これは A-1 (seed match) 効果なのか、photon の generic behavior 改善なのかを切り分けるには A-0 計測が必要だった。本 PR で eval matrix を A-1 / A-0 / OFF の 3 アーム比較に拡張する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)