### PR TITLE
fix(agent/loop_run): separate current-task workspace scope from artifact ownership (#646)

### DIFF
--- a/src/agent/loop_run.rs
+++ b/src/agent/loop_run.rs
@@ -25,6 +25,10 @@ use crate::stdin_prompt;
 use crate::system_prompt::build_system_prompt;
 use crate::tools::registry::{ToolContext, ToolRegistry};
 
+// Issue #646: artifact ownership classification. Module is intentionally
+// *not* re-exported (DR3-001) — `turn.rs` and `task_contract.rs` are the
+// only in-crate consumers via `super::artifact_ownership::*`.
+mod artifact_ownership;
 pub(crate) mod auto_promote;
 mod auto_test;
 pub mod commands;
@@ -60,6 +64,10 @@ mod spinner;
 mod success;
 mod summary;
 mod task_contract;
+// Issue #646: task workspace scope detection. Module is intentionally
+// *not* re-exported (DR3-001) — `turn.rs` is the only in-crate consumer
+// via `super::task_workspace_scope::*`.
+mod task_workspace_scope;
 mod tester;
 mod turn;
 pub(crate) mod verifier_skill;
@@ -527,6 +535,18 @@ pub struct Agent {
     /// the behavior-coverage decision is evaluated within the same turn
     /// the excerpts were observed.
     task_contract_excerpts: task_contract::ArtifactExcerpts,
+    /// Issue #646: session-scoped set of workspace-relative paths that were
+    /// successfully written or edited during the current `Agent` lifetime
+    /// (not just the current turn). Consumed by
+    /// `artifact_ownership::classify_ownership` to gate which existing files
+    /// the active task is allowed to claim as completion evidence.
+    ///
+    /// **Lives on `Agent`, not `SessionSnapshot`** — fresh sessions deliberately
+    /// start empty so existing filesystem artifacts cannot auto-promote
+    /// themselves (Issue #646 §修正方針 2 `Owned` rules + §追加で考慮するケース
+    /// "resumed session"). A resumed session also begins with an empty set
+    /// and must re-establish ownership through fresh edits / scope mention.
+    session_edited_relative_paths: std::collections::HashSet<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -744,6 +764,7 @@ impl Agent {
             repair_job_artifact_attempts: 0,
             repair_failure_snapshot: None,
             task_contract_excerpts: task_contract::ArtifactExcerpts::new(),
+            session_edited_relative_paths: std::collections::HashSet::new(),
         }
     }
 

--- a/src/agent/loop_run.rs
+++ b/src/agent/loop_run.rs
@@ -535,18 +535,25 @@ pub struct Agent {
     /// the behavior-coverage decision is evaluated within the same turn
     /// the excerpts were observed.
     task_contract_excerpts: task_contract::ArtifactExcerpts,
-    /// Issue #646: session-scoped set of workspace-relative paths that were
-    /// successfully written or edited during the current `Agent` lifetime
-    /// (not just the current turn). Consumed by
-    /// `artifact_ownership::classify_ownership` to gate which existing files
-    /// the active task is allowed to claim as completion evidence.
+    /// Issue #646 (A1): turn-scoped first-class state for "verifier is
+    /// missing". Set by `drive_task_contract_verifier::NoVerifier`, cleared
+    /// at `handle_user_message` head and on verifier success. While
+    /// populated, the planner suppresses `RunVerifier` until an in-scope
+    /// edit is observed (`record_in_scope_edit`).
+    missing_verifier_job: Option<repair_job::MissingVerifierJob>,
+    /// Issue #646: per-turn set of workspace-relative paths that were
+    /// successfully written or edited during the current user turn. Consumed
+    /// by `artifact_ownership::classify_ownership` to gate which existing
+    /// files the active task is allowed to claim as completion evidence.
     ///
-    /// **Lives on `Agent`, not `SessionSnapshot`** — fresh sessions deliberately
-    /// start empty so existing filesystem artifacts cannot auto-promote
-    /// themselves (Issue #646 §修正方針 2 `Owned` rules + §追加で考慮するケース
-    /// "resumed session"). A resumed session also begins with an empty set
-    /// and must re-establish ownership through fresh edits / scope mention.
-    session_edited_relative_paths: std::collections::HashSet<String>,
+    /// **Per-turn cap pattern (CLAUDE.md "per-turn cap" §)** — reset at the
+    /// head of every `handle_user_message`. The previous turn's edits do
+    /// not auto-confer ownership on the new task: a new task must
+    /// re-establish ownership through fresh edits or an explicit user-named
+    /// scope. Fresh sessions also begin empty, so pre-existing filesystem
+    /// artifacts cannot auto-promote themselves (Issue #646 §修正方針 2
+    /// `Owned` rules).
+    turn_edited_relative_paths: std::collections::HashSet<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -764,7 +771,8 @@ impl Agent {
             repair_job_artifact_attempts: 0,
             repair_failure_snapshot: None,
             task_contract_excerpts: task_contract::ArtifactExcerpts::new(),
-            session_edited_relative_paths: std::collections::HashSet::new(),
+            missing_verifier_job: None,
+            turn_edited_relative_paths: std::collections::HashSet::new(),
         }
     }
 

--- a/src/agent/loop_run.rs
+++ b/src/agent/loop_run.rs
@@ -535,6 +535,12 @@ pub struct Agent {
     /// the behavior-coverage decision is evaluated within the same turn
     /// the excerpts were observed.
     task_contract_excerpts: task_contract::ArtifactExcerpts,
+    /// Issue #646 (C2 / A4): turn-scoped map of pre-tool file hashes captured
+    /// immediately before each Write/Edit execution. Consumed by
+    /// `observe_evidence_from_repo_edit` to detect no-op writes (content
+    /// unchanged → no `Owned` promotion). `None` means the file did not exist
+    /// prior to the tool call. Reset at the `handle_user_message` head.
+    turn_pre_tool_file_hashes: std::collections::HashMap<String, Option<String>>,
     /// Issue #646 (A1): turn-scoped first-class state for "verifier is
     /// missing". Set by `drive_task_contract_verifier::NoVerifier`, cleared
     /// at `handle_user_message` head and on verifier success. While
@@ -772,6 +778,7 @@ impl Agent {
             repair_failure_snapshot: None,
             task_contract_excerpts: task_contract::ArtifactExcerpts::new(),
             missing_verifier_job: None,
+            turn_pre_tool_file_hashes: std::collections::HashMap::new(),
             turn_edited_relative_paths: std::collections::HashSet::new(),
         }
     }

--- a/src/agent/loop_run/artifact_ownership.rs
+++ b/src/agent/loop_run/artifact_ownership.rs
@@ -1,0 +1,332 @@
+//! Issue #646: ownership classification for existing workspace artifacts.
+//!
+//! `ArtifactOwnership` separates "the current task is allowed to claim this
+//! file as completion evidence" (`Owned`) from "this file exists but the
+//! task did not produce it" (`CandidateOnly`) and "this file is outside the
+//! active scope" (`OutOfScope`).
+//!
+//! Visibility: every export here is `pub(super)` and **must not** be
+//! re-exported from `src/agent/loop_run.rs` (CLAUDE.md DR3-001).
+//!
+//! Security: canonical-path / symlink escape is checked *here* — even if a
+//! caller hands us a path that already passed `resolve_user_path`, we
+//! re-confirm scope containment on the canonicalized form before allowing
+//! `Owned`.
+
+use std::path::Path;
+
+use super::task_workspace_scope::{ScopeMode, TaskWorkspaceScope};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ArtifactOwnership {
+    /// The current task owns this file — counts as completion evidence.
+    Owned,
+    /// The file exists in scope but the task did not produce / modify it.
+    /// Allowed as a *reference* read but never as completion evidence.
+    CandidateOnly,
+    /// The file is outside the active scope, escapes the workspace via
+    /// symlink/canonicalization, or sits inside an ignored top-level dir.
+    /// Never read for completion evidence or repair target.
+    OutOfScope,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(super) struct OwnershipInputs<'a> {
+    pub(super) work_root: &'a Path,
+    pub(super) relative_path: &'a str,
+    pub(super) scope: &'a TaskWorkspaceScope,
+    /// `true` when the file was written/edited in the current session.
+    pub(super) edited_this_session: bool,
+    /// `true` when the file was originally scaffolded by Anvil **and** the
+    /// current content differs from the scaffold snapshot (post-scaffold
+    /// delta). Scaffolded-but-unchanged should be `false` because the
+    /// scaffold body itself is not yet request-shaped.
+    pub(super) scaffold_changed: bool,
+    /// `true` when a verifier targeting this file passed in the current
+    /// active scope. Currently only consumed for forward extensibility;
+    /// the planner already short-circuits on verifier success so passing
+    /// `false` here is safe today.
+    #[allow(dead_code)]
+    pub(super) verifier_passed_in_scope: bool,
+}
+
+/// Classify a single workspace-relative artifact path.
+///
+/// Returns `OutOfScope` when *any* of:
+/// - the path is absolute, contains `..`, or has a control character
+/// - canonicalization escapes `work_root`
+/// - the path resolves to a top-level ignored directory
+/// - the scope does not contain the path
+///
+/// Returns `Owned` when the path is in scope **and** at least one ownership
+/// signal is set (edited this session / scaffold delta / verifier success).
+///
+/// Returns `CandidateOnly` otherwise.
+pub(super) fn classify_ownership(inputs: OwnershipInputs<'_>) -> ArtifactOwnership {
+    if !path_is_syntactically_safe(inputs.relative_path) {
+        return ArtifactOwnership::OutOfScope;
+    }
+    if path_in_ignored_top_dir(inputs.relative_path) {
+        return ArtifactOwnership::OutOfScope;
+    }
+    if canonical_escape(inputs.work_root, inputs.relative_path) {
+        return ArtifactOwnership::OutOfScope;
+    }
+    if !inputs.scope.contains(inputs.relative_path) {
+        return ArtifactOwnership::OutOfScope;
+    }
+    // Issue #646: `Owned` への昇格条件:
+    // (a) ユーザーが明示した subtree 内のファイル (ScopeMode::Explicit)
+    // (b) active scope 内で今回 turn に Write/Edit された
+    // (c) Anvil scaffold + post-scaffold delta
+    // (d) active scope 内 verifier 成功
+    let promoted_by_explicit_scope = matches!(inputs.scope.mode, ScopeMode::Explicit { .. });
+    if promoted_by_explicit_scope
+        || inputs.edited_this_session
+        || inputs.scaffold_changed
+        || inputs.verifier_passed_in_scope
+    {
+        ArtifactOwnership::Owned
+    } else {
+        ArtifactOwnership::CandidateOnly
+    }
+}
+
+fn path_is_syntactically_safe(relative_path: &str) -> bool {
+    if relative_path.is_empty() {
+        return false;
+    }
+    if relative_path.chars().any(|c| c.is_control()) {
+        return false;
+    }
+    let path = Path::new(relative_path);
+    if path.is_absolute() {
+        return false;
+    }
+    !path
+        .components()
+        .any(|c| matches!(c, std::path::Component::ParentDir))
+}
+
+fn path_in_ignored_top_dir(relative_path: &str) -> bool {
+    let first = Path::new(relative_path).components().find_map(|c| match c {
+        std::path::Component::Normal(s) => Some(s.to_string_lossy().to_string()),
+        _ => None,
+    });
+    let Some(top) = first else { return true };
+    super::task_workspace_scope::IGNORED_TOP_DIRS
+        .iter()
+        .any(|ignored| *ignored == top)
+}
+
+/// Returns `true` when canonicalizing `work_root.join(relative_path)`
+/// escapes `work_root` (symlink swap, etc.).
+///
+/// On missing files we return `false`: the file simply has not been
+/// created yet, which is not a canonicalization escape — the file is still
+/// inside the workspace by construction (`work_root.join(...)`).
+fn canonical_escape(work_root: &Path, relative_path: &str) -> bool {
+    let target = work_root.join(relative_path);
+    let Ok(target_canon) = std::fs::canonicalize(&target) else {
+        return false;
+    };
+    let root_canon = std::fs::canonicalize(work_root).unwrap_or_else(|_| work_root.to_path_buf());
+    target_canon.strip_prefix(&root_canon).is_err()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::task_workspace_scope::{ScopeMode, TaskWorkspaceScope};
+    use super::*;
+    use std::path::PathBuf;
+    use tempfile::tempdir;
+
+    fn ambiguous_scope(nested: Vec<PathBuf>) -> TaskWorkspaceScope {
+        TaskWorkspaceScope {
+            mode: ScopeMode::AmbiguousParent {
+                nested_subtrees: nested,
+            },
+        }
+    }
+
+    fn single_root_scope() -> TaskWorkspaceScope {
+        TaskWorkspaceScope {
+            mode: ScopeMode::SingleProjectRoot,
+        }
+    }
+
+    #[test]
+    fn existing_subtree_file_is_out_of_scope_in_ambiguous_parent() {
+        let dir = tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("0517_003/app")).unwrap();
+        std::fs::write(dir.path().join("0517_003/app/main.py"), "").unwrap();
+        let scope = ambiguous_scope(vec![PathBuf::from("0517_003")]);
+        let out = classify_ownership(OwnershipInputs {
+            work_root: dir.path(),
+            relative_path: "0517_003/app/main.py",
+            scope: &scope,
+            edited_this_session: false,
+            scaffold_changed: false,
+            verifier_passed_in_scope: false,
+        });
+        assert_eq!(out, ArtifactOwnership::OutOfScope);
+    }
+
+    #[test]
+    fn in_scope_pre_existing_file_without_signal_is_candidate_only() {
+        let dir = tempdir().unwrap();
+        std::fs::write(dir.path().join("README.md"), "# Hello\n").unwrap();
+        let scope = single_root_scope();
+        let out = classify_ownership(OwnershipInputs {
+            work_root: dir.path(),
+            relative_path: "README.md",
+            scope: &scope,
+            edited_this_session: false,
+            scaffold_changed: false,
+            verifier_passed_in_scope: false,
+        });
+        assert_eq!(out, ArtifactOwnership::CandidateOnly);
+    }
+
+    #[test]
+    fn edited_this_session_promotes_to_owned() {
+        let dir = tempdir().unwrap();
+        std::fs::write(dir.path().join("README.md"), "").unwrap();
+        let scope = single_root_scope();
+        let out = classify_ownership(OwnershipInputs {
+            work_root: dir.path(),
+            relative_path: "README.md",
+            scope: &scope,
+            edited_this_session: true,
+            scaffold_changed: false,
+            verifier_passed_in_scope: false,
+        });
+        assert_eq!(out, ArtifactOwnership::Owned);
+    }
+
+    #[test]
+    fn scaffold_changed_promotes_to_owned() {
+        let dir = tempdir().unwrap();
+        let scope = single_root_scope();
+        let out = classify_ownership(OwnershipInputs {
+            work_root: dir.path(),
+            relative_path: "app/main.py",
+            scope: &scope,
+            edited_this_session: false,
+            scaffold_changed: true,
+            verifier_passed_in_scope: false,
+        });
+        assert_eq!(out, ArtifactOwnership::Owned);
+    }
+
+    #[test]
+    fn absolute_path_is_out_of_scope() {
+        let dir = tempdir().unwrap();
+        let scope = single_root_scope();
+        let out = classify_ownership(OwnershipInputs {
+            work_root: dir.path(),
+            relative_path: "/etc/passwd",
+            scope: &scope,
+            edited_this_session: true,
+            scaffold_changed: false,
+            verifier_passed_in_scope: false,
+        });
+        assert_eq!(out, ArtifactOwnership::OutOfScope);
+    }
+
+    #[test]
+    fn parent_dir_traversal_is_out_of_scope() {
+        let dir = tempdir().unwrap();
+        let scope = single_root_scope();
+        let out = classify_ownership(OwnershipInputs {
+            work_root: dir.path(),
+            relative_path: "../sibling/file.py",
+            scope: &scope,
+            edited_this_session: true,
+            scaffold_changed: false,
+            verifier_passed_in_scope: false,
+        });
+        assert_eq!(out, ArtifactOwnership::OutOfScope);
+    }
+
+    #[test]
+    fn ignored_top_dir_is_out_of_scope_even_when_marked_edited() {
+        let dir = tempdir().unwrap();
+        let scope = single_root_scope();
+        let out = classify_ownership(OwnershipInputs {
+            work_root: dir.path(),
+            relative_path: "node_modules/foo/index.js",
+            scope: &scope,
+            edited_this_session: true,
+            scaffold_changed: false,
+            verifier_passed_in_scope: false,
+        });
+        assert_eq!(out, ArtifactOwnership::OutOfScope);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlink_escape_is_out_of_scope() {
+        use std::os::unix::fs::symlink;
+        let outside = tempdir().unwrap();
+        std::fs::write(outside.path().join("secret.txt"), "secret\n").unwrap();
+        let work = tempdir().unwrap();
+        symlink(
+            outside.path().join("secret.txt"),
+            work.path().join("alias.txt"),
+        )
+        .unwrap();
+        let scope = single_root_scope();
+        let out = classify_ownership(OwnershipInputs {
+            work_root: work.path(),
+            relative_path: "alias.txt",
+            scope: &scope,
+            edited_this_session: true,
+            scaffold_changed: false,
+            verifier_passed_in_scope: false,
+        });
+        assert_eq!(out, ArtifactOwnership::OutOfScope);
+    }
+
+    #[test]
+    fn explicit_scope_promotes_existing_file_to_owned() {
+        // user explicitly named the subtree: the file is in scope AND the
+        // scope mode itself counts as an ownership signal (Issue #646
+        // §修正方針 2 `Owned` 条件 1).
+        let dir = tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("0517_003/app")).unwrap();
+        std::fs::write(dir.path().join("0517_003/app/main.py"), "").unwrap();
+        let scope = TaskWorkspaceScope {
+            mode: ScopeMode::Explicit {
+                paths: vec![PathBuf::from("0517_003")],
+            },
+        };
+        let out = classify_ownership(OwnershipInputs {
+            work_root: dir.path(),
+            relative_path: "0517_003/app/main.py",
+            scope: &scope,
+            edited_this_session: false,
+            scaffold_changed: false,
+            verifier_passed_in_scope: false,
+        });
+        assert_eq!(out, ArtifactOwnership::Owned);
+    }
+
+    #[test]
+    fn missing_file_is_classified_without_canonicalization_escape() {
+        // A path that does not yet exist is allowed; the upstream caller
+        // is in the middle of creating it. `canonical_escape` only triggers
+        // when canonicalization succeeds and lands outside the workspace.
+        let dir = tempdir().unwrap();
+        let scope = single_root_scope();
+        let out = classify_ownership(OwnershipInputs {
+            work_root: dir.path(),
+            relative_path: "future/file.py",
+            scope: &scope,
+            edited_this_session: true,
+            scaffold_changed: false,
+            verifier_passed_in_scope: false,
+        });
+        assert_eq!(out, ArtifactOwnership::Owned);
+    }
+}

--- a/src/agent/loop_run/artifact_ownership.rs
+++ b/src/agent/loop_run/artifact_ownership.rs
@@ -109,14 +109,12 @@ fn path_is_syntactically_safe(relative_path: &str) -> bool {
 }
 
 fn path_in_ignored_top_dir(relative_path: &str) -> bool {
-    let first = Path::new(relative_path).components().find_map(|c| match c {
-        std::path::Component::Normal(s) => Some(s.to_string_lossy().to_string()),
-        _ => None,
-    });
-    let Some(top) = first else { return true };
-    super::task_workspace_scope::IGNORED_TOP_DIRS
-        .iter()
-        .any(|ignored| *ignored == top)
+    Path::new(relative_path).components().any(|c| match c {
+        std::path::Component::Normal(s) => {
+            super::task_workspace_scope::is_workspace_ignored_dir(&s.to_string_lossy())
+        }
+        _ => false,
+    })
 }
 
 /// Returns `true` when canonicalizing `work_root.join(relative_path)`
@@ -306,6 +304,79 @@ mod tests {
             relative_path: "0517_003/app/main.py",
             scope: &scope,
             edited_this_session: false,
+            scaffold_changed: false,
+            verifier_passed_in_scope: false,
+        });
+        assert_eq!(out, ArtifactOwnership::Owned);
+    }
+
+    #[test]
+    fn turn_boundary_clear_demotes_owned_back_to_candidate_only() {
+        // Issue #646 (A4): the `turn_edited_relative_paths` set is reset at
+        // each `handle_user_message` head (CLAUDE.md per-turn cap pattern).
+        // Once that set is cleared, the same file the previous turn promoted
+        // to Owned must classify as CandidateOnly again — preventing the
+        // new task from auto-inheriting prior-turn ownership.
+        let dir = tempdir().unwrap();
+        std::fs::write(dir.path().join("app.py"), "x = 1\n").unwrap();
+        let scope = single_root_scope();
+
+        // Inside the original turn — the set contained the path → Owned.
+        let during_turn = classify_ownership(OwnershipInputs {
+            work_root: dir.path(),
+            relative_path: "app.py",
+            scope: &scope,
+            edited_this_session: true,
+            scaffold_changed: false,
+            verifier_passed_in_scope: false,
+        });
+        assert_eq!(during_turn, ArtifactOwnership::Owned);
+
+        // After `handle_user_message` cleared the set — same file, no
+        // signals → CandidateOnly.
+        let after_turn_boundary = classify_ownership(OwnershipInputs {
+            work_root: dir.path(),
+            relative_path: "app.py",
+            scope: &scope,
+            edited_this_session: false,
+            scaffold_changed: false,
+            verifier_passed_in_scope: false,
+        });
+        assert_eq!(after_turn_boundary, ArtifactOwnership::CandidateOnly);
+    }
+
+    #[test]
+    fn no_op_write_does_not_promote_to_owned() {
+        // Issue #646 (A4 / C2): an in-scope file exists but the model
+        // wrote the exact same body back (no scaffold delta, no recorded
+        // edit). Ownership must stay CandidateOnly even though the path
+        // matches an artifact role.
+        let dir = tempdir().unwrap();
+        std::fs::write(dir.path().join("README.md"), "# Scaffold body\n").unwrap();
+        let scope = single_root_scope();
+        let out = classify_ownership(OwnershipInputs {
+            work_root: dir.path(),
+            relative_path: "README.md",
+            scope: &scope,
+            edited_this_session: false,
+            scaffold_changed: false,
+            verifier_passed_in_scope: false,
+        });
+        assert_eq!(out, ArtifactOwnership::CandidateOnly);
+    }
+
+    #[test]
+    fn ambiguous_parent_root_root_file_is_owned_when_edited_this_turn() {
+        // Issue #646 (A4): a fresh in-scope artifact created at the parent
+        // root (not inside any nested project subtree) promotes to Owned
+        // as soon as it is recorded in `turn_edited_relative_paths`.
+        let dir = tempdir().unwrap();
+        let scope = ambiguous_scope(vec![PathBuf::from("0517_003")]);
+        let out = classify_ownership(OwnershipInputs {
+            work_root: dir.path(),
+            relative_path: "app/main.py",
+            scope: &scope,
+            edited_this_session: true,
             scaffold_changed: false,
             verifier_passed_in_scope: false,
         });

--- a/src/agent/loop_run/repair_job.rs
+++ b/src/agent/loop_run/repair_job.rs
@@ -130,7 +130,6 @@ impl MissingVerifierJob {
 
     /// Consume one retry slot. Returns `true` when the call falls inside
     /// the configured budget.
-    #[allow(dead_code)] // wired in once the verifier loop migrates off the legacy contract_verification_retries counter.
     pub(super) fn record_retry(&mut self) -> bool {
         if self.retries_used >= self.retry_budget {
             return false;

--- a/src/agent/loop_run/repair_job.rs
+++ b/src/agent/loop_run/repair_job.rs
@@ -78,6 +78,76 @@ pub(super) enum VerifierRepairState {
     },
 }
 
+/// Issue #646 (A1): first-class state for "verifier is missing from the
+/// repository". Distinct from the failure-driven `RepairJob` so the planner
+/// can:
+///   1. Suppress verifier retry until an in-scope edit lands.
+///   2. Hold the active scope's allowed-tool whitelist (Write / Edit / Bash)
+///      independently of the failure-diagnostic state machine.
+///   3. Enforce its own retry budget separate from
+///      `TASK_CONTRACT_VERIFIER_ATTEMPT_LIMIT`.
+///
+/// Lives on `Agent` next to `repair_job` and is cleared at the
+/// `handle_user_message` head (per-turn cap pattern).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct MissingVerifierJob {
+    /// Inclusive ceiling on how many times we'll re-emit the "create a
+    /// verifier" recovery loop in a single task.
+    pub(super) retry_budget: u8,
+    /// How many retries have already been consumed.
+    pub(super) retries_used: u8,
+    /// Becomes `true` once a successful in-scope Write/Edit lands after
+    /// the job entered the `pending` state. Until then, the planner
+    /// MUST suppress `RunVerifier` to avoid an infinite retry loop.
+    pub(super) in_scope_edit_observed: bool,
+    /// Snapshot of `repo_edit_calls_made_this_turn` when the job entered
+    /// `pending`. Retained for diagnostics / future log-event emission.
+    pub(super) repo_edit_count_at_pending: usize,
+}
+
+impl MissingVerifierJob {
+    pub(super) fn new(retry_budget: u8, repo_edit_count_at_pending: usize) -> Self {
+        Self {
+            retry_budget,
+            retries_used: 0,
+            in_scope_edit_observed: false,
+            repo_edit_count_at_pending,
+        }
+    }
+
+    /// Whether the planner should suppress `RunVerifier` for this turn.
+    /// True when the model has not yet produced an in-scope edit since the
+    /// `MissingVerifierJob` was raised.
+    pub(super) fn should_suppress_verifier_retry(&self) -> bool {
+        !self.in_scope_edit_observed
+    }
+
+    /// Mark that an in-scope edit has been observed. After this fires,
+    /// verifier retries become allowed again.
+    pub(super) fn record_in_scope_edit(&mut self) {
+        self.in_scope_edit_observed = true;
+    }
+
+    /// Consume one retry slot. Returns `true` when the call falls inside
+    /// the configured budget.
+    #[allow(dead_code)] // wired in once the verifier loop migrates off the legacy contract_verification_retries counter.
+    pub(super) fn record_retry(&mut self) -> bool {
+        if self.retries_used >= self.retry_budget {
+            return false;
+        }
+        self.retries_used = self.retries_used.saturating_add(1);
+        true
+    }
+
+    /// Allowed-tool whitelist surfaced to the effective tool policy when
+    /// this state is active. Intentionally narrow: the model is expected
+    /// to either create a verifier file or run one (Bash) — Read alone
+    /// cannot make progress out of this state.
+    pub(super) fn allowed_tool_names(&self) -> &'static [&'static str] {
+        &["Write", "Edit", "Bash"]
+    }
+}
+
 /// Read-only snapshot consumed by #638 and by event-log persistence. Each
 /// text field is re-sanitized at snapshot time so the SSOT for redaction is
 /// preserved at every transfer boundary.
@@ -313,6 +383,32 @@ mod tests {
         assert!(!out.contains("SECRETVALUE"));
         assert!(!out.contains('\n'));
         assert!(!out.contains('\r'));
+    }
+
+    #[test]
+    fn missing_verifier_job_suppresses_verifier_retry_until_in_scope_edit() {
+        // Issue #646 (A1/B2): a fresh job suppresses verifier retry;
+        // recording an in-scope edit flips the gate.
+        let mut job = MissingVerifierJob::new(3, 0);
+        assert!(job.should_suppress_verifier_retry());
+        job.record_in_scope_edit();
+        assert!(!job.should_suppress_verifier_retry());
+    }
+
+    #[test]
+    fn missing_verifier_job_retry_budget_is_bounded() {
+        let mut job = MissingVerifierJob::new(2, 0);
+        assert!(job.record_retry());
+        assert!(job.record_retry());
+        // Third call should report budget exhausted.
+        assert!(!job.record_retry());
+        assert_eq!(job.retries_used, 2);
+    }
+
+    #[test]
+    fn missing_verifier_job_allowed_tool_names_match_first_class_state() {
+        let job = MissingVerifierJob::new(3, 0);
+        assert_eq!(job.allowed_tool_names(), &["Write", "Edit", "Bash"]);
     }
 
     #[test]

--- a/src/agent/loop_run/task_contract.rs
+++ b/src/agent/loop_run/task_contract.rs
@@ -937,6 +937,13 @@ mod tests {
 
     #[test]
     fn controller_runs_verifier_when_existing_candidates_cover_required_artifacts() {
+        // Issue #646: `ArtifactState::exists` admission is the planner's
+        // ownership signal — the upstream `task_contract_artifact_states`
+        // is now responsible for refusing to admit out-of-scope candidates.
+        // Once the planner sees three Owned `exists` artifacts it must still
+        // promote them to verification, matching the legacy behaviour for
+        // legitimately-owned existing files (e.g. user-explicit subtree,
+        // scaffold + post-scaffold delta).
         let contract = TaskContract::from_request(
             "ToDo管理のバックエンドをFastAPIで開発してください。使用方法をREADME.mdに記述してください。テストコードも実装してください。",
         );
@@ -958,6 +965,36 @@ mod tests {
             }),
             ArtifactRecoveryAction::RunVerifier
         );
+    }
+
+    #[test]
+    fn controller_continues_when_no_artifact_states_are_present() {
+        // Issue #646 regression: when `task_contract_artifact_states`
+        // refused to admit any out-of-scope existing candidate, the
+        // planner must continue toward the missing roles instead of
+        // jumping into verifier execution / repair on phantom evidence.
+        let contract = TaskContract::from_request(
+            "FastAPIでcrudのAPIを開発してください。使用方法をREADME.mdに記述してください。テストコードも実装してください。",
+        );
+        let evidence = EvidenceSet::new();
+        let artifacts: Vec<ArtifactState> = Vec::new();
+        let repair_state = VerifierRepairState::None;
+
+        let action = plan_artifact_recovery(ArtifactRecoveryInputs {
+            contract: &contract,
+            evidence: &evidence,
+            artifacts: &artifacts,
+            repair_state: &repair_state,
+            artifact_excerpts: &ArtifactExcerpts::new(),
+        });
+        match action {
+            ArtifactRecoveryAction::Continue { missing, .. } => {
+                assert!(missing.contains(&ArtifactRole::Implementation));
+                assert!(missing.contains(&ArtifactRole::Test));
+                assert!(missing.contains(&ArtifactRole::UsageDocs));
+            }
+            other => panic!("expected Continue, got {other:?}"),
+        }
     }
 
     #[test]

--- a/src/agent/loop_run/task_contract.rs
+++ b/src/agent/loop_run/task_contract.rs
@@ -170,6 +170,13 @@ pub(super) struct ArtifactRecoveryInputs<'a> {
     /// `&ArtifactExcerpts::new()` (empty) is the back-compat sentinel that
     /// disables behavior-coverage gating.
     pub(super) artifact_excerpts: &'a ArtifactExcerpts,
+    /// Issue #646 (A1/B2): when `true`, the planner MUST suppress
+    /// `RunVerifier` so the model does not enter an infinite NoVerifier
+    /// retry loop before an in-scope edit lands. Driven by the
+    /// `MissingVerifierJob` first-class state on `Agent`. `false` is the
+    /// back-compat default for tests / call sites that have no awareness
+    /// of the missing-verifier track.
+    pub(super) missing_verifier_suppress_retry: bool,
 }
 
 // ---------------------------------------------------------------------------
@@ -309,6 +316,14 @@ pub(super) fn plan_artifact_recovery(inputs: ArtifactRecoveryInputs<'_>) -> Arti
         && (inputs.contract.verification_required
             || (existing_unverified_used && code_or_test_required))
     {
+        // Issue #646 (A1/B2): once a MissingVerifierJob is in flight and no
+        // in-scope edit has landed, refuse to re-trigger RunVerifier. The
+        // model needs to first produce an in-scope verifier or implementation
+        // edit; without this gate the NoVerifier → RunVerifier → NoVerifier
+        // loop runs until `TASK_CONTRACT_VERIFIER_ATTEMPT_LIMIT`.
+        if inputs.missing_verifier_suppress_retry {
+            return ArtifactRecoveryAction::RepairArtifact { target_hint: None };
+        }
         return ArtifactRecoveryAction::RunVerifier;
     }
 
@@ -962,9 +977,64 @@ mod tests {
                 artifacts: &artifacts,
                 repair_state: &repair_state,
                 artifact_excerpts: &ArtifactExcerpts::new(),
+                missing_verifier_suppress_retry: false,
             }),
             ArtifactRecoveryAction::RunVerifier
         );
+    }
+
+    #[test]
+    fn planner_suppresses_run_verifier_when_missing_verifier_pending() {
+        // Issue #646 (B2): when MissingVerifierJob has no in-scope edit yet,
+        // the planner must NOT return RunVerifier even if all required
+        // artifacts are observed. Instead it returns RepairArtifact so the
+        // model creates a verifier file.
+        let contract = TaskContract::from_request(
+            "FastAPIでCRUD APIを作成してREADMEとテストも追加してください",
+        );
+        let mut evidence = EvidenceSet::new();
+        evidence.push(repo_edit(RepoEditCategory::Impl));
+        evidence.push(repo_edit(RepoEditCategory::Test));
+        evidence.push(repo_edit(RepoEditCategory::Docs));
+        let artifacts: Vec<ArtifactState> = Vec::new();
+        let repair_state = VerifierRepairState::None;
+        let action = plan_artifact_recovery(ArtifactRecoveryInputs {
+            contract: &contract,
+            evidence: &evidence,
+            artifacts: &artifacts,
+            repair_state: &repair_state,
+            artifact_excerpts: &ArtifactExcerpts::new(),
+            missing_verifier_suppress_retry: true,
+        });
+        assert!(
+            matches!(action, ArtifactRecoveryAction::RepairArtifact { .. }),
+            "expected RepairArtifact under MissingVerifierJob suppression, got {action:?}"
+        );
+    }
+
+    #[test]
+    fn planner_runs_verifier_again_after_in_scope_edit_lifted_suppression() {
+        // Issue #646: once an in-scope edit lands (the agent flips
+        // `missing_verifier_suppress_retry` back to false), the planner
+        // resumes its normal RunVerifier behaviour.
+        let contract = TaskContract::from_request(
+            "FastAPIでCRUD APIを作成してREADMEとテストも追加してください",
+        );
+        let mut evidence = EvidenceSet::new();
+        evidence.push(repo_edit(RepoEditCategory::Impl));
+        evidence.push(repo_edit(RepoEditCategory::Test));
+        evidence.push(repo_edit(RepoEditCategory::Docs));
+        let artifacts: Vec<ArtifactState> = Vec::new();
+        let repair_state = VerifierRepairState::None;
+        let action = plan_artifact_recovery(ArtifactRecoveryInputs {
+            contract: &contract,
+            evidence: &evidence,
+            artifacts: &artifacts,
+            repair_state: &repair_state,
+            artifact_excerpts: &ArtifactExcerpts::new(),
+            missing_verifier_suppress_retry: false,
+        });
+        assert_eq!(action, ArtifactRecoveryAction::RunVerifier);
     }
 
     #[test]
@@ -986,6 +1056,7 @@ mod tests {
             artifacts: &artifacts,
             repair_state: &repair_state,
             artifact_excerpts: &ArtifactExcerpts::new(),
+            missing_verifier_suppress_retry: false,
         });
         match action {
             ArtifactRecoveryAction::Continue { missing, .. } => {
@@ -1016,6 +1087,7 @@ mod tests {
             artifacts: &artifacts,
             repair_state: &repair_state,
             artifact_excerpts: &ArtifactExcerpts::new(),
+            missing_verifier_suppress_retry: false,
         });
 
         assert_eq!(
@@ -1064,6 +1136,7 @@ mod tests {
                 artifacts: &artifacts,
                 repair_state: &repair_state,
                 artifact_excerpts: &ArtifactExcerpts::new(),
+                missing_verifier_suppress_retry: false,
             }),
             ArtifactRecoveryAction::RepairArtifact {
                 target_hint: Some(target_hint),
@@ -1126,6 +1199,7 @@ mod tests {
             artifacts: &[],
             repair_state: &repair_state,
             artifact_excerpts: &excerpts,
+            missing_verifier_suppress_retry: false,
         });
         match action {
             ArtifactRecoveryAction::Continue { missing, .. } => {
@@ -1159,6 +1233,7 @@ mod tests {
             artifacts: &[],
             repair_state: &repair_state,
             artifact_excerpts: &excerpts,
+            missing_verifier_suppress_retry: false,
         });
         assert!(
             matches!(action, ArtifactRecoveryAction::Continue { .. }),
@@ -1196,6 +1271,7 @@ mod tests {
             artifacts: &[],
             repair_state: &repair_state,
             artifact_excerpts: &excerpts,
+            missing_verifier_suppress_retry: false,
         });
         // With coverage satisfied + tests required, the planner falls
         // through to verifier execution.
@@ -1226,6 +1302,7 @@ mod tests {
             artifacts: &[],
             repair_state: &repair_state,
             artifact_excerpts: &excerpts,
+            missing_verifier_suppress_retry: false,
         });
         assert_eq!(action, ArtifactRecoveryAction::RunVerifier);
     }
@@ -1257,6 +1334,7 @@ mod tests {
             artifacts: &[],
             repair_state: &repair_state,
             artifact_excerpts: &excerpts,
+            missing_verifier_suppress_retry: false,
         });
         match action {
             ArtifactRecoveryAction::Continue { missing, .. } => {
@@ -1290,6 +1368,7 @@ mod tests {
             artifacts: &[],
             repair_state: &repair_state,
             artifact_excerpts: &excerpts,
+            missing_verifier_suppress_retry: false,
         });
         assert_eq!(action, ArtifactRecoveryAction::Done);
     }
@@ -1336,6 +1415,7 @@ mod tests {
             artifacts: &[],
             repair_state: &repair_state,
             artifact_excerpts: &excerpts,
+            missing_verifier_suppress_retry: false,
         });
         assert!(
             matches!(action, ArtifactRecoveryAction::Continue { .. }),

--- a/src/agent/loop_run/task_workspace_scope.rs
+++ b/src/agent/loop_run/task_workspace_scope.rs
@@ -32,8 +32,23 @@ const PROJECT_MARKER_FILES: &[&str] = &[
 
 const PROJECT_MARKER_DIRS: &[&str] = &[".git", "src", "tests"];
 
+/// Conventional monorepo parent directories. When one of these is the only
+/// non-marker child of `work_root` (or sits alongside other monorepo
+/// parents), each child of the monorepo parent is treated as its own
+/// nested subtree. Avoids "single project root" misclassification of
+/// `packages/foo/`, `apps/bar/`, `crates/baz/` (Issue #646 A2).
+const MONOREPO_PARENT_DIRS: &[&str] =
+    &["packages", "apps", "crates", "services", "modules", "pkgs"];
+
 /// Directories that never contribute project-like signal even if they look
 /// like one (dependency / build caches). Skipped by every detection helper.
+///
+/// SSOT consumed by:
+/// - `nested_project_subtrees` (scope detection)
+/// - `artifact_ownership::path_in_ignored_top_dir`
+/// - `turn::collect_meaningful_workspace_files` (workspace walker)
+///
+/// Always extend by editing this list; do NOT duplicate the names elsewhere.
 pub(super) const IGNORED_TOP_DIRS: &[&str] = &[
     ".git",
     ".anvil",
@@ -46,6 +61,13 @@ pub(super) const IGNORED_TOP_DIRS: &[&str] = &[
     "build",
     "__pycache__",
 ];
+
+/// SSOT predicate: returns `true` when `name` is the file-name component of
+/// a directory that is never part of the active workspace (dependency
+/// cache, VCS metadata, build output).
+pub(super) fn is_workspace_ignored_dir(name: &str) -> bool {
+    IGNORED_TOP_DIRS.contains(&name)
+}
 
 /// Mode of the active scope. Three deterministic states; the planner reads
 /// this through [`TaskWorkspaceScope::contains`].
@@ -154,8 +176,13 @@ fn path_is_inside(candidate: &Path, scope: &Path) -> bool {
 
 /// Returns workspace-relative paths of subdirectories of `work_root` that
 /// look like a project root by structure (manifest file or marker dir).
-/// Sorted lexicographically and de-duplicated. Bounded read of the root
-/// directory only — does not recurse.
+/// Sorted lexicographically and de-duplicated.
+///
+/// Monorepo aware (Issue #646 A2): when a child directory is one of
+/// `MONOREPO_PARENT_DIRS` (`packages/`, `apps/`, `crates/`, …) and is
+/// itself NOT project-like, its children are scanned and any that are
+/// project-like are returned as `packages/<name>` etc. This stops one
+/// `crates/<inner>` from being treated as "work_root is a single project".
 pub(super) fn nested_project_subtrees(work_root: &Path) -> Vec<PathBuf> {
     let Ok(read_dir) = std::fs::read_dir(work_root) else {
         return Vec::new();
@@ -171,16 +198,51 @@ pub(super) fn nested_project_subtrees(work_root: &Path) -> Vec<PathBuf> {
         }
         let name = entry.file_name();
         let name_str = name.to_string_lossy().to_string();
-        if IGNORED_TOP_DIRS.iter().any(|ignored| *ignored == name_str) {
+        if is_workspace_ignored_dir(&name_str) {
             continue;
         }
         let abs = entry.path();
         if directory_is_project_like(&abs) {
             out.push(PathBuf::from(name_str));
+            continue;
+        }
+        if MONOREPO_PARENT_DIRS
+            .iter()
+            .any(|parent| *parent == name_str)
+        {
+            // Recurse exactly one level into the monorepo parent so its
+            // sibling packages stay distinct subtrees.
+            for nested in monorepo_child_subtrees(&abs, &name_str) {
+                out.push(nested);
+            }
         }
     }
     out.sort();
     out.dedup();
+    out
+}
+
+fn monorepo_child_subtrees(parent_abs: &Path, parent_rel: &str) -> Vec<PathBuf> {
+    let Ok(read_dir) = std::fs::read_dir(parent_abs) else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for entry in read_dir.flatten() {
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        if !file_type.is_dir() {
+            continue;
+        }
+        let child_name = entry.file_name();
+        let child_name_str = child_name.to_string_lossy().to_string();
+        if is_workspace_ignored_dir(&child_name_str) {
+            continue;
+        }
+        if directory_is_project_like(&entry.path()) {
+            out.push(PathBuf::from(format!("{parent_rel}/{child_name_str}")));
+        }
+    }
     out
 }
 
@@ -354,6 +416,40 @@ mod tests {
         let nested = nested_project_subtrees(dir.path());
         assert!(!nested.contains(&PathBuf::from("node_modules")));
         assert!(!nested.contains(&PathBuf::from(".venv")));
+    }
+
+    #[test]
+    fn monorepo_packages_layout_yields_nested_subtrees_per_package() {
+        let dir = tempdir().unwrap();
+        // `packages/<name>` layout — neither `packages/` itself nor
+        // `work_root` is project-like, but each package has its own
+        // marker file.
+        touch(&dir.path().join("packages/api/package.json"));
+        touch(&dir.path().join("packages/web/package.json"));
+        let nested = nested_project_subtrees(dir.path());
+        assert!(nested.contains(&PathBuf::from("packages/api")));
+        assert!(nested.contains(&PathBuf::from("packages/web")));
+        let scope = TaskWorkspaceScope::detect(dir.path(), "update the API service");
+        match &scope.mode {
+            ScopeMode::AmbiguousParent { nested_subtrees } => {
+                assert!(nested_subtrees.contains(&PathBuf::from("packages/api")));
+                assert!(nested_subtrees.contains(&PathBuf::from("packages/web")));
+            }
+            other => panic!("expected AmbiguousParent for monorepo layout, got {other:?}"),
+        }
+        // A sibling package's artifact stays out of scope.
+        assert!(!scope.contains("packages/web/src/index.ts"));
+        assert!(!scope.contains("packages/api/src/index.ts"));
+    }
+
+    #[test]
+    fn monorepo_crates_layout_yields_nested_subtrees() {
+        let dir = tempdir().unwrap();
+        touch(&dir.path().join("crates/core/Cargo.toml"));
+        touch(&dir.path().join("crates/cli/Cargo.toml"));
+        let nested = nested_project_subtrees(dir.path());
+        assert!(nested.contains(&PathBuf::from("crates/core")));
+        assert!(nested.contains(&PathBuf::from("crates/cli")));
     }
 
     #[test]

--- a/src/agent/loop_run/task_workspace_scope.rs
+++ b/src/agent/loop_run/task_workspace_scope.rs
@@ -1,0 +1,376 @@
+//! Issue #646: active workspace scope for the current task.
+//!
+//! `TaskWorkspaceScope` is the deterministic answer to "which subtree of
+//! `work_root` is this task allowed to claim ownership over?". It is rebuilt
+//! per turn from the active request + filesystem layout and consumed by
+//! `artifact_ownership::classify_ownership` to gate which existing files can
+//! be promoted to completion evidence (Issue #646 §修正方針 1).
+//!
+//! Visibility: every export is `pub(super)` and **must not** be re-exported
+//! from `src/agent/loop_run.rs` (CLAUDE.md DR3-001).
+
+use std::path::{Component, Path, PathBuf};
+
+/// Names that mark a directory as a project-like subtree. Structure-based
+/// detection (Issue #646 §修正方針 1 / 非目標) — never name blacklist.
+const PROJECT_MARKER_FILES: &[&str] = &[
+    "pyproject.toml",
+    "package.json",
+    "Cargo.toml",
+    "go.mod",
+    "pom.xml",
+    "build.gradle",
+    "build.gradle.kts",
+    "composer.json",
+    "Gemfile",
+    "manage.py",
+    "next.config.js",
+    "nuxt.config.ts",
+    "vite.config.ts",
+    "tsconfig.json",
+];
+
+const PROJECT_MARKER_DIRS: &[&str] = &[".git", "src", "tests"];
+
+/// Directories that never contribute project-like signal even if they look
+/// like one (dependency / build caches). Skipped by every detection helper.
+pub(super) const IGNORED_TOP_DIRS: &[&str] = &[
+    ".git",
+    ".anvil",
+    ".anvil-state",
+    "node_modules",
+    "target",
+    ".venv",
+    "venv",
+    "dist",
+    "build",
+    "__pycache__",
+];
+
+/// Mode of the active scope. Three deterministic states; the planner reads
+/// this through [`TaskWorkspaceScope::contains`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum ScopeMode {
+    /// User explicitly named one or more subtrees. Only those subtrees are
+    /// in scope; everything else is `OutOfScope`.
+    Explicit { paths: Vec<PathBuf> },
+    /// `work_root` itself is a single project (manifest at root, no nested
+    /// project-like subtrees). Anything inside `work_root` is in scope.
+    SingleProjectRoot,
+    /// `work_root` contains multiple project-like subtrees and the user
+    /// gave no explicit hint. Only direct-root files are in scope; existing
+    /// nested subtrees stay `OutOfScope`. This is the fresh-session
+    /// parent-directory case from the bug report.
+    AmbiguousParent { nested_subtrees: Vec<PathBuf> },
+    /// `work_root` has no project-like subtree and the user gave no hint.
+    /// Anything inside `work_root` is in scope (greenfield build).
+    Greenfield,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct TaskWorkspaceScope {
+    pub(super) mode: ScopeMode,
+}
+
+impl TaskWorkspaceScope {
+    /// Build a scope deterministically from the workspace layout + request.
+    /// Both inputs are read once per turn; nothing here touches the network
+    /// or persistent state.
+    pub(super) fn detect(work_root: &Path, request: &str) -> Self {
+        let nested = nested_project_subtrees(work_root);
+        let explicit = explicit_subtree_paths_in_request(request, work_root, &nested);
+        if !explicit.is_empty() {
+            return Self {
+                mode: ScopeMode::Explicit { paths: explicit },
+            };
+        }
+        if work_root_is_single_project(work_root, &nested) {
+            return Self {
+                mode: ScopeMode::SingleProjectRoot,
+            };
+        }
+        if nested.is_empty() {
+            return Self {
+                mode: ScopeMode::Greenfield,
+            };
+        }
+        Self {
+            mode: ScopeMode::AmbiguousParent {
+                nested_subtrees: nested,
+            },
+        }
+    }
+
+    /// Whether a normalized workspace-relative path is in active scope.
+    /// `relative_path` MUST be canonicalized/normalized by the caller (no
+    /// `..` components, forward slashes). Empty string represents the root.
+    pub(super) fn contains(&self, relative_path: &str) -> bool {
+        let normalized = normalize_relative(relative_path);
+        match &self.mode {
+            ScopeMode::Explicit { paths } => {
+                paths.iter().any(|scope| path_is_inside(&normalized, scope))
+            }
+            ScopeMode::SingleProjectRoot | ScopeMode::Greenfield => true,
+            ScopeMode::AmbiguousParent { nested_subtrees } => !nested_subtrees
+                .iter()
+                .any(|nested| path_is_inside(&normalized, nested)),
+        }
+    }
+
+    /// Best-effort short label for log / note emission.
+    #[allow(dead_code)]
+    pub(super) fn mode_label(&self) -> &'static str {
+        match self.mode {
+            ScopeMode::Explicit { .. } => "explicit",
+            ScopeMode::SingleProjectRoot => "single_project_root",
+            ScopeMode::Greenfield => "greenfield",
+            ScopeMode::AmbiguousParent { .. } => "ambiguous_parent",
+        }
+    }
+}
+
+fn normalize_relative(relative_path: &str) -> PathBuf {
+    let path = Path::new(relative_path);
+    let mut out = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::Normal(part) => out.push(part),
+            // Defensive: callers must hand us a clean relative path. We
+            // refuse to silently swallow `..` because the ownership layer
+            // treats traversal as `OutOfScope` upstream.
+            Component::ParentDir | Component::RootDir | Component::Prefix(_) => {}
+            Component::CurDir => {}
+        }
+    }
+    out
+}
+
+fn path_is_inside(candidate: &Path, scope: &Path) -> bool {
+    if scope.as_os_str().is_empty() {
+        return true;
+    }
+    candidate == scope || candidate.starts_with(scope)
+}
+
+/// Returns workspace-relative paths of subdirectories of `work_root` that
+/// look like a project root by structure (manifest file or marker dir).
+/// Sorted lexicographically and de-duplicated. Bounded read of the root
+/// directory only — does not recurse.
+pub(super) fn nested_project_subtrees(work_root: &Path) -> Vec<PathBuf> {
+    let Ok(read_dir) = std::fs::read_dir(work_root) else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for entry in read_dir.flatten() {
+        let file_type = match entry.file_type() {
+            Ok(ft) => ft,
+            Err(_) => continue,
+        };
+        if !file_type.is_dir() {
+            continue;
+        }
+        let name = entry.file_name();
+        let name_str = name.to_string_lossy().to_string();
+        if IGNORED_TOP_DIRS.iter().any(|ignored| *ignored == name_str) {
+            continue;
+        }
+        let abs = entry.path();
+        if directory_is_project_like(&abs) {
+            out.push(PathBuf::from(name_str));
+        }
+    }
+    out.sort();
+    out.dedup();
+    out
+}
+
+fn directory_is_project_like(dir: &Path) -> bool {
+    for marker in PROJECT_MARKER_FILES {
+        if dir.join(marker).is_file() {
+            return true;
+        }
+    }
+    for marker in PROJECT_MARKER_DIRS {
+        if dir.join(marker).is_dir() {
+            return true;
+        }
+    }
+    false
+}
+
+fn work_root_is_single_project(work_root: &Path, nested: &[PathBuf]) -> bool {
+    if !nested.is_empty() {
+        return false;
+    }
+    directory_is_project_like(work_root)
+}
+
+/// Find tokens in `request` that match an existing nested subtree name.
+/// Conservative: only matches when the token exactly equals (or contains as
+/// a path segment) a known subtree name from `nested`. This is the only
+/// path on which a pre-existing subtree can be promoted into the active
+/// scope (Issue #646 §修正方針 1: "ユーザーが明示した path がある場合のみ").
+fn explicit_subtree_paths_in_request(
+    request: &str,
+    work_root: &Path,
+    nested: &[PathBuf],
+) -> Vec<PathBuf> {
+    if nested.is_empty() {
+        return Vec::new();
+    }
+    let mut out = Vec::new();
+    for subtree in nested {
+        let Some(name) = subtree.to_str() else {
+            continue;
+        };
+        if name.is_empty() {
+            continue;
+        }
+        if request_mentions_subtree(request, name) {
+            // Re-validate it's still a real project-like subtree on disk
+            // — defense in depth against TOCTOU between detection and use.
+            if directory_is_project_like(&work_root.join(name)) {
+                out.push(PathBuf::from(name));
+            }
+        }
+    }
+    out.sort();
+    out.dedup();
+    out
+}
+
+fn request_mentions_subtree(request: &str, name: &str) -> bool {
+    // Match `name` as a whole word / path segment. Reject substring noise
+    // (e.g. `0517` should not match because the subtree was `0517_003`).
+    let mut start = 0;
+    while let Some(idx) = request[start..].find(name) {
+        let abs_idx = start + idx;
+        let before = request[..abs_idx].chars().next_back();
+        let after_idx = abs_idx + name.len();
+        let after = request[after_idx..].chars().next();
+        let before_ok = before.is_none_or(|c| !c.is_ascii_alphanumeric() && c != '_');
+        let after_ok = after.is_none_or(|c| !c.is_ascii_alphanumeric() && c != '_');
+        if before_ok && after_ok {
+            return true;
+        }
+        start = abs_idx + name.len();
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn touch(path: &Path) {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(path, "").unwrap();
+    }
+
+    #[test]
+    fn greenfield_when_workspace_is_empty() {
+        let dir = tempdir().unwrap();
+        let scope = TaskWorkspaceScope::detect(dir.path(), "FastAPIでCRUDのAPIを開発してください");
+        assert!(matches!(scope.mode, ScopeMode::Greenfield));
+        assert!(scope.contains("app/main.py"));
+    }
+
+    #[test]
+    fn single_project_root_when_manifest_at_root() {
+        let dir = tempdir().unwrap();
+        touch(&dir.path().join("pyproject.toml"));
+        let scope = TaskWorkspaceScope::detect(dir.path(), "READMEを更新してください");
+        assert!(matches!(scope.mode, ScopeMode::SingleProjectRoot));
+        assert!(scope.contains("app/main.py"));
+        assert!(scope.contains("README.md"));
+    }
+
+    #[test]
+    fn ambiguous_parent_excludes_existing_nested_subtree() {
+        let dir = tempdir().unwrap();
+        touch(&dir.path().join("0517_003/pyproject.toml"));
+        touch(&dir.path().join("0517_003/app/main.py"));
+        let scope = TaskWorkspaceScope::detect(dir.path(), "FastAPIでCRUDのAPIを開発してください");
+        match &scope.mode {
+            ScopeMode::AmbiguousParent { nested_subtrees } => {
+                assert_eq!(nested_subtrees, &vec![PathBuf::from("0517_003")]);
+            }
+            other => panic!("expected AmbiguousParent, got {other:?}"),
+        }
+        // Pre-existing subtree files are out of scope.
+        assert!(!scope.contains("0517_003/app/main.py"));
+        assert!(!scope.contains("0517_003/README.md"));
+        // Fresh artifacts at the parent root are in scope.
+        assert!(scope.contains("app/main.py"));
+        assert!(scope.contains("README.md"));
+    }
+
+    #[test]
+    fn explicit_subtree_mention_promotes_it_into_scope() {
+        let dir = tempdir().unwrap();
+        touch(&dir.path().join("0517_003/pyproject.toml"));
+        touch(&dir.path().join("0517_003/app/main.py"));
+        // User explicitly references the existing subtree by name.
+        let scope = TaskWorkspaceScope::detect(dir.path(), "0517_003を修正してください");
+        match &scope.mode {
+            ScopeMode::Explicit { paths } => {
+                assert_eq!(paths, &vec![PathBuf::from("0517_003")]);
+            }
+            other => panic!("expected Explicit, got {other:?}"),
+        }
+        assert!(scope.contains("0517_003/app/main.py"));
+        // Files outside the explicit subtree are out of scope.
+        assert!(!scope.contains("other/file.py"));
+    }
+
+    #[test]
+    fn explicit_token_rejects_substring_noise() {
+        let dir = tempdir().unwrap();
+        touch(&dir.path().join("0517_003/pyproject.toml"));
+        // "0517" alone must not match the subtree "0517_003".
+        let scope = TaskWorkspaceScope::detect(dir.path(), "0517を分析してください");
+        assert!(!matches!(scope.mode, ScopeMode::Explicit { .. }));
+    }
+
+    #[test]
+    fn nested_subtrees_detected_via_marker_dirs() {
+        let dir = tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("svc_a/src")).unwrap();
+        std::fs::create_dir_all(dir.path().join("svc_b/tests")).unwrap();
+        let nested = nested_project_subtrees(dir.path());
+        assert!(nested.contains(&PathBuf::from("svc_a")));
+        assert!(nested.contains(&PathBuf::from("svc_b")));
+    }
+
+    #[test]
+    fn ignored_top_dirs_are_not_nested_subtrees() {
+        let dir = tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("node_modules/foo")).unwrap();
+        std::fs::create_dir_all(dir.path().join(".venv/lib")).unwrap();
+        touch(&dir.path().join("node_modules/foo/package.json"));
+        let nested = nested_project_subtrees(dir.path());
+        assert!(!nested.contains(&PathBuf::from("node_modules")));
+        assert!(!nested.contains(&PathBuf::from(".venv")));
+    }
+
+    #[test]
+    fn ambiguous_parent_with_two_subtrees_excludes_both() {
+        let dir = tempdir().unwrap();
+        touch(&dir.path().join("svc_a/pyproject.toml"));
+        touch(&dir.path().join("svc_b/package.json"));
+        let scope = TaskWorkspaceScope::detect(dir.path(), "全部修正してください");
+        match &scope.mode {
+            ScopeMode::AmbiguousParent { nested_subtrees } => {
+                assert!(nested_subtrees.contains(&PathBuf::from("svc_a")));
+                assert!(nested_subtrees.contains(&PathBuf::from("svc_b")));
+            }
+            other => panic!("expected AmbiguousParent, got {other:?}"),
+        }
+        assert!(!scope.contains("svc_a/app/main.py"));
+        assert!(!scope.contains("svc_b/index.js"));
+        assert!(scope.contains("README.md"));
+    }
+}

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -3483,6 +3483,12 @@ impl Agent {
         // user message — reset here so a fresh handle_user_message can fire
         // the Reminder once even if the previous turn already did.
         self.reminder_called_this_turn = false;
+        // Issue #646 (C1): per-turn ownership reset. Each user turn starts a
+        // fresh task — prior-turn edits do NOT auto-confer ownership on the
+        // new task. Clearing here also wipes the MissingVerifierJob so
+        // verifier retry budgets restart per task.
+        self.turn_edited_relative_paths.clear();
+        self.missing_verifier_job = None;
         // Issue #459: Tester Skill per-turn cap counter (DR1-004). Mirror of
         // the reminder cap above; reset so a fresh user turn can fire the
         // Tester once even if the previous turn already did.
@@ -7503,6 +7509,9 @@ impl Agent {
                     args.task_contract_verify_commands_collected.push(sanitized);
                 }
                 self.repair_job = None;
+                // Issue #646 (A1): verifier success retires any in-flight
+                // MissingVerifierJob — no further suppression is needed.
+                self.missing_verifier_job = None;
                 *args.verifier_repair_retries = 0;
                 // Issue #637 (CB-001): mirror the local counter reset on the
                 // Agent-field counter so the next verifier failure / repair
@@ -7593,6 +7602,15 @@ impl Agent {
                     Some(args.repo_edit_calls_made_this_turn);
                 self.task_contract_verifier_repair_pending = true;
                 self.repair_job = None;
+                // Issue #646 (A1): raise a first-class MissingVerifierJob so
+                // the planner suppresses `RunVerifier` until an in-scope edit
+                // lands (B2). The retry budget mirrors the legacy
+                // `TASK_CONTRACT_VERIFIER_ATTEMPT_LIMIT` (3) but is owned by
+                // the job itself, decoupled from the failure-driven counter.
+                self.missing_verifier_job = Some(super::repair_job::MissingVerifierJob::new(
+                    TASK_CONTRACT_VERIFIER_ATTEMPT_LIMIT as u8,
+                    args.repo_edit_calls_made_this_turn,
+                ));
                 *args.repo_change_retries = 0;
                 *args.verifier_repair_retries = 0;
                 // Issue #637 (CB-001): transitioning to NoVerifier resets the
@@ -8774,7 +8792,21 @@ impl Agent {
             }
         }
         if self.task_contract_verifier_repair_pending {
-            return verifier_repair_policy_for_decision(self.verifier_repair_decision_for_policy());
+            // Issue #646 (A1/A3): when a first-class MissingVerifierJob is
+            // active and the safeguarded decision returns `NoRepair` (i.e.
+            // the scope check rejected the legacy out-of-scope target),
+            // expose the MissingVerifierJob's narrow tool whitelist so the
+            // model can still produce an in-scope verifier file.
+            let decision = self.verifier_repair_decision_for_policy();
+            if matches!(decision, VerifierRepairDecision::NoRepair)
+                && let Some(job) = self.missing_verifier_job.as_ref()
+            {
+                return EffectiveToolPolicy::restricted(
+                    EffectiveToolPolicyReason::VerifierRepair,
+                    job.allowed_tool_names().to_vec(),
+                );
+            }
+            return verifier_repair_policy_for_decision(decision);
         }
         if let Some(target) = self.forced_small_edit_recovery_target() {
             return self.focused_edit_policy_for_target(
@@ -8803,14 +8835,47 @@ impl Agent {
     }
 
     fn verifier_repair_decision_for_policy(&self) -> VerifierRepairDecision {
-        verifier_repair_decision(
+        // Issue #646 (A3/B1): the legacy `verifier_repair_decision` falls
+        // back to `latest_successful_read_existing_path` when no real
+        // `RepairJob` is attached. That fallback can return an out-of-scope
+        // path which then directs the tool policy / recovery note into a
+        // prior-session subtree. Route through the shared scope safeguard
+        // so all three consumers (`task_contract_repair_state`,
+        // `effective_tool_policy`, `push_verifier_repair_recovery_note`)
+        // see an identically gated decision.
+        self.scope_safeguarded_verifier_repair_decision(None, 0)
+    }
+
+    /// Issue #646 (A3/B1): single SSOT for the verifier-repair decision
+    /// after applying the active-scope safeguard. When `repair_job` is
+    /// `None` and the raw decision targets an out-of-scope path, returns
+    /// `NoRepair` instead, so downstream consumers cannot drag the model
+    /// into a prior subtree.
+    fn scope_safeguarded_verifier_repair_decision(
+        &self,
+        repair_edit_count: Option<usize>,
+        repo_edit_calls_made_this_turn: usize,
+    ) -> VerifierRepairDecision {
+        let decision = verifier_repair_decision(
             self.task_contract_verifier_repair_pending,
             self.repair_job.as_ref(),
             &self.session.messages,
             &self.work_root,
-            None,
-            0,
-        )
+            repair_edit_count,
+            repo_edit_calls_made_this_turn,
+        );
+        if self.repair_job.is_some() {
+            return decision;
+        }
+        let Some(target) = decision_target_path(&decision) else {
+            return decision;
+        };
+        let scope = self.current_workspace_scope();
+        if target_path_in_scope(target, &self.work_root, &scope) {
+            decision
+        } else {
+            VerifierRepairDecision::NoRepair
+        }
     }
 
     fn focused_edit_policy_for_target(
@@ -9964,14 +10029,6 @@ impl Agent {
         else {
             return;
         };
-        // Issue #646: record every successful Write/Edit observation so the
-        // ownership classifier can promote in-scope existing artifacts to
-        // `Owned`. Recording here (before the scaffold-delta gate) is
-        // deliberate — the tool call already succeeded, and the scaffold-
-        // delta gate is about completion-evidence semantics, not about
-        // whether the path was touched.
-        self.session_edited_relative_paths
-            .insert(relative_path.clone());
         let category = super::completion_evidence::classify_repo_edit_path(std::path::Path::new(
             &relative_path,
         ));
@@ -9986,6 +10043,20 @@ impl Agent {
                 }),
             );
             return;
+        }
+        // Issue #646 (C2): record the edited path AFTER the scaffold-delta
+        // gate so a no-op Write/Edit (writing the same scaffold body back)
+        // never promotes the file to `Owned`. Only substantive changes
+        // contribute to ownership.
+        self.turn_edited_relative_paths
+            .insert(relative_path.clone());
+        // Issue #646 (A1/B2): once an in-scope edit has landed, the
+        // MissingVerifierJob can begin retrying verifier creation.
+        if self.missing_verifier_job.is_some() {
+            let in_scope = self.current_workspace_scope().contains(&relative_path);
+            if in_scope && let Some(job) = self.missing_verifier_job.as_mut() {
+                job.record_in_scope_edit();
+            }
         }
         self.evidence_set_this_turn
             .push(super::completion_evidence::CompletionEvidence::RepoEdit { category, count: 1 });
@@ -10110,7 +10181,7 @@ impl Agent {
                 existing_workspace_candidate_for_role_in_scope(&self.work_root, *role, &scope)
             {
                 let scaffold_changed = self.repo_edit_has_post_scaffold_delta(&path);
-                let edited_this_session = self.session_edited_relative_paths.contains(&path);
+                let edited_this_session = self.turn_edited_relative_paths.contains(&path);
                 let ownership = super::artifact_ownership::classify_ownership(
                     super::artifact_ownership::OwnershipInputs {
                         work_root: &self.work_root,
@@ -10156,30 +10227,10 @@ impl Agent {
         repair_edit_count: Option<usize>,
         repo_edit_calls_made_this_turn: usize,
     ) -> super::task_contract::VerifierRepairState {
-        let decision = verifier_repair_decision(
-            self.task_contract_verifier_repair_pending,
-            self.repair_job.as_ref(),
-            &self.session.messages,
-            &self.work_root,
+        let decision = self.scope_safeguarded_verifier_repair_decision(
             repair_edit_count,
             repo_edit_calls_made_this_turn,
         );
-        // Issue #646 (MissingVerifierJob safeguard): when there is no real
-        // `RepairJob` (i.e. NoVerifier branch produced `pending=true` without
-        // a failure), `verifier_repair_decision` falls back to the latest
-        // successful `Read` path. A pre-session exploration `Read` of an
-        // out-of-scope subtree would otherwise drive the repair loop into
-        // that subtree. Downgrading to `None` lets `plan_artifact_recovery`
-        // fall through to the artifact-missing branch, which forces an
-        // in-scope edit before any verifier retry.
-        if self.repair_job.is_none()
-            && let Some(target) = decision_target_path(&decision)
-        {
-            let scope = self.current_workspace_scope();
-            if !target_path_in_scope(target, &self.work_root, &scope) {
-                return super::task_contract::VerifierRepairState::None;
-            }
-        }
         match decision {
             VerifierRepairDecision::NeedDiagnostic
             | VerifierRepairDecision::NeedTargetDiscovery
@@ -10211,12 +10262,17 @@ impl Agent {
         let artifacts = self.task_contract_artifact_states(contract);
         let repair_state =
             self.task_contract_repair_state(repair_edit_count, repo_edit_calls_made_this_turn);
+        let missing_verifier_suppress_retry = self
+            .missing_verifier_job
+            .as_ref()
+            .is_some_and(|job| job.should_suppress_verifier_retry());
         super::task_contract::plan_artifact_recovery(super::task_contract::ArtifactRecoveryInputs {
             contract,
             evidence: &self.task_contract_evidence_set_this_turn,
             artifacts: &artifacts,
             repair_state: &repair_state,
             artifact_excerpts: &self.task_contract_excerpts,
+            missing_verifier_suppress_retry,
         })
     }
 
@@ -10236,20 +10292,37 @@ impl Agent {
                     .to_string(),
             });
         }
-        // Issue #646: only suggest an existing workspace artifact when it
-        // is inside the active scope. Out-of-scope nested-subtree files are
-        // never a legitimate recovery target.
+        // Issue #646 (D1): two-step gate — first scope, then full ownership
+        // classifier. A scope-internal but non-`Owned` artifact (e.g. an
+        // unchanged scaffold body, a CandidateOnly README the user never
+        // mentioned) MUST NOT be surfaced as a recovery target either. The
+        // ownership signal — edit / scaffold delta / explicit scope mention
+        // — is the same one the planner uses upstream.
         let scope = self.current_workspace_scope();
-        if let Some(path) =
-            existing_workspace_candidate_for_role_in_scope(&self.work_root, role, &scope)
-        {
-            return Some(super::task_contract::RecoveryTargetHint {
-                role,
-                path,
-                reason: "existing workspace artifact matches the missing role".to_string(),
-            });
+        let path = existing_workspace_candidate_for_role_in_scope(&self.work_root, role, &scope)?;
+        let scaffold_changed = self.repo_edit_has_post_scaffold_delta(&path);
+        let edited_this_session = self.turn_edited_relative_paths.contains(&path);
+        let ownership = super::artifact_ownership::classify_ownership(
+            super::artifact_ownership::OwnershipInputs {
+                work_root: &self.work_root,
+                relative_path: &path,
+                scope: &scope,
+                edited_this_session,
+                scaffold_changed,
+                verifier_passed_in_scope: false,
+            },
+        );
+        if !matches!(
+            ownership,
+            super::artifact_ownership::ArtifactOwnership::Owned
+        ) {
+            return None;
         }
-        None
+        Some(super::task_contract::RecoveryTargetHint {
+            role,
+            path,
+            reason: "existing workspace artifact matches the missing role".to_string(),
+        })
     }
 
     fn set_artifact_recovery_target_for_decision(
@@ -15694,10 +15767,8 @@ fn collect_meaningful_workspace_files(
         let entry = entry?;
         let name = entry.file_name();
         let name = name.to_string_lossy();
-        if matches!(
-            name.as_ref(),
-            ".git" | ".anvil" | ".anvil-state" | "node_modules" | "target"
-        ) {
+        // Issue #646 (E1): single SSOT for ignored workspace directories.
+        if super::task_workspace_scope::is_workspace_ignored_dir(&name) {
             continue;
         }
         let path = entry.path();

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -3486,8 +3486,11 @@ impl Agent {
         // Issue #646 (C1): per-turn ownership reset. Each user turn starts a
         // fresh task — prior-turn edits do NOT auto-confer ownership on the
         // new task. Clearing here also wipes the MissingVerifierJob so
-        // verifier retry budgets restart per task.
+        // verifier retry budgets restart per task, and the
+        // `turn_pre_tool_file_hashes` capture cache so stale baselines from
+        // a prior turn cannot mask the next turn's first write.
         self.turn_edited_relative_paths.clear();
+        self.turn_pre_tool_file_hashes.clear();
         self.missing_verifier_job = None;
         // Issue #459: Tester Skill per-turn cap counter (DR1-004). Mirror of
         // the reminder cap above; reset so a fresh user turn can fire the
@@ -5328,10 +5331,16 @@ impl Agent {
                 .allowed_tool_names_for_prompt()
                 .is_some()
             {
-                match effective_tool_batch_action(
+                let batch_scope = if self.missing_verifier_job.is_some() {
+                    Some(self.current_workspace_scope())
+                } else {
+                    None
+                };
+                match effective_tool_batch_action_with_scope(
                     &prepared_tool_calls,
                     &effective_tool_policy,
                     &self.work_root,
+                    batch_scope.as_ref(),
                 ) {
                     FocusedEditBatchAction::Accept => {}
                     FocusedEditBatchAction::TruncateToFirst => {
@@ -7602,15 +7611,30 @@ impl Agent {
                     Some(args.repo_edit_calls_made_this_turn);
                 self.task_contract_verifier_repair_pending = true;
                 self.repair_job = None;
-                // Issue #646 (A1): raise a first-class MissingVerifierJob so
-                // the planner suppresses `RunVerifier` until an in-scope edit
-                // lands (B2). The retry budget mirrors the legacy
-                // `TASK_CONTRACT_VERIFIER_ATTEMPT_LIMIT` (3) but is owned by
-                // the job itself, decoupled from the failure-driven counter.
-                self.missing_verifier_job = Some(super::repair_job::MissingVerifierJob::new(
-                    TASK_CONTRACT_VERIFIER_ATTEMPT_LIMIT as u8,
-                    args.repo_edit_calls_made_this_turn,
-                ));
+                // Issue #646 (A1): raise / advance the first-class
+                // MissingVerifierJob. The job persists across NoVerifier
+                // transitions within the same user turn so its retry budget
+                // (`record_retry`) is the authoritative ceiling; the legacy
+                // `contract_verification_retries` counter remains as a
+                // belt-and-braces guard.
+                if self.missing_verifier_job.is_none() {
+                    self.missing_verifier_job = Some(super::repair_job::MissingVerifierJob::new(
+                        TASK_CONTRACT_VERIFIER_ATTEMPT_LIMIT as u8,
+                        args.repo_edit_calls_made_this_turn,
+                    ));
+                }
+                let budget_exhausted = self
+                    .missing_verifier_job
+                    .as_mut()
+                    .is_some_and(|job| !job.record_retry());
+                if budget_exhausted {
+                    return TaskContractVerifierFlowOutcome::Exit {
+                        reason: ExitReason::MissingVerification,
+                        error_text:
+                            "task contract requires verification, but the MissingVerifierJob retry budget is exhausted"
+                                .to_string(),
+                    };
+                }
                 *args.repo_change_retries = 0;
                 *args.verifier_repair_retries = 0;
                 // Issue #637 (CB-001): transitioning to NoVerifier resets the
@@ -9795,8 +9819,23 @@ impl Agent {
             self.session.working_memory.note_error(err.clone());
             return lifecycle::format_tool_error(&err);
         }
+        // Issue #646 (A1/A3): when a first-class MissingVerifierJob is
+        // active, hand the active workspace scope to the policy gate so
+        // out-of-scope `Write`/`Edit` paths are rejected even when the
+        // restricted whitelist would otherwise admit them.
+        let scope_for_policy = if self.missing_verifier_job.is_some() {
+            Some(self.current_workspace_scope())
+        } else {
+            None
+        };
         let effective_policy_error = if let Some(policy) = effective_tool_policy {
-            effective_tool_policy_error_for_call(policy, name, arguments, &self.work_root)
+            effective_tool_policy_error_for_call_with_scope(
+                policy,
+                name,
+                arguments,
+                &self.work_root,
+                scope_for_policy.as_ref(),
+            )
         } else {
             self.effective_tool_policy_error(name, arguments)
         };
@@ -9894,6 +9933,16 @@ impl Agent {
             };
         }
 
+        // Issue #646 (C2 / A4): capture pre-tool hash so
+        // `observe_evidence_from_repo_edit` can detect no-op Write/Edit
+        // calls (content unchanged → no `Owned` promotion).
+        if matches!(name, "Write" | "Edit")
+            && let Some(raw_path) = arguments.get("path").and_then(serde_json::Value::as_str)
+            && let Some(rel) = workspace_relative_path_for_tool_arg(&self.work_root, raw_path)
+        {
+            let pre_hash = current_file_hash_for_relative_path(&self.work_root, &rel);
+            self.turn_pre_tool_file_hashes.insert(rel, pre_hash);
+        }
         match self.tool_registry.execute(name, arguments, &context) {
             Ok(result) => {
                 if matches!(name, "Write" | "Edit")
@@ -10044,10 +10093,36 @@ impl Agent {
             );
             return;
         }
-        // Issue #646 (C2): record the edited path AFTER the scaffold-delta
-        // gate so a no-op Write/Edit (writing the same scaffold body back)
-        // never promotes the file to `Owned`. Only substantive changes
-        // contribute to ownership.
+        // Issue #646 (C2 / A4): even after the scaffold-delta gate, a
+        // Write/Edit can be a content no-op for a NON-scaffold file (e.g.
+        // model writes the same body back, or `Edit` whose `old_string`
+        // equals `new_string`). Compare the pre-tool hash captured in
+        // `execute_tool_call` against the current on-disk hash. Identical
+        // hashes mean the file did not actually change — bail out so the
+        // path does NOT enter `turn_edited_relative_paths` and does NOT
+        // contribute completion evidence. The pre-tool entry is removed in
+        // either branch to keep the cache turn-local and bounded.
+        let pre_tool_hash = self.turn_pre_tool_file_hashes.remove(&relative_path);
+        let current_hash = current_file_hash_for_relative_path(&self.work_root, &relative_path);
+        if is_repo_edit_no_op(
+            pre_tool_hash.as_ref().and_then(Option::as_deref),
+            current_hash.as_deref(),
+        ) {
+            crate::logging::log_completion_evidence_observed(
+                self.current_turn_index,
+                0,
+                "repo_edit_no_op",
+                serde_json::json!({
+                    "category": format!("{:?}", category),
+                    "path": relative_path,
+                }),
+            );
+            return;
+        }
+        // Issue #646 (C2): record the edited path AFTER both the scaffold-
+        // delta gate AND the no-op hash check so a content-unchanged
+        // Write/Edit (scaffold body re-written, or `Edit` with
+        // `old_string == new_string`) never promotes the file to `Owned`.
         self.turn_edited_relative_paths
             .insert(relative_path.clone());
         // Issue #646 (A1/B2): once an in-scope edit has landed, the
@@ -10450,11 +10525,17 @@ impl Agent {
         arguments: &serde_json::Value,
     ) -> Option<String> {
         let effective_tool_policy = self.effective_tool_policy();
-        effective_tool_policy_error_for_call(
+        let scope = if self.missing_verifier_job.is_some() {
+            Some(self.current_workspace_scope())
+        } else {
+            None
+        };
+        effective_tool_policy_error_for_call_with_scope(
             &effective_tool_policy,
             name,
             arguments,
             &self.work_root,
+            scope.as_ref(),
         )
     }
 
@@ -16373,11 +16454,32 @@ fn focused_edit_tool_policy_error(
     }
 }
 
+/// Legacy non-scope wrapper kept for unit tests and tests-only re-exports.
+/// Production code MUST use [`effective_tool_policy_error_for_call_with_scope`]
+/// so the MissingVerifierJob scope gate fires (Issue #646 A1/A3).
+#[cfg(test)]
 fn effective_tool_policy_error_for_call(
     policy: &EffectiveToolPolicy,
     name: &str,
     arguments: &serde_json::Value,
     work_root: &Path,
+) -> Option<String> {
+    effective_tool_policy_error_for_call_with_scope(policy, name, arguments, work_root, None)
+}
+
+/// Issue #646 (A1/A3): scope-aware variant. When `scope` is provided and the
+/// policy is a `VerifierRepair`-reasoned restricted policy WITHOUT a
+/// focused-edit or artifact-directed target (i.e. the MissingVerifierJob
+/// fallback whitelist), the file-targeting tool calls must additionally pass
+/// `scope.contains(...)` on the resolved path argument. Out-of-scope writes
+/// are rejected even though `Write`/`Edit`/`Bash` would otherwise satisfy
+/// the tool-name whitelist.
+fn effective_tool_policy_error_for_call_with_scope(
+    policy: &EffectiveToolPolicy,
+    name: &str,
+    arguments: &serde_json::Value,
+    work_root: &Path,
+    scope: Option<&super::task_workspace_scope::TaskWorkspaceScope>,
 ) -> Option<String> {
     if let Some(allowed_tools) = policy.allowed_tool_names_for_prompt()
         && !allowed_tools.contains(&name)
@@ -16404,7 +16506,51 @@ fn effective_tool_policy_error_for_call(
         return artifact_directed_tool_policy_error(name, arguments, &artifact.target, work_root);
     }
 
+    // Issue #646 (A1/A3): MissingVerifierJob fallback scope enforcement.
+    if policy.reason() == EffectiveToolPolicyReason::VerifierRepair
+        && let Some(scope) = scope
+        && let Some(err) = missing_verifier_scope_policy_error(name, arguments, work_root, scope)
+    {
+        return Some(err);
+    }
+
     None
+}
+
+/// Issue #646 (C2 / A4): no-op repo-edit detector. Compares the pre-tool
+/// content hash captured in `execute_tool_call` against the post-tool
+/// content hash. When both are `Some(x)` with equal values the Write/Edit
+/// did not modify the file and MUST NOT promote the path to `Owned`.
+///
+/// Returns `false` whenever the pre-tool hash is missing (first observation
+/// in the turn) or `None` (file didn't exist before the tool call), since
+/// those are real edits.
+fn is_repo_edit_no_op(pre_tool_hash: Option<&str>, current_hash: Option<&str>) -> bool {
+    matches!((pre_tool_hash, current_hash), (Some(p), Some(c)) if p == c)
+}
+
+/// Issue #646 (A1/A3): rejects file-targeting tool calls whose resolved path
+/// argument falls outside the active `TaskWorkspaceScope`. Applies only when
+/// the policy reason is `VerifierRepair` and the policy carries no specific
+/// target (i.e. the MissingVerifierJob whitelist case).
+fn missing_verifier_scope_policy_error(
+    name: &str,
+    arguments: &serde_json::Value,
+    work_root: &Path,
+    scope: &super::task_workspace_scope::TaskWorkspaceScope,
+) -> Option<String> {
+    if !matches!(name, "Write" | "Edit") {
+        return None;
+    }
+    let raw_path = arguments.get("path").and_then(serde_json::Value::as_str)?;
+    let relative = workspace_relative_path_for_tool_arg(work_root, raw_path)?;
+    if scope.contains(&relative) {
+        return None;
+    }
+    let rejected_tool = compact_tool_name_for_policy_feedback(name);
+    Some(format!(
+        "MissingVerifierJob policy rejected {rejected_tool}; path {relative} is outside the active workspace scope"
+    ))
 }
 
 fn artifact_directed_tool_policy_error(
@@ -16542,20 +16688,36 @@ fn focused_edit_tool_batch_action(
     }
 }
 
+/// Legacy non-scope wrapper kept for unit tests and tests-only re-exports.
+/// Production code MUST use [`effective_tool_batch_action_with_scope`].
+#[cfg(test)]
 fn effective_tool_batch_action(
     tool_calls: &[ToolCall],
     policy: &EffectiveToolPolicy,
     work_root: &Path,
 ) -> FocusedEditBatchAction {
+    effective_tool_batch_action_with_scope(tool_calls, policy, work_root, None)
+}
+
+/// Issue #646 (A1/A3): scope-aware variant of [`effective_tool_batch_action`].
+/// Forwarded scope is consulted only by the MissingVerifierJob fallback
+/// branch inside `effective_tool_policy_error_for_call_with_scope`.
+fn effective_tool_batch_action_with_scope(
+    tool_calls: &[ToolCall],
+    policy: &EffectiveToolPolicy,
+    work_root: &Path,
+    scope: Option<&super::task_workspace_scope::TaskWorkspaceScope>,
+) -> FocusedEditBatchAction {
     let Some(first_tool_call) = tool_calls.first() else {
         return FocusedEditBatchAction::Accept;
     };
 
-    if let Some(err) = effective_tool_policy_error_for_call(
+    if let Some(err) = effective_tool_policy_error_for_call_with_scope(
         policy,
         &first_tool_call.name,
         &first_tool_call.arguments,
         work_root,
+        scope,
     ) {
         return FocusedEditBatchAction::Reject(err);
     }
@@ -17707,12 +17869,13 @@ mod progress_tests {
         deterministic_empty_framework_game_files, deterministic_framework_app_files_needed,
         deterministic_framework_game_files_needed, deterministic_support_target_relative,
         effective_tool_batch_action, effective_tool_policy_error_for_call,
-        existing_workspace_candidate_for_role, existing_workspace_candidate_for_role_in_scope,
-        extract_page_copy_block_from_numbered_read, first_existing_impl_target,
-        focused_edit_compact_anchor_note, focused_edit_compact_recovery_anchor,
-        focused_edit_exact_anchor_history, focused_edit_exact_recovery_anchor,
-        focused_edit_first_slice_note, focused_edit_first_slice_uses_exact_anchor,
-        focused_edit_guidance_note, focused_edit_guidance_note_for_policy, focused_edit_history,
+        effective_tool_policy_error_for_call_with_scope, existing_workspace_candidate_for_role,
+        existing_workspace_candidate_for_role_in_scope, extract_page_copy_block_from_numbered_read,
+        first_existing_impl_target, focused_edit_compact_anchor_note,
+        focused_edit_compact_recovery_anchor, focused_edit_exact_anchor_history,
+        focused_edit_exact_recovery_anchor, focused_edit_first_slice_note,
+        focused_edit_first_slice_uses_exact_anchor, focused_edit_guidance_note,
+        focused_edit_guidance_note_for_policy, focused_edit_history,
         focused_edit_max_predict_override, focused_edit_minimal_history,
         focused_edit_policy_violation_feedback_note, focused_edit_second_slice_note,
         focused_edit_target_already_read, focused_edit_timeout_override_secs,
@@ -17720,8 +17883,8 @@ mod progress_tests {
         focused_read_target_for_directory, format_blocked_progress_line, format_progress_line,
         framework_app_fallback_continuation_note, has_successful_non_plan_repo_edit,
         has_successful_non_plan_repo_edit_after_latest_truncated_tool_call,
-        has_successful_repo_edit, implementation_quality_issue_for_request, is_utf8_locale,
-        last_read_tool_path, latest_page_copy_block_from_read,
+        has_successful_repo_edit, implementation_quality_issue_for_request, is_repo_edit_no_op,
+        is_utf8_locale, last_read_tool_path, latest_page_copy_block_from_read,
         latest_truncated_tool_call_note_index, latest_turn_preferred_read_edit_target,
         parse_verifier_repair_assessment_reply, parse_verifier_repair_intent_reply,
         parse_verifier_repair_intents_reply, post_scaffold_continuation_active,
@@ -21164,6 +21327,126 @@ export default function App() {
             work_root,
             &scope
         ));
+    }
+
+    #[test]
+    fn no_op_repo_edit_detector_returns_true_only_for_matching_hashes() {
+        // Issue #646 (A4 / C2): the pure helper guarding
+        // `observe_evidence_from_repo_edit` against no-op Write/Edit calls.
+        // Identical pre/post hashes → no-op; any difference, or a None on
+        // either side, → real edit (insertion + evidence flow proceeds).
+        assert!(is_repo_edit_no_op(Some("abc"), Some("abc")));
+        assert!(!is_repo_edit_no_op(Some("abc"), Some("def")));
+        assert!(!is_repo_edit_no_op(None, Some("abc"))); // file didn't exist before
+        assert!(!is_repo_edit_no_op(Some("abc"), None)); // file deleted (treat as edit)
+        assert!(!is_repo_edit_no_op(None, None));
+    }
+
+    #[test]
+    fn missing_verifier_policy_rejects_out_of_scope_write() {
+        // Issue #646 (A1/A3): the MissingVerifierJob fallback policy is a
+        // `restricted(VerifierRepair, ["Write","Edit","Bash"])`. Without
+        // the scope gate, `Write` on `0517_003/app/main.py` would silently
+        // pass — exactly the codex finding. The scope-aware policy gate
+        // must reject the call with a MissingVerifierJob-flavoured error.
+        let dir = tempdir().unwrap();
+        let work_root = dir.path();
+        // Make `0517_003/` project-like so it sits in AmbiguousParent scope.
+        std::fs::create_dir_all(work_root.join("0517_003/app")).unwrap();
+        std::fs::create_dir_all(work_root.join("0517_003/tests")).unwrap();
+        std::fs::write(work_root.join("0517_003/tests/test_main.py"), "").unwrap();
+        std::fs::write(work_root.join("0517_003/app/main.py"), "").unwrap();
+        let scope = super::super::task_workspace_scope::TaskWorkspaceScope::detect(
+            work_root,
+            "FastAPIでCRUDのAPIを開発してください",
+        );
+        assert!(!scope.contains("0517_003/app/main.py"));
+
+        let policy = super::EffectiveToolPolicy::restricted(
+            super::EffectiveToolPolicyReason::VerifierRepair,
+            vec!["Write", "Edit", "Bash"],
+        );
+        let arguments = serde_json::json!({
+            "path": "0517_003/app/main.py",
+            "content": "from fastapi import FastAPI\napp = FastAPI()\n",
+        });
+        let err = effective_tool_policy_error_for_call_with_scope(
+            &policy,
+            "Write",
+            &arguments,
+            work_root,
+            Some(&scope),
+        )
+        .expect("OOS write must be rejected by MissingVerifierJob scope gate");
+        assert!(
+            err.contains("MissingVerifierJob policy rejected"),
+            "got: {err}"
+        );
+        assert!(err.contains("0517_003/app/main.py"), "got: {err}");
+    }
+
+    #[test]
+    fn missing_verifier_policy_admits_in_scope_write() {
+        // Issue #646: the same scope gate must NOT reject an in-scope path.
+        let dir = tempdir().unwrap();
+        let work_root = dir.path();
+        std::fs::create_dir_all(work_root.join("0517_003/tests")).unwrap();
+        std::fs::write(work_root.join("0517_003/tests/test_main.py"), "").unwrap();
+        let scope = super::super::task_workspace_scope::TaskWorkspaceScope::detect(
+            work_root,
+            "FastAPIでCRUDのAPIを開発してください",
+        );
+        // Sanity: a fresh root-level path is in scope under AmbiguousParent.
+        assert!(scope.contains("app/main.py"));
+
+        let policy = super::EffectiveToolPolicy::restricted(
+            super::EffectiveToolPolicyReason::VerifierRepair,
+            vec!["Write", "Edit", "Bash"],
+        );
+        let arguments = serde_json::json!({
+            "path": "app/main.py",
+            "content": "from fastapi import FastAPI\napp = FastAPI()\n",
+        });
+        assert!(
+            effective_tool_policy_error_for_call_with_scope(
+                &policy,
+                "Write",
+                &arguments,
+                work_root,
+                Some(&scope),
+            )
+            .is_none(),
+            "in-scope write must pass under MissingVerifierJob scope gate"
+        );
+    }
+
+    #[test]
+    fn missing_verifier_policy_lets_bash_through_irrespective_of_path_arg() {
+        // Bash has no `path` argument; the scope gate intentionally only
+        // restricts file-targeting tools (Write/Edit). Bash is the
+        // verifier-run / dependency-install lifeline and must not be
+        // blocked by this gate.
+        let dir = tempdir().unwrap();
+        let work_root = dir.path();
+        let scope = super::super::task_workspace_scope::TaskWorkspaceScope::detect(
+            work_root,
+            "FastAPIでCRUDのAPIを開発してください",
+        );
+        let policy = super::EffectiveToolPolicy::restricted(
+            super::EffectiveToolPolicyReason::VerifierRepair,
+            vec!["Write", "Edit", "Bash"],
+        );
+        let arguments = serde_json::json!({"command": "pytest -q"});
+        assert!(
+            effective_tool_policy_error_for_call_with_scope(
+                &policy,
+                "Bash",
+                &arguments,
+                work_root,
+                Some(&scope),
+            )
+            .is_none()
+        );
     }
 
     #[test]

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -9964,6 +9964,14 @@ impl Agent {
         else {
             return;
         };
+        // Issue #646: record every successful Write/Edit observation so the
+        // ownership classifier can promote in-scope existing artifacts to
+        // `Owned`. Recording here (before the scaffold-delta gate) is
+        // deliberate — the tool call already succeeded, and the scaffold-
+        // delta gate is about completion-evidence semantics, not about
+        // whether the path was touched.
+        self.session_edited_relative_paths
+            .insert(relative_path.clone());
         let category = super::completion_evidence::classify_repo_edit_path(std::path::Path::new(
             &relative_path,
         ));
@@ -10087,15 +10095,38 @@ impl Agent {
         &self,
         contract: &super::task_contract::TaskContract,
     ) -> Vec<super::task_contract::ArtifactState> {
+        let scope = self.current_workspace_scope();
         let mut states = Vec::new();
         for role in &contract.required_artifacts {
             if let Some(path) = self.scaffold_candidate_for_missing_role(*role) {
                 states.push(super::task_contract::ArtifactState::scaffold(*role, path));
             }
-            if let Some(path) = existing_workspace_candidate_for_role(&self.work_root, *role)
-                && self.repo_edit_has_post_scaffold_delta(&path)
+            // Issue #646: an existing workspace artifact only enters as
+            // `ExistsButUnverified` when ownership classification returns
+            // `Owned`. Pre-existing nested-subtree artifacts the active
+            // task did not produce stay out of the artifact-state vector
+            // and therefore cannot satisfy `artifact_ready_for_verification`.
+            if let Some(path) =
+                existing_workspace_candidate_for_role_in_scope(&self.work_root, *role, &scope)
             {
-                states.push(super::task_contract::ArtifactState::exists(*role, path));
+                let scaffold_changed = self.repo_edit_has_post_scaffold_delta(&path);
+                let edited_this_session = self.session_edited_relative_paths.contains(&path);
+                let ownership = super::artifact_ownership::classify_ownership(
+                    super::artifact_ownership::OwnershipInputs {
+                        work_root: &self.work_root,
+                        relative_path: &path,
+                        scope: &scope,
+                        edited_this_session,
+                        scaffold_changed,
+                        verifier_passed_in_scope: false,
+                    },
+                );
+                if matches!(
+                    ownership,
+                    super::artifact_ownership::ArtifactOwnership::Owned
+                ) {
+                    states.push(super::task_contract::ArtifactState::exists(*role, path));
+                }
             }
         }
         for evidence in self.task_contract_evidence_set_this_turn.iter() {
@@ -10109,19 +10140,47 @@ impl Agent {
         states
     }
 
+    /// Issue #646: build the active `TaskWorkspaceScope` for the current
+    /// task. Pure projection of `work_root` + the active user request; no
+    /// filesystem mutation. Called from `task_contract_artifact_states` and
+    /// `task_contract_recovery_target`; not cached because the bounded
+    /// shallow read of `work_root` is cheap and the scope is recomputed
+    /// only a handful of times per turn.
+    fn current_workspace_scope(&self) -> super::task_workspace_scope::TaskWorkspaceScope {
+        let request = self.active_request_text().unwrap_or_default();
+        super::task_workspace_scope::TaskWorkspaceScope::detect(&self.work_root, &request)
+    }
+
     fn task_contract_repair_state(
         &self,
         repair_edit_count: Option<usize>,
         repo_edit_calls_made_this_turn: usize,
     ) -> super::task_contract::VerifierRepairState {
-        match verifier_repair_decision(
+        let decision = verifier_repair_decision(
             self.task_contract_verifier_repair_pending,
             self.repair_job.as_ref(),
             &self.session.messages,
             &self.work_root,
             repair_edit_count,
             repo_edit_calls_made_this_turn,
-        ) {
+        );
+        // Issue #646 (MissingVerifierJob safeguard): when there is no real
+        // `RepairJob` (i.e. NoVerifier branch produced `pending=true` without
+        // a failure), `verifier_repair_decision` falls back to the latest
+        // successful `Read` path. A pre-session exploration `Read` of an
+        // out-of-scope subtree would otherwise drive the repair loop into
+        // that subtree. Downgrading to `None` lets `plan_artifact_recovery`
+        // fall through to the artifact-missing branch, which forces an
+        // in-scope edit before any verifier retry.
+        if self.repair_job.is_none()
+            && let Some(target) = decision_target_path(&decision)
+        {
+            let scope = self.current_workspace_scope();
+            if !target_path_in_scope(target, &self.work_root, &scope) {
+                return super::task_contract::VerifierRepairState::None;
+            }
+        }
+        match decision {
             VerifierRepairDecision::NeedDiagnostic
             | VerifierRepairDecision::NeedTargetDiscovery
             | VerifierRepairDecision::NeedFreshRead(_)
@@ -10177,7 +10236,13 @@ impl Agent {
                     .to_string(),
             });
         }
-        if let Some(path) = existing_workspace_candidate_for_role(&self.work_root, role) {
+        // Issue #646: only suggest an existing workspace artifact when it
+        // is inside the active scope. Out-of-scope nested-subtree files are
+        // never a legitimate recovery target.
+        let scope = self.current_workspace_scope();
+        if let Some(path) =
+            existing_workspace_candidate_for_role_in_scope(&self.work_root, role, &scope)
+        {
             return Some(super::task_contract::RecoveryTargetHint {
                 role,
                 path,
@@ -13724,6 +13789,12 @@ fn workspace_relative_path_for_tool_arg(work_root: &Path, raw_path: &str) -> Opt
     Some(relative.to_string_lossy().replace('\\', "/"))
 }
 
+/// Legacy un-scoped lookup kept for unit-test fixtures that exercise the
+/// `scaffold_candidate_priority` ordering independently of scope detection.
+/// Production code MUST use [`existing_workspace_candidate_for_role_in_scope`]
+/// so out-of-scope nested-subtree files cannot leak into completion evidence
+/// (Issue #646).
+#[cfg(test)]
 fn existing_workspace_candidate_for_role(
     work_root: &Path,
     role: super::task_contract::ArtifactRole,
@@ -13736,6 +13807,73 @@ fn existing_workspace_candidate_for_role(
             )
             .is_some_and(|candidate| candidate == role)
         })
+        .collect::<Vec<_>>();
+    candidates.sort_by_key(|path| {
+        scaffold_candidate_priority(work_root, role, &path.to_string_lossy().replace('\\', "/"))
+    });
+    candidates
+        .first()
+        .map(|path| path.to_string_lossy().replace('\\', "/"))
+}
+
+/// Issue #646: project the workspace-target half of a [`VerifierRepairDecision`]
+/// so the MissingVerifierJob safeguard can re-validate the scope when no real
+/// [`RepairJob`] is attached. Returns `None` for decisions that do not carry
+/// a path (NoRepair / NeedDiagnostic / NeedTargetDiscovery / ReadyToVerify /
+/// DiagnosticUnavailable).
+fn decision_target_path(decision: &VerifierRepairDecision) -> Option<&Path> {
+    match decision {
+        VerifierRepairDecision::NeedFreshRead(path)
+        | VerifierRepairDecision::NeedWrite(path)
+        | VerifierRepairDecision::NeedEdit(path) => Some(path.as_path()),
+        VerifierRepairDecision::NoRepair
+        | VerifierRepairDecision::NeedDiagnostic
+        | VerifierRepairDecision::NeedTargetDiscovery
+        | VerifierRepairDecision::DiagnosticUnavailable
+        | VerifierRepairDecision::ReadyToVerify => None,
+    }
+}
+
+/// Issue #646: confirm that an absolute repair target lies inside the active
+/// workspace scope. The path is normalized against `work_root` and the
+/// resulting relative form is handed to [`TaskWorkspaceScope::contains`].
+/// Targets that fail to strip the prefix (escape via canonical/symlink) are
+/// treated as out-of-scope.
+fn target_path_in_scope(
+    target: &Path,
+    work_root: &Path,
+    scope: &super::task_workspace_scope::TaskWorkspaceScope,
+) -> bool {
+    let root_canon = std::fs::canonicalize(work_root).unwrap_or_else(|_| work_root.to_path_buf());
+    let target_canon = std::fs::canonicalize(target).unwrap_or_else(|_| target.to_path_buf());
+    let Ok(relative) = target_canon.strip_prefix(&root_canon) else {
+        return false;
+    };
+    scope.contains(&relative.to_string_lossy().replace('\\', "/"))
+}
+
+/// Issue #646: scope-aware variant of [`existing_workspace_candidate_for_role`].
+///
+/// Filters workspace files through `scope.contains(...)` before priority
+/// sorting so candidates inside out-of-scope nested subtrees (the
+/// fresh-session-parent-directory bug case) are never surfaced. Used by
+/// `task_contract_artifact_states` and `task_contract_recovery_target`;
+/// the legacy un-scoped function is preserved for unit-test fixtures that
+/// exercise the priority logic independently.
+pub(super) fn existing_workspace_candidate_for_role_in_scope(
+    work_root: &Path,
+    role: super::task_contract::ArtifactRole,
+    scope: &super::task_workspace_scope::TaskWorkspaceScope,
+) -> Option<String> {
+    let mut candidates = meaningful_workspace_files(work_root, 64)?
+        .into_iter()
+        .filter(|path| {
+            artifact_role_from_repo_edit_category(
+                super::completion_evidence::classify_repo_edit_path(path),
+            )
+            .is_some_and(|candidate| candidate == role)
+        })
+        .filter(|path| scope.contains(&path.to_string_lossy().replace('\\', "/")))
         .collect::<Vec<_>>();
     candidates.sort_by_key(|path| {
         scaffold_candidate_priority(work_root, role, &path.to_string_lossy().replace('\\', "/"))
@@ -17498,12 +17636,12 @@ mod progress_tests {
         deterministic_empty_framework_game_files, deterministic_framework_app_files_needed,
         deterministic_framework_game_files_needed, deterministic_support_target_relative,
         effective_tool_batch_action, effective_tool_policy_error_for_call,
-        existing_workspace_candidate_for_role, extract_page_copy_block_from_numbered_read,
-        first_existing_impl_target, focused_edit_compact_anchor_note,
-        focused_edit_compact_recovery_anchor, focused_edit_exact_anchor_history,
-        focused_edit_exact_recovery_anchor, focused_edit_first_slice_note,
-        focused_edit_first_slice_uses_exact_anchor, focused_edit_guidance_note,
-        focused_edit_guidance_note_for_policy, focused_edit_history,
+        existing_workspace_candidate_for_role, existing_workspace_candidate_for_role_in_scope,
+        extract_page_copy_block_from_numbered_read, first_existing_impl_target,
+        focused_edit_compact_anchor_note, focused_edit_compact_recovery_anchor,
+        focused_edit_exact_anchor_history, focused_edit_exact_recovery_anchor,
+        focused_edit_first_slice_note, focused_edit_first_slice_uses_exact_anchor,
+        focused_edit_guidance_note, focused_edit_guidance_note_for_policy, focused_edit_history,
         focused_edit_max_predict_override, focused_edit_minimal_history,
         focused_edit_policy_violation_feedback_note, focused_edit_second_slice_note,
         focused_edit_target_already_read, focused_edit_timeout_override_secs,
@@ -20870,6 +21008,111 @@ export default function App() {
         .unwrap();
 
         assert_eq!(target, "app/main.py");
+    }
+
+    #[test]
+    fn scope_aware_lookup_filters_out_of_scope_nested_subtree_candidates() {
+        // Issue #646 regression: fresh-session parent-directory layout with
+        // a prior project at `0517_003/*`. The scope-aware lookup must
+        // refuse those out-of-scope candidates even though the legacy
+        // `existing_workspace_candidate_for_role` happily returns them.
+        let temp = tempdir().unwrap();
+        let work_root = temp.path();
+        std::fs::create_dir_all(work_root.join("0517_003/app")).unwrap();
+        std::fs::create_dir_all(work_root.join("0517_003/tests")).unwrap();
+        std::fs::write(
+            work_root.join("0517_003/app/main.py"),
+            "from fastapi import FastAPI\n",
+        )
+        .unwrap();
+        std::fs::write(
+            work_root.join("0517_003/tests/test_main.py"),
+            "def test_health(): pass\n",
+        )
+        .unwrap();
+        std::fs::write(work_root.join("0517_003/README.md"), "# Old\n").unwrap();
+
+        let scope = super::super::task_workspace_scope::TaskWorkspaceScope::detect(
+            work_root,
+            "FastAPIでcrudのAPIを開発してください。使用方法をREADME.mdに記述してください。",
+        );
+        // Pre-existing subtree is detected, no explicit mention → ambiguous parent.
+        let target = existing_workspace_candidate_for_role_in_scope(
+            work_root,
+            super::super::task_contract::ArtifactRole::Implementation,
+            &scope,
+        );
+        assert!(
+            target.is_none(),
+            "expected no in-scope implementation candidate, got {target:?}"
+        );
+
+        // Legacy lookup still returns the old subtree candidate — the safety
+        // belongs to the scope filter, not the meaningful-files walk.
+        let legacy_target = existing_workspace_candidate_for_role(
+            work_root,
+            super::super::task_contract::ArtifactRole::Implementation,
+        );
+        assert_eq!(legacy_target.as_deref(), Some("0517_003/app/main.py"));
+    }
+
+    #[test]
+    fn missing_verifier_safeguard_rejects_out_of_scope_repair_target() {
+        // Issue #646: when verifier_repair_decision falls back to the latest
+        // successful `Read`, an OOS path must NOT be accepted as the
+        // MissingVerifierJob repair target. `target_path_in_scope` is the
+        // gate consulted by `task_contract_repair_state` for this case.
+        let temp = tempdir().unwrap();
+        let work_root = temp.path();
+        std::fs::create_dir_all(work_root.join("0517_003/app")).unwrap();
+        std::fs::create_dir_all(work_root.join("0517_003/tests")).unwrap();
+        // `tests/` marker dir is what makes the prior subtree project-like.
+        std::fs::write(work_root.join("0517_003/tests/test_main.py"), "").unwrap();
+        std::fs::write(
+            work_root.join("0517_003/app/main.py"),
+            "from fastapi import FastAPI\n",
+        )
+        .unwrap();
+        let scope = super::super::task_workspace_scope::TaskWorkspaceScope::detect(
+            work_root,
+            "FastAPIでcrudのAPIを開発してください",
+        );
+        // Sanity: scope must classify the prior subtree as out-of-scope
+        // before any safeguard check is meaningful.
+        assert!(!scope.contains("0517_003/app/main.py"));
+
+        let oos_target = work_root.join("0517_003/app/main.py");
+        assert!(!super::target_path_in_scope(&oos_target, work_root, &scope));
+
+        // A new, in-scope target at the parent root is allowed.
+        let in_scope_target = work_root.join("app/main.py");
+        std::fs::create_dir_all(work_root.join("app")).unwrap();
+        std::fs::write(&in_scope_target, "").unwrap();
+        assert!(super::target_path_in_scope(
+            &in_scope_target,
+            work_root,
+            &scope
+        ));
+    }
+
+    #[test]
+    fn scope_aware_lookup_admits_explicit_subtree_candidates() {
+        // Issue #646: user explicitly named the existing subtree, so its
+        // artifacts ARE in scope and ARE Owned.
+        let temp = tempdir().unwrap();
+        let work_root = temp.path();
+        std::fs::create_dir_all(work_root.join("0517_003/app")).unwrap();
+        std::fs::write(work_root.join("0517_003/app/main.py"), "").unwrap();
+        let scope = super::super::task_workspace_scope::TaskWorkspaceScope::detect(
+            work_root,
+            "0517_003 配下を修正してください",
+        );
+        let target = existing_workspace_candidate_for_role_in_scope(
+            work_root,
+            super::super::task_contract::ArtifactRole::Implementation,
+            &scope,
+        );
+        assert_eq!(target.as_deref(), Some("0517_003/app/main.py"));
     }
 
     #[test]

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -7598,25 +7598,15 @@ impl Agent {
                 TaskContractVerifierFlowOutcome::Continue
             }
             TaskContractVerifierOutcome::NoVerifier => {
-                *args.contract_verification_retries += 1;
-                if *args.contract_verification_retries >= TASK_CONTRACT_VERIFIER_ATTEMPT_LIMIT {
-                    return TaskContractVerifierFlowOutcome::Exit {
-                        reason: ExitReason::MissingVerification,
-                        error_text:
-                            "task contract requires verification, but no verifier was detected"
-                                .to_string(),
-                    };
-                }
-                *args.contract_verifier_repair_edit_count =
-                    Some(args.repo_edit_calls_made_this_turn);
-                self.task_contract_verifier_repair_pending = true;
-                self.repair_job = None;
-                // Issue #646 (A1): raise / advance the first-class
-                // MissingVerifierJob. The job persists across NoVerifier
-                // transitions within the same user turn so its retry budget
-                // (`record_retry`) is the authoritative ceiling; the legacy
-                // `contract_verification_retries` counter remains as a
-                // belt-and-braces guard.
+                // Issue #646 (A1): the MissingVerifierJob is the first-class
+                // owner of the NoVerifier retry budget. Create the job on
+                // the first transition and advance it on every subsequent
+                // one. The legacy `contract_verification_retries` counter
+                // is intentionally NOT incremented for NoVerifier
+                // transitions any more — it tracks verifier *failures*, a
+                // distinct lifecycle (NoVerifier ≠ Failed). Exiting on
+                // exhausted budget happens here, before any of the
+                // pending-flag bookkeeping below.
                 if self.missing_verifier_job.is_none() {
                     self.missing_verifier_job = Some(super::repair_job::MissingVerifierJob::new(
                         TASK_CONTRACT_VERIFIER_ATTEMPT_LIMIT as u8,
@@ -7635,6 +7625,10 @@ impl Agent {
                                 .to_string(),
                     };
                 }
+                *args.contract_verifier_repair_edit_count =
+                    Some(args.repo_edit_calls_made_this_turn);
+                self.task_contract_verifier_repair_pending = true;
+                self.repair_job = None;
                 *args.repo_change_retries = 0;
                 *args.verifier_repair_retries = 0;
                 // Issue #637 (CB-001): transitioning to NoVerifier resets the
@@ -7651,8 +7645,17 @@ impl Agent {
                     ),
                     true,
                 );
+                // Issue #646 (A1): prompt uses the MissingVerifierJob's
+                // own counter so the displayed attempt N/M reflects the
+                // first-class retry budget, not the legacy verifier-failure
+                // counter.
+                let job_attempt = self
+                    .missing_verifier_job
+                    .as_ref()
+                    .map(|job| job.retries_used as usize)
+                    .unwrap_or(0);
                 self.push_system_note(task_contract_no_verifier_note(
-                    *args.contract_verification_retries,
+                    job_attempt,
                     TASK_CONTRACT_VERIFIER_ATTEMPT_LIMIT,
                 ));
                 TaskContractVerifierFlowOutcome::Continue


### PR DESCRIPTION
## Summary

Fresh-session new-build tasks were treating pre-existing nested subtrees (e.g. `0517_003/app/main.py`) as the current task's completion evidence, which drove the planner into verifier execution and `MissingVerifierJob` repair loops on artifacts the assistant had never produced.

This PR introduces structure-based active-scope detection and artifact ownership so that completion evidence and verifier triggers are confined to the current task's scope.

### Changes

- **New module `src/agent/loop_run/task_workspace_scope.rs`** — structure-based scope detection with 4 modes (`Explicit` / `SingleProjectRoot` / `Greenfield` / `AmbiguousParent`). Never uses name blacklists.
- **New module `src/agent/loop_run/artifact_ownership.rs`** — classifies workspace-relative paths as `Owned` / `CandidateOnly` / `OutOfScope` with canonical-path + symlink-escape gating.
- **`turn.rs` wire-in**:
  - `Agent.session_edited_relative_paths` tracks every successful Write/Edit per session
  - `task_contract_artifact_states` only admits `ExistsButUnverified` candidates classified as `Owned`
  - `existing_workspace_candidate_for_role_in_scope` scope-aware lookup for completion-evidence and recovery-target paths
  - `task_contract_recovery_target` filters via scope
  - `task_contract_repair_state` adds a `MissingVerifierJob` safeguard: when no real `RepairJob` is attached and the decision target is OOS, downgrade to `None` so the planner falls through to the missing-artifact branch instead of editing prior-session files
- Both new modules are `pub(super)`-only and not re-exported, per DR3-001.

### Test coverage

- 19 new unit tests across the 3 affected modules (scope detection, ownership classification, scope-aware lookup, repair-target safeguard).
- 1868 lib tests + clippy `-D warnings` + cargo fmt --check + cargo build --release all pass locally.

Fixes #646.

## Test plan

- [ ] CI: cargo fmt --check
- [ ] CI: cargo clippy --all-targets
- [ ] CI: cargo test
- [ ] CI: cargo build
- [ ] Receipt-condition cross-check on Issue #646