### PR TITLE
feat(loop): CompletionEvidence union + post-hoc evidence observation (Issue #606 Phase α-1)

### DIFF
--- a/src/agent/loop_run.rs
+++ b/src/agent/loop_run.rs
@@ -28,6 +28,14 @@ use crate::tools::registry::{ToolContext, ToolRegistry};
 pub(crate) mod auto_promote;
 mod auto_test;
 pub mod commands;
+// Issue #606: pure data model for post-hoc completion-evidence observation.
+// Internal API surfaced via `super::completion_evidence::` from `protocol.rs`,
+// `success.rs`, and `turn.rs`. Two pure helpers are re-exported below with
+// `#[doc(hidden)] pub` so integration tests (`tests/completion_evidence_smoke.rs`)
+// can verify the SSOT classifier and the DR4-002 security gate without
+// reaching into private module state — see `is_completion_verifier_command`
+// / `classify_repo_edit_path` in `loop_run::completion_evidence`.
+pub(crate) mod completion_evidence;
 mod deterministic;
 pub(crate) mod feedback_kind_confirm;
 mod footer;
@@ -79,6 +87,34 @@ pub use turn::PHOTON_OUTCOME_DETAIL_NO_PROGRESS_DESPITE_INJECT;
 // `tests/photon_provenance_smoke.rs` can verify the 7 status branches and the
 // per-seed rendering without constructing a full Agent (Ollama-free).
 pub use commands::build_photon_why_message;
+
+// Issue #606: integration-test-only seams for the completion-evidence
+// pipeline. Marked `#[doc(hidden)]` so they do not appear in the public docs
+// but are reachable from `tests/completion_evidence_smoke.rs`.
+//
+// `classify_repo_edit_path_for_test` exposes the SSOT path classifier so
+// integration tests can pin the DR1-001 ordering invariant (`.mdx → Docs`)
+// from outside the crate without reaching into `pub(crate)` types.
+//
+// `is_completion_verifier_command_for_test` exposes the DR4-002 security
+// gate so tests can pin that shell control operators reject a verifier
+// invocation without spinning up a full Agent.
+#[doc(hidden)]
+pub fn classify_repo_edit_path_for_test(path: &std::path::Path) -> &'static str {
+    use completion_evidence::RepoEditCategory;
+    match completion_evidence::classify_repo_edit_path(path) {
+        RepoEditCategory::Impl => "impl",
+        RepoEditCategory::Test => "test",
+        RepoEditCategory::Docs => "docs",
+        RepoEditCategory::Setup => "setup",
+        RepoEditCategory::Other => "other",
+    }
+}
+
+#[doc(hidden)]
+pub fn is_completion_verifier_command_for_test(command: &str) -> bool {
+    completion_evidence::is_completion_verifier_command(command)
+}
 
 // Issue #465 / Phase 5: expose Reminder types needed by tests/agent_skill_registry_smoke.rs
 // (E2E tests live outside the crate so `pub(crate) mod reminder` cannot be reached
@@ -394,6 +430,17 @@ pub struct Agent {
     /// independent variables (Issue S7-001 SSOT).
     pub(super) last_auto_promote_outcome:
         Option<crate::agent::loop_run::auto_promote::AutoPromoteOutcomeSummary>,
+    /// Issue #606 (DR1-007 / #D-06): per-turn accumulator of post-hoc
+    /// completion-evidence observations. Push-only `Vec` populated by the
+    /// Bash hook (`VerifierExitZero`) and the Edit/Write hook (`RepoEdit`)
+    /// in `turn.rs::execute_tool_call`, consumed by
+    /// `success.rs::run_post_loop_success_verifier` via
+    /// `ProtocolKind::evidence_set_satisfies`. Reset at the head of
+    /// `run_actor_loop` alongside the existing per-turn caps so multi-turn
+    /// sessions never observe stale evidence. **Not serialized** — lives
+    /// on `Agent` instead of `SessionSnapshot` because the OR-satisfaction
+    /// is evaluated within the same turn the evidence was observed.
+    pub(super) evidence_set_this_turn: completion_evidence::EvidenceSet,
 }
 
 /// Issue #594: state machine for the `/photon-why` slash command. Lives at
@@ -513,6 +560,7 @@ impl Agent {
             last_injected_summary_turn_index: None,
             photon_user_feedback_called_this_turn: false,
             last_auto_promote_outcome: None,
+            evidence_set_this_turn: completion_evidence::EvidenceSet::new(),
         }
     }
 }

--- a/src/agent/loop_run/completion_evidence.rs
+++ b/src/agent/loop_run/completion_evidence.rs
@@ -1,0 +1,615 @@
+//! Issue #606: post-hoc completion-evidence observation.
+//!
+//! `success_issue_with_context` historically rejected verifier-only turns
+//! (e.g. a Bash turn that ran `cargo test` with exit 0 but produced no
+//! repository edits) with per-protocol reject strings such as
+//! `"code protocol requires at least one repository edit"`. This module
+//! provides the pure data model the agent layer pushes evidence into
+//! during a turn (`Bash` hook for `VerifierExitZero`, `Edit/Write` hook
+//! for `RepoEdit`), and `success.rs` consumes via
+//! `ProtocolKind::evidence_set_satisfies` to short-circuit the reject when
+//! observed evidence already satisfies the active protocol (OR semantics).
+//!
+//! ## Layer rules (CLAUDE.md DR3-002)
+//!
+//! This module holds pure types, the SSOT path classifier, the DR4-002
+//! verifier shell-control gate, and the DR4-003 verifier-command redactor.
+//! It **must not** import from `agent::loop_run::Agent` / `photon` (those
+//! layers consume it via `pub(crate)` re-export from `loop_run.rs`; DR3-001
+//! forbids re-export from `mod.rs`-equivalent facades, so the parent module
+//! pulls in only the items it actually wires up).
+//!
+//! The single allowed cross-module dependency is
+//! `crate::session::feedback::mask_secrets`, used by
+//! `redact_verifier_command_for_storage` as the upstream SSOT for token /
+//! kv / URL-userinfo redaction — the agent → session direction is permitted
+//! by CLAUDE.md DR3-002 (the forbidden direction is photon importing
+//! session / agent).
+//!
+//! ## DR1-001 ordering invariant
+//!
+//! `classify_repo_edit_path` evaluates suffix predicates in a **fixed**
+//! sequence:
+//!   1. `is_test_file` (covers `__tests__/` / `.test.` / `.spec.` /
+//!      `test_*.py` / `*_test.py`)
+//!   2. `is_setup_file` (covers `package.json` / `tsconfig.json` / lock files)
+//!   3. Docs extension (`.md` / `.mdx` / `.txt` / `.rst`)
+//!   4. `is_implementation_file` (covers `.rs` / `.py` / `.ts` / `.tsx` / ...)
+//!   5. fallback `Other`
+//!
+//! Docs comes **before** `is_implementation_file` because `.mdx` is in the
+//! impl SSOT (`util::file_classify::is_implementation_file`) — DR1-001 pins
+//! that a `README.mdx` returns `Docs`, not `Impl`.
+//!
+//! ## DR1-004 / #D-07: `UserExplicitDone` is intentionally omitted
+//!
+//! The original Issue #606 design considered a `UserExplicitDone` variant for
+//! "the user said 'done' / 'thanks'", but it was dropped during multi-stage
+//! design review (YAGNI: there is no proven turn-completion path that needs
+//! it today, and adding the variant pre-commits to a fragile NLP gate).
+
+use std::path::Path;
+use std::sync::OnceLock;
+
+use regex::Regex;
+
+use crate::tools::bash::BashCommandClass;
+use crate::util::file_classify::{is_implementation_file, is_setup_file, is_test_file};
+
+/// Repository edit category emitted by `Edit` / `Write` tool calls. Mirrors
+/// the SSOT classifiers in `util::file_classify` but distinguishes Docs from
+/// Impl so the protocol receivers can require the appropriate flavour.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum RepoEditCategory {
+    Impl,
+    Test,
+    Docs,
+    Setup,
+    Other,
+}
+
+/// Post-hoc observation of one completion-relevant tool invocation in a
+/// turn. The agent layer pushes one variant per observed signal — multiple
+/// edits in the same turn are recorded as multiple `RepoEdit` entries so the
+/// downstream OR-satisfaction can count per category.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub(crate) enum CompletionEvidence {
+    /// A successful repository edit (Write / Edit tool call). `count` is
+    /// always 1 today but the field is preserved for future aggregation.
+    RepoEdit {
+        category: RepoEditCategory,
+        count: usize,
+    },
+    /// A Bash command classified as `BuildTest` that exited with code 0.
+    /// `command` is masked through `redact_verifier_command_for_storage`
+    /// before persistence (T-2.x); for α-1 logging the raw normalized
+    /// command is acceptable inside the in-process `EvidenceSet` because we
+    /// never serialize the set itself in α-1.
+    VerifierExitZero {
+        class: BashCommandClass,
+        command: String,
+    },
+    /// The model produced an answer-only reply (no tool calls). Reserved
+    /// for AnswerOnly protocol acceptance.
+    AnswerOnly,
+}
+
+/// Push-only accumulator of evidence observations within one turn. The
+/// owning `Agent` resets it at the top of `run_actor_loop` (T-1.8) so the
+/// per-turn semantics never leak across turns.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct EvidenceSet {
+    items: Vec<CompletionEvidence>,
+}
+
+impl EvidenceSet {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    pub(crate) fn clear(&mut self) {
+        self.items.clear();
+    }
+
+    pub(crate) fn push(&mut self, evidence: CompletionEvidence) {
+        self.items.push(evidence);
+    }
+
+    pub(crate) fn iter(&self) -> impl Iterator<Item = &CompletionEvidence> {
+        self.items.iter()
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.items.len()
+    }
+
+    #[allow(dead_code)] // Reserved for future α-2 photon outcome evaluation.
+    pub(crate) fn is_empty(&self) -> bool {
+        self.items.is_empty()
+    }
+}
+
+/// Classify a repository-edit path into a `RepoEditCategory`. Evaluation
+/// order is fixed per DR1-001 — see module-level doc for why Docs comes
+/// before Impl (`.mdx` would otherwise be claimed by Impl).
+pub(crate) fn classify_repo_edit_path<P: AsRef<Path>>(path: P) -> RepoEditCategory {
+    let path = path.as_ref();
+    if is_test_file(path) {
+        return RepoEditCategory::Test;
+    }
+    if is_setup_file(path) {
+        return RepoEditCategory::Setup;
+    }
+    if has_docs_extension(path) {
+        return RepoEditCategory::Docs;
+    }
+    if is_implementation_file(path) {
+        return RepoEditCategory::Impl;
+    }
+    RepoEditCategory::Other
+}
+
+fn has_docs_extension(path: &Path) -> bool {
+    matches!(
+        path.extension().and_then(|ext| ext.to_str()),
+        Some("md" | "mdx" | "txt" | "rst")
+    )
+}
+
+/// Issue #606 T-3.1 (Phase 3 Security pulled forward): refuse to treat a
+/// Bash command as VerifierExitZero evidence when it contains shell control
+/// operators that can mask a non-zero internal exit (DR4-002). Examples:
+///
+/// * `cargo test || true` — internal exit is laundered to 0
+/// * `npm test ; echo ok` — second command's exit is what `$?` reports
+/// * `pytest && false` — explicit follow-on failure that still exits the
+///   pipe with 0 if the first command crashed and `pipefail` is unset
+///
+/// We accept only commands whose shell text does not contain any of the
+/// blocked operators. The full normalized command string is checked
+/// (newlines included so a multi-line heredoc can't hide an `|| true`).
+pub(crate) fn is_completion_verifier_command(command: &str) -> bool {
+    !contains_evidence_poisoning_shell_control(command)
+}
+
+/// Returns true when `command` contains a shell control character that could
+/// mask the real exit code of the inner verifier invocation, or otherwise
+/// modify what is actually executed (command substitution, escapes). Pure /
+/// stable — exposed at module scope so the `turn.rs` hook can use it without
+/// going through `is_completion_verifier_command` when it wants the
+/// negative form.
+///
+/// ## CB-001 (high) fix: quote-agnostic scanning
+///
+/// The earlier implementation tried to skip text inside single / double
+/// quotes to avoid rejecting commands like
+/// `cargo test -- --filter 'a | b'`. That parser, however, did **not** honor
+/// shell backslash escapes and so could be tricked by an attacker into
+/// laundering a control operator past the gate, e.g.
+///
+/// * `cargo test \" || true` — the leading `\"` is treated as the start of a
+///   double-quoted string by the old scanner, which then skips the rest of
+///   the input and never sees `||`. But the real shell treats `\"` as a
+///   literal quote and evaluates `|| true` as a control operator.
+/// * `cargo test "$(whoami)"` — the old scanner skips the entire double-
+///   quoted region without ever inspecting `$(`. The real shell still runs
+///   command substitution inside double quotes.
+/// * ``cargo test "`whoami`"`` — same shape, backtick form.
+///
+/// Rather than trying to keep a hand-written shell tokenizer correct (which
+/// would now have to model `\\`, `\"`, `$''`, `$"..."`, here-docs, ...), we
+/// switch to a **conservative quote-agnostic deny list**. Any of the
+/// following anywhere in `command` disqualifies the command from becoming
+/// `VerifierExitZero` evidence — regardless of whether it sits inside a
+/// quote:
+///
+/// * `;`, `&`, `|`, `<`, `>` — control operators / redirects
+/// * backtick — command substitution
+/// * `$(` — command substitution
+/// * `\n`, `\r` — newline could hide a follow-on `|| true`
+/// * `\\` (backslash) — shell escapes can hide any of the above
+///
+/// This trades a small amount of recall (a legitimate
+/// `cargo test -- --filter 'a | b'` will no longer count as evidence) for a
+/// hard guarantee that the gate cannot be bypassed by escape / quote
+/// confusion. The gate is **evidence-only**: rejecting a command here just
+/// means it doesn't count as `VerifierExitZero`; the command still executes
+/// normally through the Bash tool.
+pub(crate) fn contains_evidence_poisoning_shell_control(command: &str) -> bool {
+    let bytes = command.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        let b = bytes[i];
+        match b {
+            b';' | b'&' | b'|' | b'<' | b'>' | b'`' | b'\n' | b'\r' | b'\\' => {
+                return true;
+            }
+            b'$' => {
+                if i + 1 < bytes.len() && bytes[i + 1] == b'(' {
+                    return true;
+                }
+                i += 1;
+            }
+            _ => {
+                i += 1;
+            }
+        }
+    }
+    false
+}
+
+// --- CB-002 fix: dedicated redaction for stored verifier commands -----------
+
+/// Match `Authorization: ...`, `Cookie: ...`, `X-API-Key: ...` and similar
+/// header-shaped key/value pairs whose value can be a credential.
+///
+/// The value side (`[^'"\n\r]+`) deliberately runs **through internal
+/// whitespace** so multi-token credentials like `Bearer abc123` collapse to
+/// a single `<REDACTED>` rather than leaving the secret tail (`abc123`)
+/// visible after the scheme word. We stop at the next quote / newline /
+/// carriage return — the typical shell-quoted header form is
+/// `-H 'Authorization: Bearer abc123'`, where the closing `'` bounds the
+/// value precisely. Bare-token forms like `Authorization=Bearer abc123`
+/// without a surrounding quote also work because the regex consumes
+/// everything up to the next quote / newline, which on a one-line
+/// command-string post-control-char-neutralization is end-of-string.
+///
+/// The `regex` crate is configured with `default-features = false` plus
+/// `unicode-perl` (Cargo.toml), so `(?i)` is unavailable; we spell out the
+/// ASCII case explicitly via character classes, matching the style used in
+/// `src/session/feedback.rs::kv_secret_regex`.
+fn auth_header_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(
+            r#"([Aa][Uu][Tt][Hh][Oo][Rr][Ii][Zz][Aa][Tt][Ii][Oo][Nn]|[Cc][Oo][Oo][Kk][Ii][Ee]|[Xx]-[Aa][Pp][Ii]-[Kk][Ee][Yy])\s*[:=]\s*[^'"\n\r]+"#,
+        )
+        .expect("valid static auth header regex")
+    })
+}
+
+/// Issue #606 Stage 4 (DR4-003): canonical redactor for the verifier command
+/// string stored inside `CompletionEvidence::VerifierExitZero.command` (and,
+/// in alpha-2, `SessionSnapshot.last_verifier_command` /
+/// `VerifierInvocationRecord.command`).
+///
+/// Pipeline:
+///   1. `mask_secrets` — token-prefix / kv / URL-userinfo redaction (SSOT
+///      lives in `src/session/feedback.rs`).
+///   2. Auth-header family redaction — `Authorization: Bearer ...`,
+///      `Cookie: ...`, `X-API-Key: ...` are reduced to `<HEADER>: <REDACTED>`
+///      so the credential tail is removed even when it doesn't look like one
+///      of the `kv_secret_regex` keywords.
+///   3. Control-char neutralization — ASCII `\x00..=\x1f` plus DEL (`\x7f`)
+///      get collapsed to a single space so an embedded `\n` / `\r` / `\t`
+///      can't break log lines or hide trailing operators in display.
+///
+/// Pure / safe to call on any UTF-8 string. Used in the verifier-evidence
+/// observation hook (`observe_evidence_from_bash_outcome`) and reserved for
+/// the alpha-2 last-verifier-command persistence path.
+pub(crate) fn redact_verifier_command_for_storage(cmd: &str) -> String {
+    let s1 = crate::session::feedback::mask_secrets(cmd);
+    let s2 = auth_header_regex()
+        .replace_all(&s1, "$1: <REDACTED>")
+        .into_owned();
+    s2.chars()
+        .map(|c| {
+            if (c as u32) < 0x20 || c == '\x7f' {
+                ' '
+            } else {
+                c
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    // ----------------------------- classify_repo_edit_path ----------------
+
+    #[test]
+    fn repo_edit_category_classifies_test_path() {
+        // U-01
+        assert_eq!(
+            classify_repo_edit_path(PathBuf::from("src/__tests__/foo.ts")),
+            RepoEditCategory::Test
+        );
+        assert_eq!(
+            classify_repo_edit_path(PathBuf::from("tests/foo.rs")),
+            RepoEditCategory::Test
+        );
+        assert_eq!(
+            classify_repo_edit_path(PathBuf::from("test_calculator.py")),
+            RepoEditCategory::Test
+        );
+    }
+
+    #[test]
+    fn repo_edit_category_classifies_setup_path() {
+        // U-02 — package.json explicitly; Cargo.toml is out of SSOT scope (DR1-002).
+        assert_eq!(
+            classify_repo_edit_path(PathBuf::from("package.json")),
+            RepoEditCategory::Setup
+        );
+        assert_eq!(
+            classify_repo_edit_path(PathBuf::from("tsconfig.json")),
+            RepoEditCategory::Setup
+        );
+    }
+
+    #[test]
+    fn repo_edit_category_classifies_impl_path() {
+        // U-03
+        assert_eq!(
+            classify_repo_edit_path(PathBuf::from("src/main.rs")),
+            RepoEditCategory::Impl
+        );
+        assert_eq!(
+            classify_repo_edit_path(PathBuf::from("src/app/page.tsx")),
+            RepoEditCategory::Impl
+        );
+    }
+
+    #[test]
+    fn repo_edit_category_classifies_docs_path() {
+        // U-04 — Docs must be evaluated BEFORE `is_implementation_file`
+        // because `.mdx` is in the impl SSOT (DR1-001).
+        assert_eq!(
+            classify_repo_edit_path(PathBuf::from("README.md")),
+            RepoEditCategory::Docs
+        );
+        assert_eq!(
+            classify_repo_edit_path(PathBuf::from("docs/intro.mdx")),
+            RepoEditCategory::Docs
+        );
+        assert_eq!(
+            classify_repo_edit_path(PathBuf::from("CHANGELOG.rst")),
+            RepoEditCategory::Docs
+        );
+        assert_eq!(
+            classify_repo_edit_path(PathBuf::from("notes.txt")),
+            RepoEditCategory::Docs
+        );
+    }
+
+    #[test]
+    fn repo_edit_category_classifies_other_path() {
+        // U-05
+        assert_eq!(
+            classify_repo_edit_path(PathBuf::from("Makefile")),
+            RepoEditCategory::Other
+        );
+        assert_eq!(
+            classify_repo_edit_path(PathBuf::from("Cargo.toml")),
+            RepoEditCategory::Other
+        );
+    }
+
+    // ----------------------------- EvidenceSet basics ---------------------
+
+    #[test]
+    fn evidence_set_push_and_iterate() {
+        let mut set = EvidenceSet::new();
+        assert!(set.is_empty());
+        set.push(CompletionEvidence::RepoEdit {
+            category: RepoEditCategory::Impl,
+            count: 1,
+        });
+        set.push(CompletionEvidence::VerifierExitZero {
+            class: BashCommandClass::BuildTest,
+            command: "cargo test".to_string(),
+        });
+        assert_eq!(set.len(), 2);
+        assert!(!set.is_empty());
+        let collected: Vec<_> = set.iter().collect();
+        assert_eq!(collected.len(), 2);
+    }
+
+    #[test]
+    fn evidence_set_clear_resets_state() {
+        let mut set = EvidenceSet::new();
+        set.push(CompletionEvidence::AnswerOnly);
+        set.clear();
+        assert!(set.is_empty());
+    }
+
+    // ----------------------------- security gate --------------------------
+
+    #[test]
+    fn verifier_command_with_or_true_is_rejected() {
+        // U-21 (DR4-002): `||` is a shell control operator that can mask a
+        // failing inner exit code.
+        assert!(!is_completion_verifier_command("cargo test || true"));
+        assert!(!is_completion_verifier_command("pytest && false"));
+        assert!(!is_completion_verifier_command("npm test ; echo ok"));
+    }
+
+    #[test]
+    fn verifier_command_with_pipe_or_redirect_is_rejected() {
+        assert!(!is_completion_verifier_command("cargo test | tee out.log"));
+        assert!(!is_completion_verifier_command("cargo test > out.log"));
+        assert!(!is_completion_verifier_command("cat input | pytest"));
+    }
+
+    #[test]
+    fn verifier_command_with_backtick_or_dollar_paren_is_rejected() {
+        assert!(!is_completion_verifier_command(
+            "cargo test --test `whoami`"
+        ));
+        assert!(!is_completion_verifier_command(
+            "cargo test --test $(whoami)"
+        ));
+    }
+
+    #[test]
+    fn verifier_command_with_embedded_newline_is_rejected() {
+        // A multi-line heredoc-style command sneaking in an `|| true`
+        // should still be rejected for the bare newline alone.
+        assert!(!is_completion_verifier_command("cargo test\necho bypass"));
+    }
+
+    #[test]
+    fn verifier_command_plain_cargo_test_is_accepted() {
+        assert!(is_completion_verifier_command("cargo test"));
+        assert!(is_completion_verifier_command("cargo test --workspace"));
+        assert!(is_completion_verifier_command("pytest -q"));
+        assert!(is_completion_verifier_command("npm test"));
+    }
+
+    #[test]
+    fn verifier_command_accepts_typical_release_and_module_filters() {
+        // CB-001: the new strict gate is still permissive enough for the
+        // common verifier shapes that have no shell-meta characters.
+        assert!(is_completion_verifier_command("cargo test --release"));
+        assert!(is_completion_verifier_command("cargo test foo::bar"));
+        assert!(is_completion_verifier_command(
+            "cargo test --no-default-features"
+        ));
+        assert!(is_completion_verifier_command("pytest -k some_name"));
+    }
+
+    // -- CB-001 (high): quote-agnostic / backslash-aware shell-control gate --
+
+    #[test]
+    fn cb_001_escaped_quote_followed_by_or_true_is_rejected() {
+        // The old scanner mis-treated `\"` as a string opener and never saw
+        // the trailing `|| true`. The shell evaluates `\"` as a literal
+        // quote and `|| true` as a real control operator, so the verifier
+        // could exit 0 even when the inner `cargo test` failed.
+        assert!(!is_completion_verifier_command("cargo test \\\" || true"));
+        // Backslash alone also disqualifies — escapes can hide any operator.
+        assert!(!is_completion_verifier_command("cargo test \\; echo bad"));
+    }
+
+    #[test]
+    fn cb_001_double_quoted_command_substitution_is_rejected() {
+        // `"$(...)"` runs command substitution inside double quotes — the
+        // old quote-skipping scanner missed it entirely.
+        assert!(!is_completion_verifier_command("cargo test \"$(whoami)\""));
+        assert!(!is_completion_verifier_command(
+            "cargo test --bin \"$(echo a)\""
+        ));
+    }
+
+    #[test]
+    fn cb_001_double_quoted_backtick_is_rejected() {
+        // Backticks inside double quotes still run command substitution.
+        assert!(!is_completion_verifier_command("cargo test \"`whoami`\""));
+    }
+
+    #[test]
+    fn cb_001_double_quoted_pipe_is_rejected_by_strict_gate() {
+        // Note: this differs from the pre-CB-001 behavior, which
+        // accepted operators inside any matched-quote region. The new
+        // gate is conservative on purpose: rejecting the evidence is
+        // safe (the command itself still executes through Bash), and
+        // accepting it requires us to reproduce the full shell quoting
+        // grammar correctly — a hand-rolled tokenizer's track record
+        // here is what produced CB-001 in the first place.
+        assert!(!is_completion_verifier_command("cargo test \"a | b\""));
+        assert!(!is_completion_verifier_command(
+            "cargo test -- --filter 'a | b'"
+        ));
+    }
+
+    #[test]
+    fn cb_001_bare_backslash_anywhere_is_rejected() {
+        // Backslashes can encode any control character via shell escapes
+        // — refuse them outright in the verifier-evidence gate.
+        assert!(!is_completion_verifier_command("cargo test --bin foo\\bar"));
+        assert!(!is_completion_verifier_command("pytest path\\to\\test"));
+    }
+
+    // -- CB-002 (medium): dedicated verifier-command storage redactor --------
+
+    #[test]
+    fn cb_002_authorization_bearer_header_is_redacted() {
+        let out = redact_verifier_command_for_storage(
+            "curl -H 'Authorization: Bearer abc123def456' http://localhost/x",
+        );
+        assert!(
+            !out.contains("abc123def456"),
+            "Bearer token must be redacted, got: {out}"
+        );
+        assert!(
+            out.contains("Authorization") && out.contains("<REDACTED>"),
+            "expected Authorization tag preserved with <REDACTED> sentinel, got: {out}"
+        );
+    }
+
+    #[test]
+    fn cb_002_cookie_header_is_redacted() {
+        let out = redact_verifier_command_for_storage(
+            "curl -H 'Cookie: session=xyz987' http://localhost/x",
+        );
+        assert!(
+            !out.contains("session=xyz987"),
+            "Cookie value must be redacted, got: {out}"
+        );
+        assert!(
+            out.contains("Cookie") && out.contains("<REDACTED>"),
+            "expected Cookie tag preserved with <REDACTED> sentinel, got: {out}"
+        );
+    }
+
+    #[test]
+    fn cb_002_x_api_key_header_is_redacted() {
+        let out = redact_verifier_command_for_storage(
+            "curl -H 'X-API-Key: super-secret-value-123' http://localhost/x",
+        );
+        assert!(
+            !out.contains("super-secret-value-123"),
+            "X-API-Key value must be redacted, got: {out}"
+        );
+        assert!(
+            out.contains("X-API-Key") && out.contains("<REDACTED>"),
+            "expected X-API-Key tag preserved with <REDACTED> sentinel, got: {out}"
+        );
+    }
+
+    #[test]
+    fn cb_002_control_chars_are_neutralized() {
+        let out = redact_verifier_command_for_storage("cargo test\necho bad\twith\ttab");
+        assert!(!out.contains('\n'), "newline must be neutralized: {out:?}");
+        assert!(!out.contains('\t'), "tab must be neutralized: {out:?}");
+        assert!(!out.contains('\r'), "CR must be neutralized: {out:?}");
+        // Body content survives (just with spaces in place of controls).
+        assert!(out.contains("cargo test") && out.contains("echo bad"));
+    }
+
+    #[test]
+    fn cb_002_existing_mask_secrets_behavior_is_preserved() {
+        // SECRET=... kv shape is still redacted by the wrapped mask_secrets
+        // SSOT (`src/session/feedback.rs::kv_secret_regex`).
+        let out =
+            redact_verifier_command_for_storage("env SECRET=topsecretvalue cargo test --release");
+        assert!(
+            !out.contains("topsecretvalue"),
+            "kv secret must remain redacted by mask_secrets: {out}"
+        );
+        assert!(
+            out.contains("SECRET=***"),
+            "expected kv keyword preserved with *** sentinel, got: {out}"
+        );
+        // URL userinfo redaction still applies.
+        let out2 = redact_verifier_command_for_storage("curl https://user:pw@example.com/path");
+        assert!(
+            !out2.contains("user:pw"),
+            "URL userinfo must be masked: {out2}"
+        );
+    }
+
+    #[test]
+    fn cb_002_plain_command_passes_through_unchanged() {
+        // Pure-ASCII verifier commands with no secrets / control chars are
+        // returned essentially as-is (only the redaction passes touch the
+        // string).
+        let out = redact_verifier_command_for_storage("cargo test --workspace --all-targets");
+        assert_eq!(out, "cargo test --workspace --all-targets");
+    }
+}

--- a/src/agent/loop_run/protocol.rs
+++ b/src/agent/loop_run/protocol.rs
@@ -1,5 +1,6 @@
 use crate::modes::plan_act::WorkMode;
 
+use super::completion_evidence::{CompletionEvidence, EvidenceSet, RepoEditCategory};
 use super::summary::LoopStats;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -9,6 +10,180 @@ pub(super) enum ProtocolKind {
     Docs,
     AnswerOnly,
     GenericCode,
+}
+
+impl ProtocolKind {
+    /// Issue #606 T-1.9: stable `&'static str` label used in completion
+    /// evidence log payloads. Lower-case snake_case matches the enum
+    /// rename convention used elsewhere in the codebase.
+    pub(super) fn label(self) -> &'static str {
+        match self {
+            ProtocolKind::Python => "python",
+            ProtocolKind::TypeScriptUi => "typescript_ui",
+            ProtocolKind::Docs => "docs",
+            ProtocolKind::AnswerOnly => "answer_only",
+            ProtocolKind::GenericCode => "generic_code",
+        }
+    }
+
+    /// Issue #606 T-1.4: does this protocol accept the given single
+    /// `CompletionEvidence` as proof of forward progress this turn? Pure
+    /// function over the (kind, evidence) cross-product:
+    ///
+    /// | kind          | RepoEdit accepted categories | VerifierExitZero | AnswerOnly |
+    /// |---------------|------------------------------|------------------|------------|
+    /// | Python        | Impl / Test                  | yes              | no         |
+    /// | TypeScriptUi  | Impl                         | yes              | no         |
+    /// | GenericCode   | Impl / Test / Setup / Other  | yes              | no         |
+    /// | AnswerOnly    | (none)                       | yes              | yes        |
+    /// | Docs          | Docs                         | no               | no         |
+    ///
+    /// `RepoEdit { category: Other }` is accepted only by `GenericCode` —
+    /// it is not a strong-enough signal for Python / TypeScriptUi / Docs.
+    pub(super) fn accepts(self, evidence: &CompletionEvidence) -> bool {
+        match (self, evidence) {
+            // Python protocol — implementation OR test edit OR verifier pass.
+            (
+                ProtocolKind::Python,
+                CompletionEvidence::RepoEdit {
+                    category: RepoEditCategory::Impl | RepoEditCategory::Test,
+                    ..
+                },
+            ) => true,
+            (ProtocolKind::Python, CompletionEvidence::VerifierExitZero { .. }) => true,
+            // TypeScript UI protocol — implementation edit OR verifier pass.
+            (
+                ProtocolKind::TypeScriptUi,
+                CompletionEvidence::RepoEdit {
+                    category: RepoEditCategory::Impl,
+                    ..
+                },
+            ) => true,
+            (ProtocolKind::TypeScriptUi, CompletionEvidence::VerifierExitZero { .. }) => true,
+            // GenericCode — any RepoEdit (incl. Setup / Other) OR verifier pass.
+            (ProtocolKind::GenericCode, CompletionEvidence::RepoEdit { .. }) => true,
+            (ProtocolKind::GenericCode, CompletionEvidence::VerifierExitZero { .. }) => true,
+            // AnswerOnly — accepts a verifier pass (e.g. user asked the
+            // model to run a read-only sanity script) OR an explicit
+            // AnswerOnly marker. RepoEdit is NOT accepted because the
+            // protocol forbids file changes.
+            (ProtocolKind::AnswerOnly, CompletionEvidence::VerifierExitZero { .. }) => true,
+            (ProtocolKind::AnswerOnly, CompletionEvidence::AnswerOnly) => true,
+            // Docs protocol — only a Docs RepoEdit counts. Verifier pass
+            // alone is not a docs artifact, even though a docs-style build
+            // command (e.g. `mkdocs build`) might exit 0.
+            (
+                ProtocolKind::Docs,
+                CompletionEvidence::RepoEdit {
+                    category: RepoEditCategory::Docs,
+                    ..
+                },
+            ) => true,
+            _ => false,
+        }
+    }
+
+    /// Issue #606 T-1.4: OR-fold — true when any single observation in the
+    /// set is accepted by this protocol.
+    pub(super) fn evidence_set_satisfies(self, set: &EvidenceSet) -> bool {
+        set.iter().any(|ev| self.accepts(ev))
+    }
+
+    /// Issue #606 T-1.4: human-friendly list of evidence shapes this
+    /// protocol still wants observed in the current turn. Used by
+    /// `success.rs` to populate `agent.completion_evidence.unsatisfied`
+    /// log payloads when the OR-fold returned false. The returned slice
+    /// of `&'static str` keeps allocation low and the names stable for
+    /// log analysers (no `format!` interpolation).
+    pub(super) fn evidence_set_missing_shapes(self, set: &EvidenceSet) -> Vec<&'static str> {
+        // For each shape we *would* accept, mark "missing" when the set
+        // does not contain a matching observation. The order here matches
+        // the documentation table above so log readers see a consistent
+        // ordering.
+        let mut missing: Vec<&'static str> = Vec::new();
+        match self {
+            ProtocolKind::Python => {
+                if !set.iter().any(|ev| {
+                    matches!(
+                        ev,
+                        CompletionEvidence::RepoEdit {
+                            category: RepoEditCategory::Impl | RepoEditCategory::Test,
+                            ..
+                        }
+                    )
+                }) {
+                    missing.push("repo_edit_impl_or_test");
+                }
+                if !set
+                    .iter()
+                    .any(|ev| matches!(ev, CompletionEvidence::VerifierExitZero { .. }))
+                {
+                    missing.push("verifier_exit_zero");
+                }
+            }
+            ProtocolKind::TypeScriptUi => {
+                if !set.iter().any(|ev| {
+                    matches!(
+                        ev,
+                        CompletionEvidence::RepoEdit {
+                            category: RepoEditCategory::Impl,
+                            ..
+                        }
+                    )
+                }) {
+                    missing.push("repo_edit_impl");
+                }
+                if !set
+                    .iter()
+                    .any(|ev| matches!(ev, CompletionEvidence::VerifierExitZero { .. }))
+                {
+                    missing.push("verifier_exit_zero");
+                }
+            }
+            ProtocolKind::GenericCode => {
+                if !set
+                    .iter()
+                    .any(|ev| matches!(ev, CompletionEvidence::RepoEdit { .. }))
+                {
+                    missing.push("repo_edit_any");
+                }
+                if !set
+                    .iter()
+                    .any(|ev| matches!(ev, CompletionEvidence::VerifierExitZero { .. }))
+                {
+                    missing.push("verifier_exit_zero");
+                }
+            }
+            ProtocolKind::AnswerOnly => {
+                if !set
+                    .iter()
+                    .any(|ev| matches!(ev, CompletionEvidence::VerifierExitZero { .. }))
+                {
+                    missing.push("verifier_exit_zero");
+                }
+                if !set
+                    .iter()
+                    .any(|ev| matches!(ev, CompletionEvidence::AnswerOnly))
+                {
+                    missing.push("answer_only");
+                }
+            }
+            ProtocolKind::Docs => {
+                if !set.iter().any(|ev| {
+                    matches!(
+                        ev,
+                        CompletionEvidence::RepoEdit {
+                            category: RepoEditCategory::Docs,
+                            ..
+                        }
+                    )
+                }) {
+                    missing.push("repo_edit_docs");
+                }
+            }
+        }
+        missing
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -23,6 +198,14 @@ pub(super) struct ProtocolSuccessContext<'a> {
     pub(super) model_repo_edits_this_turn: usize,
     pub(super) requested_paths: &'a [String],
     pub(super) verifier_passed_after_edit: Option<bool>,
+    /// Issue #606 (T-1.4): Stage-2 short-circuit signal. When the agent
+    /// post-hoc-observed enough evidence to satisfy the active protocol via
+    /// `ProtocolKind::evidence_set_satisfies`, `success.rs` sets this to
+    /// `true` so the per-protocol per-kind reject text never fires. Stage 1
+    /// (`deterministic_only` / `verifier_passed_after_edit == Some(false)`)
+    /// still wins because those are deterministic failure signals, not
+    /// missing-evidence signals.
+    pub(super) evidence_satisfied: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -63,6 +246,7 @@ impl ExecutionProtocol {
             model_repo_edits_this_turn: 0,
             requested_paths: &[],
             verifier_passed_after_edit: None,
+            evidence_satisfied: false,
         })
     }
 
@@ -70,6 +254,9 @@ impl ExecutionProtocol {
         self,
         context: ProtocolSuccessContext<'_>,
     ) -> Option<String> {
+        // Issue #606 T-1.5: Stage-1 deterministic failure signals always win.
+        // Stage-2 (`evidence_satisfied`) is honored only after Stage-1 cleared.
+        let evidence_satisfied = context.evidence_satisfied;
         let evidence = self.success_evidence(context);
         if evidence.deterministic_only {
             return Some(
@@ -79,6 +266,13 @@ impl ExecutionProtocol {
         }
         if evidence.verifier_passed_after_edit == Some(false) {
             return Some("protocol verifier failed after the edit".to_string());
+        }
+        // Stage-2: post-hoc evidence short-circuit. AnswerOnly is intentionally
+        // NOT shortcut here — its reject ("answer-only protocol completed with
+        // repository edits") fires when `evidence.total_changed > 0` because
+        // it represents a *behavioural violation*, not missing evidence.
+        if evidence_satisfied && !matches!(self.kind, ProtocolKind::AnswerOnly) {
+            return None;
         }
         match self.kind {
             ProtocolKind::AnswerOnly => {
@@ -348,6 +542,7 @@ mod tests {
             model_repo_edits_this_turn: 0,
             requested_paths: &[],
             verifier_passed_after_edit: None,
+            evidence_satisfied: false,
         }
     }
 
@@ -424,6 +619,7 @@ mod tests {
             model_repo_edits_this_turn: 1,
             requested_paths: &[],
             verifier_passed_after_edit: None,
+            evidence_satisfied: false,
         });
 
         assert!(evidence.changed_relevant_artifact);
@@ -447,6 +643,7 @@ mod tests {
                     model_repo_edits_this_turn: 1,
                     requested_paths: &[],
                     verifier_passed_after_edit: None,
+                    evidence_satisfied: false,
                 })
                 .is_none()
         );
@@ -465,6 +662,7 @@ mod tests {
                     model_repo_edits_this_turn: 1,
                     requested_paths: &requested,
                     verifier_passed_after_edit: None,
+                    evidence_satisfied: false,
                 })
                 .is_some()
         );
@@ -476,6 +674,7 @@ mod tests {
                     model_repo_edits_this_turn: 1,
                     requested_paths: &requested,
                     verifier_passed_after_edit: None,
+                    evidence_satisfied: false,
                 })
                 .is_none()
         );
@@ -492,6 +691,7 @@ mod tests {
             model_repo_edits_this_turn: 1,
             requested_paths: &requested,
             verifier_passed_after_edit: None,
+            evidence_satisfied: false,
         });
 
         assert!(evidence.requested_path_changed);
@@ -510,6 +710,7 @@ mod tests {
                 model_repo_edits_this_turn: 1,
                 requested_paths: &[],
                 verifier_passed_after_edit: Some(false),
+                evidence_satisfied: false,
             }),
             Some("protocol verifier failed after the edit".to_string())
         );
@@ -521,6 +722,7 @@ mod tests {
                     model_repo_edits_this_turn: 1,
                     requested_paths: &[],
                     verifier_passed_after_edit: Some(true),
+                    evidence_satisfied: false,
                 })
                 .is_none()
         );
@@ -533,5 +735,190 @@ mod tests {
             vec!["src/app/page.tsx".to_string(), "README.md".to_string()]
         );
         assert!(requested_paths_from_text("../secret.py /tmp/x.py https://x/y.py").is_empty());
+    }
+
+    // ----------------------------- Issue #606 T-1.4 -----------------------
+
+    use crate::tools::bash::BashCommandClass;
+
+    fn ev_verifier() -> CompletionEvidence {
+        CompletionEvidence::VerifierExitZero {
+            class: BashCommandClass::BuildTest,
+            command: "cargo test".to_string(),
+        }
+    }
+
+    fn ev_repo_edit(category: RepoEditCategory) -> CompletionEvidence {
+        CompletionEvidence::RepoEdit { category, count: 1 }
+    }
+
+    /// U-09 — 5 ProtocolKind × evidence variant matrix smoke.
+    #[test]
+    fn protocol_kind_accepts_each_completion_evidence_kind() {
+        let verifier = ev_verifier();
+        let impl_edit = ev_repo_edit(RepoEditCategory::Impl);
+        let test_edit = ev_repo_edit(RepoEditCategory::Test);
+        let docs_edit = ev_repo_edit(RepoEditCategory::Docs);
+        let setup_edit = ev_repo_edit(RepoEditCategory::Setup);
+        let other_edit = ev_repo_edit(RepoEditCategory::Other);
+        let answer_only = CompletionEvidence::AnswerOnly;
+
+        // Python
+        assert!(ProtocolKind::Python.accepts(&verifier));
+        assert!(ProtocolKind::Python.accepts(&impl_edit));
+        assert!(ProtocolKind::Python.accepts(&test_edit));
+        assert!(!ProtocolKind::Python.accepts(&docs_edit));
+        assert!(!ProtocolKind::Python.accepts(&setup_edit));
+        assert!(!ProtocolKind::Python.accepts(&other_edit));
+        assert!(!ProtocolKind::Python.accepts(&answer_only));
+
+        // TypeScriptUi
+        assert!(ProtocolKind::TypeScriptUi.accepts(&verifier));
+        assert!(ProtocolKind::TypeScriptUi.accepts(&impl_edit));
+        assert!(!ProtocolKind::TypeScriptUi.accepts(&test_edit));
+        assert!(!ProtocolKind::TypeScriptUi.accepts(&docs_edit));
+
+        // GenericCode — any RepoEdit, plus VerifierExitZero
+        assert!(ProtocolKind::GenericCode.accepts(&verifier));
+        assert!(ProtocolKind::GenericCode.accepts(&impl_edit));
+        assert!(ProtocolKind::GenericCode.accepts(&test_edit));
+        assert!(ProtocolKind::GenericCode.accepts(&docs_edit));
+        assert!(ProtocolKind::GenericCode.accepts(&setup_edit));
+        assert!(ProtocolKind::GenericCode.accepts(&other_edit));
+        assert!(!ProtocolKind::GenericCode.accepts(&answer_only));
+
+        // AnswerOnly
+        assert!(ProtocolKind::AnswerOnly.accepts(&verifier));
+        assert!(ProtocolKind::AnswerOnly.accepts(&answer_only));
+        assert!(!ProtocolKind::AnswerOnly.accepts(&impl_edit));
+        assert!(!ProtocolKind::AnswerOnly.accepts(&docs_edit));
+
+        // Docs
+        assert!(ProtocolKind::Docs.accepts(&docs_edit));
+        assert!(!ProtocolKind::Docs.accepts(&verifier));
+        assert!(!ProtocolKind::Docs.accepts(&impl_edit));
+        assert!(!ProtocolKind::Docs.accepts(&answer_only));
+    }
+
+    /// U-10 — AnswerOnly + VerifierExitZero + no repo edits → done. The
+    /// success.rs Stage-2 short-circuit is suppressed for AnswerOnly, but
+    /// the original AnswerOnly logic still accepts `total_changed == 0`.
+    #[test]
+    fn answer_only_with_verifier_exit_zero_is_done() {
+        let protocol = ExecutionProtocol::from_work_mode(WorkMode::AnswerOnly);
+        // total_changed == 0 (verifier ran but no edits)
+        assert!(
+            protocol
+                .success_issue_with_context(ProtocolSuccessContext {
+                    stats: &stats(&[], 0),
+                    deterministic_recovery_recorded: false,
+                    model_repo_edits_this_turn: 0,
+                    requested_paths: &[],
+                    verifier_passed_after_edit: None,
+                    evidence_satisfied: true,
+                })
+                .is_none()
+        );
+    }
+
+    /// U-11 — AnswerOnly + RepoEdit only (no verifier) is still rejected
+    /// even when `evidence_satisfied = true`. This pins VR-02 regression:
+    /// the Stage-2 short-circuit must NOT silence the answer-only edit ban.
+    #[test]
+    fn answer_only_with_repo_edit_only_is_still_rejected() {
+        let protocol = ExecutionProtocol::from_work_mode(WorkMode::AnswerOnly);
+        let issue = protocol.success_issue_with_context(ProtocolSuccessContext {
+            stats: &stats(&["README.md"], 1),
+            deterministic_recovery_recorded: false,
+            model_repo_edits_this_turn: 1,
+            requested_paths: &[],
+            verifier_passed_after_edit: None,
+            evidence_satisfied: true, // ← even with evidence flag set
+        });
+        assert_eq!(
+            issue,
+            Some(
+                "answer-only protocol completed with repository edits; retry without changing files"
+                    .to_string()
+            )
+        );
+    }
+
+    /// U-12 — Stage-1 (`verifier_passed_after_edit == Some(false)`) wins
+    /// over Stage-2 (`evidence_satisfied == true`). Deterministic verifier
+    /// failure must not be silenced by post-hoc evidence.
+    #[test]
+    fn verifier_passed_after_edit_some_false_overrides_evidence_satisfied() {
+        let protocol = ExecutionProtocol::from_work_mode(WorkMode::GenericCode);
+        let stats = stats(&["src/app.ts"], 1);
+        assert_eq!(
+            protocol.success_issue_with_context(ProtocolSuccessContext {
+                stats: &stats,
+                deterministic_recovery_recorded: false,
+                model_repo_edits_this_turn: 1,
+                requested_paths: &[],
+                verifier_passed_after_edit: Some(false),
+                evidence_satisfied: true,
+            }),
+            Some("protocol verifier failed after the edit".to_string())
+        );
+    }
+
+    /// U-19 — `evidence_set_missing_shapes` returns the static labels
+    /// describing which shape is still wanted. Empty set → all shapes.
+    #[test]
+    fn evidence_set_missing_shapes_describes_unsatisfied_protocol() {
+        let empty = EvidenceSet::new();
+        assert_eq!(
+            ProtocolKind::Python.evidence_set_missing_shapes(&empty),
+            vec!["repo_edit_impl_or_test", "verifier_exit_zero"]
+        );
+        assert_eq!(
+            ProtocolKind::TypeScriptUi.evidence_set_missing_shapes(&empty),
+            vec!["repo_edit_impl", "verifier_exit_zero"]
+        );
+        assert_eq!(
+            ProtocolKind::GenericCode.evidence_set_missing_shapes(&empty),
+            vec!["repo_edit_any", "verifier_exit_zero"]
+        );
+        assert_eq!(
+            ProtocolKind::AnswerOnly.evidence_set_missing_shapes(&empty),
+            vec!["verifier_exit_zero", "answer_only"]
+        );
+        assert_eq!(
+            ProtocolKind::Docs.evidence_set_missing_shapes(&empty),
+            vec!["repo_edit_docs"]
+        );
+
+        // Partial — a Test edit satisfies Python's repo-edit slot but
+        // leaves the verifier slot open.
+        let mut set = EvidenceSet::new();
+        set.push(ev_repo_edit(RepoEditCategory::Test));
+        assert_eq!(
+            ProtocolKind::Python.evidence_set_missing_shapes(&set),
+            vec!["verifier_exit_zero"]
+        );
+    }
+
+    /// Integration of T-1.3 evidence_set_satisfies into protocol decisions.
+    #[test]
+    fn evidence_set_satisfies_python_with_test_edit() {
+        let mut set = EvidenceSet::new();
+        set.push(ev_repo_edit(RepoEditCategory::Test));
+        assert!(ProtocolKind::Python.evidence_set_satisfies(&set));
+    }
+
+    #[test]
+    fn evidence_set_satisfies_generic_code_with_verifier_exit_zero() {
+        let mut set = EvidenceSet::new();
+        set.push(ev_verifier());
+        assert!(ProtocolKind::GenericCode.evidence_set_satisfies(&set));
+    }
+
+    #[test]
+    fn evidence_set_unsatisfied_docs_with_only_verifier() {
+        let mut set = EvidenceSet::new();
+        set.push(ev_verifier());
+        assert!(!ProtocolKind::Docs.evidence_set_satisfies(&set));
     }
 }

--- a/src/agent/loop_run/success.rs
+++ b/src/agent/loop_run/success.rs
@@ -100,17 +100,39 @@ impl Agent {
                 .active_request_text()
                 .map(|text| requested_paths_from_text(&text))
                 .unwrap_or_default();
+            // Issue #606 T-1.5: Stage-2 short-circuit — if the agent observed
+            // enough evidence this turn to satisfy the active protocol, the
+            // per-kind reject text is suppressed. Stage 1 (deterministic_only /
+            // verifier_passed_after_edit == Some(false)) still wins inside
+            // `success_issue_with_context`.
+            let kind = protocol.kind();
+            let evidence_satisfied = kind.evidence_set_satisfies(&self.evidence_set_this_turn);
             if let Some(issue) = protocol.success_issue_with_context(ProtocolSuccessContext {
                 stats,
                 deterministic_recovery_recorded,
                 model_repo_edits_this_turn,
                 requested_paths: &requested_paths,
                 verifier_passed_after_edit: None,
+                evidence_satisfied,
             }) {
+                let missing = kind.evidence_set_missing_shapes(&self.evidence_set_this_turn);
+                crate::logging::log_completion_evidence_unsatisfied(
+                    self.current_turn_index,
+                    kind.label(),
+                    &missing,
+                    self.evidence_set_this_turn.len(),
+                );
                 *exit_reason = ExitReason::MissingRepoEdits;
                 *error_text = issue;
                 false
             } else {
+                if evidence_satisfied {
+                    crate::logging::log_completion_evidence_satisfied(
+                        self.current_turn_index,
+                        kind.label(),
+                        self.evidence_set_this_turn.len(),
+                    );
+                }
                 true
             }
         } else {

--- a/src/agent/loop_run/tester.rs
+++ b/src/agent/loop_run/tester.rs
@@ -1377,6 +1377,7 @@ mod tests {
             timed_out: false,
             blocked_reason: None,
             interrupted: false,
+            ..Default::default()
         }
     }
 
@@ -1762,6 +1763,7 @@ mod tests {
                 timed_out: false,
                 blocked_reason: None,
                 interrupted: false,
+                ..Default::default()
             })
         });
         assert!(result.is_ok());
@@ -1800,6 +1802,7 @@ mod tests {
                 timed_out: false,
                 blocked_reason: None,
                 interrupted: false,
+                ..Default::default()
             })
         }
     }
@@ -1815,6 +1818,7 @@ mod tests {
                 timed_out: false,
                 blocked_reason: None,
                 interrupted: false,
+                ..Default::default()
             })
         }
     }
@@ -2012,6 +2016,7 @@ mod tests {
                 timed_out: true,
                 blocked_reason: None,
                 interrupted: false,
+                ..Default::default()
             })
         };
         let outcome = run_tester_with_strategy(
@@ -2047,6 +2052,7 @@ mod tests {
                 timed_out: false,
                 blocked_reason: None,
                 interrupted: true,
+                ..Default::default()
             })
         };
         let outcome = run_tester_with_strategy(

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -3759,6 +3759,12 @@ impl Agent {
         // outcome cache. Mirror of `case_record_extracted_this_turn` semantics.
         self.session.auto_promote_called_this_turn = false;
         self.last_auto_promote_outcome = None;
+        // Issue #606 (T-1.8): reset the per-turn completion-evidence set so
+        // observations never bleed across turns. Push-only `EvidenceSet`
+        // populated by the Bash / Edit / Write hooks below; consumed by
+        // `success.rs::run_post_loop_success_verifier` via
+        // `ProtocolKind::evidence_set_satisfies`.
+        self.evidence_set_this_turn.clear();
 
         let mut tool_calls_made_this_turn = 0usize;
         let mut repo_edit_calls_made_this_turn = 0usize;
@@ -7072,6 +7078,14 @@ impl Agent {
             {
                 self.session.record_feedback(frame);
             }
+            // Issue #606 (T-1.6): post-hoc observation of a successful
+            // build/test command as `VerifierExitZero` evidence. Gated by
+            // the T-3.1 security helper `is_completion_verifier_command`
+            // which rejects shell-control operators that could mask the
+            // real exit code (DR4-002 — `cargo test || true` is poisoned).
+            if let Some(outcome) = outcome.as_ref() {
+                self.observe_evidence_from_bash_outcome(outcome);
+            }
             return match result {
                 Ok(text) => {
                     self.maybe_update_work_root(name, arguments, &text);
@@ -7127,6 +7141,17 @@ impl Agent {
                     // verify_repo_progress diff signal in
                     // `compute_anvil_score`).
                     self.session.repo_edit_succeeded_this_turn = true;
+                    // Issue #606 (T-1.7): post-hoc observation of a
+                    // successful repo edit as `RepoEdit` evidence. Path
+                    // categorisation goes through
+                    // `completion_evidence::classify_repo_edit_path`
+                    // which evaluates predicates in a fixed order so
+                    // `.mdx` reliably classifies as Docs (DR1-001).
+                    if let Some(raw_path) =
+                        arguments.get("path").and_then(serde_json::Value::as_str)
+                    {
+                        self.observe_evidence_from_repo_edit(raw_path);
+                    }
                 }
                 self.maybe_update_work_root(name, arguments, &result);
                 result
@@ -7144,6 +7169,82 @@ impl Agent {
                 lifecycle::format_tool_error(&err)
             }
         }
+    }
+
+    /// Issue #606 (T-1.6): post-hoc observation of a Bash invocation as
+    /// `VerifierExitZero` completion evidence. A signal is recorded **only**
+    /// when:
+    ///
+    /// 1. `outcome.exit_code == Some(0)` — non-zero / timeout / interrupted
+    ///    invocations are explicit failures, not silent passes.
+    /// 2. `outcome.class == BuildTest` — read-only / network / mutating
+    ///    classes don't represent verification work even when they
+    ///    happen to exit 0.
+    /// 3. `is_completion_verifier_command(&outcome.command) == true` —
+    ///    rejects commands containing shell control operators that can
+    ///    mask the real exit code (DR4-002, e.g. `cargo test || true`).
+    ///
+    /// The evidence is consumed by
+    /// `ProtocolKind::evidence_set_satisfies` in `success.rs`.
+    fn observe_evidence_from_bash_outcome(
+        &mut self,
+        outcome: &crate::tools::bash::BashExecutionOutcome,
+    ) {
+        use crate::tools::bash::BashCommandClass;
+        if outcome.exit_code != Some(0) {
+            return;
+        }
+        if !matches!(outcome.class, BashCommandClass::BuildTest) {
+            return;
+        }
+        if !super::completion_evidence::is_completion_verifier_command(&outcome.command) {
+            return;
+        }
+        // Mask the command through the dedicated verifier-storage redactor
+        // before pushing it into the in-process EvidenceSet. This wraps
+        // `mask_secrets` with the additional Authorization / Cookie /
+        // X-API-Key header family redaction and control-char neutralization
+        // mandated by Stage 4 DR4-003 (see design §6.2 / §12.2). The same
+        // helper is reserved for the alpha-2
+        // `SessionSnapshot::last_verifier_command` /
+        // `VerifierInvocationRecord::command` persistence path so a single
+        // SSOT redactor covers every place a verifier command lands on disk.
+        let masked =
+            super::completion_evidence::redact_verifier_command_for_storage(&outcome.command);
+        self.evidence_set_this_turn.push(
+            super::completion_evidence::CompletionEvidence::VerifierExitZero {
+                class: outcome.class,
+                command: masked,
+            },
+        );
+        crate::logging::log_completion_evidence_observed(
+            self.current_turn_index,
+            0, // α-1: iter_index plumbing is α-2 work; emit 0 for now.
+            "verifier_exit_zero",
+            serde_json::json!({
+                "command_class": format!("{:?}", outcome.class),
+            }),
+        );
+    }
+
+    /// Issue #606 (T-1.7): post-hoc observation of an Edit/Write success
+    /// as `RepoEdit` completion evidence. The path is run through
+    /// `classify_repo_edit_path` which uses the SSOT in `util::file_classify`
+    /// and applies the DR1-001 ordering rule (`.mdx → Docs` even though
+    /// `is_implementation_file` would otherwise claim it).
+    fn observe_evidence_from_repo_edit(&mut self, path: &str) {
+        let category =
+            super::completion_evidence::classify_repo_edit_path(std::path::Path::new(path));
+        self.evidence_set_this_turn
+            .push(super::completion_evidence::CompletionEvidence::RepoEdit { category, count: 1 });
+        crate::logging::log_completion_evidence_observed(
+            self.current_turn_index,
+            0,
+            "repo_edit",
+            serde_json::json!({
+                "category": format!("{:?}", category),
+            }),
+        );
     }
 
     fn answer_only_policy_error(

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -143,6 +143,82 @@ pub(crate) fn is_secret_like_key(key: &str) -> bool {
     upper.ends_with("_KEY") || upper.ends_with("_TOKEN")
 }
 
+// ---------------------------------------------------------------------------
+// Issue #606 T-1.9: completion-evidence log helpers.
+//
+// Three events are emitted along the post-hoc evidence observation pipeline:
+//   * `agent.completion_evidence.observed` — fired from the Bash hook
+//     (`VerifierExitZero`) and Edit/Write hook (`RepoEdit`) the moment the
+//     tool result confirms a completion-relevant signal.
+//   * `agent.completion_evidence.satisfied` — fired from success.rs when the
+//     OR-fold over the per-turn `EvidenceSet` returns true and Stage-2
+//     short-circuits the per-protocol reject text.
+//   * `agent.completion_evidence.unsatisfied` — fired from success.rs when
+//     the protocol's reject text is still produced; the payload carries the
+//     `missing_shapes` slice from `evidence_set_missing_shapes`.
+//
+// All three payloads pass through `mask_payload_inplace` (called from
+// `log_llm_event`) as the final defence line per CLAUDE.md Security
+// Invariants. The helpers only construct the payload — they do not bypass
+// that pipeline.
+// ---------------------------------------------------------------------------
+
+/// Issue #606 T-1.9 — `agent.completion_evidence.observed`.
+///
+/// `event_label` is a `&'static str` matching the `serde tag = "kind"`
+/// variant name (`repo_edit` / `verifier_exit_zero` / `answer_only`) so log
+/// readers can pivot without re-parsing the inner payload. `detail` is the
+/// optional structured side-data (e.g. `RepoEditCategory`, masked verifier
+/// command class).
+pub(crate) fn log_completion_evidence_observed(
+    turn_index: usize,
+    iter_index: usize,
+    event_label: &'static str,
+    detail: Value,
+) {
+    let payload = json!({
+        "turn_index": turn_index,
+        "iter_index": iter_index,
+        "evidence_kind": event_label,
+        "detail": detail,
+    });
+    log_llm_event("agent.completion_evidence.observed", payload);
+}
+
+/// Issue #606 T-1.9 — `agent.completion_evidence.satisfied`. `protocol_kind`
+/// is passed as `&'static str` (one of `"python"` / `"typescript_ui"` /
+/// `"docs"` / `"answer_only"` / `"generic_code"`) so this helper stays in
+/// the `crate::logging` layer without pulling in `agent::loop_run`'s
+/// `pub(super)` `ProtocolKind` enum (DR3-002 layer rule).
+pub(crate) fn log_completion_evidence_satisfied(
+    turn_index: usize,
+    protocol_kind: &'static str,
+    observed_count: usize,
+) {
+    let payload = json!({
+        "turn_index": turn_index,
+        "protocol_kind": protocol_kind,
+        "observed_count": observed_count,
+    });
+    log_llm_event("agent.completion_evidence.satisfied", payload);
+}
+
+/// Issue #606 T-1.9 — `agent.completion_evidence.unsatisfied`.
+pub(crate) fn log_completion_evidence_unsatisfied(
+    turn_index: usize,
+    protocol_kind: &'static str,
+    missing_shapes: &[&'static str],
+    observed_count: usize,
+) {
+    let payload = json!({
+        "turn_index": turn_index,
+        "protocol_kind": protocol_kind,
+        "missing_shapes": missing_shapes,
+        "observed_count": observed_count,
+    });
+    log_llm_event("agent.completion_evidence.unsatisfied", payload);
+}
+
 #[cfg(test)]
 mod tests {
     use super::{is_secret_like_key, mask_payload_inplace};
@@ -295,6 +371,56 @@ mod tests {
         assert_eq!(
             payload["MY_API_KEY_BACKUP"],
             Value::String("***".to_string())
+        );
+    }
+
+    /// Issue #606 U-16: pin that `mask_payload_inplace` preserves the
+    /// payload key set used by the three completion-evidence events
+    /// (`agent.completion_evidence.{observed,satisfied,unsatisfied}`).
+    /// Same shape as the existing reminder-payload pin (VR-06).
+    #[test]
+    fn mask_payload_inplace_preserves_completion_evidence_payload_key_set() {
+        let mut payload = json!({
+            "turn_index": 5,
+            "iter_index": 2,
+            "evidence_kind": "verifier_exit_zero",
+            "detail": {
+                "command_class": "BuildTest",
+            },
+            "protocol_kind": "python",
+            "missing_shapes": ["repo_edit_impl_or_test", "verifier_exit_zero"],
+            "observed_count": 3,
+        });
+        let before_keys: Vec<String> = payload
+            .as_object()
+            .unwrap()
+            .keys()
+            .cloned()
+            .collect::<Vec<_>>();
+        mask_payload_inplace(&mut payload);
+        let after_keys: Vec<String> = payload
+            .as_object()
+            .unwrap()
+            .keys()
+            .cloned()
+            .collect::<Vec<_>>();
+        assert_eq!(before_keys, after_keys);
+        // Inner non-secret payload values preserved.
+        assert_eq!(payload["turn_index"], json!(5));
+        assert_eq!(payload["iter_index"], json!(2));
+        assert_eq!(payload["observed_count"], json!(3));
+        assert_eq!(
+            payload["evidence_kind"].as_str().unwrap(),
+            "verifier_exit_zero"
+        );
+        assert_eq!(payload["protocol_kind"].as_str().unwrap(), "python");
+        assert_eq!(
+            payload["detail"]["command_class"].as_str().unwrap(),
+            "BuildTest"
+        );
+        assert_eq!(
+            payload["missing_shapes"][0].as_str().unwrap(),
+            "repo_edit_impl_or_test"
         );
     }
 

--- a/src/tools/bash.rs
+++ b/src/tools/bash.rs
@@ -76,6 +76,11 @@ where
 /// the agent layer (Issue #450). Not part of `ToolRegistry::execute`'s
 /// `Result<String, String>` contract; turn.rs invokes
 /// `run_with_outcome` directly when it needs the structured form.
+///
+/// Issue #606 T-1.2: `class` is populated by `run_with_outcome` so the agent
+/// layer can post-hoc-observe `CompletionEvidence::VerifierExitZero` without
+/// re-running `classify_command` on the raw command string. Defaults to
+/// `BashCommandClass::General`.
 #[derive(Debug, Clone, Default)]
 pub struct BashExecutionOutcome {
     pub command: String,
@@ -85,6 +90,7 @@ pub struct BashExecutionOutcome {
     pub timed_out: bool,
     pub blocked_reason: Option<String>,
     pub interrupted: bool,
+    pub class: BashCommandClass,
 }
 
 impl BashExecutionOutcome {
@@ -369,7 +375,13 @@ const LONG_RUNNING_TIMEOUT: Duration = Duration::from_secs(15);
 const TERMINATE_GRACE: Duration = Duration::from_secs(2);
 const POLL_INTERVAL: Duration = Duration::from_millis(100);
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Issue #606 T-1.1: `serde` derives + `Default` impl so the class can travel
+/// through `BashExecutionOutcome` and be serialized in completion-evidence
+/// payloads / persisted snapshots. `Default = General` matches the historical
+/// behaviour where unclassified commands fell through to the catch-all branch
+/// in `classify_command`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum BashCommandClass {
     ReadOnly,
     BuildTest,
@@ -377,6 +389,7 @@ pub enum BashCommandClass {
     Network,
     Mutating,
     Dangerous,
+    #[default]
     General,
 }
 
@@ -465,6 +478,7 @@ pub fn run_with_outcome(
                 timed_out: false,
                 blocked_reason: None,
                 interrupted: true,
+                class,
             };
             return Ok((
                 format!(
@@ -489,6 +503,7 @@ pub fn run_with_outcome(
                 timed_out: true,
                 blocked_reason: None,
                 interrupted: false,
+                class,
             };
             return Ok((
                 format!(
@@ -518,6 +533,7 @@ pub fn run_with_outcome(
         timed_out: false,
         blocked_reason: None,
         interrupted: false,
+        class,
     };
     Ok((
         format!(
@@ -1569,6 +1585,32 @@ mod tests {
         assert_eq!(outcome.exit_code, Some(0));
         assert!(outcome.stdout.contains("hello"));
         assert!(!outcome.timed_out);
+    }
+
+    /// Issue #606 U-17: `BashExecutionOutcome::default()` yields the catch-all
+    /// `General` class so the completion-evidence pipeline never reads
+    /// uninitialised data on legacy literal sites that use
+    /// `..Default::default()`.
+    #[test]
+    fn bash_execution_outcome_class_defaults_to_general() {
+        let outcome = BashExecutionOutcome::default();
+        assert_eq!(outcome.class, BashCommandClass::General);
+    }
+
+    /// Issue #606 U-18: `run_with_outcome` populates `class` from
+    /// `classify_command`, so a `cargo test`-style command surfaces as
+    /// `BuildTest` even before the bash exit code is inspected.
+    #[test]
+    fn bash_execution_outcome_class_populates_build_test_for_cargo_test() {
+        let temp = tempdir().unwrap();
+        // `printf` keeps the test hermetic — we only care that
+        // `run_with_outcome` plumbed the class through; the command body is
+        // wrapped through `classify_command` before spawn, so we choose a
+        // canonical BuildTest invocation that exits 0 quickly.
+        let (_text, outcome) =
+            run_with_outcome("cargo test --help", temp.path(), None, false, None, None)
+                .expect("cargo test --help must run");
+        assert_eq!(outcome.class, BashCommandClass::BuildTest);
     }
 
     /// CB-003: a Bash command that emits invalid UTF-8 on stdout must NOT

--- a/tests/completion_evidence_smoke.rs
+++ b/tests/completion_evidence_smoke.rs
@@ -1,0 +1,239 @@
+//! Issue #606 Phase α-1 — integration smoke tests for the post-hoc
+//! completion-evidence pipeline.
+//!
+//! These tests reach into the `loop_run` facade via two `#[doc(hidden)] pub`
+//! seams (`classify_repo_edit_path_for_test` / `is_completion_verifier_command_for_test`)
+//! that re-export the SSOT helpers exactly as the production hooks see
+//! them. The intent is to pin the externally-observable contract:
+//!
+//!   * Path classification follows the DR1-001 ordering (`.mdx` resolves to
+//!     `docs`, not `impl`).
+//!   * The DR4-002 security gate rejects shell-control-laundered exit codes
+//!     before they can be promoted to `VerifierExitZero` evidence.
+//!
+//! Combined with the rich module-level unit suites in
+//! `src/agent/loop_run/completion_evidence.rs` (13 tests),
+//! `src/agent/loop_run/protocol.rs` (6 new tests for the accept/satisfy/missing
+//! matrix), and `src/logging.rs` (1 new test for payload key-set preservation),
+//! these integration tests cover AP-01〜AP-07 + VR-01〜VR-06 from the
+//! work-plan (`dev-reports/issue/606/work-plan.md`).
+
+use anvil::agent::loop_run::{
+    classify_repo_edit_path_for_test, is_completion_verifier_command_for_test,
+};
+use std::path::Path;
+
+// ----------------------- AP-01 / AP-02 / AP-03 / AP-04 (verifier accept) ----
+
+/// AP-01 / AP-02 / AP-03 / AP-04 surface: a canonical build/test invocation
+/// flows through the DR4-002 security gate cleanly so the post-hoc Bash
+/// hook can promote it to `VerifierExitZero` evidence.
+#[test]
+fn verifier_invocations_pass_the_security_gate() {
+    // AP-01 — cargo test
+    assert!(is_completion_verifier_command_for_test("cargo test"));
+    assert!(is_completion_verifier_command_for_test(
+        "cargo test --workspace --all-targets"
+    ));
+    // AP-02 — pytest
+    assert!(is_completion_verifier_command_for_test("pytest"));
+    assert!(is_completion_verifier_command_for_test("pytest -q"));
+    // AP-03 — npm test
+    assert!(is_completion_verifier_command_for_test("npm test"));
+    // AP-04 — cargo build
+    assert!(is_completion_verifier_command_for_test("cargo build"));
+    assert!(is_completion_verifier_command_for_test(
+        "cargo build --release"
+    ));
+}
+
+// ----------------------- AP-06 (DR4-002 security gate) ----------------------
+
+/// AP-06 surface (combined with DR4-002): a verifier command containing
+/// shell-control operators is rejected at the gate so the bash hook never
+/// pushes a poisoned `VerifierExitZero` into `EvidenceSet`. Covers `||`,
+/// `&&`, `;`, pipe, backtick, `$()`, redirect, newline.
+#[test]
+fn verifier_command_with_shell_control_operator_is_rejected() {
+    // `cargo test || true` would exit 0 even on test failure — this is the
+    // classic evidence-poisoning shape Issue #606 §12 calls out.
+    assert!(!is_completion_verifier_command_for_test(
+        "cargo test || true"
+    ));
+    // `pytest && false` masks the inner success.
+    assert!(!is_completion_verifier_command_for_test("pytest && false"));
+    // Sequential `;` lets a follow-on command produce the final `$?`.
+    assert!(!is_completion_verifier_command_for_test("npm test ; true"));
+    // Pipe / redirect can swallow the inner exit when `pipefail` is unset.
+    assert!(!is_completion_verifier_command_for_test(
+        "cargo test | tee out.log"
+    ));
+    assert!(!is_completion_verifier_command_for_test(
+        "cargo test > out.log"
+    ));
+    // Command substitution can launder exits via the outer pipeline.
+    assert!(!is_completion_verifier_command_for_test(
+        "cargo test --test $(whoami)"
+    ));
+    assert!(!is_completion_verifier_command_for_test(
+        "cargo test --test `whoami`"
+    ));
+    // Embedded newline / CR.
+    assert!(!is_completion_verifier_command_for_test(
+        "cargo test\necho bypass"
+    ));
+    // Background — `&` lets the foreground exit before the test finishes.
+    assert!(!is_completion_verifier_command_for_test(
+        "cargo test & echo bg"
+    ));
+}
+
+// ----------------------- AP-05 (RepoEdit categories) ------------------------
+
+/// AP-05 surface (and DR1-001): Edit/Write success paths flow through the
+/// SSOT classifier exactly. `.mdx` resolves to `docs`, not `impl`, because
+/// the Docs predicate runs before `is_implementation_file`.
+#[test]
+fn edit_write_paths_classify_via_ssot_predicates() {
+    // Impl
+    assert_eq!(
+        classify_repo_edit_path_for_test(Path::new("src/main.rs")),
+        "impl"
+    );
+    assert_eq!(
+        classify_repo_edit_path_for_test(Path::new("src/components/Button.tsx")),
+        "impl"
+    );
+    // Test
+    assert_eq!(
+        classify_repo_edit_path_for_test(Path::new("src/__tests__/foo.ts")),
+        "test"
+    );
+    assert_eq!(
+        classify_repo_edit_path_for_test(Path::new("tests/integration.rs")),
+        "test"
+    );
+    assert_eq!(
+        classify_repo_edit_path_for_test(Path::new("test_calc.py")),
+        "test"
+    );
+    // Docs — `.mdx` must resolve to `docs` even though it lives in the impl
+    // SSOT extension list. Pins DR1-001 ordering invariant.
+    assert_eq!(
+        classify_repo_edit_path_for_test(Path::new("docs/intro.mdx")),
+        "docs"
+    );
+    assert_eq!(
+        classify_repo_edit_path_for_test(Path::new("README.md")),
+        "docs"
+    );
+    assert_eq!(
+        classify_repo_edit_path_for_test(Path::new("CHANGELOG.rst")),
+        "docs"
+    );
+    // Setup
+    assert_eq!(
+        classify_repo_edit_path_for_test(Path::new("package.json")),
+        "setup"
+    );
+    assert_eq!(
+        classify_repo_edit_path_for_test(Path::new("tsconfig.json")),
+        "setup"
+    );
+    // Other — `Cargo.toml` is intentionally out of the setup SSOT (DR1-002).
+    assert_eq!(
+        classify_repo_edit_path_for_test(Path::new("Cargo.toml")),
+        "other"
+    );
+    assert_eq!(
+        classify_repo_edit_path_for_test(Path::new("Makefile")),
+        "other"
+    );
+}
+
+// ----------------------- VR-06 (Agent construction non-regression) -----------
+
+/// VR-04 surface: the strict CB-001 gate accepts the common verifier
+/// shapes that don't rely on shell control characters and rejects
+/// quoted-operator forms (the old quote-skipping scanner accepted those,
+/// but it could not be made safe against backslash escapes — see
+/// `contains_evidence_poisoning_shell_control` doc and the
+/// `cb_001_*` unit tests in `completion_evidence.rs`).
+#[test]
+fn verifier_gate_accepts_typical_verifier_invocations() {
+    // Common option-only invocations have no shell-meta characters and
+    // must be accepted so a successful `cargo test` / `pytest` still
+    // contributes `VerifierExitZero` evidence.
+    assert!(is_completion_verifier_command_for_test(
+        "cargo test --workspace"
+    ));
+    assert!(is_completion_verifier_command_for_test(
+        "cargo test foo::bar"
+    ));
+    assert!(is_completion_verifier_command_for_test(
+        "pytest -k some_name"
+    ));
+    // Plain quoted filters with no shell-meta characters are still fine
+    // because the deny list only triggers on actual control characters
+    // (the quotes themselves are not banned, just no longer trusted to
+    // shield interior `|` / `;` / etc. from the gate).
+    assert!(is_completion_verifier_command_for_test(
+        "pytest -k 'foo and not bar'"
+    ));
+    // Conversely, any operator inside quotes now disqualifies — the
+    // gate is intentionally conservative because the cost of a false
+    // positive (poisoned evidence) is higher than the cost of a false
+    // negative (skipping an evidence push; the command itself still
+    // executes through Bash).
+    assert!(!is_completion_verifier_command_for_test(
+        "cargo test -- --filter 'a | b'"
+    ));
+}
+
+/// VR-06 surface: constructing a real `Agent` after wiring in the
+/// per-turn `evidence_set_this_turn` field still succeeds and the
+/// `current_turn_index` accessor / session field plumbing remains
+/// functional. Smoke check: a no-Ollama `Agent::new` + immediate drop
+/// must not panic.
+#[test]
+fn agent_construction_after_evidence_set_wiring_does_not_panic() {
+    use anvil::agent::Agent;
+    use anvil::agent::loop_run::FooterHandle;
+    use anvil::config::Config;
+    use anvil::model_registry::RuntimeModels;
+    use anvil::ollama::client::OllamaClient;
+    use anvil::session::store::{SessionSnapshot, SessionStore};
+    use tempfile::tempdir;
+
+    let dir = tempdir().unwrap();
+    let state_root = dir.path().join("state");
+    std::fs::create_dir_all(state_root.join("sessions").join("test-606-agent-smoke")).unwrap();
+
+    let mut config = Config::default();
+    config.cwd = dir.path().to_path_buf();
+    config.photon_enabled = false;
+    config.requested_model = Some("test-model".to_string());
+    config.state_dir_override = Some(state_root.clone());
+    config.yes_mode = true;
+    config.max_iterations = 1;
+
+    let session = SessionSnapshot {
+        id: "test-606-agent-smoke".to_string(),
+        workspace_key: "anvil-606-smoke".to_string(),
+        ..Default::default()
+    };
+
+    let _agent = Agent::new(
+        config,
+        RuntimeModels {
+            main: "test-model".to_string(),
+            sidecar: None,
+        },
+        OllamaClient::new("http://127.0.0.1:19999".to_string()).unwrap(),
+        SessionStore::new(&state_root, "test-606-agent-smoke", "anvil-606-smoke"),
+        session,
+        FooterHandle::disabled(),
+    );
+    // Drop the agent; the test passes if the constructor + Drop pipeline
+    // doesn't panic. The new `evidence_set_this_turn` field default-inits.
+}

--- a/tests/tester_skill_smoke.rs
+++ b/tests/tester_skill_smoke.rs
@@ -109,6 +109,7 @@ fn ok_bash_outcome(stdout: &str) -> BashExecutionOutcome {
         timed_out: false,
         blocked_reason: None,
         interrupted: false,
+        ..Default::default()
     }
 }
 


### PR DESCRIPTION
## Summary

Issue #606 の **Phase α-1** を実装。`cargo test` / `pytest` / `npm test` 単独 turn が `missing_repo_edits` で失敗扱いされる現状の loop protocol を、**CompletionEvidence union + post-hoc evidence observation (B+D 方式)** で改善。

WorkMode 既存実装は一切変更せず、ルールベース intent 分類を増やさず、Sidecar 呼び出しゼロで実現。

- 受入: **AP-01〜AP-07 全 PASS** (`/pm-auto-issue2dev` acceptance gate = `issue_acceptance=PASS, design_doc_compliance=FULL`)
- Verification: **VR-01〜VR-08 全達成**
- テスト: **2094 passed / 0 failed / 8 ignored** (worker iteration-1 計測)
- Codex review: high 1 + medium 1 件 → 全修正済
- Phase α-2 (AP-08〜10) は scope 分離のため **#608** に切り出し済

## Test plan

- [x] `cargo fmt --check`: pass
- [x] `cargo clippy --release --all-targets -- -D warnings`: 0 warnings
- [x] `cargo test --release` (lib): 1536 passed / 0 failed
- [x] `cargo test --release` (full): 2094 passed / 0 failed / 8 ignored
- [x] `session::auto_promote_scrub` regression: 27/27 pass
- [x] `modes::plan_act` regression: 13/13 pass (WorkMode 既存実装 touch なし)
- [x] AnswerOnly + repo_edit 単独 still rejected (VR-02 regression test)

## 影響

### 新規 (2 files, 854 行)
- `src/agent/loop_run/completion_evidence.rs` (615 行)
- `tests/completion_evidence_smoke.rs` (239 行)

### 変更 (8 files, 734 行追加)
- `src/agent/loop_run/protocol.rs` (+387)
- `src/logging.rs` (+126)
- `src/agent/loop_run/turn.rs` (+101)
- `src/agent/loop_run.rs` (+48)
- `src/tools/bash.rs` (+44)
- `src/agent/loop_run/success.rs` (+22)
- 他: tester.rs (+6), tester_skill_smoke.rs (+1)

合計 **1588 insertions / 1 deletion / 10 files**

## 不変条件

| 不変条件 | 影響 |
|---------|------|
| DR3-001 (facade non-export) | 影響なし |
| DR3-002 (layer) | 影響なし (completion_evidence は agent 層内に閉じる) |
| DR3-003 (test isolation) | 影響なし |
| DR4-002 (sanitize SSOT) | 影響なし (`redact_verifier_command_for_storage` 適用) |
| WorkMode (#576) | **touch なし** (AP-07 で明文化、`git diff develop -- src/modes/plan_act.rs src/agent/loop_run/work_mode_confirm.rs` = 0 行) |
| photon adoption signal | 強化 (test pass を positive outcome の根拠として利用可能、AP-10 で本格統合) |

## 関連 Issue

- Closes #606 (Phase α-1 部分)
- Refs #608 (Phase α-2: test_output / SessionSnapshot / photon adoption)
- 後続: #607 (β: 環境構築タスク EnvSetup) — 本 PR の `CompletionEvidence` 基盤を再利用

🤖 Generated with [Claude Code](https://claude.com/claude-code)