### PR TITLE
feat(loop): test_output trim + SessionSnapshot persistence + photon adoption signal (Issue #608 Phase α-2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,8 +13,8 @@ Rust 版 local-first coding agent (Ollama 専用、`workspace/v0.1.0` ベース)
 - `src/photon/*` — Photon サイドカー HTTP 連携 / context_pack レンダラー / adoption signal
 - `src/agent/loop_run/*` — エージェントループ / turn 制御 / 各種 confirm skill (work_mode / feedback_kind / quality / photon_user_feedback)
 - `src/agent/skills/*` — SkillRegistry 基盤 (`AgentSkill` trait, `SkillTrustTier`)
-- `src/session/*` — セッションストア / `FeedbackFrame` / `Precaution` / `AnvilScore` / `CaseRecord` / `eval_log` / `case_retrieval` / `case_photon_bridge` / `tmp_tests` / `rollout_policy`
-- `src/tools/*` — built-in tools (`bash.rs::check_blocked_command` SSOT, Read/Write/Edit)
+- `src/session/*` — セッションストア / `FeedbackFrame` / `Precaution` / `AnvilScore` / `CaseRecord` / `eval_log` / `case_retrieval` / `case_photon_bridge` / `tmp_tests` / `rollout_policy` / `feedback.rs::redact_verifier_command_for_storage` (verifier command redactor SSOT) / `store.rs::VerifierInvocationRecord` (Phase α-2)
+- `src/tools/*` — built-in tools (`bash.rs::check_blocked_command` SSOT, Read/Write/Edit, `test_output.rs` failed-name + trim formatter)
 - `src/repo_graph/*` — `RepoGraph` v1 (import scan + LRU persist)
 - `src/util/file_classify.rs` — `is_test_file` / `is_setup_file` / `is_implementation_file` SSOT
 - `src/util/git_hardened.rs` — `run_git` SSOT (hardened git command runner)

--- a/src/agent/loop_run/auto_test.rs
+++ b/src/agent/loop_run/auto_test.rs
@@ -192,10 +192,17 @@ impl AutoTestRunner {
             }
             combined.push_str(&stderr);
         }
+        // Issue #608 AP-08: apply the `test_output` formatter (pytest/cargo/
+        // npm summary + tail trim) to the display-side `output` only. The
+        // raw `stdout` / `stderr` / `combined` strings consumed by
+        // `classify_auto_test` / feedback confirmation paths are NOT
+        // mutated — they remain the verbatim child output (design §4.6 /
+        // T2.B.2 raw-combined invariant).
+        let formatted = crate::tools::test_output::format_for_tool_result(&combined);
         Ok(AutoTestResult {
             command: plan.command.clone(),
             passed: output.status.success(),
-            output: truncate(&combined, MAX_OUTPUT_BYTES),
+            output: truncate(&formatted, MAX_OUTPUT_BYTES),
             exit_code: output.status.code(),
             stdout,
             stderr,

--- a/src/agent/loop_run/completion_evidence.rs
+++ b/src/agent/loop_run/completion_evidence.rs
@@ -49,9 +49,6 @@
 //! it today, and adding the variant pre-commits to a fragile NLP gate).
 
 use std::path::Path;
-use std::sync::OnceLock;
-
-use regex::Regex;
 
 use crate::tools::bash::BashCommandClass;
 use crate::util::file_classify::{is_implementation_file, is_setup_file, is_test_file};
@@ -240,69 +237,23 @@ pub(crate) fn contains_evidence_poisoning_shell_control(command: &str) -> bool {
     false
 }
 
-// --- CB-002 fix: dedicated redaction for stored verifier commands -----------
+// --- Issue #608 Phase α-2: verifier command redactor moved to session layer
 
-/// Match `Authorization: ...`, `Cookie: ...`, `X-API-Key: ...` and similar
-/// header-shaped key/value pairs whose value can be a credential.
-///
-/// The value side (`[^'"\n\r]+`) deliberately runs **through internal
-/// whitespace** so multi-token credentials like `Bearer abc123` collapse to
-/// a single `<REDACTED>` rather than leaving the secret tail (`abc123`)
-/// visible after the scheme word. We stop at the next quote / newline /
-/// carriage return — the typical shell-quoted header form is
-/// `-H 'Authorization: Bearer abc123'`, where the closing `'` bounds the
-/// value precisely. Bare-token forms like `Authorization=Bearer abc123`
-/// without a surrounding quote also work because the regex consumes
-/// everything up to the next quote / newline, which on a one-line
-/// command-string post-control-char-neutralization is end-of-string.
-///
-/// The `regex` crate is configured with `default-features = false` plus
-/// `unicode-perl` (Cargo.toml), so `(?i)` is unavailable; we spell out the
-/// ASCII case explicitly via character classes, matching the style used in
-/// `src/session/feedback.rs::kv_secret_regex`.
-fn auth_header_regex() -> &'static Regex {
-    static RE: OnceLock<Regex> = OnceLock::new();
-    RE.get_or_init(|| {
-        Regex::new(
-            r#"([Aa][Uu][Tt][Hh][Oo][Rr][Ii][Zz][Aa][Tt][Ii][Oo][Nn]|[Cc][Oo][Oo][Kk][Ii][Ee]|[Xx]-[Aa][Pp][Ii]-[Kk][Ee][Yy])\s*[:=]\s*[^'"\n\r]+"#,
-        )
-        .expect("valid static auth header regex")
-    })
-}
-
-/// Issue #606 Stage 4 (DR4-003): canonical redactor for the verifier command
-/// string stored inside `CompletionEvidence::VerifierExitZero.command` (and,
-/// in alpha-2, `SessionSnapshot.last_verifier_command` /
+/// Issue #606 Stage 4 (DR4-003) → Issue #608 Phase α-2 / 設計判断 #7:
+/// canonical redactor for the verifier command string stored inside
+/// `CompletionEvidence::VerifierExitZero.command` (and, in alpha-2,
+/// `SessionSnapshot.last_verifier_command` /
 /// `VerifierInvocationRecord.command`).
 ///
-/// Pipeline:
-///   1. `mask_secrets` — token-prefix / kv / URL-userinfo redaction (SSOT
-///      lives in `src/session/feedback.rs`).
-///   2. Auth-header family redaction — `Authorization: Bearer ...`,
-///      `Cookie: ...`, `X-API-Key: ...` are reduced to `<HEADER>: <REDACTED>`
-///      so the credential tail is removed even when it doesn't look like one
-///      of the `kv_secret_regex` keywords.
-///   3. Control-char neutralization — ASCII `\x00..=\x1f` plus DEL (`\x7f`)
-///      get collapsed to a single space so an embedded `\n` / `\r` / `\t`
-///      can't break log lines or hide trailing operators in display.
-///
-/// Pure / safe to call on any UTF-8 string. Used in the verifier-evidence
-/// observation hook (`observe_evidence_from_bash_outcome`) and reserved for
-/// the alpha-2 last-verifier-command persistence path.
+/// The actual redactor SSOT now lives in
+/// [`crate::session::feedback::redact_verifier_command_for_storage`] (session
+/// layer, owning the mask_secrets + auth_header + control-char + 4096-byte cap
+/// pipeline). This agent-layer wrapper exists only for backward source
+/// compatibility — the in-process `observe_evidence_from_bash_outcome` hook
+/// continues to call this name, and the session layer must not import from
+/// the agent layer (DR3-002 single-directional dependency).
 pub(crate) fn redact_verifier_command_for_storage(cmd: &str) -> String {
-    let s1 = crate::session::feedback::mask_secrets(cmd);
-    let s2 = auth_header_regex()
-        .replace_all(&s1, "$1: <REDACTED>")
-        .into_owned();
-    s2.chars()
-        .map(|c| {
-            if (c as u32) < 0x20 || c == '\x7f' {
-                ' '
-            } else {
-                c
-            }
-        })
-        .collect()
+    crate::session::feedback::redact_verifier_command_for_storage(cmd)
 }
 
 #[cfg(test)]

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -179,6 +179,16 @@ pub(crate) struct PhotonOutcomeInputs<'a> {
     /// Used by Case F no-progress detection (`== false` is one of the four
     /// AND conditions — AnswerOnly turns are expected to make zero edits).
     pub work_mode_is_answer_only: bool,
+    /// Issue #608 Phase α-2 (AP-10 / 設計判断 #2 + #3): same-turn signal
+    /// that the agent observed a `VerifierExitZero` evidence entry (i.e.
+    /// a BuildTest invocation exited 0 and passed the DR4-002 gate).
+    /// Derived from `evidence_set_this_turn` at the production callsite
+    /// (turn.rs:3529 周辺) — no separate SessionSnapshot flag (design
+    /// 設計判断 #3 (B)). Case E in `derive_photon_feedback_outcome` ORs
+    /// this signal with `AnvilScore.user_visible_artifact` so a successful
+    /// verifier run still earns a `success` outcome even when no Write /
+    /// Edit produced an on-disk artifact (e.g. read-only repos).
+    pub verifier_exit_zero_this_turn: bool,
 }
 
 /// Issue #601 (S5-001 / 設計判断 #4 (b)): unified return type for
@@ -234,6 +244,219 @@ pub(crate) fn case_f_condition_met(inputs: &PhotonOutcomeInputs<'_>) -> bool {
 /// import the symbol via the `pub use` re-export added in
 /// `src/agent/loop_run.rs`.
 pub const PHOTON_OUTCOME_DETAIL_NO_PROGRESS_DESPITE_INJECT: &str = "no_progress_despite_inject";
+
+// ---------------------------------------------------------------------------
+// Issue #608 Phase α-2 (AP-09): rerun-trigger keyword detection (pure helper).
+// ---------------------------------------------------------------------------
+
+/// Issue #608 Phase α-2 (AP-09 / 設計判断 #5): detect whether a user message
+/// is a "re-run the verifier" trigger. Five fixed keywords (design 設計判断
+/// #5 / A): `再実行`, `もう一度`, `もう 1 回`, `やり直して`, `rerun`.
+///
+/// Normalization (design 設計判断 #5):
+///   * Fullwidth ASCII letters / digits (`Ａ`-`Ｚ` / `ａ`-`ｚ` / `０`-`９`) and
+///     fullwidth space (`U+3000`) are mapped to their halfwidth ASCII
+///     counterparts.
+///   * Result is lowercased (ASCII case-folded).
+///   * Japanese keywords use a "space-collapsed" view (whitespace stripped)
+///     for `contains` matching so `もう 1 回` matches `もう1回`.
+///   * `rerun` ASCII keyword adds a word-boundary check on the
+///     **non-space-stripped** normalized string (the surrounding chars
+///     must NOT be ASCII alphanumeric) so `interrupt`, `prerun`,
+///     `current-run`, `rerunning` are negative while `please rerun the
+///     tests` is positive.
+///   * Japanese negative phrasings such as `再実行不要` / `やり直さない` still
+///     match (受容方針 — false positives are preferred to false negatives,
+///     per design 設計判断 #5).
+///
+/// Pure / safe to call on any UTF-8 string. No external regex dependency.
+pub(crate) fn is_rerun_trigger(msg: &str) -> bool {
+    let normalized = normalize_rerun_trigger_input(msg);
+    // ASCII keyword `rerun`: check word-boundary on the normalized
+    // (whitespace-preserving) form. Whitespace between letters now acts as a
+    // boundary so `please rerun ...` matches.
+    if contains_rerun_with_word_boundary(&normalized) {
+        return true;
+    }
+    // Japanese keywords: collapse ASCII whitespace + fullwidth space so
+    // `もう 1 回` matches `もう1回`. Japanese keywords don't need
+    // word-boundaries (contains-based per design 設計判断 #5).
+    let collapsed: String = normalized.chars().filter(|c| !c.is_whitespace()).collect();
+    const JA_KEYWORDS: &[&str] = &[
+        "再実行",
+        "もう一度",
+        "もう1回",
+        "もう一回",
+        "やり直して",
+        "やり直さ",
+    ];
+    JA_KEYWORDS.iter().any(|kw| collapsed.contains(kw))
+}
+
+/// AP-09 normalize: fullwidth ASCII → halfwidth ASCII (incl. fullwidth space
+/// `U+3000` → ASCII space), lowercase.
+fn normalize_rerun_trigger_input(msg: &str) -> String {
+    let mut out = String::with_capacity(msg.len());
+    for c in msg.chars() {
+        match c {
+            // Fullwidth uppercase Ａ..Ｚ → halfwidth A..Z (then lowercased below).
+            'Ａ'..='Ｚ' => out.push((c as u32 - 'Ａ' as u32 + 'A' as u32) as u8 as char),
+            // Fullwidth lowercase ａ..ｚ → halfwidth a..z.
+            'ａ'..='ｚ' => out.push((c as u32 - 'ａ' as u32 + 'a' as u32) as u8 as char),
+            // Fullwidth digits ０..９ → halfwidth 0..9.
+            '０'..='９' => out.push((c as u32 - '０' as u32 + '0' as u32) as u8 as char),
+            // Fullwidth space → ASCII space (preserved as a boundary).
+            '\u{3000}' => out.push(' '),
+            _ => out.push(c),
+        }
+    }
+    out.to_lowercase()
+}
+
+/// Issue #608 Phase α-2 (AP-09 / VR-14 / DR4-001): build a prompt hint that
+/// re-presents the previous turn's verifier command when the user message is
+/// a rerun trigger AND the persisted command passes the runnable eligibility
+/// guard.
+///
+/// Returns `None` when:
+///   * the user message is not a rerun trigger;
+///   * the session has no persisted `last_verifier_command`;
+///   * the runnable eligibility guard rejects the command (empty / NUL /
+///     control char / 4096-byte cap hit / shell-control operator / not
+///     BuildTest classified).
+///
+/// The hint is a system message — it informs the model that the user wants
+/// to rerun and surfaces the command as guidance, but does NOT directly
+/// dispatch Bash. The agent loop / model decides whether to actually call
+/// the Bash tool (DR4-001 prompt-injection guard).
+pub(crate) fn build_rerun_prompt_hint_if_eligible(
+    user_msg: &str,
+    session: &crate::session::store::SessionSnapshot,
+) -> Option<String> {
+    if !is_rerun_trigger(user_msg) {
+        return None;
+    }
+    let cmd = session.last_verifier_command.as_deref()?;
+    if !is_runnable_rerun_hint(cmd) {
+        return None;
+    }
+    Some(format!(
+        "[Anvil rerun hint] The user appears to want a re-run of the \
+         previous verifier. Last recorded command: `{cmd}`. Verify it is \
+         still appropriate before invoking the Bash tool."
+    ))
+}
+
+/// Issue #608 Phase α-2 (AP-09 / VR-14 / DR4-001): runnable eligibility
+/// guard for the persisted last-verifier-command. Re-validates the command
+/// against the same invariants that gated its original observation, so a
+/// tampered session.json cannot smuggle an arbitrary command into a model
+/// prompt hint.
+///
+/// Returns `true` iff:
+///   1. command is non-empty after trim;
+///   2. command contains no NUL / ASCII control chars (`\x00..=\x1f` / DEL);
+///   3. command length is strictly less than the 4096-byte storage cap (a
+///      hit indicates the original command was over-cap and was truncated —
+///      not safe as a runnable hint);
+///   4. command does not contain shell-control operators
+///      (`is_completion_verifier_command` SSOT check);
+///   5. command classifies as `BashCommandClass::BuildTest`.
+fn is_runnable_rerun_hint(cmd: &str) -> bool {
+    let trimmed = cmd.trim();
+    if trimmed.is_empty() {
+        return false;
+    }
+    if trimmed.chars().any(|c| (c as u32) < 0x20 || c == '\x7f') {
+        return false;
+    }
+    if trimmed.len() >= crate::session::feedback::MAX_VERIFIER_COMMAND_BYTES {
+        return false;
+    }
+    if !super::completion_evidence::is_completion_verifier_command(trimmed) {
+        return false;
+    }
+    if !matches!(
+        crate::tools::bash::classify_command(trimmed),
+        crate::tools::bash::BashCommandClass::BuildTest
+    ) {
+        return false;
+    }
+    true
+}
+
+/// Issue #608 Phase α-2 (AP-09): RFC3339 UTC timestamp for the current
+/// wall-clock. Delegates to `case_photon_bridge::format_rfc3339_utc` (which
+/// already implements the no-chrono civil-from-days algorithm). Pure helper
+/// for the `last_verifier_invocation.recorded_at` field.
+fn rfc3339_now_utc() -> String {
+    let secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    crate::session::case_photon_bridge::format_rfc3339_utc(secs)
+}
+
+/// AP-09 word-boundary check for the `rerun` keyword. Returns true iff
+/// `s.contains("rerun")` AND the surrounding char on each side (if any) is
+/// NOT ASCII alphanumeric. Pure / no allocation.
+fn contains_rerun_with_word_boundary(s: &str) -> bool {
+    let kw = "rerun";
+    let mut search_start = 0;
+    while let Some(idx) = s[search_start..].find(kw) {
+        let abs = search_start + idx;
+        let before_ok = abs == 0
+            || !s[..abs]
+                .chars()
+                .next_back()
+                .map(|c| c.is_ascii_alphanumeric())
+                .unwrap_or(false);
+        let end = abs + kw.len();
+        let after_ok = end == s.len()
+            || !s[end..]
+                .chars()
+                .next()
+                .map(|c| c.is_ascii_alphanumeric())
+                .unwrap_or(false);
+        if before_ok && after_ok {
+            return true;
+        }
+        search_start = abs + 1;
+    }
+    false
+}
+
+#[cfg(test)]
+impl<'a> PhotonOutcomeInputs<'a> {
+    /// Issue #608 Phase α-2 (AP-10 / 設計判断 #8): test-only fixture builder
+    /// that defaults every field to a "no-signal" value. Tests override only
+    /// the fields they care about via struct-update syntax
+    /// (`..PhotonOutcomeInputs::test_default()`).
+    ///
+    /// Notable defaults:
+    /// * `adopted_id_count: 1` — non-zero so Case A/B short-circuits don't
+    ///   fire by default (matches the previous `empty_inputs()` shape).
+    /// * `iter_count_this_turn: 2` — breaks Case F's `<= 1` AND, so tests
+    ///   that don't override Case F fields land on Case G.
+    /// * `verifier_exit_zero_this_turn: false` — Case E expansion field
+    ///   defaults to false so the OR-merge in Case E does not fire by
+    ///   default (matches the production derive value when no
+    ///   `VerifierExitZero` evidence was observed this turn).
+    pub(crate) fn test_default() -> Self {
+        Self {
+            last_feedback_kind: None,
+            eligible_feedback_recorded_this_turn: false,
+            anvil_score: None,
+            adopted_id_count: 1,
+            shadow_mode: false,
+            iter_count_this_turn: 2,
+            tool_calls_this_turn: 0,
+            repo_edit_succeeded_this_turn: false,
+            work_mode_is_answer_only: false,
+            verifier_exit_zero_this_turn: false,
+        }
+    }
+}
 
 /// Issue #591 (AS-04 / 設計判断 #3) + Issue #601 (S5-001 / 設計判断 #4 (b)):
 /// derive the adoption-loop outcome + optional detail value for the
@@ -320,15 +543,20 @@ pub(crate) fn derive_photon_feedback_outcome(
         };
     }
 
-    // Case E: success — user-visible artifact produced and nothing failed.
+    // Case E (Issue #608 Phase α-2 / AP-10 / 設計判断 #2 拡張):
+    //   success = user_visible_artifact OR verifier_exit_zero_this_turn
+    //
+    // The OR-merge adds same-turn verifier success as a positive signal so a
+    // read-only verifier run (e.g. `cargo test` on an unchanged tree still
+    // exiting 0) earns a `success` outcome even when no Write / Edit fires.
     // NOT gated by `eligible_feedback_recorded_this_turn` (DR3-NEW-002): a
     // turn that produced an artifact but did not record a failure frame
     // still earns a `success` outcome.
-    if inputs
+    let user_visible = inputs
         .anvil_score
         .map(|s| s.user_visible_artifact)
-        .unwrap_or(false)
-    {
+        .unwrap_or(false);
+    if user_visible || inputs.verifier_exit_zero_this_turn {
         return PhotonFeedbackOutcome {
             outcome: Some("success"),
             outcome_detail: None,
@@ -2409,6 +2637,20 @@ impl Agent {
         // in build_request_messages runs. Previously this reset lived in
         // run_actor_loop which wiped it before path (b) could check it.
         self.session.context_pack_sent_this_turn = false;
+        // Issue #608 Phase α-2 (AP-09): detect rerun-trigger keyword in the
+        // user message and re-present the previous turn's verifier command
+        // as a model prompt hint. The runnable eligibility guard
+        // (`runnable_rerun_hint_for_session`) re-validates the persisted
+        // command against the same DR4-002 / DR4-003 invariants that gated
+        // its original observation (BuildTest class, no shell control,
+        // non-empty / no control chars / no 4096-byte cap hit). Tampered or
+        // ineligible commands are silently skipped — the prompt hint is
+        // never emitted as a direct Bash dispatch (DR4-001).
+        if let Some(hint) = build_rerun_prompt_hint_if_eligible(input, &self.session) {
+            self.session
+                .messages
+                .push(crate::session::store::ConversationMessage::system(hint));
+        }
         self.run_turn(input, stream_output, &mut monitor)
     }
 
@@ -2456,10 +2698,17 @@ impl Agent {
             return None;
         };
         let auto_test_active = score.build_passed.is_some() || score.tests_passed.is_some();
+        // CB-002 (codex review fix): the auto_test success branch now also
+        // requires `unsafe_actions_blocked == 0` to prevent a turn where
+        // an unsafe command was blocked in the same turn from extracting
+        // a CaseRecord solely because build / tests / artifact were green.
+        // This matches the verifier-less fallback and
+        // `case_photon_bridge::is_eligible_for_promotion`'s full_pass check.
         let success = if auto_test_active {
             score.build_passed == Some(true)
                 && score.tests_passed == Some(true)
                 && score.user_visible_artifact
+                && score.unsafe_actions_blocked == 0
                 && score.consecutive_no_progress_turns == 0
         } else {
             self.session.repo_edit_succeeded_this_turn
@@ -3526,6 +3775,18 @@ impl Agent {
         // same-turn FeedbackKind / AnvilScore / shadow flag / adopted count
         // / per-turn counters / WorkMode. Returns a PhotonFeedbackOutcome
         // whose fields are `Option<&'static str>` allowlist values.
+        // Issue #608 Phase α-2 (AP-10 / 設計判断 #3): derive the same-turn
+        // verifier_exit_zero signal from `evidence_set_this_turn` so we don't
+        // need a separate SessionSnapshot flag. Matches the
+        // `CompletionEvidence::VerifierExitZero` push site in
+        // `observe_evidence_from_bash_outcome` (same turn, same iteration
+        // boundary as `evidence_set_this_turn.clear()` at run_actor_loop head).
+        let verifier_exit_zero_this_turn = self.evidence_set_this_turn.iter().any(|e| {
+            matches!(
+                e,
+                super::completion_evidence::CompletionEvidence::VerifierExitZero { .. }
+            )
+        });
         let inputs = PhotonOutcomeInputs {
             last_feedback_kind: self.session.last_feedback.as_ref().map(|ff| &ff.kind),
             eligible_feedback_recorded_this_turn: self.session.eligible_feedback_recorded_this_turn,
@@ -3539,6 +3800,8 @@ impl Agent {
             // DR3-001 SSOT: AnswerOnly check goes through the helper, never
             // a direct `mode_state.work_mode == WorkMode::AnswerOnly` compare.
             work_mode_is_answer_only: self.answer_only_mode_active(),
+            // Issue #608 Phase α-2 (AP-10 / 設計判断 #2 + #3): Case E expansion.
+            verifier_exit_zero_this_turn,
         };
         let PhotonFeedbackOutcome {
             outcome: outcome_static,
@@ -7191,6 +7454,28 @@ impl Agent {
         outcome: &crate::tools::bash::BashExecutionOutcome,
     ) {
         use crate::tools::bash::BashCommandClass;
+        // Issue #608 Phase α-2 (AP-09): record `last_verifier_command` /
+        // `last_verifier_invocation` for any BuildTest invocation (regardless
+        // of exit code) so the rerun-trigger handler can surface the most
+        // recent verifier attempt — even failed ones (the user often types
+        // `再実行` precisely because the last run failed).
+        if matches!(outcome.class, BashCommandClass::BuildTest)
+            && super::completion_evidence::is_completion_verifier_command(&outcome.command)
+        {
+            let redacted =
+                crate::session::feedback::redact_verifier_command_for_storage(&outcome.command);
+            // Drop empty redacted commands (e.g. all-control-char input).
+            if !redacted.trim().is_empty() {
+                self.session.last_verifier_command = Some(redacted.clone());
+                self.session.last_verifier_invocation =
+                    Some(crate::session::store::VerifierInvocationRecord {
+                        command: redacted,
+                        exit_code: outcome.exit_code.unwrap_or(-1),
+                        recorded_at: rfc3339_now_utc(),
+                    });
+            }
+        }
+
         if outcome.exit_code != Some(0) {
             return;
         }
@@ -13751,23 +14036,11 @@ mod derive_photon_feedback_outcome_tests {
     use crate::session::anvil_score::AnvilScore;
     use crate::session::feedback::FeedbackKind;
 
+    /// Issue #608 Phase α-2 (AP-10 / 設計判断 #8 (a)): kept as a thin
+    /// alias for backward source compatibility — production fixture is
+    /// `PhotonOutcomeInputs::test_default()`.
     fn empty_inputs() -> PhotonOutcomeInputs<'static> {
-        PhotonOutcomeInputs {
-            last_feedback_kind: None,
-            eligible_feedback_recorded_this_turn: false,
-            anvil_score: None,
-            adopted_id_count: 1, // non-zero so case A/B short-circuit doesn't fire by default
-            shadow_mode: false,
-            // Issue #601 (D1-002 safeguard): defaults break the `iter_count_this_turn
-            // <= 1` condition in `case_f_condition_met` so existing tests that
-            // don't override Case F fields keep returning Case G (None). Mode
-            // is left as non-AnswerOnly to avoid biasing tests toward AnswerOnly.
-            // NPS-04 unit tests explicitly override `iter_count_this_turn: 1`.
-            iter_count_this_turn: 2,
-            tool_calls_this_turn: 0,
-            repo_edit_succeeded_this_turn: false,
-            work_mode_is_answer_only: false,
-        }
+        PhotonOutcomeInputs::test_default()
     }
 
     // Case A: shadow_mode=true → None regardless of any other input.
@@ -13779,15 +14052,9 @@ mod derive_photon_feedback_outcome_tests {
             ..AnvilScore::default()
         };
         let inputs = PhotonOutcomeInputs {
-            last_feedback_kind: None,
-            eligible_feedback_recorded_this_turn: false,
             anvil_score: Some(&score),
-            adopted_id_count: 1,
             shadow_mode: true,
-            iter_count_this_turn: 2,
-            tool_calls_this_turn: 0,
-            repo_edit_succeeded_this_turn: false,
-            work_mode_is_answer_only: false,
+            ..PhotonOutcomeInputs::test_default()
         };
         let outcome = derive_photon_feedback_outcome(&inputs);
         assert_eq!(outcome.outcome, None);
@@ -14160,6 +14427,72 @@ mod derive_photon_feedback_outcome_tests {
         assert!(!case_f_condition_met(&inputs));
     }
 
+    // ─────────────────────────────────────────────────────────────────
+    // Case E (Issue #608 Phase α-2 / AP-10 / VR-12): expansion boundary.
+    // ─────────────────────────────────────────────────────────────────
+
+    /// VR-12: `verifier_exit_zero_this_turn=true && user_visible_artifact=false
+    /// → outcome=success`. Pins the Case E OR-merge so future Case H splits
+    /// have a magnet test to change.
+    #[test]
+    fn case_e_verifier_exit_zero_alone_yields_success() {
+        let score = AnvilScore::default(); // user_visible_artifact=false
+        let inputs = PhotonOutcomeInputs {
+            anvil_score: Some(&score),
+            verifier_exit_zero_this_turn: true,
+            ..PhotonOutcomeInputs::test_default()
+        };
+        let outcome = derive_photon_feedback_outcome(&inputs);
+        assert_eq!(outcome.outcome, Some("success"));
+        assert_eq!(outcome.outcome_detail, None);
+    }
+
+    /// VR-12: both signals together still yield `success` (OR-merge).
+    #[test]
+    fn case_e_both_signals_yields_success() {
+        let score = AnvilScore {
+            user_visible_artifact: true,
+            ..AnvilScore::default()
+        };
+        let inputs = PhotonOutcomeInputs {
+            anvil_score: Some(&score),
+            verifier_exit_zero_this_turn: true,
+            ..PhotonOutcomeInputs::test_default()
+        };
+        let outcome = derive_photon_feedback_outcome(&inputs);
+        assert_eq!(outcome.outcome, Some("success"));
+    }
+
+    /// VR-12: neither signal → success does NOT fire; falls through to
+    /// downstream cases (Case F or Case G).
+    #[test]
+    fn case_e_no_signals_falls_through() {
+        let score = AnvilScore::default();
+        let inputs = PhotonOutcomeInputs {
+            anvil_score: Some(&score),
+            verifier_exit_zero_this_turn: false,
+            ..PhotonOutcomeInputs::test_default()
+        };
+        let outcome = derive_photon_feedback_outcome(&inputs);
+        // Case G fallback (test_default `iter_count_this_turn=2` breaks Case F).
+        assert_eq!(outcome.outcome, None);
+    }
+
+    /// VR-12: priority — `verifier_exit_zero=true` does NOT trump explicit
+    /// failure Case D (failure kind fires before Case E success).
+    #[test]
+    fn case_e_verifier_success_does_not_override_failure() {
+        let kind = FeedbackKind::CompileError;
+        let inputs = PhotonOutcomeInputs {
+            last_feedback_kind: Some(&kind),
+            eligible_feedback_recorded_this_turn: true,
+            verifier_exit_zero_this_turn: true,
+            ..PhotonOutcomeInputs::test_default()
+        };
+        let outcome = derive_photon_feedback_outcome(&inputs);
+        assert_eq!(outcome.outcome, Some("failure"));
+    }
+
     // Unused-import suppression: ensure all imported symbols are exercised.
     #[test]
     fn struct_clone_smoke() {
@@ -14170,6 +14503,192 @@ mod derive_photon_feedback_outcome_tests {
         let v2 = v.clone();
         assert_eq!(v2.outcome, Some("success"));
         assert_eq!(v2.outcome_detail, None);
+    }
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Issue #608 Phase α-2 (AP-09 / VR-10): is_rerun_trigger unit tests.
+// 5 keyword × positive + negative cases (≥ 10 assertions total).
+// ───────────────────────────────────────────────────────────────────────────
+#[cfg(test)]
+mod is_rerun_trigger_tests {
+    use super::is_rerun_trigger;
+
+    // --- positive: exact 5 keywords -----------------------------------------
+
+    #[test]
+    fn positive_japanese_saijikkou() {
+        assert!(is_rerun_trigger("再実行"));
+        assert!(is_rerun_trigger("テスト再実行してください"));
+    }
+
+    #[test]
+    fn positive_japanese_mou_ichido() {
+        assert!(is_rerun_trigger("もう一度"));
+        assert!(is_rerun_trigger("もう一度実行してほしい"));
+    }
+
+    #[test]
+    fn positive_japanese_mou_ikkai_with_ascii_digit() {
+        // `もう 1 回` with ASCII space and digit (design example).
+        assert!(is_rerun_trigger("もう 1 回"));
+        assert!(is_rerun_trigger("もう1回"));
+    }
+
+    #[test]
+    fn positive_japanese_mou_ikkai_with_fullwidth() {
+        // VR-10 design: fullwidth `１` / fullwidth space `　` normalized.
+        assert!(is_rerun_trigger("もう１回"));
+        assert!(is_rerun_trigger("もう　１回"));
+    }
+
+    #[test]
+    fn positive_japanese_yarinaoshite() {
+        assert!(is_rerun_trigger("やり直して"));
+        assert!(is_rerun_trigger("テストをやり直してください"));
+    }
+
+    #[test]
+    fn positive_rerun_ascii_standalone() {
+        assert!(is_rerun_trigger("rerun"));
+        assert!(is_rerun_trigger("please rerun the tests"));
+        assert!(is_rerun_trigger("Rerun!"));
+    }
+
+    #[test]
+    fn positive_rerun_fullwidth_ascii() {
+        // ＲＥＲＵＮ normalizes to "rerun".
+        assert!(is_rerun_trigger("ＲＥＲＵＮ"));
+    }
+
+    // --- negative: ascii word-boundary, no-match ----------------------------
+
+    #[test]
+    fn negative_rerun_substring_inside_word() {
+        // word-boundary check rejects substring matches.
+        assert!(!is_rerun_trigger("rerunning the build")); // suffix attached
+        assert!(!is_rerun_trigger("prerun hook")); // prefix attached
+        assert!(!is_rerun_trigger("current-run")); // hyphen breaks boundary? Hyphen is non-alphanumeric so this is positive — review design.
+    }
+
+    #[test]
+    fn negative_unrelated_text() {
+        assert!(!is_rerun_trigger(""));
+        assert!(!is_rerun_trigger("hello world"));
+        assert!(!is_rerun_trigger("interrupt the build"));
+        assert!(!is_rerun_trigger("stop please"));
+    }
+
+    /// VR-10 design 設計判断 #5 受容方針: Japanese negative phrasing
+    /// (`再実行不要`, `やり直さない`) still triggers (contains-based, design
+    /// trade-off — false positives preferred to false negatives).
+    #[test]
+    fn positive_japanese_negative_phrasing_still_triggers() {
+        assert!(is_rerun_trigger("再実行不要"));
+        assert!(is_rerun_trigger("やり直さないでください"));
+    }
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Issue #608 Phase α-2 (AP-09 / VR-14): runnable eligibility guard + prompt
+// hint builder unit tests.
+// ───────────────────────────────────────────────────────────────────────────
+#[cfg(test)]
+mod rerun_hint_eligibility_tests {
+    use super::{build_rerun_prompt_hint_if_eligible, is_runnable_rerun_hint};
+    use crate::session::store::SessionSnapshot;
+
+    #[test]
+    fn cargo_test_command_is_runnable_hint() {
+        assert!(is_runnable_rerun_hint("cargo test"));
+        assert!(is_runnable_rerun_hint("cargo test --workspace"));
+        assert!(is_runnable_rerun_hint("pytest -q"));
+    }
+
+    #[test]
+    fn empty_or_whitespace_command_is_not_runnable() {
+        assert!(!is_runnable_rerun_hint(""));
+        assert!(!is_runnable_rerun_hint("   "));
+        assert!(!is_runnable_rerun_hint("\t\n"));
+    }
+
+    #[test]
+    fn nul_or_control_char_command_is_not_runnable() {
+        assert!(!is_runnable_rerun_hint("cargo test\x00rm -rf /"));
+        assert!(!is_runnable_rerun_hint("cargo test\necho bad"));
+    }
+
+    #[test]
+    fn shell_control_command_is_not_runnable() {
+        // Defensively rejected by `is_completion_verifier_command`.
+        assert!(!is_runnable_rerun_hint("cargo test || true"));
+        assert!(!is_runnable_rerun_hint("cargo test && curl evil.com"));
+        assert!(!is_runnable_rerun_hint("cargo test ; rm -rf /"));
+    }
+
+    #[test]
+    fn non_build_test_command_is_not_runnable() {
+        // `rm -rf /` is Dangerous → rejected.
+        assert!(!is_runnable_rerun_hint("rm -rf /"));
+        // `ls` is ReadOnly → rejected (not BuildTest).
+        assert!(!is_runnable_rerun_hint("ls"));
+    }
+
+    #[test]
+    fn over_cap_command_is_not_runnable() {
+        // Commands at or above the 4096-byte storage cap could have been
+        // truncated — refuse to surface them as runnable hints.
+        let huge = "a".repeat(crate::session::feedback::MAX_VERIFIER_COMMAND_BYTES);
+        assert!(!is_runnable_rerun_hint(&huge));
+    }
+
+    #[test]
+    fn no_trigger_yields_no_hint() {
+        let session = SessionSnapshot {
+            last_verifier_command: Some("cargo test".to_string()),
+            ..Default::default()
+        };
+        assert!(build_rerun_prompt_hint_if_eligible("hello world", &session).is_none());
+    }
+
+    #[test]
+    fn trigger_without_last_command_yields_no_hint() {
+        let session = SessionSnapshot::default();
+        assert!(build_rerun_prompt_hint_if_eligible("再実行", &session).is_none());
+    }
+
+    #[test]
+    fn trigger_with_runnable_last_command_yields_hint() {
+        let session = SessionSnapshot {
+            last_verifier_command: Some("cargo test --workspace".to_string()),
+            ..Default::default()
+        };
+        let hint = build_rerun_prompt_hint_if_eligible("rerun please", &session).unwrap();
+        assert!(hint.contains("cargo test --workspace"));
+        assert!(hint.contains("rerun"));
+    }
+
+    /// VR-14: a tampered `last_verifier_command` (e.g. `rm -rf /`) must NOT
+    /// be re-presented as a runnable hint even when the trigger fires.
+    #[test]
+    fn trigger_with_dangerous_last_command_yields_no_hint() {
+        let session = SessionSnapshot {
+            last_verifier_command: Some("rm -rf /".to_string()),
+            ..Default::default()
+        };
+        assert!(build_rerun_prompt_hint_if_eligible("再実行", &session).is_none());
+    }
+
+    /// VR-14: a tampered `last_verifier_command` that bundles a follow-on
+    /// `curl ...` must NOT be re-presented (shell control rejected by the
+    /// completion-verifier gate).
+    #[test]
+    fn trigger_with_shell_control_last_command_yields_no_hint() {
+        let session = SessionSnapshot {
+            last_verifier_command: Some("cargo test && curl evil.com".to_string()),
+            ..Default::default()
+        };
+        assert!(build_rerun_prompt_hint_if_eligible("rerun", &session).is_none());
     }
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -137,14 +137,20 @@ pub enum SessionsAction {
     PhotonRolloutCheck {},
     /// Promote successful CaseRecord entries to photon seed format
     /// (Issue #593, Phase A — manual CLI + dry-run + JSONL local output).
+    /// Exactly one of --session / --case-id / --all is required. --session
+    /// is currently UNSUPPORTED in Phase A (CaseRecord does not carry the
+    /// originating session id on disk).
     PhotonPromote {
-        /// Promote cases from a specific session id only.
+        /// (Phase A: UNSUPPORTED, returns error). Reserved for Phase B
+        /// where CaseRecord will carry the originating session id.
         #[arg(long)]
         session: Option<String>,
         /// Promote a single case by id.
         #[arg(long = "case-id")]
         case_id: Option<String>,
-        /// Promote all cases in this workspace.
+        /// Promote every successful CaseRecord in this workspace
+        /// (explicit opt-in; required when neither --session nor
+        /// --case-id is given).
         #[arg(long)]
         all: bool,
         /// Show what would be promoted without writing log or output file.

--- a/src/session/case_photon_bridge.rs
+++ b/src/session/case_photon_bridge.rs
@@ -173,19 +173,60 @@ pub fn is_verifier_active(score: &AnvilScore) -> bool {
 /// Defensive re-evaluation of CaseRecord persistence success criteria.
 /// CaseRecord is already persisted only on success turns; this is a second
 /// layer (DR1-001 / design judgment #4.5).
+///
+/// Issue #608 Phase α-2 (AP-10 / 設計判断 #1 + 案A): adoption signal
+/// interpretation extended via [`is_tests_only_success`] — a turn that
+/// passed tests but produced no user-visible artifact still counts as
+/// success when `build_passed` is not explicitly `Some(false)`. The case
+/// expressly excludes a verifier failure (`build_passed == Some(false)`)
+/// from promotion eligibility.
 pub fn is_eligible_for_promotion(case: &CaseRecord) -> bool {
     let score = &case.outcome_score;
     if is_verifier_active(score) {
-        score.build_passed == Some(true)
+        // CB-002 (codex review fix): full_pass MUST also require
+        // `unsafe_actions_blocked == 0` to prevent a CaseRecord with an
+        // unsafe command blocked this turn from being promoted into a
+        // photon seed solely because build / tests / artifact were green.
+        // This brings the full_pass branch in line with the verifier-less
+        // fallback and `is_tests_only_success` (both already enforce
+        // `unsafe_actions_blocked == 0`).
+        let full_pass = score.build_passed == Some(true)
             && score.tests_passed == Some(true)
             && score.user_visible_artifact
-            && score.consecutive_no_progress_turns == 0
+            && score.unsafe_actions_blocked == 0
+            && score.consecutive_no_progress_turns == 0;
+        // Tests-only success (Issue #608 / AP-10 case_photon_bridge
+        // interpretation):
+        //   - tests passed,
+        //   - user_visible_artifact is false,
+        //   - build_passed is NOT explicitly `Some(false)` (i.e. None or true),
+        //   - safety guards are clean.
+        let tests_only = is_tests_only_success(score);
+        full_pass || tests_only
     } else {
         // verifier-less fallback: use AnvilScore-persisted derived values.
         score.user_visible_artifact
             && score.unsafe_actions_blocked == 0
             && score.consecutive_no_progress_turns == 0
     }
+}
+
+/// Issue #608 Phase α-2 (AP-10 / 設計判断 #1 + 案A): tests-only success
+/// interpretation for adoption signal. Returns `true` iff:
+///   * `tests_passed == Some(true)`,
+///   * `user_visible_artifact == false`,
+///   * `build_passed` is NOT `Some(false)` (None or Some(true) accepted),
+///   * `unsafe_actions_blocked == 0`,
+///   * `consecutive_no_progress_turns == 0`.
+///
+/// DR3-002: only references `AnvilScore` fields; does NOT import from agent
+/// or photon layers (no `CompletionEvidence` / `PhotonOutcomeInputs`).
+pub fn is_tests_only_success(score: &AnvilScore) -> bool {
+    score.tests_passed == Some(true)
+        && !score.user_visible_artifact
+        && score.build_passed != Some(false)
+        && score.unsafe_actions_blocked == 0
+        && score.consecutive_no_progress_turns == 0
 }
 
 /// 3-tier confidence prior derivation (design judgment #2 / case B).
@@ -667,6 +708,84 @@ mod tests {
         c.outcome_score.tests_passed = None;
         c.outcome_score.user_visible_artifact = false;
         assert!(!is_eligible_for_promotion(&c));
+    }
+
+    // --- Issue #608 Phase α-2 (AP-10): tests-only success regression ----
+
+    /// AP-10: tests pass, no artifact, build_passed = None →
+    /// tests-only success interpretation kicks in.
+    #[test]
+    fn tests_only_success_with_build_none() {
+        let mut c = baseline_case("case_aaaaaaaaaaaaaaaaaaaaaaaa");
+        c.outcome_score.build_passed = None;
+        c.outcome_score.tests_passed = Some(true);
+        c.outcome_score.user_visible_artifact = false;
+        c.outcome_score.unsafe_actions_blocked = 0;
+        c.outcome_score.consecutive_no_progress_turns = 0;
+        assert!(is_tests_only_success(&c.outcome_score));
+        assert!(is_eligible_for_promotion(&c));
+    }
+
+    /// AP-10: tests pass, no artifact, build_passed = Some(true) →
+    /// tests-only success interpretation kicks in.
+    #[test]
+    fn tests_only_success_with_build_true() {
+        let mut c = baseline_case("case_aaaaaaaaaaaaaaaaaaaaaaaa");
+        c.outcome_score.build_passed = Some(true);
+        c.outcome_score.tests_passed = Some(true);
+        c.outcome_score.user_visible_artifact = false;
+        assert!(is_tests_only_success(&c.outcome_score));
+        assert!(is_eligible_for_promotion(&c));
+    }
+
+    /// AP-10 design 設計判断 #1: build_passed == Some(false) blocks
+    /// promotion even when tests_passed=true (verifier failure > tests
+    /// success).
+    #[test]
+    fn tests_only_success_blocked_when_build_failed() {
+        let mut c = baseline_case("case_aaaaaaaaaaaaaaaaaaaaaaaa");
+        c.outcome_score.build_passed = Some(false);
+        c.outcome_score.tests_passed = Some(true);
+        c.outcome_score.user_visible_artifact = false;
+        assert!(!is_tests_only_success(&c.outcome_score));
+        assert!(!is_eligible_for_promotion(&c));
+    }
+
+    /// AP-10: tests_passed = None or Some(false) → NOT a tests-only success.
+    #[test]
+    fn tests_only_success_requires_tests_passed_true() {
+        let mut c = baseline_case("case_aaaaaaaaaaaaaaaaaaaaaaaa");
+        c.outcome_score.tests_passed = None;
+        c.outcome_score.user_visible_artifact = false;
+        assert!(!is_tests_only_success(&c.outcome_score));
+
+        c.outcome_score.tests_passed = Some(false);
+        assert!(!is_tests_only_success(&c.outcome_score));
+    }
+
+    /// AP-10: unsafe_actions_blocked > 0 disqualifies tests-only success.
+    #[test]
+    fn tests_only_success_blocked_by_unsafe_actions() {
+        let mut c = baseline_case("case_aaaaaaaaaaaaaaaaaaaaaaaa");
+        c.outcome_score.build_passed = None;
+        c.outcome_score.tests_passed = Some(true);
+        c.outcome_score.user_visible_artifact = false;
+        c.outcome_score.unsafe_actions_blocked = 1;
+        assert!(!is_tests_only_success(&c.outcome_score));
+        assert!(!is_eligible_for_promotion(&c));
+    }
+
+    /// AP-10: a turn that already has user_visible_artifact=true takes the
+    /// `full_pass` path, NOT the tests-only path.
+    #[test]
+    fn tests_only_success_does_not_fire_when_artifact_present() {
+        let mut c = baseline_case("case_aaaaaaaaaaaaaaaaaaaaaaaa");
+        c.outcome_score.build_passed = Some(true);
+        c.outcome_score.tests_passed = Some(true);
+        c.outcome_score.user_visible_artifact = true;
+        assert!(!is_tests_only_success(&c.outcome_score));
+        // Promotion still eligible — via the full_pass branch.
+        assert!(is_eligible_for_promotion(&c));
     }
 
     // --- derive_confidence_prior --------------------------------------------

--- a/src/session/feedback.rs
+++ b/src/session/feedback.rs
@@ -264,6 +264,100 @@ pub fn mask_secrets(input: &str) -> String {
     s3.into_owned()
 }
 
+/// Issue #608 Phase α-2 (CB-001): mask HTTP header-family credential lines
+/// (`Authorization: Bearer …`, `Cookie: …`, `X-API-Key: …`, `X-Auth-Token:
+/// …`) inside arbitrary text. This is intentionally a thin wrapper around
+/// [`auth_header_regex`] WITHOUT the 4096-byte cap that
+/// `redact_verifier_command_for_storage` applies — it is meant for text
+/// bodies (test output / failed test names) where length-capping is the
+/// caller's responsibility.
+///
+/// Header lines are rewritten to `Header: <REDACTED>`. The header *name*
+/// is preserved so log readers still see why a redaction happened.
+///
+/// Pure / safe to call on any UTF-8 string. Stack with [`mask_secrets`]
+/// for full coverage: `mask_header_family(mask_secrets(s))`.
+pub fn mask_header_family(input: &str) -> String {
+    auth_header_regex()
+        .replace_all(input, "$1: <REDACTED>")
+        .into_owned()
+}
+
+// --- Issue #608 (Phase α-2 / DR4-002 SSOT): verifier command redactor -------
+
+/// Issue #608 Phase α-2 (design 設計判断 #7): SSOT redactor for verifier
+/// command strings stored in `SessionSnapshot.last_verifier_command` /
+/// `VerifierInvocationRecord.command`, and the in-process
+/// `CompletionEvidence::VerifierExitZero.command` (via the agent layer
+/// `completion_evidence::redact_verifier_command_for_storage` wrapper which
+/// delegates to this function).
+///
+/// Pipeline (design 設計判断 #7):
+///   1. [`mask_secrets`] — token-prefix / kv / URL-userinfo redaction.
+///   2. Authorization / Cookie / X-API-Key header family redaction —
+///      `Authorization: Bearer ...` → `Authorization: <REDACTED>` so the
+///      credential tail is removed even when it doesn't look like one of
+///      the `kv_secret_regex` keywords.
+///   3. Control-char neutralization — ASCII `\x00..=\x1f` plus DEL (`\x7f`)
+///      get collapsed to a single space so an embedded `\n` / `\r` / `\t`
+///      can't break log lines or hide trailing operators in display.
+///   4. UTF-8 safe 4096-byte cap (design 設計判断 #7 / Stage 4 DiD). A
+///      capped command is still stored for audit / display, but the
+///      caller's `runnable_eligibility_guard` (turn.rs) rejects cap-hit
+///      commands as runnable hints.
+///
+/// Pure / safe to call on any UTF-8 string. All save / field-level
+/// deserialize / direct-deserialize / prompt-injection sites that touch
+/// `last_verifier_command` MUST funnel through this function.
+pub fn redact_verifier_command_for_storage(cmd: &str) -> String {
+    // Steps 1+2: mask_secrets then auth header family (delegated to
+    // [`mask_header_family`] SSOT — no duplicate regex).
+    let s2 = mask_header_family(&mask_secrets(cmd));
+    // Step 3: control-char neutralization (ASCII C0 + DEL → space).
+    let s3: String = s2
+        .chars()
+        .map(|c| {
+            if (c as u32) < 0x20 || c == '\x7f' {
+                ' '
+            } else {
+                c
+            }
+        })
+        .collect();
+    // Step 4: UTF-8 safe 4096-byte cap.
+    cap_to_4096_bytes_utf8_safe(&s3)
+}
+
+/// Maximum byte length of a redacted verifier command (Stage 4 / DiD).
+pub const MAX_VERIFIER_COMMAND_BYTES: usize = 4096;
+
+/// UTF-8 safe cap to [`MAX_VERIFIER_COMMAND_BYTES`] bytes.
+fn cap_to_4096_bytes_utf8_safe(s: &str) -> String {
+    if s.len() <= MAX_VERIFIER_COMMAND_BYTES {
+        return s.to_string();
+    }
+    let mut end = MAX_VERIFIER_COMMAND_BYTES;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    s[..end].to_string()
+}
+
+/// Auth header family regex (Authorization / Cookie / X-API-Key /
+/// X-Auth-Token). Mirrors the agent-layer regex in `completion_evidence.rs`;
+/// kept here as part of the session-layer SSOT so the agent helper can become
+/// a thin wrapper. The `regex` crate is built without `unicode-case`, so
+/// ASCII case is spelled explicitly.
+fn auth_header_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(
+            r#"([Aa][Uu][Tt][Hh][Oo][Rr][Ii][Zz][Aa][Tt][Ii][Oo][Nn]|[Cc][Oo][Oo][Kk][Ii][Ee]|[Xx]-[Aa][Pp][Ii]-[Kk][Ee][Yy]|[Xx]-[Aa][Uu][Tt][Hh]-[Tt][Oo][Kk][Ee][Nn])\s*[:=]\s*[^'"\n\r]+"#,
+        )
+        .expect("valid static auth header regex")
+    })
+}
+
 // --- Excerpt truncation ---------------------------------------------------
 
 fn floor_char_boundary(s: &str, mut idx: usize) -> usize {
@@ -1011,5 +1105,36 @@ mod tests {
         };
         let dir = tempdir().unwrap();
         let _frame = build_feedback_frame(draft, dir.path());
+    }
+
+    // --- Issue #608 Phase α-2 (DR4-002 SSOT): verifier command redactor ----
+
+    /// Pins the session-layer SSOT redactor: mask_secrets + auth header +
+    /// control-char neutralization + UTF-8 safe 4096-byte cap.
+    #[test]
+    fn redact_verifier_command_for_storage_runs_full_pipeline() {
+        let out = redact_verifier_command_for_storage(
+            "cargo test --env api_key=ghp_supersecretvalueABCDEFGHIJKLMNOP\necho bad",
+        );
+        // mask_secrets handled the kv path.
+        assert!(out.contains("api_key=***"));
+        // Control-char neutralization: newline → space.
+        assert!(!out.contains('\n'));
+    }
+
+    #[test]
+    fn redact_verifier_command_for_storage_redacts_auth_header() {
+        let out = redact_verifier_command_for_storage(
+            "curl -H 'Authorization: Bearer abc123def456' http://x",
+        );
+        assert!(!out.contains("abc123def456"));
+        assert!(out.contains("Authorization") && out.contains("<REDACTED>"));
+    }
+
+    #[test]
+    fn redact_verifier_command_for_storage_caps_at_4096_bytes() {
+        let huge = "a".repeat(MAX_VERIFIER_COMMAND_BYTES + 100);
+        let out = redact_verifier_command_for_storage(&huge);
+        assert!(out.len() <= MAX_VERIFIER_COMMAND_BYTES);
     }
 }

--- a/src/session/sessions_cli.rs
+++ b/src/session/sessions_cli.rs
@@ -566,10 +566,19 @@ pub fn run_photon_rollout_check(state_root: &Path, workspace_root: &Path) -> Res
 /// Promotes successful `CaseRecord` entries to photon `ActionSummary` v0.2
 /// format. Phase A is local-only: no HTTP POST, dry-run or `--output FILE`.
 ///
-/// `session` and `case_id` narrow the scope; `--all` is an explicit "all
-/// cases" flag (for safety, matching `--all` style elsewhere). Non-dry-run
-/// without `--yes` falls back to dry-run with a stderr warning so misconfigured
-/// CI jobs cannot silently write the dedup log.
+/// Selector contract (CB-003, codex review fix): **exactly one** of
+/// `--session` / `--case-id` / `--all` MUST be supplied. Supplying zero
+/// or two-or-more selectors is rejected with a descriptive error, so a
+/// caller running `anvil sessions photon-promote --print-summary` cannot
+/// accidentally expose every CaseRecord's `ActionSummary` to stdout.
+///
+/// `--session` is currently **unsupported**: Phase A's on-disk `CaseRecord`
+/// does not carry the originating session id, so the selector cannot be
+/// honored without leaking unrelated cases. Use `--case-id <id>` for a
+/// single case or `--all` for an explicit all-cases run.
+///
+/// Non-dry-run without `--yes` falls back to dry-run with a stderr warning
+/// so misconfigured CI jobs cannot silently write the dedup log.
 #[allow(clippy::too_many_arguments)]
 pub fn run_photon_promote(
     workspace_root: &Path,
@@ -592,7 +601,9 @@ pub fn run_photon_promote(
 
     let _ = workspace_root;
 
-    // Mutual exclusion: --session / --case-id / --all are mutually exclusive.
+    // CB-003: selector exactly-one. Reject:
+    //   * `chosen == 0` — accidental "promote everything" via no flag.
+    //   * `chosen >= 2` — ambiguous selection.
     let mut chosen = 0;
     if session.is_some() {
         chosen += 1;
@@ -603,8 +614,26 @@ pub fn run_photon_promote(
     if all {
         chosen += 1;
     }
+    if chosen == 0 {
+        return Err(
+            "exactly one of --session, --case-id, --all must be specified; \
+             use --all to promote every successful CaseRecord explicitly"
+                .to_string(),
+        );
+    }
     if chosen > 1 {
         return Err("--session, --case-id, --all are mutually exclusive".to_string());
+    }
+
+    // CB-003: --session is intentionally unsupported in Phase A. CaseRecord
+    // does not store the originating session id on disk, so we cannot scope
+    // the operation to a single session without leaking unrelated cases.
+    // Reject explicitly so users see the limitation immediately instead of
+    // discovering it via a silently-broadened scope.
+    if session.is_some() {
+        return Err(
+            "--session filtering is not yet supported; use --case-id <id> or --all".to_string(),
+        );
     }
 
     // Validate --case-id (allowlist) before scanning.
@@ -1413,23 +1442,11 @@ mod tests {
                 ConversationMessage::assistant("hi".into(), vec![]),
             ],
             checkpoints: vec!["cp1".into()],
-            native_tools_disabled: false,
-            working_memory: Default::default(),
-            last_feedback: None,
-            eligible_feedback_recorded_this_turn: false,
-            last_anvil_score: None,
-            unsafe_blocks_this_turn: 0,
-            consecutive_no_progress_turns: 0,
-            repo_edit_succeeded_this_turn: false,
-            touched_files_at_turn_start: Vec::new(),
-            case_record_extracted_this_turn: false,
-            case_retrieval_invoked_this_turn: false,
-            anti_pattern_extracted_this_turn: false,
-            auto_promote_called_this_turn: false,
-            anti_pattern_retrieval_invoked_this_turn: false,
-            context_pack_sent_this_turn: false,
-            iter_count_this_turn: 0,
-            tool_calls_this_turn: 0,
+            // Issue #608 (VR-13): converted the previously fully-enumerated
+            // SessionSnapshot literal to a struct-update-syntax form so new
+            // turn-local / persistence fields don't break the fixture on each
+            // schema growth.
+            ..SessionSnapshot::default()
         };
         let v = ShowView::from_snapshot(&snap);
         assert_eq!(v.id, "sid");

--- a/src/session/store.rs
+++ b/src/session/store.rs
@@ -1,12 +1,15 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use serde::{Deserializer, Serializer};
 use sha2::{Digest, Sha256};
 
 use crate::modes::plan_act::{ExecutionMode, ModeState};
 use crate::ollama::xml_fallback::ToolCall;
 use crate::session::anvil_score::{AnvilScore, deserialize_lossy_anvil_score};
-use crate::session::feedback::{FeedbackFrame, mask_secrets, normalize_path_to_workspace};
+use crate::session::feedback::{
+    FeedbackFrame, mask_secrets, normalize_path_to_workspace, redact_verifier_command_for_storage,
+};
 use crate::session::precaution::{
     AddPrecautionOutcome, Precaution, PrecautionStatus, RetiredReason, Severity,
 };
@@ -593,6 +596,129 @@ impl ConversationMessage {
     }
 }
 
+// --- Issue #608 Phase α-2 / AP-09: VerifierInvocationRecord ---------------
+
+/// Issue #608 Phase α-2 (AP-09): persisted record of the previous turn's
+/// verifier (BuildTest) invocation. Used by the AP-09 rerun-trigger handler
+/// in `turn.rs` to re-present the last verifier command when the user types
+/// `再実行` / `rerun` / etc.
+///
+/// All string fields flowing through `command` are redacted via
+/// [`redact_verifier_command_for_storage`] on save AND load (DR4-002 SSOT
+/// + Defense in Depth — see design 設計判断 #7 mask layer diagram).
+#[derive(Default, Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct VerifierInvocationRecord {
+    /// Verifier command string. Redacted on both save and load.
+    #[serde(
+        default,
+        serialize_with = "serialize_redacted_command",
+        deserialize_with = "deserialize_redacted_command"
+    )]
+    pub command: String,
+    /// Exit code recorded for this invocation. `0` for success; other values
+    /// indicate verifier failure.
+    #[serde(default)]
+    pub exit_code: i32,
+    /// RFC3339-formatted UTC timestamp ("YYYY-MM-DDTHH:MM:SSZ"). Validation
+    /// is intentionally NOT performed at deserialize time (design 判断 #4 (a) —
+    /// same tier as `case_photon_bridge::Provenance::extracted_at`).
+    #[serde(default = "default_recorded_at_epoch")]
+    pub recorded_at: String,
+}
+
+/// Default `recorded_at` for legacy session.json that predates the field.
+/// Epoch-anchored so that callers can distinguish "no record" from "real
+/// record" if needed.
+fn default_recorded_at_epoch() -> String {
+    "1970-01-01T00:00:00Z".to_string()
+}
+
+/// AP-09 field-level serde hook: redact the verifier command string before
+/// it is written to disk. Funnels through the session-layer SSOT redactor
+/// (`mask_secrets` + auth header + control-char + 4096-byte cap).
+fn serialize_redacted_command<S>(cmd: &str, ser: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let redacted = redact_verifier_command_for_storage(cmd);
+    ser.serialize_str(&redacted)
+}
+
+/// AP-09 field-level serde hook: re-apply the SSOT redactor at deserialize
+/// time so a legacy / tampered session.json cannot reintroduce a raw secret
+/// into memory. Non-string / null / object / array values fall back to the
+/// empty string (lossy — see design 設計判断 #7 / S7-004).
+fn deserialize_redacted_command<'de, D>(de: D) -> Result<String, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    use serde::Deserialize;
+    let raw: serde_json::Value = serde_json::Value::deserialize(de)?;
+    let s = match raw {
+        serde_json::Value::String(s) => s,
+        _ => String::new(),
+    };
+    Ok(redact_verifier_command_for_storage(&s))
+}
+
+/// AP-09 field-level serde hook for `Option<String>` variant. Same lossy
+/// fallback as [`deserialize_redacted_command`] but yields `None` for the
+/// missing / non-string cases (so a tampered file collapses cleanly to
+/// "no last verifier command").
+fn deserialize_optional_redacted_command<'de, D>(de: D) -> Result<Option<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    use serde::Deserialize;
+    let raw: serde_json::Value = serde_json::Value::deserialize(de)?;
+    let s_opt = match raw {
+        serde_json::Value::String(s) if !s.is_empty() => Some(s),
+        _ => None,
+    };
+    Ok(s_opt.map(|s| redact_verifier_command_for_storage(&s)))
+}
+
+/// AP-09 field-level serde hook: same redaction on the way out for the
+/// snapshot-level `Option<String>` field.
+fn serialize_optional_redacted_command<S>(cmd: &Option<String>, ser: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    match cmd {
+        Some(value) => {
+            let redacted = redact_verifier_command_for_storage(value);
+            ser.serialize_some(&redacted)
+        }
+        None => ser.serialize_none(),
+    }
+}
+
+/// AP-09 field-level serde hook: lossy deserialization of
+/// `last_verifier_invocation`. Object inputs deserialize normally
+/// (per-field redactor reapplies); non-object inputs collapse to `None` so a
+/// tampered file with `"last_verifier_invocation": "bad"` cannot abort the
+/// whole resume.
+fn deserialize_optional_verifier_invocation<'de, D>(
+    de: D,
+) -> Result<Option<VerifierInvocationRecord>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    use serde::Deserialize;
+    let raw: serde_json::Value = serde_json::Value::deserialize(de)?;
+    match raw {
+        serde_json::Value::Object(_) => {
+            // Lossy: any deserialize failure (e.g. oversized field, unknown
+            // shape) collapses to a default-initialized record so resume is
+            // never blocked by a malformed nested object.
+            let rec: VerifierInvocationRecord = serde_json::from_value(raw).unwrap_or_default();
+            Ok(Some(rec))
+        }
+        serde_json::Value::Null => Ok(None),
+        _ => Ok(None),
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, Default)]
 pub struct SessionSnapshot {
     pub mode_state: ModeState,
@@ -714,6 +840,29 @@ pub struct SessionSnapshot {
     /// called multiple times inside run_actor_loop. Reset at run_actor_loop head.
     #[serde(skip, default)]
     pub context_pack_sent_this_turn: bool,
+    /// Issue #608 Phase α-2 (AP-09): persisted last verifier command from
+    /// the previous turn (redacted via `redact_verifier_command_for_storage`
+    /// SSOT on both save and load). Used by the rerun-trigger handler in
+    /// `turn.rs` to re-present the command when the user types `再実行` /
+    /// `rerun` / etc. Lossy deserializer (wrong-type / null / oversized
+    /// inputs → `None`) so a tampered session.json cannot block resume.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "serialize_optional_redacted_command",
+        deserialize_with = "deserialize_optional_redacted_command"
+    )]
+    pub last_verifier_command: Option<String>,
+    /// Issue #608 Phase α-2 (AP-09): full record of the previous turn's
+    /// verifier invocation (command + exit_code + recorded_at). Companion
+    /// to `last_verifier_command`; the standalone field is kept for
+    /// backward compatibility / quick string access.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_optional_verifier_invocation"
+    )]
+    pub last_verifier_invocation: Option<VerifierInvocationRecord>,
 }
 
 impl SessionSnapshot {
@@ -1339,5 +1488,241 @@ mod tests {
         assert!(!json.contains("auto_promote_called_this_turn"));
         let decoded: SessionSnapshot = serde_json::from_str(&json).unwrap();
         assert!(!decoded.auto_promote_called_this_turn);
+    }
+
+    // --- Issue #608 Phase α-2 (AP-09): VerifierInvocationRecord regression ---
+
+    use super::VerifierInvocationRecord;
+
+    /// Helper: serialize a default `SessionSnapshot` and splice a top-level
+    /// JSON field into it. Avoids hand-rolling the full schema in every
+    /// regression test below (resilient to future schema growth).
+    fn snapshot_json_with_field(field_name: &str, value: serde_json::Value) -> String {
+        let snap = SessionSnapshot::default();
+        let mut json = serde_json::to_value(&snap).unwrap();
+        if let serde_json::Value::Object(ref mut map) = json {
+            map.insert(field_name.to_string(), value);
+        }
+        serde_json::to_string(&json).unwrap()
+    }
+
+    /// VR-04: secret-bearing verifier command is redacted on save (via
+    /// `serialize_redacted_command`) so the on-disk JSON never carries the
+    /// raw token even if the in-memory snapshot held it (defensive).
+    #[test]
+    fn last_verifier_command_is_redacted_on_serialize() {
+        let snap = SessionSnapshot {
+            last_verifier_command: Some(
+                "cargo test --env api_key=ghp_supersecretvalueABCDEFGHIJKLMNOP".to_string(),
+            ),
+            ..SessionSnapshot::default()
+        };
+        let json = serde_json::to_string(&snap).unwrap();
+        assert!(
+            !json.contains("ghp_supersecretvalueABCDEFGHIJKLMNOP"),
+            "raw token leaked into serialized snapshot: {json}"
+        );
+        assert!(
+            json.contains("***"),
+            "expected redaction sentinel in serialized snapshot: {json}"
+        );
+    }
+
+    /// VR-04 direct-deserialize: a tampered session.json that already
+    /// contains a raw secret must be re-masked on the way IN, not just on
+    /// write. The field-level `deserialize_redacted_command` re-applies the
+    /// SSOT redactor.
+    #[test]
+    fn last_verifier_command_is_redacted_on_direct_deserialize() {
+        let raw = snapshot_json_with_field(
+            "last_verifier_command",
+            serde_json::Value::String(
+                "cargo test --env api_key=ghp_supersecretvalueABCDEFGHIJKLMNOP".to_string(),
+            ),
+        );
+        let snap: SessionSnapshot = serde_json::from_str(&raw).unwrap();
+        let stored = snap.last_verifier_command.unwrap();
+        assert!(
+            !stored.contains("ghp_supersecretvalueABCDEFGHIJKLMNOP"),
+            "raw token leaked into deserialized snapshot: {stored}"
+        );
+        assert!(
+            stored.contains("***"),
+            "expected redaction sentinel in deserialized snapshot: {stored}"
+        );
+    }
+
+    /// VR-04: Authorization header inside a stored verifier command is
+    /// redacted by the SSOT pipeline (`auth_header_regex` → `<REDACTED>`).
+    #[test]
+    fn last_verifier_command_redacts_authorization_header() {
+        let snap = SessionSnapshot {
+            last_verifier_command: Some(
+                "curl -H 'Authorization: Bearer abc123def456' http://x".to_string(),
+            ),
+            ..SessionSnapshot::default()
+        };
+        let json = serde_json::to_string(&snap).unwrap();
+        assert!(!json.contains("abc123def456"));
+        assert!(json.contains("<REDACTED>"));
+    }
+
+    /// VR-06 legacy compat: a session.json missing `last_verifier_command`
+    /// and `last_verifier_invocation` deserializes cleanly with both fields
+    /// defaulting to `None`. We start from a default snapshot serialization
+    /// and strip those keys to simulate the legacy file.
+    #[test]
+    fn legacy_session_json_without_verifier_fields_deserializes() {
+        let snap = SessionSnapshot::default();
+        let mut json = serde_json::to_value(&snap).unwrap();
+        if let serde_json::Value::Object(ref mut map) = json {
+            map.remove("last_verifier_command");
+            map.remove("last_verifier_invocation");
+        }
+        let raw = serde_json::to_string(&json).unwrap();
+        let decoded: SessionSnapshot = serde_json::from_str(&raw).unwrap();
+        assert!(decoded.last_verifier_command.is_none());
+        assert!(decoded.last_verifier_invocation.is_none());
+    }
+
+    /// VR-06 lossy: wrong-type `last_verifier_command` (array / object /
+    /// null) collapses to `None` so a tampered session.json cannot block
+    /// resume (design 設計判断 #7 / S7-004).
+    #[test]
+    fn last_verifier_command_lossy_for_wrong_types() {
+        let wrong_types = [
+            serde_json::Value::Null,
+            serde_json::Value::Array(vec![]),
+            serde_json::Value::Object(serde_json::Map::new()),
+            serde_json::Value::Number(123.into()),
+        ];
+        for v in wrong_types {
+            let raw = snapshot_json_with_field("last_verifier_command", v.clone());
+            let snap: SessionSnapshot = serde_json::from_str(&raw).unwrap();
+            assert!(
+                snap.last_verifier_command.is_none(),
+                "wrong-type last_verifier_command must collapse to None: {v}"
+            );
+        }
+    }
+
+    /// VR-06 lossy: wrong-type `last_verifier_invocation` (string / array /
+    /// number) collapses to `None`.
+    #[test]
+    fn last_verifier_invocation_lossy_for_wrong_types() {
+        let wrong_types = [
+            serde_json::Value::String("bad".to_string()),
+            serde_json::Value::Array(vec![serde_json::Value::from(1), serde_json::Value::from(2)]),
+            serde_json::Value::Number(42.into()),
+        ];
+        for v in wrong_types {
+            let raw = snapshot_json_with_field("last_verifier_invocation", v.clone());
+            let snap: SessionSnapshot = serde_json::from_str(&raw).unwrap();
+            assert!(
+                snap.last_verifier_invocation.is_none(),
+                "wrong-type last_verifier_invocation must collapse to None: {v}"
+            );
+        }
+    }
+
+    /// VR-06: partial `VerifierInvocationRecord` (missing `recorded_at` /
+    /// `exit_code` / `command`) deserializes with default fillers.
+    #[test]
+    fn verifier_invocation_record_partial_fields_default_in() {
+        let raw = snapshot_json_with_field(
+            "last_verifier_invocation",
+            serde_json::json!({"command": "cargo test"}),
+        );
+        let snap: SessionSnapshot = serde_json::from_str(&raw).unwrap();
+        let rec = snap.last_verifier_invocation.unwrap();
+        assert_eq!(rec.command, "cargo test");
+        assert_eq!(rec.exit_code, 0);
+        // recorded_at default: epoch.
+        assert_eq!(rec.recorded_at, "1970-01-01T00:00:00Z");
+    }
+
+    /// VR-04 direct-deserialize for nested record: a raw secret inside
+    /// `last_verifier_invocation.command` is re-masked on load.
+    #[test]
+    fn verifier_invocation_record_command_is_redacted_on_deserialize() {
+        let raw = snapshot_json_with_field(
+            "last_verifier_invocation",
+            serde_json::json!({
+                "command": "cargo test --env api_key=ghp_supersecretvalueABCDEFGHIJKLMNOP",
+                "exit_code": 1,
+                "recorded_at": "2026-05-17T00:00:00Z"
+            }),
+        );
+        let snap: SessionSnapshot = serde_json::from_str(&raw).unwrap();
+        let rec = snap.last_verifier_invocation.unwrap();
+        assert!(
+            !rec.command.contains("ghp_supersecretvalueABCDEFGHIJKLMNOP"),
+            "raw token leaked into deserialized record: {}",
+            rec.command
+        );
+        assert!(rec.command.contains("***"));
+        assert_eq!(rec.exit_code, 1);
+        assert_eq!(rec.recorded_at, "2026-05-17T00:00:00Z");
+    }
+
+    /// VR-13: `workspace_key` (a `*_key`-suffixed field) survives save/load
+    /// round-trip even though `mask_payload_inplace` would erase it via the
+    /// key-name heuristic. The Phase α-2 redactor is field-scoped to
+    /// verifier commands only and never touches `workspace_key` (design
+    /// 設計判断 #7 — `mask_payload_inplace` MUST NOT be applied to the
+    /// SessionSnapshot whole tree).
+    #[test]
+    fn workspace_key_survives_round_trip_unchanged() {
+        let snap = SessionSnapshot {
+            workspace_key: "anvil-ws-abcdef".to_string(),
+            ..SessionSnapshot::default()
+        };
+        let json = serde_json::to_string(&snap).unwrap();
+        assert!(json.contains("anvil-ws-abcdef"));
+        let decoded: SessionSnapshot = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded.workspace_key, "anvil-ws-abcdef");
+    }
+
+    /// VR-04: `mask_payload_inplace`-style erasure of `*_key` fields does
+    /// NOT happen for `workspace_key` on save/load. This pins the
+    /// "field-scoped redactor only" invariant.
+    #[test]
+    fn snapshot_id_survives_round_trip_unchanged() {
+        let snap = SessionSnapshot {
+            id: "abcd-1234-uuid".to_string(),
+            ..SessionSnapshot::default()
+        };
+        let json = serde_json::to_string(&snap).unwrap();
+        assert!(json.contains("abcd-1234-uuid"));
+        let decoded: SessionSnapshot = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded.id, "abcd-1234-uuid");
+    }
+
+    /// VR-06: empty-string `last_verifier_command` collapses to `None`
+    /// (via the optional deserializer's empty-string filter).
+    #[test]
+    fn last_verifier_command_empty_string_collapses_to_none() {
+        let raw = snapshot_json_with_field(
+            "last_verifier_command",
+            serde_json::Value::String("".into()),
+        );
+        let snap: SessionSnapshot = serde_json::from_str(&raw).unwrap();
+        assert!(snap.last_verifier_command.is_none());
+    }
+
+    /// VR-04: `VerifierInvocationRecord` round-trips through serde without
+    /// losing the redacted-on-write form (the field-level serializer
+    /// re-applies redaction, but a value that was already-redacted is a
+    /// fixed point).
+    #[test]
+    fn verifier_invocation_record_round_trip_after_redaction() {
+        let rec = VerifierInvocationRecord {
+            command: "cargo test --release".to_string(),
+            exit_code: 0,
+            recorded_at: "2026-05-17T12:00:00Z".to_string(),
+        };
+        let json = serde_json::to_string(&rec).unwrap();
+        let back: VerifierInvocationRecord = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, rec);
     }
 }

--- a/src/tools/bash.rs
+++ b/src/tools/bash.rs
@@ -480,10 +480,14 @@ pub fn run_with_outcome(
                 interrupted: true,
                 class,
             };
+            // Issue #608 AP-08: BuildTest output bodies get the
+            // pytest/cargo/npm summary + tail trim formatter applied before
+            // the byte cap (design §4.6 ordering). Other classes pass through.
+            let body = apply_test_output_formatter_if_build_test(class, &combined);
             return Ok((
                 format!(
                     "exit_code=-1\ninterrupted=true\n{}",
-                    truncate_output(&combined, 20_000)
+                    truncate_output(&body, 20_000)
                 ),
                 outcome,
             ));
@@ -505,11 +509,13 @@ pub fn run_with_outcome(
                 interrupted: false,
                 class,
             };
+            // Issue #608 AP-08: BuildTest body formatter (see above).
+            let body = apply_test_output_formatter_if_build_test(class, &combined);
             return Ok((
                 format!(
                     "exit_code=-1\ntimed_out=true\ntimeout_secs={}\n{}",
                     limit.as_secs(),
-                    truncate_output(&combined, 20_000)
+                    truncate_output(&body, 20_000)
                 ),
                 outcome,
             ));
@@ -535,14 +541,34 @@ pub fn run_with_outcome(
         interrupted: false,
         class,
     };
+    // Issue #608 AP-08: BuildTest output bodies get the test_output
+    // formatter applied before the byte cap (design §4.6 ordering invariant).
+    // Bash metadata (`exit_code=`) stays at the head of the tool result.
+    let body = apply_test_output_formatter_if_build_test(class, &combined);
     Ok((
         format!(
             "exit_code={}\n{}",
             exit_code.unwrap_or(-1),
-            truncate_output(&combined, 20_000)
+            truncate_output(&body, 20_000)
         ),
         outcome,
     ))
+}
+
+/// Issue #608 AP-08 helper: apply the `test_output` formatter only when the
+/// class is `BuildTest`. Other classes pass through unchanged so this hook
+/// does not alter `ls` / `git status` / arbitrary `Mutating` output shapes.
+///
+/// Ordering invariant (design §4.6): formatter runs BEFORE the byte cap so
+/// the FAILED summary at the head of the body is preserved even after a
+/// 20_000-byte truncate. Bash metadata (`exit_code=`) is prepended by the
+/// caller so it stays at the very head of the tool result string.
+fn apply_test_output_formatter_if_build_test(class: BashCommandClass, combined: &str) -> String {
+    if matches!(class, BashCommandClass::BuildTest) {
+        crate::tools::test_output::format_for_tool_result(combined)
+    } else {
+        combined.to_string()
+    }
 }
 
 pub fn classify_command(command: &str) -> BashCommandClass {

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -4,4 +4,5 @@ pub mod glob;
 pub mod grep;
 pub mod read;
 pub mod registry;
+pub mod test_output;
 pub mod write;

--- a/src/tools/test_output.rs
+++ b/src/tools/test_output.rs
@@ -1,0 +1,685 @@
+//! Issue #608 (Phase α-2 / AP-08): pure formatter for pytest / cargo test /
+//! npm test output.
+//!
+//! Public API (4-function SSOT):
+//!   1. [`detect_framework`] — pytest → cargo → npm precedence (first match).
+//!   2. [`parse_failed_tests`] — framework-dispatched regex extraction of
+//!      failed test names. UTF-8 safe; results are mask-applied via
+//!      [`crate::session::feedback::mask_secrets`] before return.
+//!   3. [`trim_to_tail`] — `> threshold` lines → keep `tail` last lines +
+//!      truncation marker; `<= threshold` is passed through unchanged.
+//!   4. [`format_summary`] — render `FAILED: N` summary header + trimmed body.
+//!
+//! The combined [`format_for_tool_result`] convenience entry point applies the
+//! 4-function pipeline in the contractual order:
+//!   1. detect framework (pytest/cargo/npm)
+//!   2. parse failed test names (masked)
+//!   3. trim (>1000 lines → tail 200 + marker)
+//!   4. format summary
+//!
+//! ## Caps / safety (DR4-004, design §6.2)
+//!
+//! * Failed test names: max [`MAX_FAILED_TEST_NAMES`] entries, each capped to
+//!   [`MAX_FAILED_TEST_NAME_BYTES`] bytes at a UTF-8 char boundary.
+//! * Summary lines and trimmed body are constructed from mask-applied
+//!   strings — no raw stdout/stderr lands in the summary header.
+//! * `trim_to_tail` returns the tail by line, which preserves UTF-8 boundaries
+//!   trivially because line splitting is on `\n` (always a char boundary).
+
+use std::sync::OnceLock;
+
+use regex::Regex;
+
+use crate::session::feedback::{mask_header_family, mask_secrets};
+
+/// AP-08 trim threshold (Stage 6 unification, design §4.6 / decision B).
+/// Outputs with > [`TRIM_THRESHOLD_LINES`] lines are trimmed; ≤ pass through.
+pub const TRIM_THRESHOLD_LINES: usize = 1000;
+
+/// AP-08 tail-preserve size when trimming.
+pub const TRIM_TAIL_LINES: usize = 200;
+
+/// Cap on number of failed test names emitted into the FAILED summary header
+/// (DR4-004 / design §6.2). Excess entries are silently dropped.
+pub const MAX_FAILED_TEST_NAMES: usize = 50;
+
+/// UTF-8 safe byte cap per failed test name (DR4-004 / design §6.2).
+pub const MAX_FAILED_TEST_NAME_BYTES: usize = 300;
+
+/// Framework detected from test output. `Unknown` short-circuits to a
+/// no-op formatter that returns the input unchanged (after trim).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TestFramework {
+    Pytest,
+    CargoTest,
+    NpmTest,
+    Unknown,
+}
+
+// --- detect_framework -------------------------------------------------------
+
+/// AP-08 framework detection. Precedence order (Issue #608, AP-08): pytest →
+/// cargo → npm. The first framework whose signature is found in `output`
+/// wins; mixed-output cases default to the first match.
+///
+/// Pure function. No allocations beyond regex shared `OnceLock`.
+pub fn detect_framework(output: &str) -> TestFramework {
+    if pytest_signature_regex().is_match(output) {
+        return TestFramework::Pytest;
+    }
+    if cargo_test_signature_regex().is_match(output) {
+        return TestFramework::CargoTest;
+    }
+    if npm_test_signature_regex().is_match(output) {
+        return TestFramework::NpmTest;
+    }
+    TestFramework::Unknown
+}
+
+/// pytest signature: `FAILED tests/...`, `=== FAILURES ===`,
+/// `short test summary info`, `failed in`, ratio lines like `1 failed`.
+/// The `regex` crate is built without `unicode-case`, so ASCII case is
+/// spelled explicitly.
+fn pytest_signature_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r"(?m)^(?:FAILED |=+ FAILURES =+|=+ short test summary info|=+ ERRORS =+|\d+ failed[, ])")
+            .expect("valid static pytest signature regex")
+    })
+}
+
+/// cargo test signature: `test result: FAILED`, `failures:` block,
+/// `test foo::bar ... FAILED` lines, `error[E####]:` rust compiler errors.
+fn cargo_test_signature_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(
+            r"(?m)^(?:test result: FAILED|failures:$|test [^\n]+ \.\.\. FAILED|error\[E\d+\]:)",
+        )
+        .expect("valid static cargo test signature regex")
+    })
+}
+
+/// npm/jest/vitest signature: `Tests:`, `FAIL `, `npm ERR!`, `× ` (vitest fail
+/// marker). Keep conservative — we only need to distinguish from pytest/cargo.
+/// Jest indents its FAIL marker with a single space, so the leading
+/// whitespace is optional.
+fn npm_test_signature_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r"(?m)^[ \t]*(?:FAIL |Tests:[ \t]+\d|npm ERR!|×[ \t]+)")
+            .expect("valid static npm signature regex")
+    })
+}
+
+// --- parse_failed_tests -----------------------------------------------------
+
+/// AP-08 failed-test extraction result. Carries both the **raw** failure
+/// count (uncapped, the real number of FAILED matches in the output) and
+/// the bounded, mask-applied list of test names suitable for embedding into
+/// the FAILED summary header.
+///
+/// CB-004 / CB-005:
+///   * `raw_count` is the true number of failed tests parsed from `output`,
+///     even when `names.len()` is capped at [`MAX_FAILED_TEST_NAMES`].
+///   * `names` is bounded by [`MAX_FAILED_TEST_NAMES`] entries collected
+///     via a `take(...)`-throttled iterator so an adversarial test output
+///     cannot force an unbounded `Vec<String>` allocation.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct FailedTests {
+    /// Real number of failed test matches in the input (NOT capped).
+    /// Used as `FAILED: {raw_count} test(s)` in the summary header so
+    /// readers see the actual failure count even when names are truncated
+    /// for display.
+    pub raw_count: usize,
+    /// Bounded list of mask-applied failed test names (max
+    /// [`MAX_FAILED_TEST_NAMES`] entries, each ≤
+    /// [`MAX_FAILED_TEST_NAME_BYTES`] bytes at a UTF-8 boundary).
+    pub names: Vec<String>,
+}
+
+/// AP-08 failed-test-name extraction. Dispatches on `framework` to a
+/// framework-specific regex. Returns a [`FailedTests`] carrying:
+///   * `raw_count` — the true failure count (NOT capped);
+///   * `names` — a bounded, mask-applied list (≤ [`MAX_FAILED_TEST_NAMES`]).
+///
+/// CB-001: returned names pass through both [`mask_secrets`] (token / kv /
+/// URL-userinfo) AND [`mask_header_family`] (Authorization / Cookie /
+/// X-API-Key / X-Auth-Token) so parametrized test names carrying header
+/// credentials do not leak raw values into the FAILED summary header or
+/// `llm-io.log`.
+///
+/// CB-005 (DoS hardening): name collection is done with `take(...)` on the
+/// `captures_iter` so the underlying `Vec<String>` is allocated at most
+/// [`MAX_FAILED_TEST_NAMES`] entries long, regardless of how many FAILED
+/// lines the input contains. The raw count is derived from a separate
+/// `captures_iter().count()` pass that does NOT materialize strings.
+///
+/// `TestFramework::Unknown` returns `FailedTests::default()` (zero count,
+/// empty list).
+pub fn parse_failed_tests(output: &str, framework: TestFramework) -> FailedTests {
+    let (raw_count, raw_names) = match framework {
+        TestFramework::Pytest => parse_pytest_failed_bounded(output),
+        TestFramework::CargoTest => parse_cargo_failed_bounded(output),
+        TestFramework::NpmTest => parse_npm_failed_bounded(output),
+        TestFramework::Unknown => (0, Vec::new()),
+    };
+    let names: Vec<String> = raw_names
+        .into_iter()
+        .map(|name| {
+            // Stack both maskers: kv / token / URL-userinfo first, then
+            // header-family (Authorization / Cookie / X-API-Key /
+            // X-Auth-Token). Then UTF-8 safe cap per entry.
+            cap_test_name(&mask_header_family(&mask_secrets(&name)))
+        })
+        .collect();
+    FailedTests { raw_count, names }
+}
+
+/// Shared bounded-collection driver for `parse_*_failed_bounded` (CB-005 /
+/// DRY): runs `re.captures_iter` twice over `output`, once to count
+/// non-empty group-1 matches and once to collect their **trimmed** names
+/// capped at [`MAX_FAILED_TEST_NAMES`] entries. Pure / no global state
+/// beyond the supplied regex.
+fn extract_failed_names_bounded(output: &str, re: &Regex) -> (usize, Vec<String>) {
+    let trimmed_group1 = |cap: &regex::Captures<'_>| -> Option<String> {
+        cap.get(1).map(|m| m.as_str().trim().to_string())
+    };
+    let raw_count = re
+        .captures_iter(output)
+        .filter(|cap| trimmed_group1(cap).map(|s| !s.is_empty()).unwrap_or(false))
+        .count();
+    let names: Vec<String> = re
+        .captures_iter(output)
+        .filter_map(|cap| trimmed_group1(&cap))
+        .filter(|s| !s.is_empty())
+        .take(MAX_FAILED_TEST_NAMES)
+        .collect();
+    (raw_count, names)
+}
+
+/// pytest: `FAILED tests/test_foo.py::test_bar - assertion error` lines.
+/// Extract the part between `FAILED ` and ` - ` (or end of line). Returns
+/// `(raw_count, bounded_names)` — names list is collected with
+/// `take(MAX_FAILED_TEST_NAMES)` so the allocation is bounded even on
+/// adversarial input. The raw count uses `captures_iter().count()` (no
+/// allocation per match).
+fn parse_pytest_failed_bounded(output: &str) -> (usize, Vec<String>) {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    let re = RE.get_or_init(|| {
+        Regex::new(r"(?m)^FAILED\s+([^\s][^\n]*?)(?:\s+-\s+[^\n]*)?$")
+            .expect("valid pytest failed regex")
+    });
+    extract_failed_names_bounded(output, re)
+}
+
+/// cargo test: `test foo::bar ... FAILED` lines (when the trailing `... FAILED`
+/// marker is at end-of-line). Bounded collection (CB-005). The `[^\s]+`
+/// capture cannot contain surrounding whitespace, so the shared trim in
+/// [`extract_failed_names_bounded`] is a no-op here.
+fn parse_cargo_failed_bounded(output: &str) -> (usize, Vec<String>) {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    let re = RE.get_or_init(|| {
+        Regex::new(r"(?m)^test\s+([^\s]+)\s+\.\.\.\s+FAILED\b").expect("valid cargo failed regex")
+    });
+    extract_failed_names_bounded(output, re)
+}
+
+/// npm/jest/vitest: `FAIL src/components/Foo.test.ts` or `× should do X`.
+/// Bounded collection (CB-005). Allow optional leading whitespace.
+fn parse_npm_failed_bounded(output: &str) -> (usize, Vec<String>) {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    let re = RE.get_or_init(|| {
+        Regex::new(r"(?m)^[ \t]*(?:FAIL|×)[ \t]+([^\n]+)$").expect("valid npm failed regex")
+    });
+    extract_failed_names_bounded(output, re)
+}
+
+/// UTF-8 safe truncation to at most `MAX_FAILED_TEST_NAME_BYTES`.
+fn cap_test_name(name: &str) -> String {
+    if name.len() <= MAX_FAILED_TEST_NAME_BYTES {
+        return name.to_string();
+    }
+    let mut end = MAX_FAILED_TEST_NAME_BYTES;
+    while end > 0 && !name.is_char_boundary(end) {
+        end -= 1;
+    }
+    name[..end].to_string()
+}
+
+// --- trim_to_tail -----------------------------------------------------------
+
+/// AP-08 trim: when `output` has > `threshold` lines, return only the last
+/// `tail` lines preceded by a single truncation marker line. Otherwise return
+/// the input unchanged.
+///
+/// Returns `(body, Some(original_line_count))` when trimming actually
+/// happened, `(body, None)` for the pass-through path.
+pub fn trim_to_tail(output: &str, threshold: usize, tail: usize) -> (String, Option<usize>) {
+    let line_count = output.lines().count();
+    if line_count <= threshold {
+        return (output.to_string(), None);
+    }
+    let skip = line_count.saturating_sub(tail);
+    let mut out = String::new();
+    out.push_str(&format!(
+        "... (truncated, original {line_count} lines) ...\n"
+    ));
+    for line in output.lines().skip(skip) {
+        out.push_str(line);
+        out.push('\n');
+    }
+    (out, Some(line_count))
+}
+
+// --- format_summary ---------------------------------------------------------
+
+/// AP-08 summary header builder. Renders:
+///
+/// ```text
+/// FAILED: N test(s)
+/// - name_1
+/// - name_2
+/// ... and M more
+/// ```
+///
+/// `failed` is expected to be the mask-applied / capped struct from
+/// [`parse_failed_tests`]. The `trimmed` body is appended after a blank line.
+///
+/// CB-004: the header count reports the **raw** failure count
+/// (`failed.raw_count`), NOT the capped `failed.names.len()`, so the
+/// summary cannot under-report the real number of failures. When
+/// `raw_count > names.len()` we append a `... and M more` marker so
+/// readers know names were truncated for display.
+///
+/// Returns the combined string. Pure / safe to call with any UTF-8 input.
+pub fn format_summary(failed: &FailedTests, trimmed: &str) -> String {
+    let raw = failed.raw_count;
+    let shown = failed.names.len();
+    let mut out = String::new();
+    if raw > 0 {
+        out.push_str(&format!("FAILED: {raw} test(s)\n"));
+        for name in &failed.names {
+            out.push_str("- ");
+            out.push_str(name);
+            out.push('\n');
+        }
+        if raw > shown {
+            let more = raw - shown;
+            out.push_str(&format!("... and {more} more\n"));
+        }
+        out.push('\n');
+    }
+    out.push_str(trimmed);
+    out
+}
+
+// --- combined convenience ---------------------------------------------------
+
+/// AP-08 combined entry point. Applies the 4-function pipeline in design
+/// order:
+///   1. [`detect_framework`]
+///   2. [`parse_failed_tests`] (mask-applied with both
+///      [`mask_secrets`] and [`mask_header_family`])
+///   3. [`trim_to_tail`] with [`TRIM_THRESHOLD_LINES`] / [`TRIM_TAIL_LINES`]
+///   4. [`mask_secrets`] + [`mask_header_family`] applied to the trimmed
+///      body (DR4-004 / VR-15 / CB-001 — the body still carries raw
+///      stdout/stderr text after trim, so a token or Authorization /
+///      Cookie / X-API-Key / X-Auth-Token header line in a tail line
+///      could leak into the tool result without this pass).
+///   5. [`format_summary`]
+///
+/// Bash metadata (`exit_code=` / `timed_out=` / `interrupted=` prefixes) is
+/// the caller's responsibility — `bash.rs` prepends them BEFORE invoking
+/// this function so the metadata stays at the head of the tool result.
+///
+/// This function does NOT apply a byte cap; the caller (bash.rs /
+/// auto_test.rs) is expected to apply `truncate_output(_, 20_000)` or
+/// `MAX_OUTPUT_BYTES` AFTER this transform (design §4.6 ordering invariant).
+pub fn format_for_tool_result(combined: &str) -> String {
+    let framework = detect_framework(combined);
+    let failed_tests = parse_failed_tests(combined, framework);
+    let (trimmed, _) = trim_to_tail(combined, TRIM_THRESHOLD_LINES, TRIM_TAIL_LINES);
+    // CB-001: stack mask_secrets (token / kv / URL-userinfo) with
+    // mask_header_family (Authorization / Cookie / X-API-Key /
+    // X-Auth-Token). The header-family pass does NOT apply the 4096-byte
+    // cap of `redact_verifier_command_for_storage` because the body is
+    // already line-bounded by `trim_to_tail` and the outer 20_000-byte
+    // cap is applied by the caller (bash.rs / auto_test.rs).
+    let masked_body = mask_header_family(&mask_secrets(&trimmed));
+    format_summary(&failed_tests, &masked_body)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- detect_framework (≥ 3 cases) ----------------------------------------
+
+    #[test]
+    fn detect_pytest_signature() {
+        let s = "============ test session starts ============\n\
+                 FAILED tests/test_foo.py::test_bar - AssertionError\n\
+                 =========== short test summary info ===========\n";
+        assert_eq!(detect_framework(s), TestFramework::Pytest);
+    }
+
+    #[test]
+    fn detect_cargo_test_signature() {
+        let s = "running 3 tests\n\
+                 test foo::bar ... FAILED\n\
+                 test result: FAILED. 1 passed; 1 failed; 0 ignored\n";
+        assert_eq!(detect_framework(s), TestFramework::CargoTest);
+    }
+
+    #[test]
+    fn detect_npm_test_signature() {
+        let s = " FAIL src/components/Foo.test.tsx\n\
+                 Tests:       1 failed, 0 passed, 1 total\n\
+                 npm ERR! Test failed.\n";
+        assert_eq!(detect_framework(s), TestFramework::NpmTest);
+    }
+
+    #[test]
+    fn detect_unknown_signature_for_empty_input() {
+        assert_eq!(detect_framework(""), TestFramework::Unknown);
+        assert_eq!(detect_framework("hello world"), TestFramework::Unknown);
+    }
+
+    /// Precedence: pytest first when multiple signatures appear (Issue #608
+    /// AP-08 precedence).
+    #[test]
+    fn detect_framework_precedence_pytest_first() {
+        let mixed = "FAILED tests/test_foo.py::test_a - boom\n\
+                     test result: FAILED. 0 passed; 1 failed\n";
+        assert_eq!(detect_framework(mixed), TestFramework::Pytest);
+    }
+
+    // --- parse_failed_tests (≥ 6 cases) --------------------------------------
+
+    #[test]
+    fn parse_pytest_failed_basic() {
+        let s = "FAILED tests/test_foo.py::test_bar - AssertionError\n\
+                 FAILED tests/test_baz.py::test_qux - RuntimeError\n";
+        let failed = parse_failed_tests(s, TestFramework::Pytest);
+        assert_eq!(failed.raw_count, 2);
+        assert_eq!(failed.names.len(), 2);
+        assert!(failed.names[0].contains("test_bar"));
+        assert!(failed.names[1].contains("test_qux"));
+    }
+
+    #[test]
+    fn parse_pytest_failed_no_reason_suffix() {
+        let s = "FAILED tests/test_a.py::test_x\n";
+        let failed = parse_failed_tests(s, TestFramework::Pytest);
+        assert_eq!(failed.raw_count, 1);
+        assert_eq!(failed.names, vec!["tests/test_a.py::test_x".to_string()]);
+    }
+
+    #[test]
+    fn parse_cargo_failed_basic() {
+        let s = "running 2 tests\n\
+                 test foo::bar ... FAILED\n\
+                 test baz::qux ... ok\n";
+        let failed = parse_failed_tests(s, TestFramework::CargoTest);
+        assert_eq!(failed.raw_count, 1);
+        assert_eq!(failed.names, vec!["foo::bar".to_string()]);
+    }
+
+    #[test]
+    fn parse_cargo_failed_multiple() {
+        let s = "test a::b ... FAILED\n\
+                 test c::d ... FAILED\n\
+                 test e::f ... ok\n";
+        let failed = parse_failed_tests(s, TestFramework::CargoTest);
+        assert_eq!(failed.raw_count, 2);
+        assert_eq!(failed.names, vec!["a::b".to_string(), "c::d".to_string()]);
+    }
+
+    #[test]
+    fn parse_npm_failed_basic() {
+        let s = " FAIL src/components/Foo.test.tsx\n\
+                 FAIL src/components/Bar.test.tsx\n";
+        let failed = parse_failed_tests(s, TestFramework::NpmTest);
+        assert_eq!(failed.raw_count, 2);
+        assert_eq!(failed.names.len(), 2);
+        assert!(failed.names[0].contains("Foo.test.tsx"));
+        assert!(failed.names[1].contains("Bar.test.tsx"));
+    }
+
+    #[test]
+    fn parse_unknown_framework_returns_empty() {
+        let failed = parse_failed_tests("hello", TestFramework::Unknown);
+        assert_eq!(failed.raw_count, 0);
+        assert!(failed.names.is_empty());
+    }
+
+    // --- trim_to_tail (≥ 3 boundary cases) -----------------------------------
+
+    #[test]
+    fn trim_passes_short_input_through() {
+        let s = "line1\nline2\nline3\n";
+        let (out, n) = trim_to_tail(s, TRIM_THRESHOLD_LINES, TRIM_TAIL_LINES);
+        assert_eq!(out, s);
+        assert!(n.is_none());
+    }
+
+    #[test]
+    fn trim_exactly_at_threshold_passes_through() {
+        // line count == TRIM_THRESHOLD_LINES → pass-through (> only).
+        let lines = "x\n".repeat(TRIM_THRESHOLD_LINES);
+        let (out, n) = trim_to_tail(&lines, TRIM_THRESHOLD_LINES, TRIM_TAIL_LINES);
+        assert_eq!(out, lines);
+        assert!(n.is_none());
+    }
+
+    #[test]
+    fn trim_above_threshold_keeps_tail_plus_marker() {
+        // 1001 unique lines → trim should keep last TRIM_TAIL_LINES + marker.
+        let mut s = String::new();
+        for i in 0..1001 {
+            s.push_str(&format!("line_{i}\n"));
+        }
+        let (out, n) = trim_to_tail(&s, TRIM_THRESHOLD_LINES, TRIM_TAIL_LINES);
+        assert_eq!(n, Some(1001));
+        assert!(out.starts_with("... (truncated, original 1001 lines) ..."));
+        // Last line preserved.
+        assert!(out.contains("line_1000\n"));
+        // Earliest line trimmed away.
+        assert!(!out.contains("line_0\n"));
+    }
+
+    #[test]
+    fn trim_large_input_keeps_only_tail() {
+        let mut s = String::new();
+        for i in 0..5000 {
+            s.push_str(&format!("line_{i}\n"));
+        }
+        let (out, n) = trim_to_tail(&s, TRIM_THRESHOLD_LINES, TRIM_TAIL_LINES);
+        assert_eq!(n, Some(5000));
+        // The result is marker + last 200 lines.
+        let body_lines: Vec<&str> = out.lines().collect();
+        assert_eq!(body_lines.len(), 1 + TRIM_TAIL_LINES);
+        assert!(body_lines[0].starts_with("... (truncated"));
+        assert_eq!(body_lines[1], "line_4800");
+        assert_eq!(*body_lines.last().unwrap(), "line_4999");
+    }
+
+    // --- format_summary (≥ 3 cases) ------------------------------------------
+
+    #[test]
+    fn format_summary_empty_failed_renders_only_body() {
+        let body = "hello\n";
+        let out = format_summary(&FailedTests::default(), body);
+        assert_eq!(out, "hello\n");
+    }
+
+    #[test]
+    fn format_summary_one_failed_renders_header_and_body() {
+        let failed = FailedTests {
+            raw_count: 1,
+            names: vec!["foo::bar".to_string()],
+        };
+        let out = format_summary(&failed, "body\n");
+        assert!(out.starts_with("FAILED: 1 test(s)\n- foo::bar\n"));
+        assert!(out.ends_with("body\n"));
+    }
+
+    #[test]
+    fn format_summary_many_failed_renders_header_count() {
+        let failed = FailedTests {
+            raw_count: 3,
+            names: vec!["a".to_string(), "b".to_string(), "c".to_string()],
+        };
+        let out = format_summary(&failed, "");
+        assert!(out.starts_with("FAILED: 3 test(s)\n- a\n- b\n- c\n"));
+    }
+
+    /// CB-004: when names are capped but raw_count is higher, the header
+    /// reports the raw count and a `... and N more` marker is rendered.
+    #[test]
+    fn format_summary_uses_raw_count_with_truncation_marker() {
+        let names: Vec<String> = (0..MAX_FAILED_TEST_NAMES)
+            .map(|i| format!("t{i}"))
+            .collect();
+        let failed = FailedTests {
+            raw_count: 80,
+            names,
+        };
+        let out = format_summary(&failed, "body\n");
+        // Header shows REAL count (80), not the capped 50.
+        assert!(
+            out.starts_with("FAILED: 80 test(s)\n"),
+            "header should use raw_count=80, got: {:?}",
+            &out[..out.find('\n').map(|i| i + 1).unwrap_or(out.len())]
+        );
+        // Marker is rendered for the truncated names.
+        let extra = 80 - MAX_FAILED_TEST_NAMES;
+        assert!(
+            out.contains(&format!("... and {extra} more\n")),
+            "truncation marker missing: {:?}",
+            out
+        );
+    }
+
+    // --- mask integration (DR4-004) -----------------------------------------
+
+    /// Failed test names containing secrets must be redacted before they
+    /// appear in the FAILED summary (design §6 / VR-15). `mask_secrets`
+    /// keys on word boundaries, so we exercise the kv-shape (`api_key=...`)
+    /// path that hits the kv_secret_regex SSOT.
+    #[test]
+    fn parse_masks_secrets_in_failed_names() {
+        let leak = "FAILED tests/test_foo.py::test[api_key=sk_live_supersecretvalue]\n";
+        let failed = parse_failed_tests(leak, TestFramework::Pytest);
+        assert_eq!(failed.raw_count, 1);
+        assert_eq!(failed.names.len(), 1);
+        assert!(
+            !failed.names[0].contains("sk_live_supersecretvalue"),
+            "raw token must not leak through parse_failed_tests: {:?}",
+            failed.names[0]
+        );
+        assert!(failed.names[0].contains("***"));
+    }
+
+    /// CB-001: failed test names carrying header-family credentials
+    /// (Authorization / Cookie / X-API-Key / X-Auth-Token) must be redacted
+    /// through `mask_header_family` so the raw value never lands in the
+    /// FAILED summary.
+    #[test]
+    fn parse_masks_header_family_in_failed_names() {
+        let leak = "FAILED tests/test_a.py::test[hdr=Authorization: Bearer abc123def456ghi]\n";
+        let failed = parse_failed_tests(leak, TestFramework::Pytest);
+        assert_eq!(failed.raw_count, 1);
+        assert!(
+            !failed.names[0].contains("abc123def456ghi"),
+            "raw bearer token leaked: {:?}",
+            failed.names[0]
+        );
+        assert!(
+            failed.names[0].contains("<REDACTED>"),
+            "header redaction marker missing: {:?}",
+            failed.names[0]
+        );
+    }
+
+    // --- combined pipeline (smoke) ------------------------------------------
+
+    #[test]
+    fn format_for_tool_result_pytest_short() {
+        let s = "FAILED tests/test_a.py::test_x - AssertionError\n";
+        let out = format_for_tool_result(s);
+        assert!(out.starts_with("FAILED: 1 test(s)"));
+        assert!(out.contains("test_x"));
+    }
+
+    #[test]
+    fn format_for_tool_result_unknown_passes_through() {
+        let s = "just normal output\n";
+        let out = format_for_tool_result(s);
+        // No FAILED header (Unknown framework → empty failed list).
+        assert!(!out.starts_with("FAILED:"));
+        assert_eq!(out, s);
+    }
+
+    #[test]
+    fn cap_test_name_truncates_long_string() {
+        let long = "a".repeat(MAX_FAILED_TEST_NAME_BYTES + 100);
+        let capped = cap_test_name(&long);
+        assert!(capped.len() <= MAX_FAILED_TEST_NAME_BYTES);
+    }
+
+    #[test]
+    fn parse_failed_tests_caps_at_max_count() {
+        let mut s = String::new();
+        for i in 0..(MAX_FAILED_TEST_NAMES + 10) {
+            s.push_str(&format!("test n::t{i} ... FAILED\n"));
+        }
+        let failed = parse_failed_tests(&s, TestFramework::CargoTest);
+        // CB-004: raw_count reports the true total (MAX + 10), not the cap.
+        assert_eq!(failed.raw_count, MAX_FAILED_TEST_NAMES + 10);
+        // CB-005: names allocation is bounded at MAX_FAILED_TEST_NAMES.
+        assert_eq!(failed.names.len(), MAX_FAILED_TEST_NAMES);
+    }
+
+    /// CB-004 regression: 80 failed tests produce header `FAILED: 80 test(s)`
+    /// (raw count) with `... and 30 more` marker (80 - 50 cap = 30).
+    #[test]
+    fn parse_failed_tests_80_fails_reports_raw_count_in_header() {
+        let mut s = String::new();
+        for i in 0..80 {
+            s.push_str(&format!("test n::t{i} ... FAILED\n"));
+        }
+        let failed = parse_failed_tests(&s, TestFramework::CargoTest);
+        assert_eq!(failed.raw_count, 80);
+        assert_eq!(failed.names.len(), MAX_FAILED_TEST_NAMES);
+        let out = format_summary(&failed, "");
+        assert!(out.starts_with("FAILED: 80 test(s)\n"));
+        assert!(
+            out.contains("... and 30 more\n"),
+            "expected `... and 30 more`, got: {:?}",
+            out
+        );
+    }
+
+    /// CB-005 (DoS resistance): with very large adversarial output, the
+    /// `names` Vec is still bounded at MAX_FAILED_TEST_NAMES. We sanity-check
+    /// that 10_000 lines / 5_000 fails do not produce a 5_000-entry Vec.
+    #[test]
+    fn parse_failed_tests_huge_input_keeps_names_bounded() {
+        let mut s = String::with_capacity(10_000 * 30);
+        for i in 0..5_000 {
+            s.push_str(&format!("test n::t{i} ... FAILED\n"));
+        }
+        for i in 0..5_000 {
+            s.push_str(&format!("noise line {i}\n"));
+        }
+        let failed = parse_failed_tests(&s, TestFramework::CargoTest);
+        assert_eq!(failed.raw_count, 5_000);
+        assert_eq!(
+            failed.names.len(),
+            MAX_FAILED_TEST_NAMES,
+            "names should remain bounded at MAX_FAILED_TEST_NAMES even on 5000-fail input"
+        );
+    }
+}

--- a/tests/case_photon_bridge_smoke.rs
+++ b/tests/case_photon_bridge_smoke.rs
@@ -461,3 +461,223 @@ fn output_flag_writes_jsonl_one_line_per_summary() {
         assert_eq!(parsed.schema_version, ACTION_SUMMARY_SCHEMA_VERSION);
     }
 }
+
+// ---------------------------------------------------------------------------
+// Issue #608 Phase α-2 (AP-10 / 案A): tests-only success regression
+// ---------------------------------------------------------------------------
+
+/// AP-10: a CaseRecord with `tests_passed=true` and no artifact, where
+/// `build_passed` is None, must still pass the quality gate so it is
+/// promoted to a photon seed. Pins the design 設計判断 #1 (案A) interpretation.
+#[test]
+fn ap10_tests_only_success_passes_quality_gate() {
+    let mut c = make_case(&unique_case_id(70));
+    c.outcome_score.build_passed = None;
+    c.outcome_score.tests_passed = Some(true);
+    c.outcome_score.user_visible_artifact = false;
+    let promoted: HashSet<String> = HashSet::new();
+    let r = check_quality_gate(&c, &promoted, c.created_at + 1);
+    assert!(
+        r.is_ok(),
+        "tests-only success must pass quality gate, got {:?}",
+        r
+    );
+}
+
+/// AP-10: `build_passed == Some(false)` must override tests-only success
+/// (verifier failure > test success per design 設計判断 #1).
+#[test]
+fn ap10_build_failure_overrides_tests_only_success() {
+    let mut c = make_case(&unique_case_id(71));
+    c.outcome_score.build_passed = Some(false);
+    c.outcome_score.tests_passed = Some(true);
+    c.outcome_score.user_visible_artifact = false;
+    let promoted: HashSet<String> = HashSet::new();
+    let r = check_quality_gate(&c, &promoted, c.created_at + 1);
+    assert_eq!(r, Err(SkipReason::NotSuccessState));
+}
+
+/// AP-10: tests_only path runs through full pipeline (convert →
+/// ActionSummary serialization). Confidence comes from the verifier-active
+/// 3-tier derivation: tests_passed=true && user_visible_artifact=false ⇒
+/// confidence_prior = 0.8.
+#[test]
+fn ap10_tests_only_success_yields_08_confidence_in_summary() {
+    let mut c = make_case(&unique_case_id(72));
+    c.outcome_score.tests_passed = Some(true);
+    c.outcome_score.user_visible_artifact = false;
+    let s = convert_case_to_action_summary(&c, "sess-ap10", "2026-05-17T00:00:00Z");
+    let prov = s.provenance.unwrap();
+    assert!(prov.verifier_active);
+    assert_eq!(prov.confidence_prior, 0.8);
+    assert!(s.summary_id.starts_with(SUMMARY_ID_PREFIX));
+}
+
+// ---------------------------------------------------------------------------
+// CB-002 (codex review fix): unsafe_actions_blocked must block full_pass
+// promotion even when build / tests / artifact are all green.
+// ---------------------------------------------------------------------------
+
+/// CB-002: a CaseRecord with `build_passed = true`, `tests_passed = true`,
+/// `user_visible_artifact = true` but `unsafe_actions_blocked > 0` MUST
+/// be rejected by the quality gate with `SkipReason::NotSuccessState`.
+/// Previously the full_pass branch ignored `unsafe_actions_blocked`,
+/// allowing an unsafe turn to be promoted into a photon seed.
+#[test]
+fn cb_002_full_pass_with_unsafe_blocks_fails_quality_gate() {
+    let mut c = make_case(&unique_case_id(80));
+    // baseline_score() already has unsafe_actions_blocked=0; flip it.
+    c.outcome_score.build_passed = Some(true);
+    c.outcome_score.tests_passed = Some(true);
+    c.outcome_score.user_visible_artifact = true;
+    c.outcome_score.unsafe_actions_blocked = 1;
+    let promoted: HashSet<String> = HashSet::new();
+    let r = check_quality_gate(&c, &promoted, c.created_at + 1);
+    assert_eq!(
+        r,
+        Err(SkipReason::NotSuccessState),
+        "CB-002: unsafe_actions_blocked > 0 must trigger NotSuccessState even on full_pass"
+    );
+}
+
+/// CB-002: the verifier-less fallback already enforced
+/// `unsafe_actions_blocked == 0`. Pin that path so the invariant holds
+/// across both branches.
+#[test]
+fn cb_002_verifier_less_with_unsafe_blocks_fails_quality_gate() {
+    let mut c = make_case(&unique_case_id(81));
+    c.outcome_score.build_passed = None;
+    c.outcome_score.tests_passed = None;
+    c.outcome_score.user_visible_artifact = true;
+    c.outcome_score.unsafe_actions_blocked = 1;
+    let promoted: HashSet<String> = HashSet::new();
+    let r = check_quality_gate(&c, &promoted, c.created_at + 1);
+    assert_eq!(r, Err(SkipReason::NotSuccessState));
+}
+
+/// CB-002 promotion-pipeline regression: a CaseRecord with
+/// `unsafe_actions_blocked > 0` must be SKIPPED end-to-end by
+/// `run_photon_promote` even when build/tests/artifact are green.
+/// Failing means the case appears in the dedup log → CaseRecord leaked.
+#[test]
+fn cb_002_unsafe_full_pass_is_skipped_by_run_photon_promote() {
+    let tmp = TempDir::new().unwrap();
+    let mut c = make_case(&unique_case_id(82));
+    c.outcome_score.unsafe_actions_blocked = 2;
+    write_case(tmp.path(), &c);
+
+    run_photon_promote(
+        tmp.path(),
+        tmp.path(),
+        None,
+        None,
+        true, // --all (CB-003 selector exactly-one)
+        false,
+        true,
+        false,
+        None,
+    )
+    .unwrap();
+
+    let promoted = read_promote_log(tmp.path()).unwrap();
+    assert!(
+        !promoted.contains(&c.case_id),
+        "CB-002: case with unsafe_actions_blocked > 0 must NOT appear in dedup log as promoted; got: {promoted:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// CB-003 (codex review fix): photon-promote selector exactly-one + --session
+// unsupported.
+// ---------------------------------------------------------------------------
+
+/// CB-003: zero selectors is rejected (previously interpreted as
+/// "promote everything").
+#[test]
+fn cb_003_no_selector_rejected() {
+    let tmp = TempDir::new().unwrap();
+    let r = run_photon_promote(
+        tmp.path(),
+        tmp.path(),
+        None,
+        None,
+        false,
+        true,
+        true,
+        false,
+        None,
+    );
+    assert!(r.is_err(), "no selector must return Err; got {r:?}");
+    let msg = r.unwrap_err();
+    assert!(
+        msg.contains("exactly one"),
+        "error must mention `exactly one` selector requirement; got {msg:?}"
+    );
+}
+
+/// CB-003: `--session` is explicitly unsupported in Phase A.
+#[test]
+fn cb_003_session_selector_rejected_as_unsupported() {
+    let tmp = TempDir::new().unwrap();
+    let r = run_photon_promote(
+        tmp.path(),
+        tmp.path(),
+        Some("sess-x".to_string()),
+        None,
+        false,
+        true,
+        true,
+        false,
+        None,
+    );
+    assert!(r.is_err(), "--session selector must return Err; got {r:?}");
+    let msg = r.unwrap_err();
+    assert!(
+        msg.contains("--session"),
+        "error must reference --session; got {msg:?}"
+    );
+    assert!(
+        msg.contains("not yet supported")
+            || msg.contains("unsupported")
+            || msg.contains("not supported"),
+        "error must say unsupported; got {msg:?}"
+    );
+}
+
+/// CB-003: `--case-id` only is accepted.
+#[test]
+fn cb_003_case_id_selector_accepted() {
+    let tmp = TempDir::new().unwrap();
+    let c = make_case(&unique_case_id(83));
+    write_case(tmp.path(), &c);
+    let r = run_photon_promote(
+        tmp.path(),
+        tmp.path(),
+        None,
+        Some(c.case_id.clone()),
+        false,
+        true,
+        false,
+        false,
+        None,
+    );
+    assert!(r.is_ok(), "--case-id alone must be accepted; got {r:?}");
+}
+
+/// CB-003: `--all` only is accepted.
+#[test]
+fn cb_003_all_selector_accepted() {
+    let tmp = TempDir::new().unwrap();
+    let r = run_photon_promote(
+        tmp.path(),
+        tmp.path(),
+        None,
+        None,
+        true,
+        true,
+        false,
+        false,
+        None,
+    );
+    assert!(r.is_ok(), "--all alone must be accepted; got {r:?}");
+}

--- a/tests/completion_evidence_smoke.rs
+++ b/tests/completion_evidence_smoke.rs
@@ -237,3 +237,151 @@ fn agent_construction_after_evidence_set_wiring_does_not_panic() {
     // Drop the agent; the test passes if the constructor + Drop pipeline
     // doesn't panic. The new `evidence_set_this_turn` field default-inits.
 }
+
+// ----------------------- Issue #608 Phase 2C (AP-08 hook regressions) ------
+
+/// AP-08 hook regression: Bash tool output for a BuildTest class command
+/// flows through the `test_output` formatter (FAILED summary + tail trim)
+/// before the byte cap. Verifies the FAILED summary header is exposed at the
+/// head of the body (after `exit_code=` metadata).
+#[test]
+fn test_output_formatter_pipeline_renders_failed_summary_head() {
+    use anvil::tools::test_output::format_for_tool_result;
+    // Synthetic pytest output where the FAILED line is buried in noise.
+    let mut s = String::new();
+    for i in 0..200 {
+        s.push_str(&format!("noise line {i}\n"));
+    }
+    s.push_str("FAILED tests/test_a.py::test_x - boom\n");
+    let formatted = format_for_tool_result(&s);
+    assert!(
+        formatted.starts_with("FAILED: 1 test(s)"),
+        "FAILED header must be at head of formatted body: {:?}",
+        &formatted[..50.min(formatted.len())]
+    );
+    assert!(formatted.contains("test_x"));
+}
+
+/// AP-08 leak regression: a verifier command that printed an Authorization
+/// header to stderr must not surface that header through the formatter
+/// output. mask_secrets (token + URL credential) is applied to the trimmed
+/// body in `format_for_tool_result`.
+#[test]
+fn test_output_formatter_strips_url_credentials_from_body() {
+    use anvil::tools::test_output::format_for_tool_result;
+    let mut s = String::new();
+    s.push_str("FAILED tests/test_a.py::test_x\n");
+    for i in 0..50 {
+        s.push_str(&format!("frame {i}\n"));
+    }
+    s.push_str("calling https://user:hunter2@api.example.com/x\n");
+    let formatted = format_for_tool_result(&s);
+    assert!(
+        !formatted.contains("hunter2"),
+        "URL userinfo must be redacted by formatter body mask: {:?}",
+        formatted
+    );
+    assert!(
+        formatted.starts_with("FAILED: 1 test(s)"),
+        "summary header missing: {:?}",
+        &formatted[..50.min(formatted.len())]
+    );
+}
+
+/// CB-001 regression: header-family credentials (Authorization / Cookie /
+/// X-API-Key / X-Auth-Token) printed in stderr of a failing verifier must
+/// not surface through the formatter pipeline. The body redaction stacks
+/// `mask_secrets` + `mask_header_family` so these header lines are
+/// rewritten to `Header: <REDACTED>` before reaching the tool result.
+#[test]
+fn test_output_formatter_strips_header_family_credentials_from_body() {
+    use anvil::tools::test_output::format_for_tool_result;
+    let mut s = String::new();
+    s.push_str("FAILED tests/test_a.py::test_x\n");
+    for i in 0..50 {
+        s.push_str(&format!("frame {i}\n"));
+    }
+    s.push_str("> Authorization: Bearer cb001_bearer_leak_value_AAA\n");
+    s.push_str("> Cookie: session=cb001_cookie_leak_value_BBB; theme=dark\n");
+    s.push_str("> X-API-Key: cb001_apikey_leak_value_CCC\n");
+    s.push_str("> X-Auth-Token: cb001_xauthtoken_leak_value_DDD\n");
+    let formatted = format_for_tool_result(&s);
+    for leak in [
+        "cb001_bearer_leak_value_AAA",
+        "cb001_cookie_leak_value_BBB",
+        "cb001_apikey_leak_value_CCC",
+        "cb001_xauthtoken_leak_value_DDD",
+    ] {
+        assert!(
+            !formatted.contains(leak),
+            "raw header credential {leak} leaked into formatter output: {:?}",
+            formatted
+        );
+    }
+    assert!(
+        formatted.contains("<REDACTED>"),
+        "header redaction marker missing: {:?}",
+        formatted
+    );
+    assert!(
+        formatted.starts_with("FAILED: 1 test(s)"),
+        "summary header missing: {:?}",
+        &formatted[..50.min(formatted.len())]
+    );
+}
+
+/// CB-001 regression: header-family credentials embedded INSIDE the FAILED
+/// test name (parametrized test that captures a header value) must also
+/// be redacted in the FAILED summary bullet line.
+#[test]
+fn test_output_formatter_strips_header_family_credentials_from_failed_name() {
+    use anvil::tools::test_output::format_for_tool_result;
+    let s = "FAILED tests/test_a.py::test[hdr=Authorization: Bearer cb001_in_name_value] - boom\n";
+    let formatted = format_for_tool_result(s);
+    assert!(
+        !formatted.contains("cb001_in_name_value"),
+        "raw bearer in failed-name leaked into formatter output: {:?}",
+        formatted
+    );
+    assert!(formatted.contains("<REDACTED>"));
+    assert!(formatted.starts_with("FAILED: 1 test(s)"));
+}
+
+// ----------------------- Issue #608 Phase 2H VR-coverage smoke -------------
+
+/// Phase 2H VR-06: legacy session.json (no AP-09 fields) still
+/// deserializes cleanly. Light cross-crate smoke that the SessionSnapshot
+/// schema growth is forward-compatible.
+#[test]
+fn legacy_session_json_without_ap09_fields_deserializes_via_default() {
+    use anvil::session::store::SessionSnapshot;
+    let snap = SessionSnapshot::default();
+    assert!(snap.last_verifier_command.is_none());
+    assert!(snap.last_verifier_invocation.is_none());
+    let json = serde_json::to_string(&snap).unwrap();
+    // skip_serializing_if = "Option::is_none" — keys absent for None.
+    assert!(!json.contains("\"last_verifier_command\""));
+    assert!(!json.contains("\"last_verifier_invocation\""));
+    let back: SessionSnapshot = serde_json::from_str(&json).unwrap();
+    assert!(back.last_verifier_command.is_none());
+}
+
+/// Phase 2H VR-04: secret-bearing verifier command is redacted on save,
+/// re-redacted on load (defense-in-depth). Smoke check at the
+/// integration layer.
+#[test]
+fn verifier_command_persisted_with_secrets_is_redacted_round_trip() {
+    use anvil::session::store::SessionSnapshot;
+    let snap = SessionSnapshot {
+        last_verifier_command: Some(
+            "cargo test --env api_key=ghp_supersecretvalueABCDEFGHIJKLMNOP".to_string(),
+        ),
+        ..Default::default()
+    };
+    let json = serde_json::to_string(&snap).unwrap();
+    assert!(!json.contains("ghp_supersecretvalueABCDEFGHIJKLMNOP"));
+    let back: SessionSnapshot = serde_json::from_str(&json).unwrap();
+    let stored = back.last_verifier_command.unwrap();
+    assert!(!stored.contains("ghp_supersecretvalueABCDEFGHIJKLMNOP"));
+    assert!(stored.contains("***"));
+}

--- a/tests/photon_evaluate_signal_smoke.rs
+++ b/tests/photon_evaluate_signal_smoke.rs
@@ -1038,3 +1038,63 @@ fn nps07_resume_does_not_inherit_counters() {
         "deserialized SessionSnapshot must default tool_calls_this_turn to 0"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Issue #608 Phase α-2 (AP-10 / 案A): context_pack_event schema invariant +
+// Case E expansion regression.
+//
+// VR-09 invariant: the case_pack_event keys remain stable — adding the
+// same-turn verifier success signal (Case E expansion) is a derive-only
+// change to `derive_photon_feedback_outcome`. The wire shape (key set,
+// outcome static allowlist) is unchanged so any photon-side consumer can
+// continue parsing without schema migration.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn ap10_context_pack_event_keys_unchanged_after_case_e_expansion() {
+    let _ = shared_log_path();
+    let session_id = "ap10-context-pack-event-keys";
+
+    let mut photon_server = mockito::Server::new();
+    let _pack_mock = photon_server
+        .mock("POST", "/v1/context/pack")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(mock_context_pack_body(1))
+        .create();
+    let (capture, _eval_mock) = mock_evaluate_with_capture(&mut photon_server);
+
+    let (mut agent, _dir) = build_live_agent(session_id, photon_server.url(), false, 1000);
+    let _ = agent.process_line("hello", false);
+
+    let body = first_eval_body_as_json(&capture);
+    let event = body
+        .get("context_pack_event")
+        .expect("context_pack_event present");
+    // The key set is fixed by 案A (Issue #608 Phase α-2 design 設計判断 #1).
+    // Case E expansion is a same-turn derive only; no key was added.
+    let expected_keys: std::collections::HashSet<&str> = [
+        "context_pack_request_id",
+        "adoption_status",
+        "evidence_expand_requested",
+        "evidence_ids_expanded",
+        "items_adopted_count",
+        "items_ignored_count",
+        "summary_ids_adopted",
+        "summary_ids_adopted_truncated",
+        "outcome",
+        "outcome_detail",
+    ]
+    .into_iter()
+    .collect();
+    let actual_keys: std::collections::HashSet<&str> = event
+        .as_object()
+        .expect("context_pack_event must be an object")
+        .keys()
+        .map(|s| s.as_str())
+        .collect();
+    assert_eq!(
+        actual_keys, expected_keys,
+        "context_pack_event key set must be schema-stable (案A invariant)"
+    );
+}

--- a/tests/test_output_smoke.rs
+++ b/tests/test_output_smoke.rs
@@ -1,0 +1,315 @@
+//! Issue #608 (Phase α-2 / AP-08): integration smoke tests for the
+//! `tools::test_output` formatter pipeline.
+//!
+//! These tests exercise the public 4-function SSOT exposed by the new module
+//! (`detect_framework` / `parse_failed_tests` / `trim_to_tail` /
+//! `format_summary`) plus the convenience entry point `format_for_tool_result`
+//! that bash.rs / auto_test.rs wire up.
+//!
+//! They pin:
+//!   * pytest / cargo test / npm test long-output → FAILED summary + tail
+//!     trim (>1000 lines threshold) (VR-08).
+//!   * Truncation marker shape (`(truncated, original N lines)`) (VR-08).
+//!   * Secret-bearing failed test names never leak raw tokens through the
+//!     pipeline (DR4-004 / VR-15).
+//!   * Bash metadata (`exit_code=`) stays at the head of the tool result,
+//!     FAILED summary appears at the head of the body (VR-08).
+
+use anvil::tools::test_output::{
+    FailedTests, MAX_FAILED_TEST_NAME_BYTES, MAX_FAILED_TEST_NAMES, TRIM_TAIL_LINES,
+    TRIM_THRESHOLD_LINES, TestFramework, detect_framework, format_for_tool_result, format_summary,
+    parse_failed_tests, trim_to_tail,
+};
+
+// ----------------------- AP-08 framework hook ----------------------------
+
+#[test]
+fn pytest_long_output_summarized_with_failed_header_and_tail_trim() {
+    // Construct >1000 lines of synthetic pytest output with the FAILED at the
+    // top and a tail that contains a useful debugging line.
+    let mut s = String::new();
+    s.push_str("FAILED tests/test_user.py::test_login - assertion error\n");
+    s.push_str("FAILED tests/test_user.py::test_logout - RuntimeError\n");
+    for i in 0..2000 {
+        s.push_str(&format!("noisy stack frame {i}\n"));
+    }
+    s.push_str("=== short test summary info ===\n");
+    s.push_str("FAILED tests/test_user.py::test_signup - boom\n");
+    let out = format_for_tool_result(&s);
+    // FAILED header appears at head of body.
+    assert!(out.starts_with("FAILED:"), "output head: {:?}", &out[..50]);
+    assert!(out.contains("test_login"));
+    assert!(out.contains("test_logout"));
+    assert!(out.contains("test_signup"));
+    // Truncation marker is present and reports the original line count.
+    let original_lines = s.lines().count();
+    assert!(
+        out.contains(&format!("(truncated, original {original_lines} lines)")),
+        "missing truncation marker in: {:?}",
+        out
+    );
+    // Earliest noisy line is trimmed away.
+    assert!(!out.contains("noisy stack frame 0\n"));
+    // Tail preserved.
+    assert!(out.contains("=== short test summary info ===\n"));
+}
+
+#[test]
+fn cargo_test_long_output_summarized() {
+    let mut s = String::new();
+    s.push_str("running 3 tests\n");
+    s.push_str("test foo::bar ... FAILED\n");
+    for i in 0..1200 {
+        s.push_str(&format!("noise line {i}\n"));
+    }
+    s.push_str("test result: FAILED. 1 passed; 1 failed; 0 ignored\n");
+    let out = format_for_tool_result(&s);
+    assert!(out.starts_with("FAILED: 1 test(s)"), "got: {:?}", out);
+    assert!(out.contains("foo::bar"));
+    // tail preserved
+    assert!(out.contains("test result: FAILED."));
+}
+
+#[test]
+fn npm_test_long_output_summarized() {
+    let mut s = String::new();
+    s.push_str(" FAIL src/components/Foo.test.tsx\n");
+    s.push_str(" FAIL src/components/Bar.test.tsx\n");
+    for i in 0..1300 {
+        s.push_str(&format!("line {i}\n"));
+    }
+    s.push_str("Tests:       2 failed, 5 passed, 7 total\n");
+    let out = format_for_tool_result(&s);
+    assert!(out.starts_with("FAILED: 2 test(s)"), "got head: {:?}", out);
+    assert!(out.contains("Foo.test.tsx"));
+    assert!(out.contains("Bar.test.tsx"));
+    assert!(out.contains("Tests:       2 failed"));
+}
+
+// ----------------------- VR-15 secret masking through pipeline -----------
+
+#[test]
+fn failed_test_names_with_kv_secrets_are_masked_in_summary() {
+    let s = "FAILED tests/test_a.py::test[api_key=sk_live_supersecretvalue]\n";
+    let out = format_for_tool_result(s);
+    assert!(
+        !out.contains("sk_live_supersecretvalue"),
+        "raw kv secret must not appear in formatter output: {:?}",
+        out
+    );
+    assert!(
+        out.contains("FAILED: 1 test(s)"),
+        "summary header missing: {:?}",
+        out
+    );
+}
+
+#[test]
+fn failed_test_names_with_url_credentials_are_masked() {
+    let s = "FAILED tests/test_a.py::test[remote=https://user:hunter2@example.com]\n";
+    let out = format_for_tool_result(s);
+    assert!(
+        !out.contains("hunter2"),
+        "raw URL userinfo must not appear in formatter output: {:?}",
+        out
+    );
+}
+
+// ----------------------- VR-08 trim boundary --------------------------------
+
+#[test]
+fn trim_boundary_at_threshold_passes_through() {
+    let s = "x\n".repeat(TRIM_THRESHOLD_LINES);
+    let (out, marker) = trim_to_tail(&s, TRIM_THRESHOLD_LINES, TRIM_TAIL_LINES);
+    assert!(marker.is_none());
+    assert_eq!(out, s);
+}
+
+#[test]
+fn trim_boundary_above_threshold_trims_to_tail() {
+    let mut s = String::new();
+    for i in 0..(TRIM_THRESHOLD_LINES + 1) {
+        s.push_str(&format!("line_{i}\n"));
+    }
+    let (out, marker) = trim_to_tail(&s, TRIM_THRESHOLD_LINES, TRIM_TAIL_LINES);
+    assert_eq!(marker, Some(TRIM_THRESHOLD_LINES + 1));
+    assert!(out.starts_with("... (truncated, original"));
+}
+
+// ----------------------- format_summary direct check ------------------------
+
+#[test]
+fn format_summary_renders_header_for_named_tests() {
+    let failed = FailedTests {
+        raw_count: 2,
+        names: vec!["foo::bar".into(), "baz::qux".into()],
+    };
+    let out = format_summary(&failed, "body\n");
+    assert!(out.contains("FAILED: 2 test(s)"));
+    assert!(out.contains("- foo::bar\n"));
+    assert!(out.contains("- baz::qux\n"));
+    assert!(out.contains("body\n"));
+}
+
+// ----------------------- VR-08 cap enforcement ------------------------------
+
+#[test]
+fn parse_caps_at_max_count_to_prevent_unbounded_summary() {
+    let mut s = String::new();
+    for i in 0..(MAX_FAILED_TEST_NAMES + 50) {
+        s.push_str(&format!("test n::t{i} ... FAILED\n"));
+    }
+    let failed = parse_failed_tests(&s, TestFramework::CargoTest);
+    // CB-004: raw_count reports the true total (cap + 50), not the bounded
+    // names.len(). CB-005: names allocation is bounded by MAX_FAILED_TEST_NAMES.
+    assert_eq!(failed.raw_count, MAX_FAILED_TEST_NAMES + 50);
+    assert_eq!(failed.names.len(), MAX_FAILED_TEST_NAMES);
+}
+
+#[test]
+fn parse_caps_per_name_byte_length() {
+    // Use a real per-test FAILED line with a very long signature.
+    let huge = "a".repeat(MAX_FAILED_TEST_NAME_BYTES + 200);
+    let s = format!("test n::{huge} ... FAILED\n");
+    let failed = parse_failed_tests(&s, TestFramework::CargoTest);
+    assert_eq!(failed.raw_count, 1);
+    assert_eq!(failed.names.len(), 1);
+    assert!(failed.names[0].len() <= MAX_FAILED_TEST_NAME_BYTES);
+}
+
+// ----------------------- CB-001 header-family redaction --------------------
+
+/// CB-001: failed test outputs that contain Authorization / Cookie /
+/// X-API-Key / X-Auth-Token header lines (either in the trimmed body or in
+/// the failed test name itself) must not leak the raw credential through
+/// the formatter. Header lines are rewritten to `Header: <REDACTED>`.
+#[test]
+fn format_for_tool_result_redacts_authorization_header_in_body() {
+    let s = "FAILED tests/test_a.py::test_x - boom\n\
+             curl -H 'Authorization: Bearer secret_bearer_token_value_XYZ' http://x\n";
+    let out = format_for_tool_result(s);
+    assert!(
+        !out.contains("secret_bearer_token_value_XYZ"),
+        "raw bearer token must not appear in tool result: {:?}",
+        out
+    );
+    assert!(
+        out.contains("Authorization") && out.contains("<REDACTED>"),
+        "Authorization redaction marker missing: {:?}",
+        out
+    );
+}
+
+#[test]
+fn format_for_tool_result_redacts_cookie_header_in_body() {
+    let s = "FAILED tests/test_a.py::test_x - boom\n\
+             Cookie: session=eat_my_cookie_token_42; theme=dark\n";
+    let out = format_for_tool_result(s);
+    assert!(
+        !out.contains("eat_my_cookie_token_42"),
+        "raw cookie must not appear in tool result: {:?}",
+        out
+    );
+    assert!(out.contains("Cookie") && out.contains("<REDACTED>"));
+}
+
+#[test]
+fn format_for_tool_result_redacts_x_api_key_in_body() {
+    let s = "FAILED tests/test_a.py::test_x - boom\n\
+             X-API-Key: live_api_key_value_777\n";
+    let out = format_for_tool_result(s);
+    assert!(
+        !out.contains("live_api_key_value_777"),
+        "raw X-API-Key value leaked: {:?}",
+        out
+    );
+    assert!(out.contains("<REDACTED>"));
+}
+
+#[test]
+fn format_for_tool_result_redacts_x_auth_token_in_body() {
+    let s = "FAILED tests/test_a.py::test_x - boom\n\
+             X-Auth-Token: live_auth_token_value_888\n";
+    let out = format_for_tool_result(s);
+    assert!(
+        !out.contains("live_auth_token_value_888"),
+        "raw X-Auth-Token value leaked: {:?}",
+        out
+    );
+    assert!(out.contains("<REDACTED>"));
+}
+
+#[test]
+fn format_for_tool_result_redacts_authorization_in_failed_test_name() {
+    // The Authorization header appears INSIDE the FAILED test name
+    // (parametrized test). It must be redacted in the FAILED summary
+    // header / `- name` bullet line, not just the body.
+    let s =
+        "FAILED tests/test_a.py::test[hdr=Authorization: Bearer leaked_bearer_value_42] - boom\n";
+    let out = format_for_tool_result(s);
+    assert!(
+        !out.contains("leaked_bearer_value_42"),
+        "bearer leaked into FAILED summary bullet: {:?}",
+        out
+    );
+    assert!(out.contains("<REDACTED>"));
+    assert!(out.starts_with("FAILED: 1 test(s)"));
+}
+
+// ----------------------- CB-004 raw count + truncation marker --------------
+
+/// CB-004: 80 failed tests must produce `FAILED: 80 test(s)` (the raw
+/// count) plus `... and 30 more` marker (80 - MAX_FAILED_TEST_NAMES).
+#[test]
+fn format_summary_80_failed_reports_raw_count_with_more_marker() {
+    let mut s = String::new();
+    for i in 0..80 {
+        s.push_str(&format!("test n::t{i} ... FAILED\n"));
+    }
+    let out = format_for_tool_result(&s);
+    assert!(
+        out.starts_with("FAILED: 80 test(s)\n"),
+        "header should use raw count 80, got: {:?}",
+        &out[..out.find('\n').map(|i| i + 1).unwrap_or(out.len())]
+    );
+    let extra = 80 - MAX_FAILED_TEST_NAMES;
+    assert!(
+        out.contains(&format!("... and {extra} more\n")),
+        "expected `... and {extra} more` marker, got: {:?}",
+        out
+    );
+}
+
+// ----------------------- CB-005 bounded allocation on huge input ------------
+
+/// CB-005: 10_000-line output with 5_000 FAILED lines must NOT produce
+/// a 5_000-entry names Vec. raw_count still reports the true total so
+/// the summary stays accurate.
+#[test]
+fn parse_failed_tests_huge_adversarial_input_keeps_names_bounded() {
+    let mut s = String::with_capacity(10_000 * 32);
+    for i in 0..5_000 {
+        s.push_str(&format!("test n::t{i} ... FAILED\n"));
+    }
+    for i in 0..5_000 {
+        s.push_str(&format!("noise line {i}\n"));
+    }
+    let failed = parse_failed_tests(&s, TestFramework::CargoTest);
+    assert_eq!(failed.raw_count, 5_000);
+    assert_eq!(failed.names.len(), MAX_FAILED_TEST_NAMES);
+}
+
+// ----------------------- detect_framework precedence ------------------------
+
+#[test]
+fn detect_framework_pytest_wins_when_signature_present() {
+    let s = "FAILED tests/x.py::a - boom\n\
+             test result: FAILED. 0 passed; 1 failed\n";
+    assert_eq!(detect_framework(s), TestFramework::Pytest);
+}
+
+#[test]
+fn detect_framework_unknown_for_random_text() {
+    let s = "hello world\nplain text here\n";
+    assert_eq!(detect_framework(s), TestFramework::Unknown);
+}


### PR DESCRIPTION
## Summary

Issue #606 Phase α-1 (#610) で導入した `CompletionEvidence` 基盤の上に、Phase α-2 を実装。

- **AP-08**: pytest / cargo test / npm test の長大 backtrace を trim + 失敗 test 名サマリ生成 (`src/tools/test_output.rs` 新規)
- **AP-09**: `SessionSnapshot.last_verifier_command` + `VerifierInvocationRecord` 永続化、「再実行/もう一度」trigger で前回 verifier command を再提示
- **AP-10**: same-turn `verifier_exit_zero_this_turn` を photon adoption signal の outcome 算出に編入 (案A、ActionSummary schema 不変)
- **Sanitize**: `redact_verifier_command_for_storage` SSOT + `mask_header_family`
- **Codex review**: CB-001 (high) / CB-002 (medium) / CB-003 (low) 全反映

## Test plan

- [x] `cargo fmt --check`: pass
- [x] `cargo clippy --release --all-targets -- -D warnings`: 0 warnings
- [x] `cargo test --release` (lib): 1609 passed / 0 failed
- [x] `cargo test --release` (full): 2202 passed / 0 failed / 8 ignored
- [x] SessionSnapshot serde 互換 regression (legacy session.json deserialize OK)
- [x] WorkMode (#576) touch なし
- [x] photon cross-layer import なし

## 影響

### 新規 (2 files, 686 行)
- `src/tools/test_output.rs` (+501 行) — 4 関数 SSOT formatter + 23 unit test
- `tests/test_output_smoke.rs` (+185 行) — 12 integration test

### 修正 (12 files, +1020 / -122 行)
- `src/agent/loop_run/turn.rs`: `PhotonOutcomeInputs.verifier_exit_zero_this_turn` + `is_rerun_trigger` + 再提示 + Case E 拡張
- `src/session/store.rs`: `VerifierInvocationRecord` + `last_verifier_command` + serde 互換
- `src/session/feedback.rs`: `redact_verifier_command_for_storage` SSOT + `mask_header_family` (CB-001)
- `src/session/case_photon_bridge.rs`: `is_tests_only_success` + CB-002 guard
- `src/session/sessions_cli.rs`: selector exactly-one (CB-003) + `--session` unsupported error
- `src/tools/bash.rs`: BuildTest output に formatter 接続 + `exit_code=` 先頭維持
- `src/agent/loop_run/auto_test.rs`: AutoTestResult.output formatter 接続
- `src/agent/loop_run/completion_evidence.rs`: redactor 委譲
- `src/tools/mod.rs`: `pub mod test_output;`
- `src/cli.rs`: doc strings (CB-003)
- `CLAUDE.md`: File Map 更新 (test_output / redactor / VerifierInvocationRecord)
- 各 test smoke 拡張

**合計**: 16 files / **+2706 / -122 行**

## 不変条件

| 不変条件 | 影響 |
|---------|------|
| DR3-001 (facade) | 影響なし |
| DR3-002 (layer) | **案A 採用 → 影響なし** (ActionSummary schema 不変) |
| DR3-003 (test isolation) | 影響なし |
| DR4-002 (sanitize) | `redact_verifier_command_for_storage` SSOT 新設で **強化** |
| WorkMode (#576) | touch なし (AP-07 同等原則を維持) |
| photon adoption signal | **強化** (verifier success を outcome 算出に編入) |

## 関連 Issue

- Closes #608
- 依存: #606 (Phase α-1) ✅ merged via #610
- Refs #604 (auto-promote hook で本 PR の `is_tests_only_success` を活用)
- 後続: #607 (β: EnvSetup) — 本 PR の `test_output` formatter を再利用可能

🤖 Generated with [Claude Code](https://claude.com/claude-code)