### PR TITLE
refactor(agent/loop_run): introduce behavior-aware artifact completion (#636)

### DIFF
--- a/src/agent/loop_run.rs
+++ b/src/agent/loop_run.rs
@@ -513,6 +513,16 @@ pub struct Agent {
     /// of every user turn alongside `repair_job`. Not persisted to
     /// `self.session.messages` (design policy §5 — A-only, turn-local).
     repair_failure_snapshot: Option<repair_job::VerifierFailureSnapshot>,
+    /// Issue #636: per-turn behavior-coverage excerpts keyed by artifact role.
+    /// Populated by `turn.rs::observe_evidence_from_repo_edit` via
+    /// `bounded_post_edit_excerpt`, read by
+    /// `task_contract::plan_artifact_recovery` through
+    /// `ArtifactRecoveryInputs::artifact_excerpts`. Reset at the head of
+    /// `run_actor_loop` together with the other `*_this_turn` per-turn
+    /// state so excerpts never bleed across user turns. Not serialized —
+    /// the behavior-coverage decision is evaluated within the same turn
+    /// the excerpts were observed.
+    task_contract_excerpts: task_contract::ArtifactExcerpts,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -729,6 +739,7 @@ impl Agent {
             repair_job: None,
             repair_job_artifact_attempts: 0,
             repair_failure_snapshot: None,
+            task_contract_excerpts: task_contract::ArtifactExcerpts::new(),
         }
     }
 

--- a/src/agent/loop_run/required_behavior.rs
+++ b/src/agent/loop_run/required_behavior.rs
@@ -228,6 +228,50 @@ impl RequiredBehaviorContract {
         roles.dedup();
         roles
     }
+
+    /// Issue #636: judgement API — does `excerpt` hit any of the
+    /// operation keywords backing `self.operations`?
+    ///
+    /// Short ASCII keywords (`read`, `run`) go through the token-boundary
+    /// `keyword_hit` SSOT so `README` / `running` do not false-positive.
+    /// `KeywordMatch` / `OPERATION_KEYWORDS` stay private to this module
+    /// (DR1-005 / DR3-001 — no facade re-export). Returns `false` when
+    /// `operations` is `None` or empty.
+    pub(super) fn excerpt_hits_any_operation(&self, excerpt: &str) -> bool {
+        let Some(ops) = self.operations.as_ref() else {
+            return false;
+        };
+        if ops.is_empty() {
+            return false;
+        }
+        let lower = excerpt.to_ascii_lowercase();
+        for (needle, op, mode) in OPERATION_KEYWORDS {
+            if ops.contains(op) && keyword_hit(&lower, needle, *mode) {
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Issue #636: judgement API — does `excerpt` hit any of the
+    /// `domain_terms`?
+    ///
+    /// `domain_terms` are user-derived vocabulary so we match by
+    /// case-insensitive substring without applying the short-token
+    /// boundary rule (CB-004 keeps schema vs request alignment). Returns
+    /// `false` when `domain_terms` is `None` or empty.
+    pub(super) fn excerpt_hits_any_domain_term(&self, excerpt: &str) -> bool {
+        let Some(terms) = self.domain_terms.as_ref() else {
+            return false;
+        };
+        if terms.is_empty() {
+            return false;
+        }
+        let lower = excerpt.to_ascii_lowercase();
+        terms
+            .iter()
+            .any(|term| !term.is_empty() && lower.contains(&term.to_ascii_lowercase()))
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1286,5 +1330,83 @@ mod tests {
             !arts.contains(&ArtifactKind::Implementation),
             "unbacked Implementation must be dropped, got: {arts:?}"
         );
+    }
+
+    // -----------------------------------------------------------------
+    // Group E: Issue #636 judgement APIs (5 tests)
+    // -----------------------------------------------------------------
+
+    fn contract_with_ops(ops: Vec<Operation>) -> RequiredBehaviorContract {
+        let mut c = empty_contract();
+        c.operations = Some(ops);
+        c
+    }
+
+    fn contract_with_terms(terms: Vec<String>) -> RequiredBehaviorContract {
+        let mut c = empty_contract();
+        c.domain_terms = Some(terms);
+        c
+    }
+
+    #[test]
+    fn excerpt_hits_any_operation_matches_with_token_boundary_for_short_keyword() {
+        let c = contract_with_ops(vec![Operation::Read]);
+        // `README` should NOT count as a `read` operation.
+        assert!(!c.excerpt_hits_any_operation("Update README only"));
+        // Bare `read` token boundary matches.
+        assert!(c.excerpt_hits_any_operation("we will Read the user record"));
+        // `run` token boundary
+        let c = contract_with_ops(vec![Operation::Run]);
+        assert!(!c.excerpt_hits_any_operation("the running task"));
+        assert!(c.excerpt_hits_any_operation("run the verifier"));
+    }
+
+    #[test]
+    fn excerpt_hits_any_operation_matches_substring_for_long_keyword() {
+        for op in [
+            Operation::Create,
+            Operation::Update,
+            Operation::Delete,
+            Operation::Validate,
+        ] {
+            let c = contract_with_ops(vec![op]);
+            let excerpt = match op {
+                Operation::Create => "We CREATE a new entity here",
+                Operation::Update => "Update the existing record",
+                Operation::Delete => "delete the row from storage",
+                Operation::Validate => "Validate the payload structure",
+                _ => unreachable!(),
+            };
+            assert!(
+                c.excerpt_hits_any_operation(excerpt),
+                "op {op:?} should match {excerpt:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn excerpt_hits_any_operation_returns_false_when_operations_is_none() {
+        let c = empty_contract();
+        assert!(!c.excerpt_hits_any_operation("create read update delete"));
+        let mut c2 = empty_contract();
+        c2.operations = Some(Vec::new());
+        assert!(!c2.excerpt_hits_any_operation("create read update delete"));
+    }
+
+    #[test]
+    fn excerpt_hits_any_domain_term_matches_case_insensitive() {
+        let c = contract_with_terms(vec!["Task".to_string(), "api/v1".to_string()]);
+        assert!(c.excerpt_hits_any_domain_term("def list_tasks():\n    return Task.all()"));
+        assert!(c.excerpt_hits_any_domain_term("GET /api/v1/items"));
+        assert!(!c.excerpt_hits_any_domain_term("nothing relevant here"));
+    }
+
+    #[test]
+    fn excerpt_hits_any_domain_term_returns_false_when_domain_terms_is_none() {
+        let c = empty_contract();
+        assert!(!c.excerpt_hits_any_domain_term("Task api"));
+        let mut c2 = empty_contract();
+        c2.domain_terms = Some(Vec::new());
+        assert!(!c2.excerpt_hits_any_domain_term("Task api"));
     }
 }

--- a/src/agent/loop_run/task_contract.rs
+++ b/src/agent/loop_run/task_contract.rs
@@ -144,12 +144,95 @@ pub(super) enum ArtifactRecoveryAction {
     Done,
 }
 
+/// Issue #636: bounded `ArtifactRole -> excerpt` sidecar carried alongside
+/// the existing artifact / evidence inputs into `plan_artifact_recovery`.
+/// `KISS / DR1-004`: kept as a `HashMap` type alias instead of a wrapper
+/// struct. The `bounded_post_edit_excerpt` SSOT in `turn.rs` is responsible
+/// for sizing each value at or below [`MAX_ARTIFACT_EXCERPT_BYTES`] before
+/// insertion. No `pub use` is added at the loop_run facade (DR3-001).
+pub(super) type ArtifactExcerpts = std::collections::HashMap<ArtifactRole, String>;
+
+/// Issue #636: upper byte cap for any single post-edit excerpt collected
+/// by `bounded_post_edit_excerpt`. 8 KiB is intentionally smaller than
+/// `required_behavior::MAX_REQUEST_SCAN_BYTES` (64 KiB) so per-turn excerpt
+/// memory stays bounded even when many artifact roles fire. Used as the
+/// SSOT by `turn.rs::bounded_post_edit_excerpt`; not re-exported via the
+/// `loop_run` facade (DR3-001).
+pub(super) const MAX_ARTIFACT_EXCERPT_BYTES: usize = 8 * 1024;
+
 #[derive(Debug, Clone, Copy)]
 pub(super) struct ArtifactRecoveryInputs<'a> {
     pub(super) contract: &'a TaskContract,
     pub(super) evidence: &'a EvidenceSet,
     pub(super) artifacts: &'a [ArtifactState],
     pub(super) repair_state: &'a VerifierRepairState,
+    /// Issue #636: bounded post-edit excerpt per observed role.
+    /// `&ArtifactExcerpts::new()` (empty) is the back-compat sentinel that
+    /// disables behavior-coverage gating.
+    pub(super) artifact_excerpts: &'a ArtifactExcerpts,
+}
+
+// ---------------------------------------------------------------------------
+// Issue #636: behavior coverage judgement (private to task_contract).
+// ---------------------------------------------------------------------------
+
+/// Whether the contract has any actionable behavior signal that can drive
+/// the coverage gate. If neither `operations` nor `domain_terms` was
+/// extracted, the gate is disabled and the legacy completion path runs.
+fn behavior_coverage_enabled(contract: &TaskContract) -> bool {
+    contract.required_behavior.operations.is_some()
+        || contract.required_behavior.domain_terms.is_some()
+}
+
+/// True when `excerpt` either hits any operation keyword or contains any
+/// domain term. Both judgements stay behind the `required_behavior`
+/// SSOT (DR1-005) so `KeywordMatch` / `OPERATION_KEYWORDS` never escape
+/// the schema module.
+fn excerpt_satisfies_behavior(contract: &TaskContract, excerpt: &str) -> bool {
+    contract
+        .required_behavior
+        .excerpt_hits_any_operation(excerpt)
+        || contract
+            .required_behavior
+            .excerpt_hits_any_domain_term(excerpt)
+}
+
+/// `usage_docs` surface marker categories. Short tokens (`run`) use the
+/// token-boundary helper so "running" / "github.run" do not false-positive.
+const USAGE_DOCS_SETUP_MARKERS: &[(&str, bool)] = &[("install", false), ("setup", false)];
+const USAGE_DOCS_RUN_MARKERS: &[(&str, bool)] = &[("run", true), ("start", false)];
+const USAGE_DOCS_VERIFY_MARKERS: &[(&str, bool)] = &[("test", false), ("verify", false)];
+
+/// At least two of {setup, run, verification} surface categories must
+/// appear in the README excerpt for usage_docs to count as covered. One
+/// category is too weak (scaffold READMEs that only mention `install`),
+/// three is overly strict for minimal but honest docs.
+fn usage_docs_surface_satisfied(excerpt: &str) -> bool {
+    let lower = excerpt.to_ascii_lowercase();
+    let hit = |markers: &[(&str, bool)]| -> bool {
+        markers
+            .iter()
+            .any(|(needle, token_boundary)| usage_docs_marker_hit(&lower, needle, *token_boundary))
+    };
+    let mut categories = 0;
+    if hit(USAGE_DOCS_SETUP_MARKERS) {
+        categories += 1;
+    }
+    if hit(USAGE_DOCS_RUN_MARKERS) {
+        categories += 1;
+    }
+    if hit(USAGE_DOCS_VERIFY_MARKERS) {
+        categories += 1;
+    }
+    categories >= 2
+}
+
+fn usage_docs_marker_hit(lower: &str, needle: &str, token_boundary: bool) -> bool {
+    if token_boundary {
+        contains_ascii_token(lower, needle)
+    } else {
+        lower.contains(needle)
+    }
 }
 
 pub(super) fn plan_artifact_recovery(inputs: ArtifactRecoveryInputs<'_>) -> ArtifactRecoveryAction {
@@ -178,6 +261,36 @@ pub(super) fn plan_artifact_recovery(inputs: ArtifactRecoveryInputs<'_>) -> Arti
             target_hint: recovery_target_hint_for_missing(inputs.artifacts, &missing),
             missing,
         };
+    }
+
+    // Issue #636: behavior-coverage gate. When the contract carries
+    // operations / domain_terms and we have at least one excerpt to
+    // inspect, observed roles must demonstrate the requested behavior.
+    // If the excerpt is absent for a role we skip its check (back-compat).
+    // Setup is treated as covered (no excerpt-level coverage rule yet).
+    if behavior_coverage_enabled(inputs.contract) && !inputs.artifact_excerpts.is_empty() {
+        for role in inputs.contract.required_artifacts.iter() {
+            if !observed.contains(role) {
+                continue;
+            }
+            let Some(excerpt) = inputs.artifact_excerpts.get(role) else {
+                continue;
+            };
+            let covered = match *role {
+                ArtifactRole::Implementation | ArtifactRole::Test => {
+                    excerpt_satisfies_behavior(inputs.contract, excerpt)
+                }
+                ArtifactRole::UsageDocs => usage_docs_surface_satisfied(excerpt),
+                ArtifactRole::Setup => true,
+            };
+            if !covered {
+                let missing = vec![*role];
+                return ArtifactRecoveryAction::Continue {
+                    target_hint: recovery_target_hint_for_missing(inputs.artifacts, &missing),
+                    missing,
+                };
+            }
+        }
     }
 
     let existing_unverified_used = inputs.artifacts.iter().any(|artifact| {
@@ -568,7 +681,11 @@ fn observed_artifacts(evidence: &EvidenceSet) -> Vec<ArtifactRole> {
     roles
 }
 
-fn role_from_repo_edit(category: RepoEditCategory) -> Option<ArtifactRole> {
+// Issue #636: `pub(super)` so `turn.rs::observe_evidence_from_repo_edit`
+// can map a `RepoEditCategory` to an `ArtifactRole` for the excerpt
+// sidecar without duplicating the table (DR1-001). DR3-001 maintained:
+// no `pub use` from `src/agent/loop_run.rs`.
+pub(super) fn role_from_repo_edit(category: RepoEditCategory) -> Option<ArtifactRole> {
     match category {
         RepoEditCategory::Impl => Some(ArtifactRole::Implementation),
         RepoEditCategory::Test => Some(ArtifactRole::Test),
@@ -837,6 +954,7 @@ mod tests {
                 evidence: &evidence,
                 artifacts: &artifacts,
                 repair_state: &repair_state,
+                artifact_excerpts: &ArtifactExcerpts::new(),
             }),
             ArtifactRecoveryAction::RunVerifier
         );
@@ -860,6 +978,7 @@ mod tests {
             evidence: &evidence,
             artifacts: &artifacts,
             repair_state: &repair_state,
+            artifact_excerpts: &ArtifactExcerpts::new(),
         });
 
         assert_eq!(
@@ -907,6 +1026,7 @@ mod tests {
                 evidence: &evidence,
                 artifacts: &artifacts,
                 repair_state: &repair_state,
+                artifact_excerpts: &ArtifactExcerpts::new(),
             }),
             ArtifactRecoveryAction::RepairArtifact {
                 target_hint: Some(target_hint),
@@ -922,5 +1042,267 @@ mod tests {
 
         assert_eq!(contract.intent, TaskIntent::Install);
         assert_eq!(contract.evaluate(&evidence), CompletionDecision::Done);
+    }
+
+    // -----------------------------------------------------------------
+    // Issue #636: behavior-aware completion (7 tests)
+    //
+    // These exercise `plan_artifact_recovery` with the new
+    // `artifact_excerpts` sidecar populated. Tests share a fixed
+    // English request so the deterministic schema extractor populates
+    // `operations` / `domain_terms` (Japanese-only requests bypass the
+    // coverage gate by design — see `behavior_coverage_skipped_when_*`).
+    // -----------------------------------------------------------------
+
+    fn build_excerpts(pairs: &[(ArtifactRole, &str)]) -> ArtifactExcerpts {
+        let mut map = ArtifactExcerpts::new();
+        for (role, body) in pairs {
+            map.insert(*role, (*body).to_string());
+        }
+        map
+    }
+
+    #[test]
+    fn scaffold_only_does_not_complete_when_behavior_unsatisfied() {
+        // Use a behaviour-bearing English request without punctuation
+        // that the deterministic extractor would also pull into
+        // domain_terms verbatim (e.g. `/`, dotted identifiers).
+        let contract = TaskContract::from_request("Implement a TaskRepo that can create entries.");
+        // Sanity: behavior schema must carry at least one signal.
+        assert!(
+            behavior_coverage_enabled(&contract),
+            "schema must have ops or terms, got behavior={:?}",
+            contract.required_behavior
+        );
+        // Implementation evidence observed but the excerpt does not hit
+        // any operation keyword or domain term.
+        let mut evidence = EvidenceSet::new();
+        evidence.push(repo_edit(RepoEditCategory::Impl));
+        let excerpts = build_excerpts(&[(
+            ArtifactRole::Implementation,
+            "fn placeholder() {}\nfn another() {}\n",
+        )]);
+        let repair_state = VerifierRepairState::None;
+        let action = plan_artifact_recovery(ArtifactRecoveryInputs {
+            contract: &contract,
+            evidence: &evidence,
+            artifacts: &[],
+            repair_state: &repair_state,
+            artifact_excerpts: &excerpts,
+        });
+        match action {
+            ArtifactRecoveryAction::Continue { missing, .. } => {
+                assert!(
+                    missing.contains(&ArtifactRole::Implementation),
+                    "expected Implementation missing, got: {missing:?}"
+                );
+            }
+            other => panic!(
+                "expected Continue, got {other:?}. behavior={:?}",
+                contract.required_behavior
+            ),
+        }
+    }
+
+    #[test]
+    fn implementation_excerpt_without_operations_or_terms_is_not_complete() {
+        let contract = TaskContract::from_request(
+            "Build a Task CRUD API: create / read / update / delete a Task entity.",
+        );
+        let mut evidence = EvidenceSet::new();
+        evidence.push(repo_edit(RepoEditCategory::Impl));
+        let excerpts = build_excerpts(&[(
+            ArtifactRole::Implementation,
+            "fn placeholder() {}\nfn another() {}\n",
+        )]);
+        let repair_state = VerifierRepairState::None;
+        let action = plan_artifact_recovery(ArtifactRecoveryInputs {
+            contract: &contract,
+            evidence: &evidence,
+            artifacts: &[],
+            repair_state: &repair_state,
+            artifact_excerpts: &excerpts,
+        });
+        assert!(
+            matches!(action, ArtifactRecoveryAction::Continue { .. }),
+            "expected Continue, got {action:?}"
+        );
+    }
+
+    #[test]
+    fn implementation_excerpt_with_operation_satisfies_coverage() {
+        let contract = TaskContract::from_request(
+            "Build a Task CRUD API: create / read / update / delete a Task entity. Verify with tests.",
+        );
+        let mut evidence = EvidenceSet::new();
+        evidence.push(repo_edit(RepoEditCategory::Impl));
+        evidence.push(repo_edit(RepoEditCategory::Test));
+        evidence.push(repo_edit(RepoEditCategory::Docs));
+        let excerpts = build_excerpts(&[
+            (
+                ArtifactRole::Implementation,
+                "fn create_task(t: Task) -> Task { /* persist */ }\nfn delete_task(id: u64) {}\n",
+            ),
+            (
+                ArtifactRole::Test,
+                "fn test_create_task() { create_task(...); }\n",
+            ),
+            (
+                ArtifactRole::UsageDocs,
+                "## Setup\ninstall deps\n## Run\nrun the server\n## Test\nrun the tests\n",
+            ),
+        ]);
+        let repair_state = VerifierRepairState::None;
+        let action = plan_artifact_recovery(ArtifactRecoveryInputs {
+            contract: &contract,
+            evidence: &evidence,
+            artifacts: &[],
+            repair_state: &repair_state,
+            artifact_excerpts: &excerpts,
+        });
+        // With coverage satisfied + tests required, the planner falls
+        // through to verifier execution.
+        assert_eq!(action, ArtifactRecoveryAction::RunVerifier);
+    }
+
+    #[test]
+    fn test_excerpt_with_operation_satisfies_coverage() {
+        let contract =
+            TaskContract::from_request("Implement create and read for Task entity. Add tests.");
+        let mut evidence = EvidenceSet::new();
+        evidence.push(repo_edit(RepoEditCategory::Impl));
+        evidence.push(repo_edit(RepoEditCategory::Test));
+        let excerpts = build_excerpts(&[
+            (
+                ArtifactRole::Implementation,
+                "fn create_task() -> Task { Task::new() }\n",
+            ),
+            (
+                ArtifactRole::Test,
+                "fn test_create_task() { let t = create_task(); assert!(true); }\n",
+            ),
+        ]);
+        let repair_state = VerifierRepairState::None;
+        let action = plan_artifact_recovery(ArtifactRecoveryInputs {
+            contract: &contract,
+            evidence: &evidence,
+            artifacts: &[],
+            repair_state: &repair_state,
+            artifact_excerpts: &excerpts,
+        });
+        assert_eq!(action, ArtifactRecoveryAction::RunVerifier);
+    }
+
+    #[test]
+    fn usage_docs_excerpt_lacking_two_surfaces_falls_to_continue() {
+        let contract = TaskContract::from_request(
+            "Build a Task CRUD API with create / read. Document usage in README.",
+        );
+        let mut evidence = EvidenceSet::new();
+        evidence.push(repo_edit(RepoEditCategory::Impl));
+        evidence.push(repo_edit(RepoEditCategory::Docs));
+        // Implementation excerpt satisfies behavior; UsageDocs excerpt
+        // only mentions install (single surface). Coverage must fail.
+        let excerpts = build_excerpts(&[
+            (
+                ArtifactRole::Implementation,
+                "fn create_task() -> Task { Task::new() }\n",
+            ),
+            (
+                ArtifactRole::UsageDocs,
+                "# Project\nTo install: cargo install foo\n",
+            ),
+        ]);
+        let repair_state = VerifierRepairState::None;
+        let action = plan_artifact_recovery(ArtifactRecoveryInputs {
+            contract: &contract,
+            evidence: &evidence,
+            artifacts: &[],
+            repair_state: &repair_state,
+            artifact_excerpts: &excerpts,
+        });
+        match action {
+            ArtifactRecoveryAction::Continue { missing, .. } => {
+                assert!(
+                    missing.contains(&ArtifactRole::UsageDocs),
+                    "expected UsageDocs missing, got: {missing:?}"
+                );
+            }
+            other => panic!("expected Continue, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn behavior_coverage_skipped_when_operations_and_domain_terms_both_none() {
+        // Pure-kanji request: extractor cannot populate operations or
+        // domain_terms, so behavior coverage stays disabled and the
+        // existing artifact-observation path drives completion.
+        let contract = TaskContract::from_request("使用方法を更新してください");
+        // Sanity-check that the schema is empty.
+        assert!(contract.required_behavior.operations.is_none());
+        assert!(contract.required_behavior.domain_terms.is_none());
+
+        let mut evidence = EvidenceSet::new();
+        evidence.push(repo_edit(RepoEditCategory::Docs));
+        // Even a trivial / unsatisfying excerpt must not block completion.
+        let excerpts = build_excerpts(&[(ArtifactRole::UsageDocs, "x")]);
+        let repair_state = VerifierRepairState::None;
+        let action = plan_artifact_recovery(ArtifactRecoveryInputs {
+            contract: &contract,
+            evidence: &evidence,
+            artifacts: &[],
+            repair_state: &repair_state,
+            artifact_excerpts: &excerpts,
+        });
+        assert_eq!(action, ArtifactRecoveryAction::Done);
+    }
+
+    #[test]
+    fn short_keyword_read_uses_token_boundary() {
+        // README must not satisfy a `read` operation contract; only an
+        // actual `read` token boundary does. Light coverage that the
+        // task_contract route delegates to the required_behavior SSOT.
+        let contract = TaskContract::from_request("implement a read endpoint");
+        assert!(
+            contract
+                .required_behavior
+                .operations
+                .as_ref()
+                .is_some_and(|ops| ops.contains(&required_behavior::Operation::Read)),
+            "schema={:?}",
+            contract.required_behavior
+        );
+        assert!(
+            contract
+                .required_artifacts
+                .contains(&ArtifactRole::Implementation)
+        );
+        // The lowercase-only request must NOT yield any CamelCase domain
+        // term that would let the README excerpt false-positive via the
+        // domain_term substring path.
+        assert!(
+            contract.required_behavior.domain_terms.is_none(),
+            "schema={:?}",
+            contract.required_behavior
+        );
+        let mut evidence = EvidenceSet::new();
+        evidence.push(repo_edit(RepoEditCategory::Impl));
+        // Excerpt mentions only README — must NOT count as a `read` hit.
+        let excerpts = build_excerpts(&[(
+            ArtifactRole::Implementation,
+            "// see README for details\nfn nothing() {}\n",
+        )]);
+        let repair_state = VerifierRepairState::None;
+        let action = plan_artifact_recovery(ArtifactRecoveryInputs {
+            contract: &contract,
+            evidence: &evidence,
+            artifacts: &[],
+            repair_state: &repair_state,
+            artifact_excerpts: &excerpts,
+        });
+        assert!(
+            matches!(action, ArtifactRecoveryAction::Continue { .. }),
+            "expected Continue (token boundary), got {action:?}"
+        );
     }
 }

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -4877,6 +4877,9 @@ impl Agent {
         // `ProtocolKind::evidence_set_satisfies`.
         self.evidence_set_this_turn.clear();
         self.task_contract_evidence_set_this_turn.clear();
+        // Issue #636: drop per-turn behavior-coverage excerpts so the
+        // current turn never observes a previous turn's edits.
+        self.task_contract_excerpts.clear();
         self.current_artifact_recovery_target = None;
         self.task_contract_verifier_repair_pending = false;
         self.repair_job = None;
@@ -9897,6 +9900,16 @@ impl Agent {
             self.task_contract_evidence_set_this_turn.push(
                 super::completion_evidence::CompletionEvidence::RepoEdit { category, count: 1 },
             );
+            // Issue #636: capture bounded post-edit excerpt for the
+            // current role so `plan_artifact_recovery` can assert that
+            // the edit actually carries the requested behavior. Silent
+            // skip on role-miss / read failure (back-compat with the
+            // existing `repo_edit_has_post_scaffold_delta` no-data path).
+            if let Some(role) = super::task_contract::role_from_repo_edit(category)
+                && let Some(excerpt) = self.bounded_post_edit_excerpt(&relative_path)
+            {
+                self.task_contract_excerpts.insert(role, excerpt);
+            }
         }
         crate::logging::log_completion_evidence_observed(
             self.current_turn_index,
@@ -9931,6 +9944,58 @@ impl Agent {
             ScaffoldDiffStatus::Changed => true,
             ScaffoldDiffStatus::UnchangedOrMissing => false,
         }
+    }
+
+    /// Issue #636: read a workspace-confined, cap-bounded excerpt of
+    /// `relative_path` for behavior-coverage judgement.
+    ///
+    /// Path confinement (defense-in-depth: callers already pass a
+    /// normalized relative path, but we re-resolve here):
+    /// - `resolve_user_path(&self.work_root, relative_path)` + canonical
+    ///   root + `strip_prefix` rejects absolute / `..` escape / out-of-
+    ///   workspace symlinks / canonicalize failures / non-files.
+    ///
+    /// Cap-before-read:
+    /// - `File::open` + `Read::take(MAX_ARTIFACT_EXCERPT_BYTES + 1)` so
+    ///   we never read more than 8 KiB + 1 byte from disk. `std::fs::read`
+    ///   / `read_to_string` are intentionally avoided.
+    ///
+    /// Content guards:
+    /// - UTF-8 invalid → `None`. Embedded NUL → `None` (non-text).
+    /// - When the cap boundary splits a multi-byte UTF-8 character we
+    ///   truncate down to the last valid char boundary instead of giving
+    ///   up (CB-001 / Issue #636 Phase 4).
+    /// - `session::feedback::mask_secrets` then
+    ///   `session::feedback::mask_header_family` stacked, matching the
+    ///   redactor SSOT used elsewhere (DR4-002).
+    /// - Post-masking re-truncation on a UTF-8 char boundary so masking
+    ///   expansion can never blow past `MAX_ARTIFACT_EXCERPT_BYTES`.
+    ///
+    /// TOCTOU hardening: on Unix we open with `O_NOFOLLOW` so a symlink
+    /// swap between the path confinement check and the open call cannot
+    /// redirect us outside the workspace (CB-002 / Issue #636 Phase 4).
+    fn bounded_post_edit_excerpt(&self, relative_path: &str) -> Option<String> {
+        use std::io::Read;
+        let target = resolve_user_path(&self.work_root, relative_path).ok()?;
+        let root = std::fs::canonicalize(&self.work_root).ok()?;
+        if target.strip_prefix(&root).is_err() {
+            return None;
+        }
+        if !target.is_file() {
+            return None;
+        }
+        let cap = super::task_contract::MAX_ARTIFACT_EXCERPT_BYTES;
+        let file = open_excerpt_file_nofollow(&target)?;
+        let mut buf: Vec<u8> = Vec::with_capacity(cap + 1);
+        file.take((cap as u64) + 1).read_to_end(&mut buf).ok()?;
+        if buf.contains(&0u8) {
+            return None;
+        }
+        let text = utf8_prefix_respecting_cap(&buf, cap)?.to_string();
+        let masked = crate::session::feedback::mask_header_family(
+            &crate::session::feedback::mask_secrets(&text),
+        );
+        Some(truncate_on_char_boundary(masked, cap))
     }
 
     fn task_contract_artifact_states(
@@ -10007,6 +10072,7 @@ impl Agent {
             evidence: &self.task_contract_evidence_set_this_turn,
             artifacts: &artifacts,
             repair_state: &repair_state,
+            artifact_excerpts: &self.task_contract_excerpts,
         })
     }
 
@@ -13491,6 +13557,68 @@ fn scaffold_candidate_priority(
         return 0;
     }
     10
+}
+
+/// Issue #636: trim `s` so its byte length is at most `cap` while
+/// preserving the leading UTF-8 char boundary. Used by
+/// `bounded_post_edit_excerpt` to re-cap a post-masking string when
+/// redaction expanded it past `MAX_ARTIFACT_EXCERPT_BYTES`.
+fn truncate_on_char_boundary(s: String, cap: usize) -> String {
+    if s.len() <= cap {
+        return s;
+    }
+    let mut end = cap;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    s[..end].to_string()
+}
+
+/// Issue #636 (CB-001): return the longest valid UTF-8 prefix of `buf`
+/// up to `cap` bytes. If the bytes inside `[0, cap)` are a valid UTF-8
+/// prefix but the cap+1 read tail straddles a multi-byte char, we shrink
+/// to `valid_up_to()` instead of rejecting the whole excerpt. Truly
+/// invalid UTF-8 (`error_len().is_some()`) still returns `None`.
+fn utf8_prefix_respecting_cap(buf: &[u8], cap: usize) -> Option<&str> {
+    let end = buf.len().min(cap);
+    let slice = &buf[..end];
+    match std::str::from_utf8(slice) {
+        Ok(s) => Some(s),
+        Err(e) => {
+            if e.error_len().is_some() {
+                return None;
+            }
+            // Tail of `slice` is a partial multi-byte char — safe to clip.
+            let valid = e.valid_up_to();
+            std::str::from_utf8(&slice[..valid]).ok()
+        }
+    }
+}
+
+/// Issue #636 (CB-002): open `target` for read with `O_NOFOLLOW` on Unix
+/// so a symlink swap between the workspace-confinement check and the
+/// open call cannot redirect us outside the workspace. On non-Unix we
+/// fall back to plain `File::open` and rely on the pre-open path checks.
+fn open_excerpt_file_nofollow(target: &Path) -> Option<std::fs::File> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        let file = std::fs::OpenOptions::new()
+            .read(true)
+            .custom_flags(libc::O_NOFOLLOW)
+            .open(target)
+            .ok()?;
+        // Re-check post-open: O_NOFOLLOW guards the final component, and
+        // `metadata()` (vs `symlink_metadata`) reflects the opened inode.
+        if !file.metadata().ok()?.is_file() {
+            return None;
+        }
+        Some(file)
+    }
+    #[cfg(not(unix))]
+    {
+        std::fs::File::open(target).ok()
+    }
 }
 
 fn current_file_hash_for_relative_path(work_root: &Path, relative_path: &str) -> Option<String> {
@@ -23243,6 +23371,196 @@ export default function App() {
         assert!(
             !payload.contains("abcdef0123456789SECRET"),
             "Header-family secrets must be redacted"
+        );
+    }
+
+    // -----------------------------------------------------------------
+    // Issue #636: per-turn excerpt lifecycle / path-confinement / cap.
+    // -----------------------------------------------------------------
+
+    /// Issue #636: the per-turn behavior-coverage excerpts map MUST be
+    /// reset whenever a new user turn begins, mirroring the existing
+    /// `evidence_set_this_turn.clear()` / `task_contract_evidence_set_*`
+    /// reset block. We don't have a direct hook to invoke run_actor_loop
+    /// in unit tests, so this test pins the same field-clear pattern the
+    /// production reset block uses (regression guard if future edits
+    /// drop the clear call).
+    #[test]
+    fn task_contract_excerpts_cleared_at_turn_start() {
+        use crate::agent::loop_run::commands::test_agent_with_config;
+        use crate::agent::loop_run::task_contract::ArtifactRole;
+        use crate::config::Config;
+
+        let (mut agent, _temp) = test_agent_with_config(Config::default());
+        agent
+            .task_contract_excerpts
+            .insert(ArtifactRole::Implementation, "stale excerpt".to_string());
+        assert!(!agent.task_contract_excerpts.is_empty());
+
+        // Production per-turn reset block (`run_actor_loop` head) calls
+        // `self.task_contract_excerpts.clear()` next to the other
+        // `*_this_turn` resets. Mirror that assignment here.
+        agent.task_contract_excerpts.clear();
+
+        assert!(
+            agent.task_contract_excerpts.is_empty(),
+            "task_contract_excerpts must be empty after per-turn reset"
+        );
+    }
+
+    /// Issue #636: absolute paths, `..`-escape paths, and non-file
+    /// targets must yield `None` from `bounded_post_edit_excerpt`. We
+    /// don't exercise OS symlinks here (CI portability) but the path
+    /// confinement is otherwise covered by `resolve_user_path` +
+    /// `strip_prefix` + `is_file()`.
+    #[test]
+    fn bounded_post_edit_excerpt_rejects_escape_paths() {
+        use crate::agent::loop_run::commands::test_agent_with_config;
+        use crate::config::Config;
+
+        let (agent, _temp) = test_agent_with_config(Config::default());
+
+        // Absolute path outside the workspace.
+        assert!(agent.bounded_post_edit_excerpt("/etc/hosts").is_none());
+
+        // `..` escape: even if it resolves to a real file, it escapes
+        // the workspace.
+        assert!(
+            agent
+                .bounded_post_edit_excerpt("../../../etc/passwd")
+                .is_none()
+        );
+
+        // Non-file (workspace root itself is a directory, not a file).
+        assert!(agent.bounded_post_edit_excerpt(".").is_none());
+
+        // Missing file inside workspace.
+        assert!(
+            agent
+                .bounded_post_edit_excerpt("does/not/exist.rs")
+                .is_none()
+        );
+    }
+
+    /// Issue #636: cap-before-read keeps the excerpt at or below the
+    /// SSOT byte cap, embedded NUL inputs are rejected as non-text, and
+    /// secret-like content is masked by stacking `mask_secrets` +
+    /// `mask_header_family` before the excerpt is returned.
+    #[test]
+    fn bounded_post_edit_excerpt_masks_caps_and_rejects_binary() {
+        use crate::agent::loop_run::commands::test_agent_with_config;
+        use crate::agent::loop_run::task_contract::MAX_ARTIFACT_EXCERPT_BYTES;
+        use crate::config::Config;
+
+        let (agent, temp) = test_agent_with_config(Config::default());
+
+        // Cap: file twice the size of the cap is truncated.
+        let big_path = temp.path().join("big.txt");
+        std::fs::write(&big_path, "a".repeat(MAX_ARTIFACT_EXCERPT_BYTES * 2)).unwrap();
+        let excerpt = agent.bounded_post_edit_excerpt("big.txt").unwrap();
+        assert!(
+            excerpt.len() <= MAX_ARTIFACT_EXCERPT_BYTES,
+            "excerpt cap violated: {} > {}",
+            excerpt.len(),
+            MAX_ARTIFACT_EXCERPT_BYTES
+        );
+
+        // Binary: NUL bytes mean we treat it as non-text and return None.
+        let bin_path = temp.path().join("bin.dat");
+        std::fs::write(&bin_path, [0x00u8, 0x01, 0x02, 0x03]).unwrap();
+        assert!(agent.bounded_post_edit_excerpt("bin.dat").is_none());
+
+        // Masking: a recognisable secret-like token must not survive
+        // verbatim. `mask_secrets` rewrites `API_KEY=...` style assigns,
+        // and `mask_header_family` removes credential tails from header
+        // family lines.
+        let secret_path = temp.path().join("secret.rs");
+        std::fs::write(
+            &secret_path,
+            "const TOKEN: &str = \"sk-proj-aaaaaaaaaaaaaaaaaaaaaaaa\";\n\
+             Authorization: Bearer abc123def456\n",
+        )
+        .unwrap();
+        let excerpt = agent.bounded_post_edit_excerpt("secret.rs").unwrap();
+        assert!(
+            !excerpt.contains("sk-proj-aaaaaaaaaaaaaaaaaaaaaaaa"),
+            "raw secret leaked: {excerpt}"
+        );
+        assert!(
+            !excerpt.contains("abc123def456"),
+            "raw Authorization tail leaked: {excerpt}"
+        );
+    }
+
+    /// Issue #636 Phase 4 (CB-001): when the byte cap falls inside a
+    /// multi-byte UTF-8 character we must truncate to the last valid
+    /// char boundary instead of returning `None`. Previously the
+    /// `cap + 1` byte read followed by a single `from_utf8(&buf)` would
+    /// reject this case as invalid UTF-8 even though the file is valid.
+    #[test]
+    fn bounded_post_edit_excerpt_truncates_at_utf8_boundary_when_cap_splits_multibyte() {
+        use crate::agent::loop_run::commands::test_agent_with_config;
+        use crate::agent::loop_run::task_contract::MAX_ARTIFACT_EXCERPT_BYTES;
+        use crate::config::Config;
+
+        let (agent, temp) = test_agent_with_config(Config::default());
+
+        // Place a multi-byte char (`あ` = 3 bytes in UTF-8) so that its
+        // first byte sits at offset `MAX_ARTIFACT_EXCERPT_BYTES - 1`,
+        // i.e. the `cap+1` read window slices it apart.
+        let prefix_len = MAX_ARTIFACT_EXCERPT_BYTES - 1;
+        let mut content = "a".repeat(prefix_len);
+        content.push('あ');
+        // Pad with more ASCII so the file is larger than `cap + 1`.
+        content.push_str(&"b".repeat(64));
+
+        let path = temp.path().join("multibyte.txt");
+        std::fs::write(&path, content).unwrap();
+
+        let excerpt = agent
+            .bounded_post_edit_excerpt("multibyte.txt")
+            .expect("excerpt must succeed even when cap splits a multi-byte char");
+        assert!(
+            excerpt.len() <= MAX_ARTIFACT_EXCERPT_BYTES,
+            "excerpt cap violated: {} > {}",
+            excerpt.len(),
+            MAX_ARTIFACT_EXCERPT_BYTES
+        );
+        assert!(
+            excerpt.is_char_boundary(excerpt.len()),
+            "excerpt must end on a valid UTF-8 char boundary"
+        );
+        // The truncation must keep the leading ASCII prefix intact.
+        assert!(excerpt.starts_with(&"a".repeat(prefix_len.min(excerpt.len()))));
+    }
+
+    /// Issue #636 Phase 4 (CB-002): a symlink pointing outside the
+    /// workspace must still be rejected after the O_NOFOLLOW hardening.
+    /// This pins both the pre-open `strip_prefix` check and the Unix
+    /// `O_NOFOLLOW` open path so a future refactor cannot regress one
+    /// without the other.
+    #[cfg(unix)]
+    #[test]
+    fn bounded_post_edit_excerpt_rejects_symlink_escaping_workspace() {
+        use crate::agent::loop_run::commands::test_agent_with_config;
+        use crate::config::Config;
+
+        let (agent, temp) = test_agent_with_config(Config::default());
+
+        // Create the symlink target *outside* the workspace.
+        let outside = tempfile::tempdir().expect("outside tempdir");
+        let outside_file = outside.path().join("secret.txt");
+        std::fs::write(&outside_file, "top secret").unwrap();
+
+        let link_path = temp.path().join("link.txt");
+        std::os::unix::fs::symlink(&outside_file, &link_path).unwrap();
+
+        // `bounded_post_edit_excerpt` must refuse the symlink whether
+        // confinement catches it first (canonical strip_prefix) or the
+        // O_NOFOLLOW open path catches it (TOCTOU race window).
+        assert!(
+            agent.bounded_post_edit_excerpt("link.txt").is_none(),
+            "symlink pointing outside the workspace must be rejected"
         );
     }
 }


### PR DESCRIPTION
## 概要

`plan_artifact_recovery` の completion 判定に `RequiredBehaviorContract` (#635) を主入力とする behavior coverage 判定を導入し、scaffold 微変更や bare な RepoEdit 観測だけで completion evidence として通る false positive を抑止します。

## 変更内容

### 新規 API（すべて `pub(super)`、facade 再公開なし — DR3-001）
- `required_behavior::RequiredBehaviorContract::excerpt_hits_any_operation` / `excerpt_hits_any_domain_term` — `OPERATION_KEYWORDS` SSOT を再利用した judgement API。短語 (`read` / `run`) は `KeywordMatch::TokenAscii` の token boundary を維持。
- `task_contract::ArtifactExcerpts` (HashMap type alias) / `MAX_ARTIFACT_EXCERPT_BYTES = 8 KiB` / `role_from_repo_edit` の `pub(super)` 昇格。
- `ArtifactRecoveryInputs` に非 Optional の borrowed sidecar `artifact_excerpts: &ArtifactExcerpts` を追加。既存テスト 5 件は literal 構築に `&ArtifactExcerpts::new()` を追記する形で維持。

### Coverage 判定（`task_contract.rs` 内 private）
- `behavior_coverage_enabled` — `operations` / `domain_terms` 共に None なら従来挙動（artifact role 観測のみ）にフォールバック。日本語のみ request など低 confidence ケースの後方互換。
- `excerpt_satisfies_behavior` — operation / domain_terms どちらかが excerpt に最低 1 件ヒットすれば成立。
- `usage_docs_surface_satisfied` — `install`/`setup` × `run`/`start` × `test`/`verify` の 3 カテゴリのうち最低 2 つに該当する surface marker を要求。framework / endpoint 固定語は採用しない。
- `plan_artifact_recovery` は coverage 不足時に `Continue { missing, target_hint }` (既存 `recovery_target_hint_for_missing` を再利用) に落とす。

### Excerpt plumbing（`turn.rs::bounded_post_edit_excerpt`）
- **Path confinement**: `resolve_user_path` → `canonicalize` → `strip_prefix` → `is_file` を再実行し、絶対 path / `..` escape / workspace 外 symlink / symlink loop / non-file は `None`。
- **Cap-before-read**: `File::open` + `Read::take(MAX + 1)` で巨大ファイル DoS を遮断。`std::fs::read` / `read_to_string` は使わない。
- **UTF-8 boundary truncation**: `utf8_prefix_respecting_cap` helper で multi-byte が cap 境界をまたいだ場合に最後の有効 UTF-8 prefix まで縮める。
- **TOCTOU 遮断**: Unix では `OpenOptions::custom_flags(libc::O_NOFOLLOW)` + post-open `metadata()?.is_file()` 再確認で symlink swap race を閉じる。
- **Secret masking**: `session::feedback::mask_secrets` の上に `mask_header_family` を stack。masking 後に cap を超えれば UTF-8 boundary で再 truncate。

### Per-turn cap
`Agent::task_contract_excerpts` を `*_this_turn.clear()` パターンで turn 境界 reset。

### スコープ外（意図的）
- `CompletionEvidence::RepoEdit` の enum schema 変更（クレート横断破壊変更を回避）
- `protocol.rs` の category-based acceptance
- `src/agent/loop_run.rs` facade への `pub use` 追加

## テスト

新規 15 件、合計 1828 件 pass:
- `required_behavior`: judgement API 5 件
- `task_contract`: scaffold 飢餓 / Impl-Test substring 充足 / UsageDocs surface 飢餓 / both-None skip など 6 件 + 任意 1 件
- `turn.rs`: per-turn clear / escape path reject / masking + cap / UTF-8 boundary / Unix symlink escape reject の 5 件

既存テスト 5 件 (`docs_only_contract_does_not_require_implementation` 等) は assertion を変更せず維持。

### 品質ゲート
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings` (0 警告)
- [x] `cargo test --lib` (1828 件 pass)

### CLAUDE.md 不変条件
- [x] DR3-001: facade 再公開なし（grep 確認）
- [x] DR3-002: photon 層への新規 import なし
- [x] Security Invariants: `mask_secrets` + `mask_header_family` stack 適用、cap-before-read

## 関連Issue

Closes #636

依存:
- #635 (`RequiredBehaviorContract` schema + extraction — `2314f51` で完了済)

関連:
- 親 Issue: #633
- 責務分離: #637 / #638 (verifier repair) — completion 判定だけを扱う

## レビュー履歴

- Issue マルチステージレビュー (claude-opus×4 + codex×4): Must Fix 7 / Should Fix 5 / Nice 2 反映
- 設計マルチステージレビュー (claude-opus×2 + codex×2): Must Fix 8 / Should Fix 10 / Nice 3 反映
- TDD 実装後 Codex コードレビュー: CB-001 (UTF-8 cap boundary) / CB-002 (TOCTOU symlink) を Phase 4 リファクタで対応済

🤖 Generated with [Claude Code](https://claude.com/claude-code)