### PR TITLE
fix(scrub): add unicode-case regex feature to fix panic in auto_promote_scrub (#604 hotfix)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ crossterm = { version = "0.28", default-features = false, features = ["events"] 
 globset = "0.4"
 ignore = "0.4"
 libc = "0.2"
-regex = { version = "1", default-features = false, features = ["std", "unicode-perl"] }
+regex = { version = "1", default-features = false, features = ["std", "unicode-perl", "unicode-case"] }
 reqwest = { version = "0.12", features = ["blocking", "rustls-tls", "json"], default-features = false }
 rustyline = { version = "14", default-features = false, features = ["with-file-history"] }
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
## Summary
- Issue #604 で導入された `src/session/auto_promote_scrub.rs` の 6 個 regex が `(?i)` を使用するが `regex` crate の `unicode-case` feature 無効で build されていたため、初回 `scrub_patterns()` 呼び出し時に panic
- `Cargo.toml` の regex features に `unicode-case` を追加して修正
- 1 line change in `Cargo.toml` only; no source changes

## Background

Today's first real production session (FastAPI hello world) passed quality_gate and reached scrub stage for the first time. The lazy `OnceLock::get_or_init` regex compile panicked:

```
thread 'main' panicked at src/session/auto_promote_scrub.rs:102:18:
output_literal_json regex must compile: Syntax(
  regex parse error:
    (?i)\{[^{}\n]*"[A-Za-z_][\w-]*"\s*:\s*[^{}\n]+\}
        ^^
  error: Unicode-aware case insensitivity matching is not available
  (make sure the unicode-case feature is enabled)
)
```

Same `(?i)` usage exists in `src/tools/grep.rs:17` (silently degraded to literal lowercase match via `.ok()` fallback). Both fixed by this PR.

## Why this was latent

- regex compile is lazy via `OnceLock::get_or_init`
- CI tests for `auto_promote_scrub` ran but somehow didn't trigger the panic (likely test process isolation)
- All 8 production `auto_promote.skipped` events today were `quality_gate` skip — they never reached scrub
- First case to pass quality_gate (FastAPI session) → panic

## Test plan
- [x] `cargo build --release` → success
- [x] `cargo clippy --release --all-targets -- -D warnings` → 0 warnings
- [x] `cargo test --release` → 1501 + multiple unit/integration suites, failed=0
- [x] `session::auto_promote_scrub` tests → 27/27 pass
- [x] Confirmed `Cargo.lock` not affected (only features added, no version change)

## Verification on develop after merge
After merge, recommend rebuild + manual smoke:
```bash
cargo build --release
export ANVIL_PHOTON_ENABLED=true
export ANVIL_PHOTON_AUTO_PROMOTE=true
export ANVIL_PHOTON_AUTO_PROMOTE_DRY_RUN=false
# run any session that passes quality_gate (real project with Cargo.toml/package.json etc.)
# should NOT panic; should either succeed upsert or hit scrub-detected answer-leak
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)