### PR TITLE
fix(agent/loop_run): semantic repair planning for verifier failures (#647)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,8 @@ Rust 版 local-first coding agent (Ollama 専用、`workspace/v0.1.0` ベース)
 - `src/photon/*` — Photon サイドカー HTTP 連携 / context_pack レンダラー / adoption signal
 - `src/agent/loop_run/*` — エージェントループ / turn 制御 / 各種 confirm skill (work_mode / feedback_kind / quality / photon_user_feedback)
 - `src/agent/loop_run/project_verifier.rs` — `ProjectVerifier` capability (verifier_repair cheap check SSOT, Issue #639). private mod, not re-exported (DR3-001) — `turn.rs` is the only in-crate consumer.
+- `src/agent/loop_run/semantic_failure.rs` — Issue #647 Phase A.1: `SemanticFailureReport` schema + `build_failure_cluster_from_observation` + `cluster_key` (deterministic, sanitize-then-shape-then-hash). private mod, not re-exported (DR3-001).
+- `src/agent/loop_run/spec_authority.rs` — Issue #647 Phase A.2: `SpecAuthority` enum (5 variant) + `select_authority` + `ArtifactConsensus` tie-break + `detect_test_weakening` / `detect_impl_weakening` (9 pure-fn detectors). private mod, not re-exported (DR3-001).
 - `src/agent/skills/*` — SkillRegistry 基盤 (`AgentSkill` trait, `SkillTrustTier`)
 - `src/session/*` — セッションストア / `FeedbackFrame` / `Precaution` / `AnvilScore` / `CaseRecord` / `eval_log` / `case_retrieval` / `case_photon_bridge` / `tmp_tests` / `rollout_policy` / `feedback.rs::redact_verifier_command_for_storage` (verifier command redactor SSOT) / `store.rs::VerifierInvocationRecord` (Phase α-2)
 - `src/tools/*` — built-in tools (`bash.rs::check_blocked_command` SSOT, Read/Write/Edit, `test_output.rs` failed-name + trim formatter)

--- a/src/agent/loop_run.rs
+++ b/src/agent/loop_run.rs
@@ -516,6 +516,18 @@ pub struct Agent {
     /// tool policy can choose a repair target without polluting the assistant
     /// history with long-lived diagnostic state.
     task_contract_verifier_repair_pending: bool,
+    /// Issue #647 (SF1 V3.2): mirror of the local
+    /// `task_contract_verifier_passed_in_loop` bool in
+    /// `handle_user_message`. Lives on `Agent` so methods invoked from
+    /// inside the actor-loop (e.g. `run_verifier_diagnostic_pass`) can read
+    /// the same "has the verifier already passed once in this run-actor-loop
+    /// iteration?" signal that the local variable carries — without
+    /// plumbing yet another `&mut bool` through six call sites. Reset at
+    /// the head of every `handle_user_message`; flipped to `true` from
+    /// `drive_task_contract_verifier` whenever the verifier classifies a
+    /// run as Passed. **Read-only** consumer in this Issue: the
+    /// `SpecAuthorityInput` builder.
+    pub(super) task_contract_verifier_passed_this_actor_loop: bool,
     /// Issue #625 / #627 / #637: turn-local diagnostic context for a failed
     /// task-contract verifier. Renamed from `verifier_repair_context` to
     /// `repair_job` and consolidated under `repair_job::RepairJob` so all
@@ -783,6 +795,7 @@ impl Agent {
             task_contract_evidence_set_this_turn: completion_evidence::EvidenceSet::new(),
             current_artifact_recovery_target: None,
             task_contract_verifier_repair_pending: false,
+            task_contract_verifier_passed_this_actor_loop: false,
             repair_job: None,
             repair_job_artifact_attempts: 0,
             repair_failure_snapshot: None,

--- a/src/agent/loop_run.rs
+++ b/src/agent/loop_run.rs
@@ -951,4 +951,69 @@ mod tests {
         assert!(should_compact_late_turn(&messages, 24_000, 4, 1));
         assert!(!should_compact_late_turn(&messages[..8], 24_000, 1, 0));
     }
+
+    // -- Phase G grep / structure tests (Issue #647 acceptance closure) -- //
+
+    #[test]
+    fn no_pub_use_for_semantic_failure_or_spec_authority() {
+        // S1-003 / DR3-001: `semantic_failure` and `spec_authority` are
+        // private modules of `loop_run`. They must NOT be widened via
+        // `pub use` re-exports — only the `turn.rs` / `repair_job.rs`
+        // in-crate consumers may access them through `super::`.
+        let source = include_str!("loop_run.rs");
+        for line in source.lines() {
+            let trimmed = line.trim_start();
+            // `//` comments / `///` doc comments / `//!` module docs are
+            // allowed to mention the names for documentation purposes.
+            if trimmed.starts_with("//") {
+                continue;
+            }
+            if trimmed.starts_with("pub use") {
+                assert!(
+                    !line.contains("semantic_failure"),
+                    "DR3-001 violated: `pub use` referencing `semantic_failure` found: {line:?}",
+                );
+                assert!(
+                    !line.contains("spec_authority"),
+                    "DR3-001 violated: `pub use` referencing `spec_authority` found: {line:?}",
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn verifier_diagnostic_failure_kind_has_8_variants() {
+        // S1-001: SemanticFailureReport is an upper-layer wrapper that
+        // **reuses** the existing 8-variant `VerifierDiagnosticFailureKind`
+        // enum. Adding or removing a variant breaks the SSOT invariant
+        // — this test fails to compile (non-exhaustive match) if the
+        // enum surface drifts.
+        use super::VerifierDiagnosticFailureKind as K;
+        let all = [
+            K::DependencyMissing,
+            K::LocalImportContractMismatch,
+            K::CompileOrSyntaxError,
+            K::AssertionMismatch,
+            K::RuntimeError,
+            K::TestBug,
+            K::ConfigOrVerifierError,
+            K::Unknown,
+        ];
+        for v in &all {
+            // Exhaustive match — extension of the enum forces this to
+            // be updated (compile-time lock).
+            let label: &'static str = match v {
+                K::DependencyMissing => "dependency_missing",
+                K::LocalImportContractMismatch => "local_import_contract_mismatch",
+                K::CompileOrSyntaxError => "compile_or_syntax_error",
+                K::AssertionMismatch => "assertion_mismatch",
+                K::RuntimeError => "runtime_error",
+                K::TestBug => "test_bug",
+                K::ConfigOrVerifierError => "config_or_verifier_error",
+                K::Unknown => "unknown",
+            };
+            assert!(!label.is_empty());
+        }
+        assert_eq!(all.len(), 8);
+    }
 }

--- a/src/agent/loop_run.rs
+++ b/src/agent/loop_run.rs
@@ -59,7 +59,17 @@ mod repair_job;
 // intentionally *not* re-exported (DR3-001) — `task_contract.rs` is the only
 // in-crate consumer via `super::required_behavior::*`.
 mod required_behavior;
+// Issue #647 (Phase A.1): semantic repair planning — bounded failure-report
+// schema and deterministic cluster-key generation. Module is intentionally
+// *not* re-exported (DR3-001) — future consumers (`turn.rs`, `repair_job.rs`)
+// reach in via `super::semantic_failure::*`.
+mod semantic_failure;
 pub mod slash_commands;
+// Issue #647 (Phase A.2): spec-authority enum + tie-break scoring + test/impl
+// weakening detectors. Module is intentionally *not* re-exported (DR3-001) —
+// future consumers (`turn.rs`, `repair_job.rs`) reach in via
+// `super::spec_authority::*`.
+mod spec_authority;
 mod spinner;
 mod success;
 mod summary;

--- a/src/agent/loop_run/repair_job.rs
+++ b/src/agent/loop_run/repair_job.rs
@@ -411,6 +411,23 @@ pub(super) fn verifier_repair_decision(
     if job.is_some_and(|job| job.assessment.is_none()) {
         return VerifierRepairDecision::DiagnosticUnavailable;
     }
+    // Issue #647 (CB-012): When semantic_plan is active but the
+    // assessment was constructed before exhausted_attempts grew (= the
+    // hint guard in `verifier_repair_context_target_path` returns
+    // `None` because exhausted_attempts is non-empty), do NOT fall
+    // through to `latest_successful_read_existing_path`. That fallback
+    // would route the repair pass to an unrelated turn-local read
+    // target. Force a fresh diagnostic instead so the next assessment
+    // reflects the advanced cluster.
+    if job.is_some_and(|job| {
+        job.semantic_plan.is_some()
+            && !job.exhausted_attempts.is_empty()
+            && super::turn::verifier_repair_context_target_path(work_root, job).is_none()
+            && job.assessment_attempts
+                < crate::agent::loop_run::turn::VERIFIER_DIAGNOSTIC_ATTEMPT_LIMIT
+    }) {
+        return VerifierRepairDecision::NeedDiagnostic;
+    }
     let target = job
         .and_then(|job| super::turn::verifier_repair_context_target_path(work_root, job))
         .or_else(|| {

--- a/src/agent/loop_run/repair_job.rs
+++ b/src/agent/loop_run/repair_job.rs
@@ -450,6 +450,36 @@ pub(super) fn verifier_repair_decision(
     }
 }
 
+/// Issue #647 (CB-013): detect the "advanced semantic_plan + stale
+/// assessment" state that CB-012 catches in the decision layer.
+///
+/// The diagnostic runner (`run_verifier_diagnostic_pass` in `turn.rs`)
+/// consults this helper to know whether to clear the stale assessment
+/// before running a fresh diagnostic. Without this clear, the runner's
+/// own `assessment.is_some()` Skipped short-circuit would fire and
+/// neutralize the CB-012 fix at the production layer — the decision
+/// layer returns `NeedDiagnostic`, but the diagnostic runner refuses
+/// to actually run because the stale assessment from the previous
+/// cluster is still in the slot.
+///
+/// The predicate mirrors the CB-007 / CB-012 invariant:
+/// * `assessment.is_some()` — a stale assessment exists
+/// * `semantic_plan.is_some()` — we are inside a semantic plan
+/// * `!exhausted_attempts.is_empty()` — at least one cluster has been
+///   exhausted, i.e. the plan has advanced
+/// * `verifier_repair_context_target_path(...) == None` — the CB-007 hint
+///   guard is already returning None for this state, confirming the
+///   assessment is stale
+pub(super) fn has_stale_assessment_after_cluster_advance(
+    job: &RepairJob,
+    work_root: &Path,
+) -> bool {
+    job.assessment.is_some()
+        && job.semantic_plan.is_some()
+        && !job.exhausted_attempts.is_empty()
+        && super::turn::verifier_repair_context_target_path(work_root, job).is_none()
+}
+
 /// Adapter moved from `turn.rs::Agent::task_contract_repair_state()`. Pure
 /// projection from `(Option<&RepairJob>, &VerifierRepairDecision)` to the
 /// two-variant projection consumed by `task_contract::plan_artifact_recovery`.
@@ -2098,6 +2128,191 @@ mod tests {
             job.semantic_plan.as_ref().unwrap().spec_authority,
             SpecAuthority::BehaviorContract,
             "CB-009: consensus-decided BehaviorContract must persist across chained advances",
+        );
+    }
+
+    /// Issue #647 (CB-013): `has_stale_assessment_after_cluster_advance`
+    /// must return `true` exactly when:
+    ///   1. `assessment.is_some()`
+    ///   2. `semantic_plan.is_some()`
+    ///   3. `!exhausted_attempts.is_empty()`
+    ///   4. `verifier_repair_context_target_path` returns `None` (the
+    ///      CB-007 guard fires)
+    ///
+    /// This is the same predicate the CB-012 decision-layer guard uses.
+    /// `run_verifier_diagnostic_pass` consults this helper to clear the
+    /// stale assessment before its own `assessment.is_some()` Skipped
+    /// short-circuit fires (without the clear, CB-012's NeedDiagnostic
+    /// would be neutralized at the production layer).
+    #[test]
+    fn cb013_has_stale_assessment_after_cluster_advance_fires_for_stale_state() {
+        use tempfile::tempdir;
+        let temp = tempdir().unwrap();
+        let work_root = temp.path().to_path_buf();
+
+        let report =
+            multi_cluster_report_fixture(VerifierDiagnosticFailureKind::AssertionMismatch, 2);
+        let cluster_ids: Vec<_> = report
+            .failure_clusters
+            .iter()
+            .map(|c| c.cluster_key.clone())
+            .collect();
+        let role = report.preferred_repair_role;
+
+        // Job state: active semantic_plan + non-empty exhausted_attempts +
+        // assessment Some. No work_root file exists, and the CB-007 guard
+        // in `verifier_repair_effective_target_hint` returns None whenever
+        // `semantic_plan.is_some() && !exhausted_attempts.is_empty()` —
+        // so `verifier_repair_context_target_path` returns None too.
+        let plan = SemanticRepairPlan {
+            semantic_report: report.clone(),
+            failure_cluster_id: cluster_ids[1].clone(),
+            semantic_cause: report.failure_kind,
+            spec_authority: SpecAuthority::ImplementationContract,
+            preferred_repair_role: role,
+            repair_hypothesis: report.repair_hypothesis.clone(),
+            expected_improvement: None,
+        };
+        let stale_hint = RecoveryTargetHint {
+            role: super::super::task_contract::ArtifactRole::Implementation,
+            path: "app/stale.py".to_string(),
+            reason: "stale cluster A".to_string(),
+        };
+        let job = RepairJob {
+            semantic_plan: Some(plan),
+            exhausted_attempts: vec![(cluster_ids[0].clone(), role)],
+            assessment: Some(super::super::VerifierRepairAssessment {
+                failure_kind: VerifierDiagnosticFailureKind::AssertionMismatch,
+                failure_type: VerifierFailureType::Unknown,
+                probable_cause_role: Some(role),
+                needed_reads: Vec::new(),
+                repair_target_hint: Some(stale_hint.clone()),
+                repair_plan: vec![stale_hint],
+                summary: None,
+                source: super::super::VerifierRepairAssessmentSource::DiagnosticPass,
+            }),
+            ..RepairJob::new_for_test()
+        };
+
+        assert!(
+            has_stale_assessment_after_cluster_advance(&job, &work_root),
+            "CB-013: stale state (advanced plan + non-empty exhausted_attempts + Some assessment) must be detected",
+        );
+    }
+
+    /// Issue #647 (CB-013): the helper must NOT fire when
+    /// `exhausted_attempts` is empty — fresh semantic_plan flow is
+    /// unaffected so the Skipped short-circuit keeps its normal behavior.
+    #[test]
+    fn cb013_has_stale_assessment_does_not_fire_when_no_exhausted_attempts() {
+        use tempfile::tempdir;
+        let temp = tempdir().unwrap();
+        let work_root = temp.path().to_path_buf();
+
+        let report =
+            multi_cluster_report_fixture(VerifierDiagnosticFailureKind::AssertionMismatch, 2);
+        let role = report.preferred_repair_role;
+        let cluster_ids: Vec<_> = report
+            .failure_clusters
+            .iter()
+            .map(|c| c.cluster_key.clone())
+            .collect();
+        let plan = SemanticRepairPlan {
+            semantic_report: report.clone(),
+            failure_cluster_id: cluster_ids[0].clone(),
+            semantic_cause: report.failure_kind,
+            spec_authority: SpecAuthority::ImplementationContract,
+            preferred_repair_role: role,
+            repair_hypothesis: report.repair_hypothesis.clone(),
+            expected_improvement: None,
+        };
+        let job = RepairJob {
+            semantic_plan: Some(plan),
+            // exhausted_attempts empty — CB-013 must NOT engage.
+            assessment: Some(super::super::VerifierRepairAssessment {
+                failure_kind: VerifierDiagnosticFailureKind::AssertionMismatch,
+                failure_type: VerifierFailureType::Unknown,
+                probable_cause_role: Some(role),
+                needed_reads: Vec::new(),
+                repair_target_hint: None,
+                repair_plan: Vec::new(),
+                summary: None,
+                source: super::super::VerifierRepairAssessmentSource::DiagnosticPass,
+            }),
+            ..RepairJob::new_for_test()
+        };
+        assert!(
+            !has_stale_assessment_after_cluster_advance(&job, &work_root),
+            "CB-013: fresh state (empty exhausted_attempts) must NOT engage the stale-clear helper",
+        );
+    }
+
+    /// Issue #647 (CB-013): the helper must NOT fire when `assessment` is
+    /// already None — there is nothing to clear, and the diagnostic
+    /// runner's normal path already handles this case.
+    #[test]
+    fn cb013_has_stale_assessment_does_not_fire_when_assessment_already_none() {
+        use tempfile::tempdir;
+        let temp = tempdir().unwrap();
+        let work_root = temp.path().to_path_buf();
+
+        let report =
+            multi_cluster_report_fixture(VerifierDiagnosticFailureKind::AssertionMismatch, 2);
+        let role = report.preferred_repair_role;
+        let cluster_ids: Vec<_> = report
+            .failure_clusters
+            .iter()
+            .map(|c| c.cluster_key.clone())
+            .collect();
+        let plan = SemanticRepairPlan {
+            semantic_report: report.clone(),
+            failure_cluster_id: cluster_ids[1].clone(),
+            semantic_cause: report.failure_kind,
+            spec_authority: SpecAuthority::ImplementationContract,
+            preferred_repair_role: role,
+            repair_hypothesis: report.repair_hypothesis.clone(),
+            expected_improvement: None,
+        };
+        let job = RepairJob {
+            semantic_plan: Some(plan),
+            exhausted_attempts: vec![(cluster_ids[0].clone(), role)],
+            assessment: None,
+            ..RepairJob::new_for_test()
+        };
+        assert!(
+            !has_stale_assessment_after_cluster_advance(&job, &work_root),
+            "CB-013: assessment already None → helper must not fire",
+        );
+    }
+
+    /// Issue #647 (CB-013): the helper must NOT fire when no
+    /// `semantic_plan` is active — the legacy / SetupRepair path keeps its
+    /// existing Skipped short-circuit behavior.
+    #[test]
+    fn cb013_has_stale_assessment_does_not_fire_when_no_semantic_plan() {
+        use tempfile::tempdir;
+        let temp = tempdir().unwrap();
+        let work_root = temp.path().to_path_buf();
+
+        let job = RepairJob {
+            semantic_plan: None,
+            // Even with an assessment present, the legacy / SetupRepair
+            // path must keep its existing Skipped short-circuit behavior.
+            assessment: Some(super::super::VerifierRepairAssessment {
+                failure_kind: VerifierDiagnosticFailureKind::AssertionMismatch,
+                failure_type: VerifierFailureType::Unknown,
+                probable_cause_role: None,
+                needed_reads: Vec::new(),
+                repair_target_hint: None,
+                repair_plan: Vec::new(),
+                summary: None,
+                source: super::super::VerifierRepairAssessmentSource::DiagnosticPass,
+            }),
+            ..RepairJob::new_for_test()
+        };
+        assert!(
+            !has_stale_assessment_after_cluster_advance(&job, &work_root),
+            "CB-013: semantic_plan None → helper must not fire",
         );
     }
 

--- a/src/agent/loop_run/repair_job.rs
+++ b/src/agent/loop_run/repair_job.rs
@@ -590,6 +590,90 @@ pub(super) fn should_re_diagnostic(repair_job: &RepairJob) -> bool {
         .contains(&(plan.failure_cluster_id.clone(), plan.preferred_repair_role))
 }
 
+/// Issue #647 (MF2.3): production dispatch helper that wires the Phase-E
+/// cluster-aware helpers into the rerun-handling path.
+///
+/// Called from `turn.rs::drive_task_contract_verifier` after a fresh
+/// `RepairJob` has been built by `verifier_repair_context_from_failure`
+/// (which carries `semantic_plan` / `exhausted_attempts` over from the
+/// previous turn via MF2.1). Drives the cluster-aware sequential repair
+/// state machine:
+///
+/// 1. If the active `semantic_plan`'s `(cluster_id, role)` is already in
+///    `exhausted_attempts` (`should_re_diagnostic` = true — the diagnostic
+///    LLM has re-proposed an already-attacked cluster), reset to the
+///    re-diagnostic path: `assessment = None`, `assessment_attempts += 1`.
+/// 2. Else, if `rerun_outcome` indicates the repair did not help
+///    (`SameFailureRemaining` / `Worsened`) AND a `semantic_plan` is
+///    active, attempt to walk to the next cluster via
+///    `advance_to_next_cluster`.
+///    - If a next cluster was found, wrap the rerun outcome via
+///      `rerun_outcome_with_cluster` so a cluster-id transition surfaces
+///      as `NewFailure` to downstream consumers.
+///    - If no next cluster is available, the report is exhausted: reset
+///      to the re-diagnostic path so a fresh diagnostic LLM call can
+///      identify a new cluster set.
+///
+/// `previous_cluster_id` is the `failure_cluster_id` carried over from the
+/// previous turn's `RepairJob.semantic_plan` (the source of truth for the
+/// "what cluster did we just attack" question). The helper does NOT touch
+/// `repair_attempt` or `applied_repair_intents` — those remain governed by
+/// the legacy diagnostic / repair-pass machinery (S7-005).
+pub(super) fn apply_semantic_repair_dispatch_after_rerun(
+    repair_job: &mut RepairJob,
+    previous_cluster_id: Option<&FailureClusterKey>,
+) {
+    // 1. Active plan is already exhausted → switch to re-diagnostic.
+    if should_re_diagnostic(repair_job) {
+        repair_job.assessment = None;
+        repair_job.assessment_attempts = repair_job.assessment_attempts.saturating_add(1);
+        return;
+    }
+
+    // 2. Only walk to the next cluster when the rerun outcome indicates the
+    //    repair did not progress (legacy failure_count-based outcome is the
+    //    SSOT here, S3-014).
+    let needs_advance = matches!(
+        repair_job.rerun_outcome,
+        Some(
+            VerifierRepairRerunOutcome::SameFailureRemaining | VerifierRepairRerunOutcome::Worsened
+        )
+    ) && repair_job.semantic_plan.is_some();
+    if !needs_advance {
+        return;
+    }
+
+    let Some(base_outcome) = repair_job.rerun_outcome else {
+        return;
+    };
+    let report = repair_job
+        .semantic_plan
+        .as_ref()
+        .map(|plan| plan.semantic_report.clone());
+    let Some(report) = report else {
+        return;
+    };
+
+    let advanced = advance_to_next_cluster(repair_job, &report);
+
+    if advanced {
+        // Cluster transition → upgrade the outcome via the SSOT wrapper.
+        let new_cluster_id = repair_job
+            .semantic_plan
+            .as_ref()
+            .map(|plan| &plan.failure_cluster_id);
+        repair_job.rerun_outcome = Some(rerun_outcome_with_cluster(
+            previous_cluster_id,
+            new_cluster_id,
+            base_outcome,
+        ));
+    } else {
+        // No remaining clusters in the report → fall back to re-diagnostic.
+        repair_job.assessment = None;
+        repair_job.assessment_attempts = repair_job.assessment_attempts.saturating_add(1);
+    }
+}
+
 /// Issue #647 (Phase E.3 / S3-014): wrap the existing
 /// `verifier_repair_rerun_outcome` (which is failure_count-based and
 /// cluster-agnostic) with a cluster-id transition rule.
@@ -1216,6 +1300,231 @@ mod tests {
         // The ledger does grow per advance — but it's an O(N_clusters)
         // bounded list, not a retry counter.
         assert_eq!(job.exhausted_attempts.len(), 3);
+    }
+
+    // ---- Issue #647 (MF2): production dispatch wiring ---- //
+
+    /// MF2.3: after carryover, when rerun outcome is bad (SameFailureRemaining)
+    /// and there is a next cluster, dispatch advances to the next cluster and
+    /// promotes rerun_outcome to NewFailure via `rerun_outcome_with_cluster`.
+    /// `assessment` is preserved (we have a plan; do not re-diagnostic yet).
+    #[test]
+    fn mf2_dispatch_advances_to_next_cluster_on_same_failure_remaining() {
+        let report =
+            multi_cluster_report_fixture(VerifierDiagnosticFailureKind::AssertionMismatch, 2);
+        let cluster_ids: Vec<_> = report
+            .failure_clusters
+            .iter()
+            .map(|c| c.cluster_key.clone())
+            .collect();
+        let mut job = job_with_first_cluster_plan(&report);
+        // Simulate a non-empty prior assessment that survived carryover.
+        let preserved_assessment = super::super::VerifierRepairAssessment {
+            failure_kind: VerifierDiagnosticFailureKind::AssertionMismatch,
+            failure_type: VerifierFailureType::Unknown,
+            probable_cause_role: Some(super::super::task_contract::ArtifactRole::Implementation),
+            needed_reads: Vec::new(),
+            repair_target_hint: None,
+            repair_plan: Vec::new(),
+            summary: Some("preserved".to_string()),
+            source: super::super::VerifierRepairAssessmentSource::DiagnosticPass,
+        };
+        job.assessment = Some(preserved_assessment);
+        job.rerun_outcome = Some(VerifierRepairRerunOutcome::SameFailureRemaining);
+
+        let previous_cluster = Some(cluster_ids[0].clone());
+        apply_semantic_repair_dispatch_after_rerun(&mut job, previous_cluster.as_ref());
+
+        // Slot walked to the next cluster.
+        assert_eq!(
+            job.semantic_plan.as_ref().unwrap().failure_cluster_id,
+            cluster_ids[1]
+        );
+        // Outcome promoted to NewFailure via cluster transition wrap.
+        assert_eq!(
+            job.rerun_outcome,
+            Some(VerifierRepairRerunOutcome::NewFailure)
+        );
+        // assessment preserved — caller proceeds to repair the new cluster
+        // without burning the diagnostic budget.
+        assert!(job.assessment.is_some());
+        assert_eq!(job.assessment_attempts, 0);
+    }
+
+    /// MF2.3: when the active plan's (cluster_id, role) is already in the
+    /// exhausted ledger (LLM re-proposed the same cluster), dispatch must
+    /// switch to the re-diagnostic path (assessment cleared, attempts bumped).
+    #[test]
+    fn mf2_dispatch_resets_for_re_diagnostic_when_plan_already_exhausted() {
+        let report =
+            multi_cluster_report_fixture(VerifierDiagnosticFailureKind::AssertionMismatch, 2);
+        let cluster_ids: Vec<_> = report
+            .failure_clusters
+            .iter()
+            .map(|c| c.cluster_key.clone())
+            .collect();
+        let role = report.preferred_repair_role;
+
+        // Job state: plan still targets cluster A, but cluster A is already
+        // in the ledger (= we've burned cluster A; diagnostic re-proposed it).
+        let plan = SemanticRepairPlan {
+            semantic_report: report.clone(),
+            failure_cluster_id: cluster_ids[0].clone(),
+            semantic_cause: report.failure_kind,
+            spec_authority: SpecAuthority::ImplementationContract,
+            preferred_repair_role: role,
+            repair_hypothesis: report.repair_hypothesis.clone(),
+            expected_improvement: None,
+        };
+        let mut job = RepairJob {
+            semantic_plan: Some(plan),
+            exhausted_attempts: vec![(cluster_ids[0].clone(), role)],
+            assessment: Some(super::super::VerifierRepairAssessment {
+                failure_kind: VerifierDiagnosticFailureKind::AssertionMismatch,
+                failure_type: VerifierFailureType::Unknown,
+                probable_cause_role: Some(role),
+                needed_reads: Vec::new(),
+                repair_target_hint: None,
+                repair_plan: Vec::new(),
+                summary: None,
+                source: super::super::VerifierRepairAssessmentSource::DiagnosticPass,
+            }),
+            rerun_outcome: Some(VerifierRepairRerunOutcome::SameFailureRemaining),
+            ..RepairJob::new_for_test()
+        };
+
+        apply_semantic_repair_dispatch_after_rerun(&mut job, Some(&cluster_ids[0]));
+
+        // Re-diagnostic switch: assessment cleared, attempts bumped.
+        assert!(job.assessment.is_none());
+        assert_eq!(job.assessment_attempts, 1);
+    }
+
+    /// MF2.3: when the rerun-outcome is bad but the report has no remaining
+    /// clusters, advance returns false and we fall back to re-diagnostic.
+    #[test]
+    fn mf2_dispatch_falls_back_to_re_diagnostic_when_no_more_clusters() {
+        let report =
+            multi_cluster_report_fixture(VerifierDiagnosticFailureKind::AssertionMismatch, 1);
+        let cluster_id = report.failure_clusters[0].cluster_key.clone();
+        let mut job = job_with_first_cluster_plan(&report);
+        job.assessment = Some(super::super::VerifierRepairAssessment {
+            failure_kind: VerifierDiagnosticFailureKind::AssertionMismatch,
+            failure_type: VerifierFailureType::Unknown,
+            probable_cause_role: Some(report.preferred_repair_role),
+            needed_reads: Vec::new(),
+            repair_target_hint: None,
+            repair_plan: Vec::new(),
+            summary: None,
+            source: super::super::VerifierRepairAssessmentSource::DiagnosticPass,
+        });
+        job.rerun_outcome = Some(VerifierRepairRerunOutcome::Worsened);
+
+        apply_semantic_repair_dispatch_after_rerun(&mut job, Some(&cluster_id));
+
+        // No more clusters → plan cleared, re-diagnostic path armed.
+        assert!(job.semantic_plan.is_none());
+        assert!(job.assessment.is_none());
+        assert_eq!(job.assessment_attempts, 1);
+    }
+
+    /// MF2.3: when the rerun outcome shows progress (Improved / NewFailure),
+    /// dispatch does NOT advance — the next cycle handles the new state.
+    #[test]
+    fn mf2_dispatch_is_noop_when_rerun_outcome_indicates_progress() {
+        let report =
+            multi_cluster_report_fixture(VerifierDiagnosticFailureKind::AssertionMismatch, 2);
+        let cluster_ids: Vec<_> = report
+            .failure_clusters
+            .iter()
+            .map(|c| c.cluster_key.clone())
+            .collect();
+        let mut job = job_with_first_cluster_plan(&report);
+        let preserved_assessment = super::super::VerifierRepairAssessment {
+            failure_kind: VerifierDiagnosticFailureKind::AssertionMismatch,
+            failure_type: VerifierFailureType::Unknown,
+            probable_cause_role: Some(report.preferred_repair_role),
+            needed_reads: Vec::new(),
+            repair_target_hint: None,
+            repair_plan: Vec::new(),
+            summary: None,
+            source: super::super::VerifierRepairAssessmentSource::DiagnosticPass,
+        };
+        job.assessment = Some(preserved_assessment.clone());
+
+        for base in [
+            VerifierRepairRerunOutcome::Improved,
+            VerifierRepairRerunOutcome::NewFailure,
+        ] {
+            job.rerun_outcome = Some(base);
+            apply_semantic_repair_dispatch_after_rerun(&mut job, Some(&cluster_ids[0]));
+            // Plan, ledger, assessment all unchanged.
+            assert_eq!(
+                job.semantic_plan.as_ref().unwrap().failure_cluster_id,
+                cluster_ids[0]
+            );
+            assert!(job.exhausted_attempts.is_empty());
+            assert!(job.assessment.is_some());
+            assert_eq!(job.rerun_outcome, Some(base));
+        }
+    }
+
+    /// MF2.3 + MF2.budget: a 3-cluster sequential repair walks all clusters
+    /// via dispatch + advance without ever incrementing the legacy retry
+    /// counters (`assessment_attempts` / `repair_attempt`). Re-diagnostic
+    /// fires only after the LAST cluster is exhausted.
+    #[test]
+    fn mf2_three_cluster_sequential_repair_walks_without_burning_budget() {
+        let report =
+            multi_cluster_report_fixture(VerifierDiagnosticFailureKind::AssertionMismatch, 3);
+        let cluster_ids: Vec<_> = report
+            .failure_clusters
+            .iter()
+            .map(|c| c.cluster_key.clone())
+            .collect();
+        let mut job = job_with_first_cluster_plan(&report);
+        let preserved_assessment = super::super::VerifierRepairAssessment {
+            failure_kind: VerifierDiagnosticFailureKind::AssertionMismatch,
+            failure_type: VerifierFailureType::Unknown,
+            probable_cause_role: Some(report.preferred_repair_role),
+            needed_reads: Vec::new(),
+            repair_target_hint: None,
+            repair_plan: Vec::new(),
+            summary: None,
+            source: super::super::VerifierRepairAssessmentSource::DiagnosticPass,
+        };
+        job.assessment = Some(preserved_assessment);
+
+        // Turn 1: cluster A fails again → advance to B.
+        job.rerun_outcome = Some(VerifierRepairRerunOutcome::SameFailureRemaining);
+        apply_semantic_repair_dispatch_after_rerun(&mut job, Some(&cluster_ids[0]));
+        assert_eq!(
+            job.semantic_plan.as_ref().unwrap().failure_cluster_id,
+            cluster_ids[1]
+        );
+        assert_eq!(job.assessment_attempts, 0);
+        assert!(job.assessment.is_some());
+
+        // Turn 2: cluster B fails → advance to C.
+        job.rerun_outcome = Some(VerifierRepairRerunOutcome::SameFailureRemaining);
+        apply_semantic_repair_dispatch_after_rerun(&mut job, Some(&cluster_ids[1]));
+        assert_eq!(
+            job.semantic_plan.as_ref().unwrap().failure_cluster_id,
+            cluster_ids[2]
+        );
+        assert_eq!(job.assessment_attempts, 0);
+        assert!(job.assessment.is_some());
+
+        // Turn 3: cluster C fails → no more clusters → re-diagnostic.
+        job.rerun_outcome = Some(VerifierRepairRerunOutcome::SameFailureRemaining);
+        apply_semantic_repair_dispatch_after_rerun(&mut job, Some(&cluster_ids[2]));
+        assert!(job.semantic_plan.is_none());
+        assert!(job.assessment.is_none());
+        // Only ONE bump for the entire 3-cluster walk (only on final exhaust).
+        assert_eq!(job.assessment_attempts, 1);
+        // repair_attempt is owned by the diagnostic / repair machinery and
+        // is not touched by this dispatch helper.
+        assert_eq!(job.repair_attempt, 0);
     }
 
     // -- Phase G grep / structure tests (Issue #647 acceptance closure) -- //

--- a/src/agent/loop_run/repair_job.rs
+++ b/src/agent/loop_run/repair_job.rs
@@ -3073,6 +3073,20 @@ mod tests {
     /// `NeedDiagnostic`. That would be a livelock: we just finished a
     /// fresh diagnostic, and routing back would consume the diagnostic
     /// budget for nothing.
+    ///
+    /// CB-017 A''' (Commit 5): natural-flow variant. Earlier revisions of
+    /// this test hand-tuned `assessment.repair_target_hint` to a cluster B
+    /// path so the post-advance `verifier_repair_decision` could resolve a
+    /// target file on disk. Commit 4 introduced
+    /// `rebind_legacy_assessment_to_current_cluster`, which is now invoked
+    /// at the production `DiagnosticSkip` callsite immediately after the
+    /// preserve-exhausted helper. The rebind transparently overwrites the
+    /// assessment slice with cluster B's `admitted_cluster_targets`, so
+    /// the test no longer needs to seed the cluster B path manually —
+    /// removing the "manual B target" blind spot the Codex review called
+    /// out. The test now drives the production sequence verbatim
+    /// (preserve-exhausted → rebind) and asserts that the assessment ends
+    /// up aligned with cluster B's fixture-admitted target (`app/main_1.py`).
     #[test]
     fn cb016_diagnostic_skip_advance_produces_fresh_plan() {
         use tempfile::tempdir;
@@ -3088,14 +3102,14 @@ mod tests {
             .collect();
         let role = report.preferred_repair_role;
 
-        // The work_root needs a file for `verifier_repair_context_target_path`
-        // / `latest_successful_read_existing_path` to resolve to it; we
-        // construct one matching the fresh repair_target_hint we will set
-        // on the assessment below. The essential CB-016.1 invariant is
-        // that the decision is NOT `NeedDiagnostic` / `DiagnosticUnavailable`
-        // post-advance.
-        let fresh_target = "app/cluster_b.py";
-        let fresh_target_path = work_root.join(fresh_target);
+        // The fixture seeds every cluster with a synthetic admitted target
+        // at `app/main_{idx}.py`. After the natural rebind, cluster B's
+        // assessment slot will point at `app/main_1.py` — we materialise
+        // that file on disk so `verifier_repair_context_target_path` can
+        // resolve a real path for the decision check below. NO manual
+        // assessment.repair_target_hint setting (CB-017 A''' natural flow).
+        let cluster_b_fixture_target = "app/main_1.py";
+        let fresh_target_path = work_root.join(cluster_b_fixture_target);
         if let Some(parent) = fresh_target_path.parent() {
             std::fs::create_dir_all(parent).unwrap();
         }
@@ -3104,12 +3118,14 @@ mod tests {
         // Job posture: cluster A exhausted (verifier rerun no-progress
         // pushed it onto the ledger and walked to cluster B on a prior
         // turn). The fresh diagnostic just ran and bumped the assessment
-        // generation to 2. The assessment now corresponds to the freshly
-        // diagnosed (still) cluster A — the LLM re-proposed it.
-        let fresh_hint = super::super::task_contract::RecoveryTargetHint {
+        // generation to 2. The assessment slot still carries cluster A's
+        // **stale** target (no manual cluster B seeding) — the rebind
+        // helper will realign it to cluster B's admitted target during
+        // the production sequence below.
+        let stale_cluster_a_hint = super::super::task_contract::RecoveryTargetHint {
             role: super::super::task_contract::ArtifactRole::Implementation,
-            path: fresh_target.to_string(),
-            reason: "fresh diagnostic re-proposed cluster A".to_string(),
+            path: "app/main_0.py".to_string(),
+            reason: "stale cluster A target — rebind must overwrite this".to_string(),
         };
         let plan_b_before = SemanticRepairPlan {
             semantic_report: report.clone(),
@@ -3131,13 +3147,15 @@ mod tests {
                 failure_type: VerifierFailureType::Unknown,
                 probable_cause_role: Some(role),
                 needed_reads: Vec::new(),
-                repair_target_hint: Some(fresh_hint.clone()),
-                repair_plan: vec![fresh_hint],
+                repair_target_hint: Some(stale_cluster_a_hint.clone()),
+                repair_plan: vec![stale_cluster_a_hint],
                 summary: None,
                 source: super::super::VerifierRepairAssessmentSource::DiagnosticPass,
             }),
             // Fresh diagnostic just landed → assessment_generation bumped to 2.
             assessment_generation: 2,
+            // Prior bind: cluster A (transition to B will land via rebind).
+            assessment_bound_cluster_id: Some(cluster_ids[0].clone()),
             ..RepairJob::new_for_test()
         };
 
@@ -3161,9 +3179,14 @@ mod tests {
             assessment_generation_at_creation: 1,
         };
 
-        // DiagnosticSkip path: the helper recognises cluster A is exhausted
-        // and walks to cluster B with the fresh assessment in hand.
+        // Mirror the production sequence in run_verifier_diagnostic_pass:
+        //   1. assign_semantic_plan_preserving_exhausted (DiagnosticSkip)
+        //      walks past cluster A to cluster B.
+        //   2. rebind_legacy_assessment_to_current_cluster realigns the
+        //      assessment slice to cluster B's admitted targets — NO
+        //      manual cluster B seeding required (CB-017 A''' blind-spot fix).
         assign_semantic_plan_preserving_exhausted(&mut job, Some(proposed_plan_a), Some(&report));
+        rebind_legacy_assessment_to_current_cluster(&mut job);
 
         let advanced = job
             .semantic_plan
@@ -3172,6 +3195,45 @@ mod tests {
         assert_eq!(
             advanced.failure_cluster_id, cluster_ids[1],
             "DiagnosticSkip must walk past exhausted cluster A to cluster B",
+        );
+        // CB-017 A''' natural flow: the rebind helper automatically
+        // realigned the assessment slot to cluster B's fixture-admitted
+        // target. No manual cluster B seeding was performed on the
+        // assessment — the test would have failed under the pre-Commit-4
+        // implementation that left assessment.repair_target_hint stuck on
+        // cluster A.
+        let assessment = job
+            .assessment
+            .as_ref()
+            .expect("rebind preserves assessment");
+        let cluster_b_admitted = report.failure_clusters[1].admitted_cluster_targets[0].clone();
+        assert_eq!(
+            assessment.repair_target_hint.as_ref(),
+            Some(&cluster_b_admitted),
+            "CB-017 A''' natural flow: rebind must point repair_target_hint at cluster B's admitted target without manual seeding",
+        );
+        assert_eq!(
+            assessment
+                .repair_target_hint
+                .as_ref()
+                .map(|h| h.path.as_str()),
+            Some(cluster_b_fixture_target),
+            "CB-017 A''' natural flow: cluster B fixture target path is app/main_1.py — not a manually injected app/cluster_b.py",
+        );
+        assert_eq!(
+            assessment.repair_plan,
+            vec![cluster_b_admitted.clone()],
+            "rebind must overwrite repair_plan with cluster B targets clone",
+        );
+        assert_eq!(
+            assessment.needed_reads,
+            vec![cluster_b_admitted],
+            "rebind must overwrite needed_reads with cluster B targets clone",
+        );
+        assert_eq!(
+            job.assessment_bound_cluster_id.as_ref(),
+            Some(&cluster_ids[1]),
+            "bound id must transition to cluster B after rebind",
         );
         // CB-016 core invariant: the new plan looks fresh
         // (plan.gen < job.gen) so the stale predicate does NOT fire.
@@ -3898,6 +3960,117 @@ mod tests {
         assert!(
             job2.assessment_bound_cluster_id.is_none(),
             "no-more-clusters fallback must reset bound id to None",
+        );
+    }
+
+    /// CB-017 A''' (Commit 5, CR-4 V2 lifecycle): `assessment_bound_cluster_id`
+    /// must be reset to `None` on every dispatch path that drops
+    /// `assessment` to `None`. This fixes the bound id and `assessment`
+    /// option in lock-step so the next diagnostic-pass rebind treats the
+    /// new assessment as a "new bind" (transition → clears
+    /// `applied_repair_intents`).
+    ///
+    /// Complements `cb017_assessment_bound_cluster_id_reset_on_dispatch_re_diagnostic`
+    /// by isolating the invariant "whenever assessment falls to None, the
+    /// bound id falls to None too" — explicitly required by Codex review 4.
+    #[test]
+    fn cb017_assessment_bound_cluster_id_reset_when_assessment_falls_to_none() {
+        let report =
+            multi_cluster_report_fixture(VerifierDiagnosticFailureKind::AssertionMismatch, 1);
+        let only_cluster = report.failure_clusters[0].cluster_key.clone();
+        let role = report.preferred_repair_role;
+
+        // Construct a job that is in the "rerun bad, plan exhausted" posture
+        // — should_re_diagnostic = true → dispatch will null the
+        // assessment AND must null the bound id in lock-step.
+        let plan_only = SemanticRepairPlan {
+            semantic_report: report.clone(),
+            failure_cluster_id: only_cluster.clone(),
+            semantic_cause: report.failure_kind,
+            spec_authority: SpecAuthority::ImplementationContract,
+            preferred_repair_role: role,
+            repair_hypothesis: report.repair_hypothesis.clone(),
+            expected_improvement: None,
+            assessment_generation_at_creation: 0,
+        };
+        let mut job = RepairJob {
+            semantic_plan: Some(plan_only),
+            exhausted_attempts: vec![(only_cluster.clone(), role)],
+            assessment: Some(assessment_with_targets(
+                Some(impl_hint("app/main_0.py")),
+                vec![impl_hint("app/main_0.py")],
+                vec![impl_hint("app/main_0.py")],
+            )),
+            rerun_outcome: Some(VerifierRepairRerunOutcome::SameFailureRemaining),
+            assessment_bound_cluster_id: Some(only_cluster.clone()),
+            ..RepairJob::new_for_test()
+        };
+
+        apply_semantic_repair_dispatch_after_rerun(&mut job, Some(&only_cluster));
+
+        // Invariant: assessment-None ↔ bound-id-None (lock-step reset).
+        assert!(
+            job.assessment.is_none(),
+            "dispatch must clear assessment when re-diagnostic is needed",
+        );
+        assert!(
+            job.assessment_bound_cluster_id.is_none(),
+            "CR-4 V2: assessment-None implies bound-id-None (lock-step lifecycle)",
+        );
+    }
+
+    /// CB-017 A''' (Commit 5, CR-4 V2 lifecycle): the legacy path
+    /// (`semantic_plan = None`) must not touch `assessment_bound_cluster_id`.
+    /// `rebind_legacy_assessment_to_current_cluster` is a complete no-op in
+    /// this case — including leaving the bound id untouched (whatever it
+    /// was — `Some(...)` or `None` — before the call must match after).
+    ///
+    /// This explicitly locks the invariant Codex review 4 called out:
+    /// "legacy 経路 (semantic_plan = None) では bound は変更されない".
+    /// Complements `cb017_rebind_no_op_when_semantic_plan_none` (which
+    /// fixes the entire job equality) by naming the bound-id invariant
+    /// directly.
+    #[test]
+    fn cb017_assessment_bound_cluster_id_unaffected_when_semantic_plan_is_none() {
+        let report =
+            multi_cluster_report_fixture(VerifierDiagnosticFailureKind::AssertionMismatch, 1);
+        let stale_bound = report.failure_clusters[0].cluster_key.clone();
+
+        // Bound id was Some(...) before — must stay Some(...) (unchanged)
+        // when the rebind sees semantic_plan = None.
+        let mut job_with_some_bound = RepairJob {
+            semantic_plan: None,
+            assessment: Some(assessment_with_targets(
+                Some(impl_hint("app/legacy.py")),
+                vec![impl_hint("app/legacy.py")],
+                vec![impl_hint("app/legacy.py")],
+            )),
+            assessment_bound_cluster_id: Some(stale_bound.clone()),
+            ..RepairJob::new_for_test()
+        };
+        rebind_legacy_assessment_to_current_cluster(&mut job_with_some_bound);
+        assert_eq!(
+            job_with_some_bound.assessment_bound_cluster_id.as_ref(),
+            Some(&stale_bound),
+            "legacy path (semantic_plan=None): bound id Some(_) must remain unchanged",
+        );
+
+        // Bound id was None before — must stay None when the rebind sees
+        // semantic_plan = None.
+        let mut job_with_none_bound = RepairJob {
+            semantic_plan: None,
+            assessment: Some(assessment_with_targets(
+                Some(impl_hint("app/legacy.py")),
+                vec![impl_hint("app/legacy.py")],
+                vec![impl_hint("app/legacy.py")],
+            )),
+            assessment_bound_cluster_id: None,
+            ..RepairJob::new_for_test()
+        };
+        rebind_legacy_assessment_to_current_cluster(&mut job_with_none_bound);
+        assert!(
+            job_with_none_bound.assessment_bound_cluster_id.is_none(),
+            "legacy path (semantic_plan=None): bound id None must remain None",
         );
     }
 

--- a/src/agent/loop_run/repair_job.rs
+++ b/src/agent/loop_run/repair_job.rs
@@ -69,6 +69,33 @@ pub(super) struct SemanticRepairPlan {
     pub(super) assessment_generation_at_creation: u32,
 }
 
+impl SemanticRepairPlan {
+    /// CB-017 A''': locate the `FailureCluster` matching this plan's
+    /// `failure_cluster_id` inside the embedded `semantic_report`.
+    ///
+    /// Returns `None` when no cluster with that id is present (defensive —
+    /// production code always seeds the plan from a cluster that already
+    /// lives in the report). This SSOT lookup keeps the cluster-key match
+    /// in one place so `rebind_legacy_assessment_to_current_cluster` and
+    /// any future consumer agree on the predicate.
+    pub(super) fn current_cluster(&self) -> Option<&super::semantic_failure::FailureCluster> {
+        self.semantic_report
+            .failure_clusters
+            .iter()
+            .find(|c| c.cluster_key == self.failure_cluster_id)
+    }
+
+    /// CB-017 A''' (CR-7 V2): the admitted, Owned-validated targets for the
+    /// plan's current cluster. Returns an empty slice when the cluster is
+    /// not found or when the cluster has no admitted targets (targetless
+    /// cluster — caller MUST skip rebinding).
+    pub(super) fn current_cluster_targets(&self) -> &[RecoveryTargetHint] {
+        self.current_cluster()
+            .map(|c| c.admitted_cluster_targets.as_slice())
+            .unwrap_or(&[])
+    }
+}
+
 /// Issue #625 / #627 / #637: turn-local diagnostic context for a failed
 /// task-contract verifier. Rename of the previous `VerifierRepairContext`
 /// type. Fields are 1:1 with the legacy definition (see design policy §4-1).
@@ -117,6 +144,21 @@ pub(super) struct RepairJob {
     /// より古い (stale)」か「plan は新 assessment と同じ世代 (まだ re-diagnostic
     /// が走っていない / advance 直後の stale state)」かを区別する。
     pub(super) assessment_generation: u32,
+    /// CB-017 A''': cluster_key-based transition detection.
+    /// `rebind_legacy_assessment_to_current_cluster` でのみ書き換えられ、
+    /// `cluster_key` の差分で `applied_repair_intents.clear()` を判定する。
+    ///
+    /// lifecycle:
+    /// - 初期値 `None` (新規 assessment / legacy fallback)
+    /// - `rebind_legacy_assessment_to_current_cluster` で
+    ///   `Some(plan.failure_cluster_id.clone())` に更新
+    /// - `verifier_repair_context_from_failure` で previous_context から
+    ///   carry over
+    /// - assessment が `None` に落ちる経路 (re-diagnostic 切替) で `None`
+    ///   に reset
+    ///
+    /// turn-local field (session.messages には persist しない)。
+    pub(super) assessment_bound_cluster_id: Option<FailureClusterKey>,
 }
 
 /// Controller-internal decision used by `run_turn` to pick the next action
@@ -321,6 +363,7 @@ impl RepairJob {
             semantic_plan: None,
             exhausted_attempts: Vec::new(),
             assessment_generation: 0,
+            assessment_bound_cluster_id: None,
         }
     }
 }
@@ -873,6 +916,11 @@ pub(super) fn apply_semantic_repair_dispatch_after_rerun(
     if should_re_diagnostic(repair_job) {
         repair_job.assessment = None;
         repair_job.assessment_attempts = repair_job.assessment_attempts.saturating_add(1);
+        // CB-017 A''' (CR-4 V2): assessment が None に落ちる経路では
+        // `assessment_bound_cluster_id` も None に reset しておく — 次の
+        // diagnostic が新 assessment を書き込む直後の rebind 呼び出しで
+        // "新 bind" として扱われ、`applied_repair_intents` が clear される。
+        repair_job.assessment_bound_cluster_id = None;
         return;
     }
 
@@ -918,10 +966,20 @@ pub(super) fn apply_semantic_repair_dispatch_after_rerun(
             new_cluster_id,
             base_outcome,
         ));
+        // CB-017 A''': after `RerunNoProgress` advance, rebind the legacy
+        // assessment slice to the new cluster's admitted targets so the
+        // controller does not keep routing to cluster A's path via
+        // `needed_reads` / `repair_plan`. The plan stamp is "stale" under
+        // this trigger (CB-016), so CB-007/CB-012 will still force a fresh
+        // diagnostic before edits land — but if the diagnostic budget is
+        // exhausted, the rebind already realigned the assessment.
+        rebind_legacy_assessment_to_current_cluster(repair_job);
     } else {
         // No remaining clusters in the report → fall back to re-diagnostic.
         repair_job.assessment = None;
         repair_job.assessment_attempts = repair_job.assessment_attempts.saturating_add(1);
+        // CB-017 A''' (CR-4 V2): re-diagnostic 経路では bound も None に reset。
+        repair_job.assessment_bound_cluster_id = None;
     }
 }
 
@@ -1008,6 +1066,67 @@ pub(super) fn assign_semantic_plan_preserving_exhausted(
     // `advance_to_next_cluster` already mutates `semantic_plan`
     // (either to the next unexhausted cluster or to `None`) and updates the
     // ledger — no further bookkeeping required here.
+}
+
+/// Issue #647 / CB-017 A''' (CR-4 V2 / CR-7 V2): rebind the legacy
+/// `VerifierRepairAssessment.repair_target_hint` / `repair_plan` /
+/// `needed_reads` triple to the current semantic-plan cluster's admitted
+/// targets — SSOT for the §0.1 invariant ("active cluster id ↔ legacy
+/// target set rebound together").
+///
+/// Behaviour:
+/// 1. `semantic_plan == None` → no-op (legacy path is respected as-is).
+/// 2. `current_cluster_targets()` is empty → no-op (caller MUST skip
+///    targetless clusters via `first_repairable_cluster` /
+///    `next_repairable_cluster`).
+/// 3. Otherwise: overwrite `assessment.repair_target_hint` with
+///    `targets[0].clone()` and `assessment.repair_plan` /
+///    `assessment.needed_reads` with `targets.clone()` — the previous
+///    cluster's stale paths are dropped so the verifier-decision routes
+///    only to the current cluster (CR-7 V2 prevents stale cluster A
+///    paths from being re-promoted by the `needed_reads` fallback).
+/// 4. Cluster transition detection uses `assessment_bound_cluster_id`
+///    (CR-4 V2 cluster-key SSOT, not path/role comparison): when the
+///    bound id is `None` OR differs from `plan.failure_cluster_id`,
+///    `applied_repair_intents.clear()` so a previous cluster's repair
+///    history does not gate the new cluster's edit pass.
+/// 5. After the rebind, `assessment_bound_cluster_id` is set to
+///    `Some(plan.failure_cluster_id.clone())` so future calls within the
+///    same cluster do not clear the ledger.
+///
+/// Note: this helper does NOT mutate `applied_repair_intents` beyond the
+/// transition-`clear()` above, and does NOT touch
+/// `assessment_generation` / `assessment_attempts` / `semantic_plan` —
+/// those remain owned by the diagnostic / dispatch machinery (S7-005
+/// boundary).
+pub(super) fn rebind_legacy_assessment_to_current_cluster(repair_job: &mut RepairJob) {
+    let Some(plan) = repair_job.semantic_plan.as_ref() else {
+        return; // semantic_plan = None → legacy 経路尊重
+    };
+    let plan_cluster_id = plan.failure_cluster_id.clone();
+    let targets = plan.current_cluster_targets().to_vec();
+    if targets.is_empty() {
+        return; // targetless cluster は rebind しない (caller が skip 済み想定)
+    }
+    // CR-4 V2: cluster_key ベースで transition 判定。
+    // 未 bind (None) は "new bind" 扱い = transition と見なし
+    // applied_repair_intents を clear する。
+    let is_cluster_transition = repair_job
+        .assessment_bound_cluster_id
+        .as_ref()
+        .map(|bound| bound != &plan_cluster_id)
+        .unwrap_or(true);
+    if let Some(assessment) = repair_job.assessment.as_mut() {
+        // CR-7 V2: Vec<RecoveryTargetHint> を clone で代入。
+        assessment.repair_target_hint = Some(targets[0].clone());
+        assessment.repair_plan = targets.clone();
+        assessment.needed_reads = targets.clone();
+    }
+    if is_cluster_transition {
+        repair_job.applied_repair_intents.clear();
+    }
+    // CR-4 V2: rebind 後は新しい cluster_id に bind。
+    repair_job.assessment_bound_cluster_id = Some(plan_cluster_id);
 }
 
 /// Issue #647 (Phase E.3 / S3-014): wrap the existing
@@ -3313,6 +3432,667 @@ mod tests {
             )
             .is_none(),
             "next_repairable_cluster must skip targetless clusters",
+        );
+    }
+
+    // ─── CB-017 A''' (Commit 4): rebind + assessment_bound_cluster_id ─────
+
+    /// Helper: build a `VerifierRepairAssessment` with caller-supplied
+    /// target slices so transition tests can compare pre/post rebind state
+    /// without re-typing the struct literal at every call site.
+    fn assessment_with_targets(
+        repair_target_hint: Option<RecoveryTargetHint>,
+        repair_plan: Vec<RecoveryTargetHint>,
+        needed_reads: Vec<RecoveryTargetHint>,
+    ) -> super::super::VerifierRepairAssessment {
+        super::super::VerifierRepairAssessment {
+            failure_kind: VerifierDiagnosticFailureKind::AssertionMismatch,
+            failure_type: VerifierFailureType::Unknown,
+            probable_cause_role: Some(super::super::task_contract::ArtifactRole::Implementation),
+            needed_reads,
+            repair_target_hint,
+            repair_plan,
+            summary: None,
+            source: super::super::VerifierRepairAssessmentSource::DiagnosticPass,
+        }
+    }
+
+    fn impl_hint(path: &str) -> RecoveryTargetHint {
+        RecoveryTargetHint {
+            role: super::super::task_contract::ArtifactRole::Implementation,
+            path: path.to_string(),
+            reason: "rebind fixture".to_string(),
+        }
+    }
+
+    /// CR-4 V2: cluster_key 変化時のみ `applied_repair_intents.clear()`。
+    /// bound = cluster A、plan = cluster B → transition と判定 → clear。
+    #[test]
+    fn cb017_rebind_clears_applied_intents_on_cluster_id_transition() {
+        let report =
+            multi_cluster_report_fixture(VerifierDiagnosticFailureKind::AssertionMismatch, 2);
+        let cluster_ids: Vec<_> = report
+            .failure_clusters
+            .iter()
+            .map(|c| c.cluster_key.clone())
+            .collect();
+        let role = report.preferred_repair_role;
+
+        // semantic_plan は cluster B を指している (admitted targets が seed されている)
+        let plan_b = SemanticRepairPlan {
+            semantic_report: report.clone(),
+            failure_cluster_id: cluster_ids[1].clone(),
+            semantic_cause: report.failure_kind,
+            spec_authority: SpecAuthority::ImplementationContract,
+            preferred_repair_role: role,
+            repair_hypothesis: report.repair_hypothesis.clone(),
+            expected_improvement: None,
+            assessment_generation_at_creation: 0,
+        };
+        let stale_hint = impl_hint("app/cluster_a.py");
+        let mut job = RepairJob {
+            semantic_plan: Some(plan_b),
+            assessment: Some(assessment_with_targets(
+                Some(stale_hint.clone()),
+                vec![stale_hint.clone()],
+                vec![stale_hint],
+            )),
+            applied_repair_intents: vec!["intent-from-cluster-a".to_string()],
+            assessment_bound_cluster_id: Some(cluster_ids[0].clone()),
+            ..RepairJob::new_for_test()
+        };
+
+        rebind_legacy_assessment_to_current_cluster(&mut job);
+
+        assert!(
+            job.applied_repair_intents.is_empty(),
+            "cluster_key transition (A → B) must clear applied_repair_intents",
+        );
+        assert_eq!(
+            job.assessment_bound_cluster_id.as_ref(),
+            Some(&cluster_ids[1]),
+            "bound id must be re-bound to the new cluster",
+        );
+    }
+
+    /// CR-4 V2: bound と plan の cluster_id が一致するときは
+    /// `applied_repair_intents` を維持。
+    #[test]
+    fn cb017_rebind_does_not_clear_applied_intents_within_same_cluster() {
+        let report =
+            multi_cluster_report_fixture(VerifierDiagnosticFailureKind::AssertionMismatch, 2);
+        let cluster_ids: Vec<_> = report
+            .failure_clusters
+            .iter()
+            .map(|c| c.cluster_key.clone())
+            .collect();
+        let role = report.preferred_repair_role;
+
+        let plan_b = SemanticRepairPlan {
+            semantic_report: report.clone(),
+            failure_cluster_id: cluster_ids[1].clone(),
+            semantic_cause: report.failure_kind,
+            spec_authority: SpecAuthority::ImplementationContract,
+            preferred_repair_role: role,
+            repair_hypothesis: report.repair_hypothesis.clone(),
+            expected_improvement: None,
+            assessment_generation_at_creation: 0,
+        };
+        // bound = B (same cluster) → no transition.
+        let mut job = RepairJob {
+            semantic_plan: Some(plan_b),
+            assessment: Some(assessment_with_targets(
+                Some(impl_hint("app/cluster_b.py")),
+                vec![impl_hint("app/cluster_b.py")],
+                vec![impl_hint("app/cluster_b.py")],
+            )),
+            applied_repair_intents: vec!["intent-for-cluster-b".to_string()],
+            assessment_bound_cluster_id: Some(cluster_ids[1].clone()),
+            ..RepairJob::new_for_test()
+        };
+
+        rebind_legacy_assessment_to_current_cluster(&mut job);
+
+        assert_eq!(
+            job.applied_repair_intents,
+            vec!["intent-for-cluster-b".to_string()],
+            "no cluster_key transition → applied_repair_intents must be preserved",
+        );
+        assert_eq!(
+            job.assessment_bound_cluster_id.as_ref(),
+            Some(&cluster_ids[1]),
+            "bound id stays on cluster B",
+        );
+    }
+
+    /// CR-4 V2: path/role が同じでも `cluster_key` が違えば transition。
+    /// path/role 比較ではなく cluster_key の差分で判定することを固定する。
+    #[test]
+    fn cb017_rebind_handles_same_file_role_in_different_clusters() {
+        let mut report =
+            multi_cluster_report_fixture(VerifierDiagnosticFailureKind::AssertionMismatch, 2);
+        // 両 cluster の admitted_cluster_targets を同じ path/role にする
+        // (multi_cluster_report_fixture は idx で path を差別化するので
+        // 手動で揃える)。
+        let shared_hint = impl_hint("app/shared.py");
+        for cluster in report.failure_clusters.iter_mut() {
+            cluster.admitted_cluster_targets = vec![shared_hint.clone()];
+        }
+        let cluster_ids: Vec<_> = report
+            .failure_clusters
+            .iter()
+            .map(|c| c.cluster_key.clone())
+            .collect();
+        assert_ne!(
+            cluster_ids[0], cluster_ids[1],
+            "cluster_keys must differ even when paths are identical",
+        );
+        let role = report.preferred_repair_role;
+
+        let plan_b = SemanticRepairPlan {
+            semantic_report: report.clone(),
+            failure_cluster_id: cluster_ids[1].clone(),
+            semantic_cause: report.failure_kind,
+            spec_authority: SpecAuthority::ImplementationContract,
+            preferred_repair_role: role,
+            repair_hypothesis: report.repair_hypothesis.clone(),
+            expected_improvement: None,
+            assessment_generation_at_creation: 0,
+        };
+        // bound = cluster A (same path/role as cluster B).
+        let mut job = RepairJob {
+            semantic_plan: Some(plan_b),
+            assessment: Some(assessment_with_targets(
+                Some(shared_hint.clone()),
+                vec![shared_hint.clone()],
+                vec![shared_hint],
+            )),
+            applied_repair_intents: vec!["intent-from-cluster-a".to_string()],
+            assessment_bound_cluster_id: Some(cluster_ids[0].clone()),
+            ..RepairJob::new_for_test()
+        };
+
+        rebind_legacy_assessment_to_current_cluster(&mut job);
+
+        assert!(
+            job.applied_repair_intents.is_empty(),
+            "CR-4 V2: same path/role but different cluster_key must still be detected as transition",
+        );
+        assert_eq!(
+            job.assessment_bound_cluster_id.as_ref(),
+            Some(&cluster_ids[1])
+        );
+    }
+
+    /// CR-7 V2: `needed_reads` is overwritten with the current cluster's
+    /// admitted targets (Vec<RecoveryTargetHint> clone), not the previous
+    /// cluster's stale paths. Closes the `needed_reads` fallback that
+    /// re-promoted cluster A paths after advance.
+    #[test]
+    fn cb017_rebind_writes_needed_reads_to_current_cluster_paths_only() {
+        let mut report =
+            multi_cluster_report_fixture(VerifierDiagnosticFailureKind::AssertionMismatch, 2);
+        // cluster B の admitted targets を確定値に差し替え (multi_cluster fixture は
+        // idx ベースなので、明示する)。
+        let cluster_b_target = impl_hint("app/cluster_b.py");
+        report.failure_clusters[1].admitted_cluster_targets = vec![cluster_b_target.clone()];
+        let cluster_ids: Vec<_> = report
+            .failure_clusters
+            .iter()
+            .map(|c| c.cluster_key.clone())
+            .collect();
+        let role = report.preferred_repair_role;
+
+        let plan_b = SemanticRepairPlan {
+            semantic_report: report.clone(),
+            failure_cluster_id: cluster_ids[1].clone(),
+            semantic_cause: report.failure_kind,
+            spec_authority: SpecAuthority::ImplementationContract,
+            preferred_repair_role: role,
+            repair_hypothesis: report.repair_hypothesis.clone(),
+            expected_improvement: None,
+            assessment_generation_at_creation: 0,
+        };
+        let stale_a = impl_hint("app/cluster_a.py");
+        let mut job = RepairJob {
+            semantic_plan: Some(plan_b),
+            assessment: Some(assessment_with_targets(
+                Some(stale_a.clone()),
+                vec![stale_a.clone()],
+                vec![stale_a.clone()],
+            )),
+            assessment_bound_cluster_id: Some(cluster_ids[0].clone()),
+            ..RepairJob::new_for_test()
+        };
+
+        rebind_legacy_assessment_to_current_cluster(&mut job);
+
+        let updated = job.assessment.as_ref().expect("assessment preserved");
+        assert_eq!(
+            updated.needed_reads,
+            vec![cluster_b_target.clone()],
+            "needed_reads must be overwritten with current cluster targets (no stale cluster A path)",
+        );
+        // Stale A path must not survive anywhere.
+        assert!(
+            !updated.needed_reads.iter().any(|h| h.path == stale_a.path),
+            "stale cluster A path must not appear in needed_reads after rebind",
+        );
+    }
+
+    /// CR-7 V2: `repair_plan` is written as a verbatim clone of the current
+    /// cluster's admitted targets — preserving order and role exactly so the
+    /// controller can iterate the slice without re-classifying.
+    #[test]
+    fn cb017_rebind_writes_repair_plan_as_targets_clone() {
+        let mut report =
+            multi_cluster_report_fixture(VerifierDiagnosticFailureKind::AssertionMismatch, 2);
+        // Multiple targets on cluster B so we can assert order preservation.
+        let t1 = impl_hint("app/b1.py");
+        let t2 = impl_hint("app/b2.py");
+        let t3 = impl_hint("app/b3.py");
+        report.failure_clusters[1].admitted_cluster_targets =
+            vec![t1.clone(), t2.clone(), t3.clone()];
+        let cluster_ids: Vec<_> = report
+            .failure_clusters
+            .iter()
+            .map(|c| c.cluster_key.clone())
+            .collect();
+        let role = report.preferred_repair_role;
+
+        let plan_b = SemanticRepairPlan {
+            semantic_report: report.clone(),
+            failure_cluster_id: cluster_ids[1].clone(),
+            semantic_cause: report.failure_kind,
+            spec_authority: SpecAuthority::ImplementationContract,
+            preferred_repair_role: role,
+            repair_hypothesis: report.repair_hypothesis.clone(),
+            expected_improvement: None,
+            assessment_generation_at_creation: 0,
+        };
+        let mut job = RepairJob {
+            semantic_plan: Some(plan_b),
+            assessment: Some(assessment_with_targets(None, Vec::new(), Vec::new())),
+            assessment_bound_cluster_id: None,
+            ..RepairJob::new_for_test()
+        };
+
+        rebind_legacy_assessment_to_current_cluster(&mut job);
+
+        let updated = job.assessment.as_ref().expect("assessment preserved");
+        assert_eq!(
+            updated.repair_plan,
+            vec![t1.clone(), t2.clone(), t3.clone()],
+            "repair_plan must be a verbatim clone of current cluster targets",
+        );
+        assert_eq!(
+            updated.repair_target_hint.as_ref(),
+            Some(&t1),
+            "repair_target_hint must be the first target (clone)",
+        );
+    }
+
+    /// Legacy path preservation: `semantic_plan = None` → rebind is a no-op.
+    #[test]
+    fn cb017_rebind_no_op_when_semantic_plan_none() {
+        let stale_hint = impl_hint("app/legacy.py");
+        let mut job = RepairJob {
+            semantic_plan: None,
+            assessment: Some(assessment_with_targets(
+                Some(stale_hint.clone()),
+                vec![stale_hint.clone()],
+                vec![stale_hint.clone()],
+            )),
+            applied_repair_intents: vec!["legacy-intent".to_string()],
+            assessment_bound_cluster_id: None,
+            ..RepairJob::new_for_test()
+        };
+
+        let before = job.clone();
+        rebind_legacy_assessment_to_current_cluster(&mut job);
+
+        assert_eq!(
+            job, before,
+            "rebind must be a complete no-op when semantic_plan is None",
+        );
+    }
+
+    /// Caller-skipped invariant: targetless cluster (admitted_cluster_targets
+    /// empty) → rebind is a no-op. `first_repairable_cluster` /
+    /// `next_repairable_cluster` already skip these, so reaching the rebind
+    /// helper with an empty target list is defensive.
+    #[test]
+    fn cb017_rebind_no_op_when_cluster_targetless() {
+        let mut report =
+            multi_cluster_report_fixture(VerifierDiagnosticFailureKind::AssertionMismatch, 2);
+        // Clear the second cluster's admitted targets to make it targetless.
+        report.failure_clusters[1].admitted_cluster_targets.clear();
+        let cluster_ids: Vec<_> = report
+            .failure_clusters
+            .iter()
+            .map(|c| c.cluster_key.clone())
+            .collect();
+        let role = report.preferred_repair_role;
+
+        let plan_b = SemanticRepairPlan {
+            semantic_report: report.clone(),
+            failure_cluster_id: cluster_ids[1].clone(),
+            semantic_cause: report.failure_kind,
+            spec_authority: SpecAuthority::ImplementationContract,
+            preferred_repair_role: role,
+            repair_hypothesis: report.repair_hypothesis.clone(),
+            expected_improvement: None,
+            assessment_generation_at_creation: 0,
+        };
+        let stale_a = impl_hint("app/cluster_a.py");
+        let mut job = RepairJob {
+            semantic_plan: Some(plan_b),
+            assessment: Some(assessment_with_targets(
+                Some(stale_a.clone()),
+                vec![stale_a.clone()],
+                vec![stale_a.clone()],
+            )),
+            applied_repair_intents: vec!["intent".to_string()],
+            assessment_bound_cluster_id: Some(cluster_ids[0].clone()),
+            ..RepairJob::new_for_test()
+        };
+
+        let before = job.clone();
+        rebind_legacy_assessment_to_current_cluster(&mut job);
+
+        assert_eq!(
+            job, before,
+            "rebind must be a complete no-op when the current cluster has no admitted targets",
+        );
+    }
+
+    /// CR-4 V2 carry-over invariant: a fresh-built RepairJob preserves the
+    /// `assessment_bound_cluster_id` field shape across `Clone` so
+    /// `verifier_repair_context_from_failure` can carry it over previous
+    /// turn contexts.
+    #[test]
+    fn cb017_assessment_bound_cluster_id_carry_over_from_previous_context() {
+        let report =
+            multi_cluster_report_fixture(VerifierDiagnosticFailureKind::AssertionMismatch, 2);
+        let cluster_a = report.failure_clusters[0].cluster_key.clone();
+
+        // Mutating the new field breaks PartialEq, confirming the field
+        // participates in equality and `Clone` preserves it.
+        let mut job = RepairJob::new_for_test();
+        assert!(job.assessment_bound_cluster_id.is_none());
+        job.assessment_bound_cluster_id = Some(cluster_a.clone());
+        let cloned = job.clone();
+        assert_eq!(
+            cloned.assessment_bound_cluster_id.as_ref(),
+            Some(&cluster_a)
+        );
+        assert_eq!(job, cloned);
+
+        let mut diverged = job.clone();
+        diverged.assessment_bound_cluster_id = None;
+        assert_ne!(job, diverged);
+    }
+
+    /// CR-4 V2: `apply_semantic_repair_dispatch_after_rerun` must reset
+    /// `assessment_bound_cluster_id` to `None` whenever it clears the
+    /// assessment for a re-diagnostic round (both `should_re_diagnostic`
+    /// path and "no more clusters" path).
+    #[test]
+    fn cb017_assessment_bound_cluster_id_reset_on_dispatch_re_diagnostic() {
+        let report =
+            multi_cluster_report_fixture(VerifierDiagnosticFailureKind::AssertionMismatch, 2);
+        let cluster_ids: Vec<_> = report
+            .failure_clusters
+            .iter()
+            .map(|c| c.cluster_key.clone())
+            .collect();
+        let role = report.preferred_repair_role;
+
+        // 1. should_re_diagnostic = true path (plan targets exhausted cluster).
+        let plan_a = SemanticRepairPlan {
+            semantic_report: report.clone(),
+            failure_cluster_id: cluster_ids[0].clone(),
+            semantic_cause: report.failure_kind,
+            spec_authority: SpecAuthority::ImplementationContract,
+            preferred_repair_role: role,
+            repair_hypothesis: report.repair_hypothesis.clone(),
+            expected_improvement: None,
+            assessment_generation_at_creation: 0,
+        };
+        let mut job = RepairJob {
+            semantic_plan: Some(plan_a),
+            exhausted_attempts: vec![(cluster_ids[0].clone(), role)],
+            assessment: Some(assessment_with_targets(None, Vec::new(), Vec::new())),
+            rerun_outcome: Some(VerifierRepairRerunOutcome::SameFailureRemaining),
+            assessment_bound_cluster_id: Some(cluster_ids[0].clone()),
+            ..RepairJob::new_for_test()
+        };
+        apply_semantic_repair_dispatch_after_rerun(&mut job, Some(&cluster_ids[0]));
+        assert!(
+            job.assessment.is_none(),
+            "re-diagnostic path clears assessment"
+        );
+        assert!(
+            job.assessment_bound_cluster_id.is_none(),
+            "re-diagnostic (already-exhausted plan) must reset bound id to None",
+        );
+
+        // 2. "no more clusters" path: plan present, rerun bad, no remaining clusters.
+        let report_one =
+            multi_cluster_report_fixture(VerifierDiagnosticFailureKind::AssertionMismatch, 1);
+        let only_cluster = report_one.failure_clusters[0].cluster_key.clone();
+        let mut job2 = job_with_first_cluster_plan(&report_one);
+        job2.assessment = Some(assessment_with_targets(None, Vec::new(), Vec::new()));
+        job2.rerun_outcome = Some(VerifierRepairRerunOutcome::Worsened);
+        job2.assessment_bound_cluster_id = Some(only_cluster.clone());
+
+        apply_semantic_repair_dispatch_after_rerun(&mut job2, Some(&only_cluster));
+        assert!(
+            job2.semantic_plan.is_none(),
+            "no more clusters → slot cleared"
+        );
+        assert!(
+            job2.assessment.is_none(),
+            "no more clusters → assessment cleared"
+        );
+        assert!(
+            job2.assessment_bound_cluster_id.is_none(),
+            "no-more-clusters fallback must reset bound id to None",
+        );
+    }
+
+    /// Production-level (CB-017 core fix): `DiagnosticSkip` path rebinds
+    /// the legacy assessment slice to cluster B's admitted targets. This is
+    /// the scenario fired by `assign_semantic_plan_preserving_exhausted`
+    /// inside `run_verifier_diagnostic_pass` when a fresh diagnostic
+    /// re-proposes an already-exhausted cluster A.
+    #[test]
+    fn cb017_diagnostic_skip_rebinds_legacy_assessment_to_cluster_b() {
+        let mut report =
+            multi_cluster_report_fixture(VerifierDiagnosticFailureKind::AssertionMismatch, 2);
+        let cluster_b_target = impl_hint("app/cluster_b.py");
+        report.failure_clusters[1].admitted_cluster_targets = vec![cluster_b_target.clone()];
+        let cluster_ids: Vec<_> = report
+            .failure_clusters
+            .iter()
+            .map(|c| c.cluster_key.clone())
+            .collect();
+        let role = report.preferred_repair_role;
+
+        // Posture: cluster A exhausted, fresh diagnostic re-proposed A,
+        // dispatch will walk to B via DiagnosticSkip. Legacy assessment
+        // currently still has cluster A paths.
+        let stale_a = impl_hint("app/cluster_a.py");
+        let mut job = RepairJob {
+            exhausted_attempts: vec![(cluster_ids[0].clone(), role)],
+            assessment: Some(assessment_with_targets(
+                Some(stale_a.clone()),
+                vec![stale_a.clone()],
+                vec![stale_a.clone()],
+            )),
+            assessment_bound_cluster_id: Some(cluster_ids[0].clone()),
+            ..RepairJob::new_for_test()
+        };
+        let doomed_plan_a = SemanticRepairPlan {
+            semantic_report: report.clone(),
+            failure_cluster_id: cluster_ids[0].clone(),
+            semantic_cause: report.failure_kind,
+            spec_authority: SpecAuthority::ImplementationContract,
+            preferred_repair_role: role,
+            repair_hypothesis: report.repair_hypothesis.clone(),
+            expected_improvement: None,
+            assessment_generation_at_creation: 0,
+        };
+
+        // Mirror the production sequence:
+        //   1. assign_semantic_plan_preserving_exhausted walks past A to B.
+        //   2. rebind_legacy_assessment_to_current_cluster realigns assessment.
+        assign_semantic_plan_preserving_exhausted(&mut job, Some(doomed_plan_a), Some(&report));
+        rebind_legacy_assessment_to_current_cluster(&mut job);
+
+        let assessment = job.assessment.as_ref().expect("assessment preserved");
+        assert_eq!(
+            assessment.repair_target_hint.as_ref(),
+            Some(&cluster_b_target),
+            "DiagnosticSkip rebind must promote cluster B target as repair_target_hint",
+        );
+        assert_eq!(
+            assessment.repair_plan,
+            vec![cluster_b_target.clone()],
+            "DiagnosticSkip rebind must overwrite repair_plan with cluster B targets",
+        );
+        assert_eq!(
+            assessment.needed_reads,
+            vec![cluster_b_target],
+            "DiagnosticSkip rebind must overwrite needed_reads with cluster B targets",
+        );
+        assert_eq!(
+            job.assessment_bound_cluster_id.as_ref(),
+            Some(&cluster_ids[1]),
+            "bound id must now point at cluster B",
+        );
+    }
+
+    /// Production-level: `RerunNoProgress` path (dispatch helper) also
+    /// rebinds the legacy assessment slice — without this, after a rerun
+    /// no-progress advance to cluster B the controller would still route to
+    /// cluster A paths via the legacy needed_reads fallback (the bug CB-017
+    /// closes for the rerun path too).
+    #[test]
+    fn cb017_rerun_no_progress_also_rebinds_legacy_assessment() {
+        let mut report =
+            multi_cluster_report_fixture(VerifierDiagnosticFailureKind::AssertionMismatch, 2);
+        let cluster_b_target = impl_hint("app/cluster_b.py");
+        report.failure_clusters[1].admitted_cluster_targets = vec![cluster_b_target.clone()];
+        let cluster_ids: Vec<_> = report
+            .failure_clusters
+            .iter()
+            .map(|c| c.cluster_key.clone())
+            .collect();
+        let role = report.preferred_repair_role;
+
+        let plan_a = SemanticRepairPlan {
+            semantic_report: report.clone(),
+            failure_cluster_id: cluster_ids[0].clone(),
+            semantic_cause: report.failure_kind,
+            spec_authority: SpecAuthority::ImplementationContract,
+            preferred_repair_role: role,
+            repair_hypothesis: report.repair_hypothesis.clone(),
+            expected_improvement: None,
+            assessment_generation_at_creation: 0,
+        };
+        let stale_a = impl_hint("app/cluster_a.py");
+        let mut job = RepairJob {
+            semantic_plan: Some(plan_a),
+            assessment: Some(assessment_with_targets(
+                Some(stale_a.clone()),
+                vec![stale_a.clone()],
+                vec![stale_a.clone()],
+            )),
+            rerun_outcome: Some(VerifierRepairRerunOutcome::SameFailureRemaining),
+            assessment_bound_cluster_id: Some(cluster_ids[0].clone()),
+            ..RepairJob::new_for_test()
+        };
+
+        apply_semantic_repair_dispatch_after_rerun(&mut job, Some(&cluster_ids[0]));
+
+        // Slot walked to cluster B AND assessment slice was rebound.
+        assert_eq!(
+            job.semantic_plan.as_ref().unwrap().failure_cluster_id,
+            cluster_ids[1],
+        );
+        let assessment = job.assessment.as_ref().expect("assessment preserved");
+        assert_eq!(
+            assessment.repair_target_hint.as_ref(),
+            Some(&cluster_b_target),
+            "RerunNoProgress advance must rebind repair_target_hint to cluster B",
+        );
+        assert_eq!(assessment.needed_reads, vec![cluster_b_target]);
+        assert_eq!(
+            job.assessment_bound_cluster_id.as_ref(),
+            Some(&cluster_ids[1]),
+        );
+    }
+
+    /// Production-level (CR-7 V2): after a `DiagnosticSkip` rebind, the
+    /// stale cluster A target must no longer appear anywhere in the
+    /// assessment slice — preventing the `verifier_repair_effective_target_hint`
+    /// fallback from re-promoting it via `needed_reads`.
+    #[test]
+    fn cb017_stale_a_target_not_re_promoted_from_needed_reads() {
+        let mut report =
+            multi_cluster_report_fixture(VerifierDiagnosticFailureKind::AssertionMismatch, 2);
+        let cluster_b_target = impl_hint("app/cluster_b.py");
+        report.failure_clusters[1].admitted_cluster_targets = vec![cluster_b_target.clone()];
+        let cluster_ids: Vec<_> = report
+            .failure_clusters
+            .iter()
+            .map(|c| c.cluster_key.clone())
+            .collect();
+        let role = report.preferred_repair_role;
+
+        let stale_a = impl_hint("app/cluster_a.py");
+        let mut job = RepairJob {
+            exhausted_attempts: vec![(cluster_ids[0].clone(), role)],
+            assessment: Some(assessment_with_targets(
+                Some(stale_a.clone()),
+                // Multiple stale entries to make sure none survive.
+                vec![stale_a.clone(), stale_a.clone()],
+                vec![stale_a.clone(), stale_a.clone(), stale_a.clone()],
+            )),
+            assessment_bound_cluster_id: Some(cluster_ids[0].clone()),
+            ..RepairJob::new_for_test()
+        };
+        let doomed_plan_a = SemanticRepairPlan {
+            semantic_report: report.clone(),
+            failure_cluster_id: cluster_ids[0].clone(),
+            semantic_cause: report.failure_kind,
+            spec_authority: SpecAuthority::ImplementationContract,
+            preferred_repair_role: role,
+            repair_hypothesis: report.repair_hypothesis.clone(),
+            expected_improvement: None,
+            assessment_generation_at_creation: 0,
+        };
+
+        assign_semantic_plan_preserving_exhausted(&mut job, Some(doomed_plan_a), Some(&report));
+        rebind_legacy_assessment_to_current_cluster(&mut job);
+
+        let assessment = job.assessment.as_ref().expect("assessment preserved");
+        let stale_path = stale_a.path.as_str();
+        assert!(
+            !assessment.needed_reads.iter().any(|h| h.path == stale_path),
+            "stale cluster A path must not survive in needed_reads",
+        );
+        assert!(
+            !assessment.repair_plan.iter().any(|h| h.path == stale_path),
+            "stale cluster A path must not survive in repair_plan",
+        );
+        assert!(
+            assessment
+                .repair_target_hint
+                .as_ref()
+                .is_none_or(|h| h.path != stale_path),
+            "stale cluster A path must not remain as repair_target_hint",
         );
     }
 }

--- a/src/agent/loop_run/repair_job.rs
+++ b/src/agent/loop_run/repair_job.rs
@@ -16,18 +16,56 @@
 
 use std::path::{Path, PathBuf};
 
+use super::semantic_failure::{FailureClusterKey, SemanticFailureReport};
+use super::spec_authority::{RepairRole, SpecAuthority};
 use super::task_contract::RecoveryTargetHint;
-use super::{VerifierFailureType, VerifierRepairAssessment, VerifierRepairRerunOutcome};
+use super::{
+    VerifierDiagnosticFailureKind, VerifierFailureType, VerifierRepairAssessment,
+    VerifierRepairRerunOutcome,
+};
 use crate::session::store::ConversationMessage;
 
 /// Maximum byte length retained for sanitized snapshot text fields. Consumed
 /// by `truncate_for_snapshot` and the `failure_snapshot` production path (Issue #638).
 pub(super) const SNAPSHOT_FIELD_BYTE_CAP: usize = 4096;
 
+/// Issue #647 (Phase B / DR1-003): 1 cluster 攻略 plan を束ねる sub-struct。
+/// `slot reuse` (設計判断 #5) 時はこの struct 単位で `RepairJob.semantic_plan`
+/// に書き戻される — 失敗 cluster は `RepairJob.exhausted_attempts` ledger に
+/// 記録され、新しい `SemanticRepairPlan` が semantic_plan slot に書き込まれる。
+///
+/// `Eq` derive は drop している (S7-001): `SemanticFailureReport` が `f32`
+/// confidence を保持するため、`TaskContract` と同方針で `PartialEq` のみ。
+#[derive(Debug, Clone, PartialEq)]
+pub(super) struct SemanticRepairPlan {
+    /// 観測 — diagnostic LLM が出力した sanitized + bounded report
+    /// (`parse_semantic_failure_report` を通過済)。
+    pub(super) semantic_report: SemanticFailureReport,
+    /// 1 plan = 1 cluster。`semantic_report.failure_clusters` のうち
+    /// 今 attack 中の cluster の `cluster_key` を保持する。
+    pub(super) failure_cluster_id: FailureClusterKey,
+    /// `semantic_report.failure_kind` のコピー (cheap-access)。
+    pub(super) semantic_cause: VerifierDiagnosticFailureKind,
+    /// この cluster に対して採用された spec authority (Phase D で
+    /// `select_authority` の結果がここに書かれる)。
+    pub(super) spec_authority: SpecAuthority,
+    /// この cluster の修復で attack するアーティファクト役割。
+    pub(super) preferred_repair_role: RepairRole,
+    /// 修復仮説。`MAX_REPAIR_HYPOTHESIS_CHARS` (240 chars) に
+    /// sanitized + truncated 済 (`semantic_report.repair_hypothesis` 由来)。
+    pub(super) repair_hypothesis: String,
+    /// rerun 後に書き込まれる予測対比の結果。未 rerun 時は `None`。
+    pub(super) expected_improvement: Option<VerifierRepairRerunOutcome>,
+}
+
 /// Issue #625 / #627 / #637: turn-local diagnostic context for a failed
 /// task-contract verifier. Rename of the previous `VerifierRepairContext`
 /// type. Fields are 1:1 with the legacy definition (see design policy §4-1).
-#[derive(Debug, Clone, PartialEq, Eq)]
+///
+/// Issue #647 (Phase B): `semantic_plan` / `exhausted_attempts` の 2 field を
+/// 追加し、`Eq` derive を drop (S7-001) — `SemanticRepairPlan` 経由で
+/// `f32` confidence を含むため `PartialEq` のみ。
+#[derive(Debug, Clone, PartialEq)]
 pub(super) struct RepairJob {
     pub(super) command: String,
     pub(super) output_excerpt: String,
@@ -50,6 +88,14 @@ pub(super) struct RepairJob {
     pub(super) previous_failure_count: Option<usize>,
     pub(super) rerun_outcome: Option<VerifierRepairRerunOutcome>,
     pub(super) repair_attempt: usize,
+    /// Issue #647 (Phase B / DR1-003): 現在 attack 中の cluster と plan。
+    /// `slot reuse` 時はこの Option を書き換える (前 cluster の attempt は
+    /// `exhausted_attempts` に push されてから replace される)。
+    pub(super) semantic_plan: Option<SemanticRepairPlan>,
+    /// Issue #647 (Phase B / DR2-007): per-job 累積の重複検出 ledger。
+    /// `slot reuse` でも保持される (per-cluster ではない) — 同じ
+    /// `(FailureClusterKey, RepairRole)` 組み合わせを 2 度 attack しないため。
+    pub(super) exhausted_attempts: Vec<(FailureClusterKey, RepairRole)>,
 }
 
 /// Controller-internal decision used by `run_turn` to pick the next action
@@ -207,6 +253,52 @@ impl RepairJob {
             repair_error: self.repair_error.as_deref().map(sanitize_repair_job_text),
             rerun_outcome: self.rerun_outcome,
             applied_repair_intent_count: self.applied_repair_intents.len() as u32,
+        }
+    }
+
+    /// Issue #647 (Phase B / S3-001): test fixture helper.
+    ///
+    /// Build a `RepairJob` with all fields at sensible defaults so test sites
+    /// only need to override the fields that matter to their scenario. Combine
+    /// with struct update syntax for partial overrides:
+    ///
+    /// ```ignore
+    /// let job = RepairJob {
+    ///     target_hint: Some(my_hint),
+    ///     ..RepairJob::new_for_test()
+    /// };
+    /// ```
+    ///
+    /// All Issue #647 semantic-repair fields (`semantic_plan` /
+    /// `exhausted_attempts`) are initialized to their empty defaults (`None` /
+    /// empty `Vec`), so existing fixtures that pre-date Phase B continue to
+    /// describe a pre-semantic-planning state.
+    #[cfg(test)]
+    pub(super) fn new_for_test() -> Self {
+        Self {
+            command: String::new(),
+            output_excerpt: String::new(),
+            failure_type: VerifierFailureType::Unknown,
+            target_hint: None,
+            repair_target_hint: None,
+            changed_file_hints: Vec::new(),
+            assessment: None,
+            assessment_attempts: 0,
+            diagnostic_attempted: false,
+            diagnostic_unavailable: false,
+            diagnostic_error: None,
+            repair_error: None,
+            applied_repair_intents: Vec::new(),
+            target_line: None,
+            error_kind: None,
+            failure_signature: String::new(),
+            failure_count: None,
+            previous_failure_signature: None,
+            previous_failure_count: None,
+            rerun_outcome: None,
+            repair_attempt: 0,
+            semantic_plan: None,
+            exhausted_attempts: Vec::new(),
         }
     }
 }
@@ -418,5 +510,185 @@ mod tests {
         let truncated = truncate_for_snapshot(&multi);
         assert!(truncated.len() <= SNAPSHOT_FIELD_BYTE_CAP);
         assert!(truncated.chars().all(|c| c == 'あ'));
+    }
+
+    // ---- Issue #647 (Phase B): SemanticRepairPlan + RepairJob::new_for_test ---- //
+
+    /// Build a minimal `SemanticFailureReport` for SemanticRepairPlan tests.
+    /// Uses Phase A.1 entry points so the fixture stays SSOT-aligned.
+    #[cfg(test)]
+    fn semantic_report_fixture(
+        kind: VerifierDiagnosticFailureKind,
+        confidence: f32,
+    ) -> super::super::semantic_failure::SemanticFailureReport {
+        let json = serde_json::json!({
+            "failure_kind": kind_label(kind),
+            "confidence": confidence,
+            "preferred_repair_role": "implementation",
+            "repair_hypothesis": "hypothesis text",
+            "failure_clusters": [
+                {
+                    "observed": "obs",
+                    "expected": "exp",
+                    "input_shape": "shape",
+                    "assertion_shape": "AssertEq",
+                    "involved_artifacts": ["test"],
+                    "affected_cases": ["case1"],
+                }
+            ],
+        });
+        super::super::semantic_failure::parse_semantic_failure_report(&json)
+            .expect("fixture parses")
+    }
+
+    #[cfg(test)]
+    fn kind_label(kind: VerifierDiagnosticFailureKind) -> &'static str {
+        match kind {
+            VerifierDiagnosticFailureKind::DependencyMissing => "dependency_missing",
+            VerifierDiagnosticFailureKind::LocalImportContractMismatch => {
+                "local_import_contract_mismatch"
+            }
+            VerifierDiagnosticFailureKind::CompileOrSyntaxError => "compile_or_syntax_error",
+            VerifierDiagnosticFailureKind::AssertionMismatch => "assertion_mismatch",
+            VerifierDiagnosticFailureKind::RuntimeError => "runtime_error",
+            VerifierDiagnosticFailureKind::TestBug => "test_bug",
+            VerifierDiagnosticFailureKind::ConfigOrVerifierError => "config_or_verifier_error",
+            VerifierDiagnosticFailureKind::Unknown => "unknown",
+        }
+    }
+
+    #[test]
+    fn semantic_repair_plan_constructs_and_compares_equal_for_same_inputs() {
+        let report = semantic_report_fixture(VerifierDiagnosticFailureKind::AssertionMismatch, 0.7);
+        let cluster_id = report.failure_clusters[0].cluster_key.clone();
+        let plan_a = SemanticRepairPlan {
+            semantic_report: report.clone(),
+            failure_cluster_id: cluster_id.clone(),
+            semantic_cause: VerifierDiagnosticFailureKind::AssertionMismatch,
+            spec_authority: SpecAuthority::BehaviorContract,
+            preferred_repair_role: super::super::task_contract::ArtifactRole::Implementation,
+            repair_hypothesis: "h".to_string(),
+            expected_improvement: None,
+        };
+        let plan_b = SemanticRepairPlan {
+            semantic_report: report,
+            failure_cluster_id: cluster_id,
+            semantic_cause: VerifierDiagnosticFailureKind::AssertionMismatch,
+            spec_authority: SpecAuthority::BehaviorContract,
+            preferred_repair_role: super::super::task_contract::ArtifactRole::Implementation,
+            repair_hypothesis: "h".to_string(),
+            expected_improvement: None,
+        };
+        assert_eq!(plan_a, plan_b);
+    }
+
+    #[test]
+    fn semantic_repair_plan_partial_eq_distinguishes_authority_and_role() {
+        let report = semantic_report_fixture(VerifierDiagnosticFailureKind::AssertionMismatch, 0.7);
+        let cluster_id = report.failure_clusters[0].cluster_key.clone();
+        let base = SemanticRepairPlan {
+            semantic_report: report.clone(),
+            failure_cluster_id: cluster_id.clone(),
+            semantic_cause: VerifierDiagnosticFailureKind::AssertionMismatch,
+            spec_authority: SpecAuthority::BehaviorContract,
+            preferred_repair_role: super::super::task_contract::ArtifactRole::Implementation,
+            repair_hypothesis: "h".to_string(),
+            expected_improvement: None,
+        };
+        let mut different_authority = base.clone();
+        different_authority.spec_authority = SpecAuthority::LlmGeneratedTest;
+        assert_ne!(base, different_authority);
+
+        let mut different_role = base.clone();
+        different_role.preferred_repair_role = super::super::task_contract::ArtifactRole::Test;
+        assert_ne!(base, different_role);
+    }
+
+    #[test]
+    fn repair_job_new_for_test_initializes_semantic_fields_empty() {
+        let job = RepairJob::new_for_test();
+        // Issue #647 (Phase B): semantic planning slots start empty so that
+        // pre-Phase-D code paths see a "no semantic plan yet" state.
+        assert!(job.semantic_plan.is_none());
+        assert!(job.exhausted_attempts.is_empty());
+    }
+
+    #[test]
+    fn repair_job_new_for_test_initializes_legacy_fields_to_neutral_defaults() {
+        let job = RepairJob::new_for_test();
+        assert_eq!(job.failure_type, VerifierFailureType::Unknown);
+        assert!(job.target_hint.is_none());
+        assert!(job.repair_target_hint.is_none());
+        assert!(job.changed_file_hints.is_empty());
+        assert!(job.assessment.is_none());
+        assert_eq!(job.assessment_attempts, 0);
+        assert!(!job.diagnostic_attempted);
+        assert!(!job.diagnostic_unavailable);
+        assert!(job.diagnostic_error.is_none());
+        assert!(job.repair_error.is_none());
+        assert!(job.applied_repair_intents.is_empty());
+        assert!(job.target_line.is_none());
+        assert!(job.error_kind.is_none());
+        assert_eq!(job.failure_signature, "");
+        assert!(job.failure_count.is_none());
+        assert!(job.previous_failure_signature.is_none());
+        assert!(job.previous_failure_count.is_none());
+        assert!(job.rerun_outcome.is_none());
+        assert_eq!(job.repair_attempt, 0);
+    }
+
+    #[test]
+    fn repair_job_supports_struct_update_syntax_for_partial_override() {
+        // S3-001: existing test fixtures override only the fields they care
+        // about and let `new_for_test()` fill the rest. Mirror that pattern
+        // here to lock the API shape (no `..Default::default()` indirection).
+        let job = RepairJob {
+            command: "pytest".to_string(),
+            failure_signature: "sig".to_string(),
+            ..RepairJob::new_for_test()
+        };
+        assert_eq!(job.command, "pytest");
+        assert_eq!(job.failure_signature, "sig");
+        // Untouched fields still take new_for_test defaults.
+        assert_eq!(job.failure_type, VerifierFailureType::Unknown);
+        assert!(job.semantic_plan.is_none());
+        assert!(job.exhausted_attempts.is_empty());
+    }
+
+    #[test]
+    fn repair_job_partial_eq_holds_with_semantic_plan_some() {
+        // S7-001: `Eq` is dropped because `SemanticFailureReport.confidence`
+        // is `f32`, but `PartialEq` must still work for assertion / diff
+        // workflows in tests.
+        let report = semantic_report_fixture(VerifierDiagnosticFailureKind::AssertionMismatch, 0.5);
+        let cluster_id = report.failure_clusters[0].cluster_key.clone();
+        let plan = SemanticRepairPlan {
+            semantic_report: report,
+            failure_cluster_id: cluster_id,
+            semantic_cause: VerifierDiagnosticFailureKind::AssertionMismatch,
+            spec_authority: SpecAuthority::ImplementationContract,
+            preferred_repair_role: super::super::task_contract::ArtifactRole::Implementation,
+            repair_hypothesis: "h".to_string(),
+            expected_improvement: None,
+        };
+        let a = RepairJob {
+            semantic_plan: Some(plan.clone()),
+            ..RepairJob::new_for_test()
+        };
+        let b = RepairJob {
+            semantic_plan: Some(plan),
+            ..RepairJob::new_for_test()
+        };
+        assert_eq!(a, b);
+
+        // Mutating exhausted_attempts breaks equality.
+        let c = RepairJob {
+            exhausted_attempts: vec![(
+                a.semantic_plan.as_ref().unwrap().failure_cluster_id.clone(),
+                super::super::task_contract::ArtifactRole::Test,
+            )],
+            ..a.clone()
+        };
+        assert_ne!(a, c);
     }
 }

--- a/src/agent/loop_run/repair_job.rs
+++ b/src/agent/loop_run/repair_job.rs
@@ -411,22 +411,35 @@ pub(super) fn verifier_repair_decision(
     if job.is_some_and(|job| job.assessment.is_none()) {
         return VerifierRepairDecision::DiagnosticUnavailable;
     }
-    // Issue #647 (CB-012): When semantic_plan is active but the
-    // assessment was constructed before exhausted_attempts grew (= the
-    // hint guard in `verifier_repair_context_target_path` returns
-    // `None` because exhausted_attempts is non-empty), do NOT fall
-    // through to `latest_successful_read_existing_path`. That fallback
-    // would route the repair pass to an unrelated turn-local read
-    // target. Force a fresh diagnostic instead so the next assessment
-    // reflects the advanced cluster.
+    // Issue #647 (CB-012 / CB-014): When semantic_plan is active but
+    // the assessment was constructed before exhausted_attempts grew
+    // (= the hint guard in `verifier_repair_context_target_path`
+    // returns `None` because exhausted_attempts is non-empty), the
+    // assessment is **stale**. Two branches:
+    //
+    //   * **CB-012** (attempts remain): force a fresh diagnostic so
+    //     the next assessment reflects the advanced cluster. Without
+    //     this branch we would fall through to
+    //     `latest_successful_read_existing_path` and route the repair
+    //     pass to an unrelated turn-local read target.
+    //   * **CB-014** (attempts exhausted): fail closed with
+    //     `DiagnosticUnavailable`. Without this branch the same
+    //     stale-target fallback path reopens at the diagnostic budget
+    //     boundary because `assessment.is_some()` keeps the earlier
+    //     `assessment.is_none() -> DiagnosticUnavailable` arm from
+    //     firing.
     if job.is_some_and(|job| {
         job.semantic_plan.is_some()
             && !job.exhausted_attempts.is_empty()
             && super::turn::verifier_repair_context_target_path(work_root, job).is_none()
-            && job.assessment_attempts
-                < crate::agent::loop_run::turn::VERIFIER_DIAGNOSTIC_ATTEMPT_LIMIT
     }) {
-        return VerifierRepairDecision::NeedDiagnostic;
+        if job.is_some_and(|job| {
+            job.assessment_attempts
+                < crate::agent::loop_run::turn::VERIFIER_DIAGNOSTIC_ATTEMPT_LIMIT
+        }) {
+            return VerifierRepairDecision::NeedDiagnostic;
+        }
+        return VerifierRepairDecision::DiagnosticUnavailable;
     }
     let target = job
         .and_then(|job| super::turn::verifier_repair_context_target_path(work_root, job))

--- a/src/agent/loop_run/repair_job.rs
+++ b/src/agent/loop_run/repair_job.rs
@@ -503,10 +503,19 @@ pub(super) fn task_contract_repair_state(
 ///
 /// `preferred_repair_role` and `repair_hypothesis` are inherited from the
 /// report — Phase E does not re-pick a per-cluster role (the diagnostic
-/// LLM emits one role per report). `spec_authority` is re-selected via
-/// `select_authority` so the same Phase-D fallback set
-/// (`ImplementationContract` + `LlmGeneratedTest`) governs the new plan
-/// deterministically.
+/// LLM emits one role per report).
+///
+/// `spec_authority` is **carried forward** verbatim from the current plan
+/// (Codex CB-009): the authority was already elected for the active report
+/// — typically by `resolve()` at the diagnostic boundary — and slot reuse
+/// only changes *which cluster* we are attacking, not *which spec source*
+/// governs the repair. The previous implementation re-ran
+/// `select_authority(&[ImplementationContract, LlmGeneratedTest], None)`
+/// inside the helper, which silently demoted higher-authority elections
+/// (`UserRequest` / `BehaviorContract`) to `ImplementationContract` every
+/// time we walked to a new cluster. When no current plan is present
+/// (initial fixture / defensive path), we still fall back to the
+/// `ImplementationContract` default so the helper remains total.
 ///
 /// Returns `false` (and clears `semantic_plan`) when the report has no
 /// remaining clusters; callers MUST treat that as "no more clusters to
@@ -517,16 +526,16 @@ pub(super) fn advance_to_next_cluster(
     report: &SemanticFailureReport,
 ) -> bool {
     // 1. Record the current plan in the exhausted_attempts ledger before
-    //    we drop it, so slot reuse preserves history (S3-010).
-    if let Some(current_plan) = repair_job.semantic_plan.as_ref() {
-        let entry = (
-            current_plan.failure_cluster_id.clone(),
-            current_plan.preferred_repair_role,
-        );
+    //    we drop it, so slot reuse preserves history (S3-010). At the same
+    //    time, capture the current plan's `spec_authority` so we can carry
+    //    it forward into the next cluster's plan (CB-009).
+    let carried_authority = repair_job.semantic_plan.as_ref().map(|plan| {
+        let entry = (plan.failure_cluster_id.clone(), plan.preferred_repair_role);
         if !repair_job.exhausted_attempts.contains(&entry) {
             repair_job.exhausted_attempts.push(entry);
         }
-    }
+        plan.spec_authority
+    });
 
     // 2. Find the next cluster in document order that is NOT exhausted
     //    under the report's preferred_repair_role.
@@ -543,20 +552,14 @@ pub(super) fn advance_to_next_cluster(
         return false;
     };
 
-    // 4. Re-pick the spec authority for the new cluster using the same
-    //    Phase-D fallback candidate set so the deterministic behaviour is
-    //    preserved across slot reuse.
-    let candidates = [
-        SpecAuthority::ImplementationContract,
-        SpecAuthority::LlmGeneratedTest,
-    ];
-    let Some(spec_authority) = super::spec_authority::select_authority(&candidates, None) else {
-        // select_authority on a non-empty filtered candidate list cannot
-        // return None today, but if a future variant change makes it
-        // possible, fail closed (no plan).
-        repair_job.semantic_plan = None;
-        return false;
-    };
+    // 4. CB-009: carry the elected authority forward across slot reuse.
+    //    Only `failure_cluster_id` (and the per-cluster fields derived
+    //    from `next_cluster` / `report`) change; the spec source that
+    //    elected this report's repair plan is preserved verbatim. When
+    //    no current plan exists (defensive path), fall back to
+    //    `ImplementationContract` — the same neutral default `resolve()`
+    //    uses when no higher-authority signal fires.
+    let spec_authority = carried_authority.unwrap_or(SpecAuthority::ImplementationContract);
 
     repair_job.semantic_plan = Some(SemanticRepairPlan {
         semantic_cause: report.failure_kind,
@@ -1929,6 +1932,156 @@ mod tests {
                 "slot must remain on cluster B (never regress to A)",
             );
         }
+    }
+
+    // ---- Issue #647 (CB-009): advance_to_next_cluster carries forward SpecAuthority ---- //
+
+    /// CB-009.3 (regression #1): when the current `SemanticRepairPlan` was
+    /// elected with `SpecAuthority::UserRequest` (e.g. the user explicitly
+    /// described the contract), advancing to the next cluster of the same
+    /// report must **preserve** the `UserRequest` authority — only the
+    /// `failure_cluster_id` and per-cluster fields change. The previous
+    /// implementation re-ran `select_authority(&[Impl, LlmGenTest], None)`
+    /// and silently demoted `UserRequest` → `ImplementationContract`
+    /// (Codex CB-009).
+    #[test]
+    fn cb009_advance_to_next_cluster_carries_forward_user_request_authority() {
+        let report =
+            multi_cluster_report_fixture(VerifierDiagnosticFailureKind::AssertionMismatch, 2);
+        let cluster_ids: Vec<_> = report
+            .failure_clusters
+            .iter()
+            .map(|c| c.cluster_key.clone())
+            .collect();
+        let role = report.preferred_repair_role;
+
+        // Initial plan: cluster A under UserRequest authority.
+        let plan = SemanticRepairPlan {
+            semantic_report: report.clone(),
+            failure_cluster_id: cluster_ids[0].clone(),
+            semantic_cause: report.failure_kind,
+            spec_authority: SpecAuthority::UserRequest,
+            preferred_repair_role: role,
+            repair_hypothesis: report.repair_hypothesis.clone(),
+            expected_improvement: None,
+        };
+        let mut job = RepairJob {
+            semantic_plan: Some(plan),
+            ..RepairJob::new_for_test()
+        };
+
+        assert!(advance_to_next_cluster(&mut job, &report));
+
+        let advanced = job.semantic_plan.as_ref().expect("slot now holds plan B");
+        assert_eq!(
+            advanced.failure_cluster_id, cluster_ids[1],
+            "advance must move the slot to the next cluster",
+        );
+        assert_eq!(
+            advanced.spec_authority,
+            SpecAuthority::UserRequest,
+            "CB-009: UserRequest authority must be carried forward across slot reuse",
+        );
+    }
+
+    /// CB-009.3 (regression #2): same invariant for `SpecAuthority::BehaviorContract`
+    /// — when the initial plan was elected via the deterministic
+    /// `RequiredBehaviorContract`, that authority must survive cluster
+    /// transitions intact (no demotion to ImplementationContract).
+    #[test]
+    fn cb009_advance_to_next_cluster_carries_forward_behavior_contract() {
+        let report =
+            multi_cluster_report_fixture(VerifierDiagnosticFailureKind::AssertionMismatch, 2);
+        let cluster_ids: Vec<_> = report
+            .failure_clusters
+            .iter()
+            .map(|c| c.cluster_key.clone())
+            .collect();
+        let role = report.preferred_repair_role;
+
+        let plan = SemanticRepairPlan {
+            semantic_report: report.clone(),
+            failure_cluster_id: cluster_ids[0].clone(),
+            semantic_cause: report.failure_kind,
+            spec_authority: SpecAuthority::BehaviorContract,
+            preferred_repair_role: role,
+            repair_hypothesis: report.repair_hypothesis.clone(),
+            expected_improvement: None,
+        };
+        let mut job = RepairJob {
+            semantic_plan: Some(plan),
+            ..RepairJob::new_for_test()
+        };
+
+        assert!(advance_to_next_cluster(&mut job, &report));
+
+        let advanced = job.semantic_plan.as_ref().expect("slot now holds plan B");
+        assert_eq!(advanced.failure_cluster_id, cluster_ids[1]);
+        assert_eq!(
+            advanced.spec_authority,
+            SpecAuthority::BehaviorContract,
+            "CB-009: BehaviorContract authority must be carried forward across slot reuse",
+        );
+    }
+
+    /// CB-009.3 (regression #3): when the initial plan's authority was
+    /// elected via consensus (here represented by a `BehaviorContract`
+    /// outcome — the test/usage-docs vs impl tie-break path in
+    /// `consensus_to_authority_for_resolve`, see CB-008), advancing to the
+    /// next cluster must keep that consensus-decided authority intact —
+    /// `advance_to_next_cluster` is **not** allowed to re-derive a new
+    /// authority from a fixed candidate base, because the candidate base
+    /// does not include `BehaviorContract` and would silently overwrite it.
+    #[test]
+    fn cb009_advance_to_next_cluster_carries_forward_consensus_decided_authority() {
+        let report =
+            multi_cluster_report_fixture(VerifierDiagnosticFailureKind::AssertionMismatch, 3);
+        let cluster_ids: Vec<_> = report
+            .failure_clusters
+            .iter()
+            .map(|c| c.cluster_key.clone())
+            .collect();
+        let role = report.preferred_repair_role;
+
+        // Plan elected via consensus → BehaviorContract on cluster A.
+        let plan = SemanticRepairPlan {
+            semantic_report: report.clone(),
+            failure_cluster_id: cluster_ids[0].clone(),
+            semantic_cause: report.failure_kind,
+            spec_authority: SpecAuthority::BehaviorContract,
+            preferred_repair_role: role,
+            repair_hypothesis: report.repair_hypothesis.clone(),
+            expected_improvement: None,
+        };
+        let mut job = RepairJob {
+            semantic_plan: Some(plan),
+            ..RepairJob::new_for_test()
+        };
+
+        // First advance: A → B. Authority must remain BehaviorContract.
+        assert!(advance_to_next_cluster(&mut job, &report));
+        assert_eq!(
+            job.semantic_plan.as_ref().unwrap().failure_cluster_id,
+            cluster_ids[1],
+        );
+        assert_eq!(
+            job.semantic_plan.as_ref().unwrap().spec_authority,
+            SpecAuthority::BehaviorContract,
+            "CB-009: consensus-decided BehaviorContract must persist after first advance",
+        );
+
+        // Second advance: B → C. Authority must STILL remain BehaviorContract
+        // (carry-forward survives chained slot reuse).
+        assert!(advance_to_next_cluster(&mut job, &report));
+        assert_eq!(
+            job.semantic_plan.as_ref().unwrap().failure_cluster_id,
+            cluster_ids[2],
+        );
+        assert_eq!(
+            job.semantic_plan.as_ref().unwrap().spec_authority,
+            SpecAuthority::BehaviorContract,
+            "CB-009: consensus-decided BehaviorContract must persist across chained advances",
+        );
     }
 
     // -- Phase G grep / structure tests (Issue #647 acceptance closure) -- //

--- a/src/agent/loop_run/repair_job.rs
+++ b/src/agent/loop_run/repair_job.rs
@@ -463,6 +463,170 @@ pub(super) fn task_contract_repair_state(
     }
 }
 
+// ---- Issue #647 (Phase E): cluster-based sequential repair helpers ---- //
+//
+// Phase E keeps the existing `repair_job: Option<RepairJob>` slot shape
+// (設計判断 #5, S3-010): instead of growing a `Vec<RepairJob>` queue, the
+// slot is reused for each cluster. Failed `(cluster_id, role)` pairs are
+// recorded on `RepairJob.exhausted_attempts` so the same cluster is never
+// re-attacked under the same role and so the bookkeeping survives the
+// slot reuse.
+//
+// The three helpers below are intentionally pure functions over
+// `&mut RepairJob` / `&RepairJob` / immutable cluster ids:
+//
+//   - `advance_to_next_cluster` mutates the slot.
+//   - `should_re_diagnostic` inspects the slot.
+//   - `rerun_outcome_with_cluster` wraps the legacy
+//     `verifier_repair_rerun_outcome` result without modifying it
+//     (S3-014: failure_count is still the SSOT for outcome).
+//
+// `Vec<(FailureClusterKey, RepairRole)>` is a tiny ledger (~64 bytes per
+// entry) so linear `contains` is fine — total entries are bounded by
+// `failure_clusters.len() * artifact roles in scope`.
+
+/// Issue #647 (Phase E.1): advance the `repair_job.semantic_plan` slot to
+/// the next unattempted cluster from `report.failure_clusters`.
+///
+/// Phase E behaviour (設計判断 #5 / S3-010):
+///
+/// 1. Push the current plan's `(failure_cluster_id, preferred_repair_role)`
+///    onto `exhausted_attempts` (idempotent — duplicates are skipped so
+///    repeated calls from `turn.rs` cannot grow the ledger unboundedly).
+/// 2. Walk `report.failure_clusters` in document order and pick the first
+///    cluster whose `(cluster_id, preferred_repair_role)` is **not** in
+///    `exhausted_attempts`.
+/// 3. If found, replace `semantic_plan` with a new `SemanticRepairPlan`
+///    targeting that cluster and return `true`.
+/// 4. If no cluster is available, leave `semantic_plan = None` and return
+///    `false` (caller falls back to re-diagnostic or task failure).
+///
+/// `preferred_repair_role` and `repair_hypothesis` are inherited from the
+/// report — Phase E does not re-pick a per-cluster role (the diagnostic
+/// LLM emits one role per report). `spec_authority` is re-selected via
+/// `select_authority` so the same Phase-D fallback set
+/// (`ImplementationContract` + `LlmGeneratedTest`) governs the new plan
+/// deterministically.
+///
+/// Returns `false` (and clears `semantic_plan`) when the report has no
+/// remaining clusters; callers MUST treat that as "no more clusters to
+/// attack in this report" and switch back to `re_diagnostic`.
+#[allow(dead_code)] // wired into turn.rs by a subsequent task; exercised here via unit tests.
+pub(super) fn advance_to_next_cluster(
+    repair_job: &mut RepairJob,
+    report: &SemanticFailureReport,
+) -> bool {
+    // 1. Record the current plan in the exhausted_attempts ledger before
+    //    we drop it, so slot reuse preserves history (S3-010).
+    if let Some(current_plan) = repair_job.semantic_plan.as_ref() {
+        let entry = (
+            current_plan.failure_cluster_id.clone(),
+            current_plan.preferred_repair_role,
+        );
+        if !repair_job.exhausted_attempts.contains(&entry) {
+            repair_job.exhausted_attempts.push(entry);
+        }
+    }
+
+    // 2. Find the next cluster in document order that is NOT exhausted
+    //    under the report's preferred_repair_role.
+    let role = report.preferred_repair_role;
+    let next_cluster = report.failure_clusters.iter().find(|cluster| {
+        !repair_job
+            .exhausted_attempts
+            .contains(&(cluster.cluster_key.clone(), role))
+    });
+
+    let Some(next_cluster) = next_cluster else {
+        // 3. No more clusters — clear the slot and signal no progress.
+        repair_job.semantic_plan = None;
+        return false;
+    };
+
+    // 4. Re-pick the spec authority for the new cluster using the same
+    //    Phase-D fallback candidate set so the deterministic behaviour is
+    //    preserved across slot reuse.
+    let candidates = [
+        SpecAuthority::ImplementationContract,
+        SpecAuthority::LlmGeneratedTest,
+    ];
+    let Some(spec_authority) = super::spec_authority::select_authority(&candidates, None) else {
+        // select_authority on a non-empty filtered candidate list cannot
+        // return None today, but if a future variant change makes it
+        // possible, fail closed (no plan).
+        repair_job.semantic_plan = None;
+        return false;
+    };
+
+    repair_job.semantic_plan = Some(SemanticRepairPlan {
+        semantic_cause: report.failure_kind,
+        spec_authority,
+        preferred_repair_role: role,
+        repair_hypothesis: report.repair_hypothesis.clone(),
+        failure_cluster_id: next_cluster.cluster_key.clone(),
+        expected_improvement: None,
+        semantic_report: report.clone(),
+    });
+    true
+}
+
+/// Issue #647 (Phase E.2): predicate that becomes `true` when the active
+/// `SemanticRepairPlan` targets a `(cluster_id, role)` pair that is already
+/// in `exhausted_attempts` — meaning the same repair has been tried and the
+/// caller MUST switch to the re-diagnostic path (`assessment = None,
+/// assessment_attempts += 1`, bounded by `VERIFIER_DIAGNOSTIC_ATTEMPT_LIMIT`
+/// in `turn.rs`) rather than redoing the same attack.
+///
+/// Returns `false` when:
+/// - `semantic_plan` is `None` (no active plan, nothing to compare).
+/// - The active plan's `(cluster_id, role)` pair is not yet in the ledger.
+#[allow(dead_code)] // wired into turn.rs by a subsequent task; exercised here via unit tests.
+pub(super) fn should_re_diagnostic(repair_job: &RepairJob) -> bool {
+    let Some(plan) = repair_job.semantic_plan.as_ref() else {
+        return false;
+    };
+    repair_job
+        .exhausted_attempts
+        .contains(&(plan.failure_cluster_id.clone(), plan.preferred_repair_role))
+}
+
+/// Issue #647 (Phase E.3 / S3-014): wrap the existing
+/// `verifier_repair_rerun_outcome` (which is failure_count-based and
+/// cluster-agnostic) with a cluster-id transition rule.
+///
+/// Rationale (S3-014): the legacy outcome compares `failure_count`
+/// monotonically — if the same number of failures remain after a repair,
+/// the outcome is `SameFailureRemaining` even when a completely different
+/// cluster is now failing. For Phase-E sequential repair this is
+/// misleading: an honest "new cluster surfaced" run looks identical to
+/// "same cluster still failing". This wrapper preserves the legacy outcome
+/// when the cluster id is unchanged (or unknown on either side) and
+/// upgrades it to `NewFailure` when the cluster id transitions.
+///
+/// Inputs:
+/// - `previous_cluster_id`: the `failure_cluster_id` from the prior
+///   `SemanticRepairPlan`. `None` means "no prior cluster was tracked"
+///   (e.g. legacy path that built no semantic plan).
+/// - `current_cluster_id`: the `failure_cluster_id` from the newly built
+///   `SemanticRepairPlan`. `None` means "no current cluster is tracked".
+/// - `base_outcome`: the verdict returned by
+///   `verifier_repair_rerun_outcome` for the same rerun (the legacy
+///   failure_count comparison stays the SSOT).
+///
+/// Returns `base_outcome` unchanged unless both sides are `Some(...)` and
+/// the cluster ids differ — then returns `NewFailure`.
+#[allow(dead_code)] // wired into turn.rs by a subsequent task; exercised here via unit tests.
+pub(super) fn rerun_outcome_with_cluster(
+    previous_cluster_id: Option<&FailureClusterKey>,
+    current_cluster_id: Option<&FailureClusterKey>,
+    base_outcome: VerifierRepairRerunOutcome,
+) -> VerifierRepairRerunOutcome {
+    match (previous_cluster_id, current_cluster_id) {
+        (Some(prev), Some(curr)) if prev != curr => VerifierRepairRerunOutcome::NewFailure,
+        _ => base_outcome,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -690,5 +854,367 @@ mod tests {
             ..a.clone()
         };
         assert_ne!(a, c);
+    }
+
+    // ---- Issue #647 (Phase E): cluster-based sequential repair ---- //
+
+    /// Helper: build a `SemanticFailureReport` with N distinct clusters by
+    /// varying the `observed` text with words that survive the
+    /// shape-normalization pass (no numeric / quoted / path / long-token
+    /// runs). Up to four clusters supported by the canned labels —
+    /// callers MUST keep `cluster_count <= 4`.
+    #[cfg(test)]
+    fn multi_cluster_report_fixture(
+        kind: VerifierDiagnosticFailureKind,
+        cluster_count: usize,
+    ) -> super::super::semantic_failure::SemanticFailureReport {
+        // Distinct word labels — bare alphabetics survive `normalize_to_shape`
+        // (no `<num>` / `<token>` / `<str>` collapse) so each cluster gets a
+        // unique `cluster_key`.
+        const LABELS: &[(&str, &str, &str, &str)] = &[
+            ("alpha", "ALPHA", "alphashape", "alphacase"),
+            ("beta", "BETA", "betashape", "betacase"),
+            ("gamma", "GAMMA", "gammashape", "gammacase"),
+            ("delta", "DELTA", "deltashape", "deltacase"),
+        ];
+        assert!(
+            cluster_count <= LABELS.len(),
+            "multi_cluster_report_fixture supports up to {} clusters",
+            LABELS.len()
+        );
+        let clusters: Vec<serde_json::Value> = LABELS
+            .iter()
+            .take(cluster_count)
+            .map(|(obs, exp, shape, case)| {
+                serde_json::json!({
+                    "observed": obs,
+                    "expected": exp,
+                    "input_shape": shape,
+                    "assertion_shape": "AssertEq",
+                    "involved_artifacts": ["implementation", "test"],
+                    "affected_cases": [case],
+                })
+            })
+            .collect();
+        let json = serde_json::json!({
+            "failure_kind": kind_label(kind),
+            "confidence": 0.8,
+            "preferred_repair_role": "implementation",
+            "repair_hypothesis": "multi-cluster hypothesis",
+            "failure_clusters": clusters,
+        });
+        super::super::semantic_failure::parse_semantic_failure_report(&json)
+            .expect("multi-cluster fixture parses")
+    }
+
+    /// Build a fresh `RepairJob` whose `semantic_plan` slot targets the
+    /// first cluster of `report`. Mirrors what Phase D writes during
+    /// `run_verifier_diagnostic_pass`.
+    #[cfg(test)]
+    fn job_with_first_cluster_plan(
+        report: &super::super::semantic_failure::SemanticFailureReport,
+    ) -> RepairJob {
+        let first = &report.failure_clusters[0];
+        let plan = SemanticRepairPlan {
+            semantic_report: report.clone(),
+            failure_cluster_id: first.cluster_key.clone(),
+            semantic_cause: report.failure_kind,
+            spec_authority: SpecAuthority::ImplementationContract,
+            preferred_repair_role: report.preferred_repair_role,
+            repair_hypothesis: report.repair_hypothesis.clone(),
+            expected_improvement: None,
+        };
+        RepairJob {
+            semantic_plan: Some(plan),
+            ..RepairJob::new_for_test()
+        }
+    }
+
+    /// Phase E.1 (S1-015): three-cluster sequential repair.
+    ///
+    /// Calling `advance_to_next_cluster` twice walks the slot from
+    /// cluster 1 → cluster 2 → cluster 3 deterministically, in the
+    /// document order returned by the diagnostic LLM.
+    #[test]
+    fn phase_e_advance_to_next_cluster_walks_three_clusters_in_order() {
+        let report =
+            multi_cluster_report_fixture(VerifierDiagnosticFailureKind::AssertionMismatch, 3);
+        let cluster_ids: Vec<_> = report
+            .failure_clusters
+            .iter()
+            .map(|c| c.cluster_key.clone())
+            .collect();
+        // Sanity check: three *distinct* cluster keys (shape varies per cluster).
+        assert_eq!(cluster_ids.len(), 3);
+        assert_ne!(cluster_ids[0], cluster_ids[1]);
+        assert_ne!(cluster_ids[1], cluster_ids[2]);
+        assert_ne!(cluster_ids[0], cluster_ids[2]);
+
+        let mut job = job_with_first_cluster_plan(&report);
+        // Initial slot: cluster 1.
+        assert_eq!(
+            job.semantic_plan.as_ref().unwrap().failure_cluster_id,
+            cluster_ids[0]
+        );
+
+        // First advance: cluster 1 → cluster 2.
+        assert!(advance_to_next_cluster(&mut job, &report));
+        assert_eq!(
+            job.semantic_plan.as_ref().unwrap().failure_cluster_id,
+            cluster_ids[1]
+        );
+
+        // Second advance: cluster 2 → cluster 3.
+        assert!(advance_to_next_cluster(&mut job, &report));
+        assert_eq!(
+            job.semantic_plan.as_ref().unwrap().failure_cluster_id,
+            cluster_ids[2]
+        );
+
+        // Third advance: no more clusters — slot cleared, return false.
+        assert!(!advance_to_next_cluster(&mut job, &report));
+        assert!(job.semantic_plan.is_none());
+    }
+
+    /// Phase E.1 / S3-010: `exhausted_attempts` accumulates across slot
+    /// reuse — each advance adds the prior `(cluster_id, role)` pair and
+    /// the ledger survives slot replacement.
+    #[test]
+    fn phase_e_exhausted_attempts_ledger_preserved_across_slot_reuse() {
+        let report =
+            multi_cluster_report_fixture(VerifierDiagnosticFailureKind::AssertionMismatch, 3);
+        let cluster_ids: Vec<_> = report
+            .failure_clusters
+            .iter()
+            .map(|c| c.cluster_key.clone())
+            .collect();
+        let role = report.preferred_repair_role;
+
+        let mut job = job_with_first_cluster_plan(&report);
+        assert!(job.exhausted_attempts.is_empty());
+
+        // Advance 1: cluster 1 → cluster 2; ledger now holds cluster 1.
+        assert!(advance_to_next_cluster(&mut job, &report));
+        assert_eq!(job.exhausted_attempts.len(), 1);
+        assert_eq!(job.exhausted_attempts[0], (cluster_ids[0].clone(), role));
+        // Slot now targets cluster 2.
+        assert_eq!(
+            job.semantic_plan.as_ref().unwrap().failure_cluster_id,
+            cluster_ids[1]
+        );
+
+        // Advance 2: cluster 2 → cluster 3; ledger preserves cluster 1.
+        assert!(advance_to_next_cluster(&mut job, &report));
+        assert_eq!(job.exhausted_attempts.len(), 2);
+        assert_eq!(job.exhausted_attempts[0], (cluster_ids[0].clone(), role));
+        assert_eq!(job.exhausted_attempts[1], (cluster_ids[1].clone(), role));
+        // Slot now targets cluster 3.
+        assert_eq!(
+            job.semantic_plan.as_ref().unwrap().failure_cluster_id,
+            cluster_ids[2]
+        );
+
+        // Advance 3: no more clusters; slot cleared, ledger still holds
+        // both 1 and 2 (the cluster 3 attempt is recorded too because we
+        // pushed it before searching).
+        assert!(!advance_to_next_cluster(&mut job, &report));
+        assert!(job.semantic_plan.is_none());
+        assert_eq!(job.exhausted_attempts.len(), 3);
+        assert_eq!(job.exhausted_attempts[2], (cluster_ids[2].clone(), role));
+    }
+
+    /// Phase E.1: `advance_to_next_cluster` is idempotent on the ledger —
+    /// calling it again after the slot is cleared does not append a
+    /// duplicate `(cluster_id, role)` entry.
+    #[test]
+    fn phase_e_advance_to_next_cluster_is_idempotent_when_no_plan_present() {
+        let report =
+            multi_cluster_report_fixture(VerifierDiagnosticFailureKind::AssertionMismatch, 1);
+        let mut job = job_with_first_cluster_plan(&report);
+
+        // First call: no other clusters → slot cleared, false returned.
+        assert!(!advance_to_next_cluster(&mut job, &report));
+        let after_first_len = job.exhausted_attempts.len();
+        assert_eq!(after_first_len, 1);
+
+        // Second call: semantic_plan is None, so no new ledger entry.
+        assert!(!advance_to_next_cluster(&mut job, &report));
+        assert_eq!(job.exhausted_attempts.len(), after_first_len);
+    }
+
+    /// Phase E.2 (S1-008): same `(cluster_id, role)` re-attempted →
+    /// `should_re_diagnostic` flips to `true` so the caller switches to
+    /// the re-diagnostic path instead of repeating the same attack.
+    #[test]
+    fn phase_e_should_re_diagnostic_true_when_current_plan_already_exhausted() {
+        let report =
+            multi_cluster_report_fixture(VerifierDiagnosticFailureKind::AssertionMismatch, 2);
+        let cluster_ids: Vec<_> = report
+            .failure_clusters
+            .iter()
+            .map(|c| c.cluster_key.clone())
+            .collect();
+        let role = report.preferred_repair_role;
+
+        // Build a job where exhausted_attempts already contains the first
+        // cluster, and the active plan still targets the first cluster
+        // (simulates "we tried cluster 1, the diagnostic LLM re-proposed
+        // the same cluster on retry").
+        let plan = SemanticRepairPlan {
+            semantic_report: report.clone(),
+            failure_cluster_id: cluster_ids[0].clone(),
+            semantic_cause: report.failure_kind,
+            spec_authority: SpecAuthority::ImplementationContract,
+            preferred_repair_role: role,
+            repair_hypothesis: report.repair_hypothesis.clone(),
+            expected_improvement: None,
+        };
+        let job = RepairJob {
+            semantic_plan: Some(plan),
+            exhausted_attempts: vec![(cluster_ids[0].clone(), role)],
+            ..RepairJob::new_for_test()
+        };
+        assert!(should_re_diagnostic(&job));
+
+        // Different cluster targeted → not yet exhausted → false.
+        let plan2 = SemanticRepairPlan {
+            semantic_report: report.clone(),
+            failure_cluster_id: cluster_ids[1].clone(),
+            semantic_cause: report.failure_kind,
+            spec_authority: SpecAuthority::ImplementationContract,
+            preferred_repair_role: role,
+            repair_hypothesis: report.repair_hypothesis.clone(),
+            expected_improvement: None,
+        };
+        let job2 = RepairJob {
+            semantic_plan: Some(plan2),
+            exhausted_attempts: vec![(cluster_ids[0].clone(), role)],
+            ..RepairJob::new_for_test()
+        };
+        assert!(!should_re_diagnostic(&job2));
+    }
+
+    /// Phase E.2: `should_re_diagnostic` returns `false` when no plan is
+    /// active (legacy fallback / SetupRepair dispatch path).
+    #[test]
+    fn phase_e_should_re_diagnostic_false_when_no_plan_present() {
+        let job = RepairJob::new_for_test();
+        assert!(!should_re_diagnostic(&job));
+    }
+
+    /// Phase E.3 (S3-014): cluster id unchanged → `rerun_outcome_with_cluster`
+    /// returns the base outcome verbatim. The legacy failure_count-based
+    /// outcome remains the SSOT.
+    #[test]
+    fn phase_e_rerun_outcome_unchanged_when_cluster_id_stable() {
+        let report =
+            multi_cluster_report_fixture(VerifierDiagnosticFailureKind::AssertionMismatch, 2);
+        let cluster_a = report.failure_clusters[0].cluster_key.clone();
+
+        // Both sides Some, same id → base outcome wins.
+        for base in [
+            VerifierRepairRerunOutcome::Improved,
+            VerifierRepairRerunOutcome::SameFailureRemaining,
+            VerifierRepairRerunOutcome::NewFailure,
+            VerifierRepairRerunOutcome::Worsened,
+        ] {
+            assert_eq!(
+                rerun_outcome_with_cluster(Some(&cluster_a), Some(&cluster_a), base),
+                base,
+                "stable cluster id must keep base outcome verbatim",
+            );
+        }
+
+        // None on either side → base outcome wins (legacy fallback).
+        assert_eq!(
+            rerun_outcome_with_cluster(
+                None,
+                Some(&cluster_a),
+                VerifierRepairRerunOutcome::Improved
+            ),
+            VerifierRepairRerunOutcome::Improved,
+        );
+        assert_eq!(
+            rerun_outcome_with_cluster(
+                Some(&cluster_a),
+                None,
+                VerifierRepairRerunOutcome::SameFailureRemaining
+            ),
+            VerifierRepairRerunOutcome::SameFailureRemaining,
+        );
+        assert_eq!(
+            rerun_outcome_with_cluster(None, None, VerifierRepairRerunOutcome::NewFailure),
+            VerifierRepairRerunOutcome::NewFailure,
+        );
+    }
+
+    /// Phase E.3 (S3-014): cluster id transitioned → outcome upgraded to
+    /// `NewFailure` regardless of the base outcome. This catches the case
+    /// where failure_count stayed the same but a different cluster is now
+    /// failing — failure_count alone would mis-report `SameFailureRemaining`.
+    #[test]
+    fn phase_e_rerun_outcome_promoted_to_new_failure_on_cluster_id_change() {
+        let report =
+            multi_cluster_report_fixture(VerifierDiagnosticFailureKind::AssertionMismatch, 2);
+        let cluster_a = report.failure_clusters[0].cluster_key.clone();
+        let cluster_b = report.failure_clusters[1].cluster_key.clone();
+        assert_ne!(cluster_a, cluster_b);
+
+        for base in [
+            VerifierRepairRerunOutcome::Improved,
+            VerifierRepairRerunOutcome::SameFailureRemaining,
+            VerifierRepairRerunOutcome::NewFailure,
+            VerifierRepairRerunOutcome::Worsened,
+        ] {
+            assert_eq!(
+                rerun_outcome_with_cluster(Some(&cluster_a), Some(&cluster_b), base),
+                VerifierRepairRerunOutcome::NewFailure,
+                "cluster id transition must promote to NewFailure (base={base:?})",
+            );
+        }
+    }
+
+    /// Phase E.4 (S7-005): three-cluster sequential repair stays inside
+    /// the existing retry budgets.
+    ///
+    /// `advance_to_next_cluster` does not touch `assessment_attempts` /
+    /// `repair_attempt` (those are bumped by the legacy diagnostic /
+    /// repair-pass machinery in `turn.rs`), so walking three clusters
+    /// in a single turn does not consume `TASK_CONTRACT_VERIFIER_ATTEMPT_LIMIT`
+    /// (= 3) or `TASK_CONTRACT_VERIFIER_REPAIR_ATTEMPT_LIMIT` (= 6) early.
+    #[test]
+    fn phase_e_three_cluster_sequential_repair_does_not_consume_retry_budget() {
+        // The constants the test references — keep this assertion in sync
+        // with `turn.rs` so a future limit change is caught here.
+        const TASK_CONTRACT_VERIFIER_ATTEMPT_LIMIT: usize = 3;
+        const TASK_CONTRACT_VERIFIER_REPAIR_ATTEMPT_LIMIT: usize = 6;
+
+        let report =
+            multi_cluster_report_fixture(VerifierDiagnosticFailureKind::AssertionMismatch, 3);
+        let mut job = job_with_first_cluster_plan(&report);
+
+        // Walk all three clusters via the Phase-E helper.
+        assert!(advance_to_next_cluster(&mut job, &report)); // 1 → 2
+        assert!(advance_to_next_cluster(&mut job, &report)); // 2 → 3
+        // Third advance: no more clusters.
+        assert!(!advance_to_next_cluster(&mut job, &report));
+
+        // The Phase-E slot reuse path must not touch the legacy retry
+        // counters — they remain at their fresh-job defaults so the
+        // existing `TASK_CONTRACT_VERIFIER_*_ATTEMPT_LIMIT` budgets are
+        // fully available for downstream `turn.rs` dispatch.
+        assert_eq!(job.assessment_attempts, 0);
+        assert_eq!(job.repair_attempt, 0);
+        assert!(
+            job.assessment_attempts < TASK_CONTRACT_VERIFIER_ATTEMPT_LIMIT,
+            "assessment_attempts must stay under TASK_CONTRACT_VERIFIER_ATTEMPT_LIMIT",
+        );
+        assert!(
+            job.repair_attempt < TASK_CONTRACT_VERIFIER_REPAIR_ATTEMPT_LIMIT,
+            "repair_attempt must stay under TASK_CONTRACT_VERIFIER_REPAIR_ATTEMPT_LIMIT",
+        );
+        // The ledger does grow per advance — but it's an O(N_clusters)
+        // bounded list, not a retry counter.
+        assert_eq!(job.exhausted_attempts.len(), 3);
     }
 }

--- a/src/agent/loop_run/repair_job.rs
+++ b/src/agent/loop_run/repair_job.rs
@@ -614,6 +614,48 @@ pub(super) fn task_contract_repair_state(
 // entry) so linear `contains` is fine — total entries are bounded by
 // `failure_clusters.len() * artifact roles in scope`.
 
+/// Issue #647 (CB-016): semantic distinction between "advance because the
+/// rerun showed no progress and we should walk to the next cluster with
+/// the same (now stale) assessment" vs "advance because a fresh
+/// diagnostic re-proposed an already-exhausted cluster and we skip to
+/// the next one with the fresh assessment in hand".
+///
+/// The two triggers differ in how the new plan's
+/// `assessment_generation_at_creation` is stamped:
+///   - `RerunNoProgress`: stamp with `job.assessment_generation` (same gen,
+///     stale plan; the controller will route through CB-012/CB-014 for a
+///     fresh diagnostic).
+///   - `DiagnosticSkip`: stamp with
+///     `job.assessment_generation.saturating_sub(1)` (one generation older
+///     than current → fresh plan; the controller proceeds to the
+///     cluster-B repair pass).
+///
+/// Without this distinction (V8 posture), both call sites stamped the
+/// post-bump `job.assessment_generation`, which made the
+/// `DiagnosticSkip` path look stale even though the caller had just
+/// landed a fresh diagnostic and the assessment in `job.assessment` was
+/// already current. The result was a livelock between
+/// `assign_semantic_plan_preserving_exhausted` advancing to cluster B
+/// and `verifier_repair_decision` immediately routing back to
+/// `NeedDiagnostic` (because `plan.gen == job.gen` looked stale).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum AdvanceTrigger {
+    /// Verifier rerun produced no progress; advance with the still-stale
+    /// assessment. The new plan's
+    /// `assessment_generation_at_creation` equals the current
+    /// `job.assessment_generation`, so the plan looks stale to
+    /// CB-007/CB-012/CB-014 and the controller will run a fresh
+    /// diagnostic before proceeding.
+    RerunNoProgress,
+    /// A fresh diagnostic re-proposed an exhausted cluster; skip to the
+    /// next cluster with the fresh assessment. The new plan's
+    /// `assessment_generation_at_creation` is one generation older than
+    /// the current `job.assessment_generation`, so the plan is fresh
+    /// and the controller proceeds directly to the cluster-B repair
+    /// pass without re-running the diagnostic.
+    DiagnosticSkip,
+}
+
 /// Issue #647 (Phase E.1): advance the `repair_job.semantic_plan` slot to
 /// the next unattempted cluster from `report.failure_clusters`.
 ///
@@ -646,6 +688,9 @@ pub(super) fn task_contract_repair_state(
 /// (initial fixture / defensive path), we still fall back to the
 /// `ImplementationContract` default so the helper remains total.
 ///
+/// `trigger` (Issue #647 CB-016) controls how the new plan's
+/// `assessment_generation_at_creation` is stamped — see `AdvanceTrigger`.
+///
 /// Returns `false` (and clears `semantic_plan`) when the report has no
 /// remaining clusters; callers MUST treat that as "no more clusters to
 /// attack in this report" and switch back to `re_diagnostic`.
@@ -653,6 +698,7 @@ pub(super) fn task_contract_repair_state(
 pub(super) fn advance_to_next_cluster(
     repair_job: &mut RepairJob,
     report: &SemanticFailureReport,
+    trigger: AdvanceTrigger,
 ) -> bool {
     // 1. Record the current plan in the exhausted_attempts ledger before
     //    we drop it, so slot reuse preserves history (S3-010). At the same
@@ -690,16 +736,33 @@ pub(super) fn advance_to_next_cluster(
     //    uses when no higher-authority signal fires.
     let spec_authority = carried_authority.unwrap_or(SpecAuthority::ImplementationContract);
 
-    // Issue #647 (CB-015): the new plan's generation snapshot is set to
-    // the **current** `RepairJob.assessment_generation`. This intentionally
-    // creates a "stale" state immediately after a cluster advance:
-    // `plan.assessment_generation_at_creation == job.assessment_generation`
-    // → `semantic_plan_is_stale` returns `true` → CB-007/CB-012 force a
-    // re-diagnostic against the new cluster. Once that re-diagnostic
-    // increments `RepairJob.assessment_generation`, the comparison
-    // flips and the controller proceeds to repair the freshly-diagnosed
-    // cluster (the liveness gap CB-015 closes).
-    let assessment_generation_at_creation = repair_job.assessment_generation;
+    // Issue #647 (CB-015 / CB-016): the new plan's generation snapshot is
+    // chosen by `trigger`:
+    //
+    //   * `AdvanceTrigger::RerunNoProgress` — stamp with the **current**
+    //     `RepairJob.assessment_generation` (CB-015 default). This
+    //     intentionally creates a "stale" state immediately after a
+    //     cluster advance:
+    //     `plan.assessment_generation_at_creation == job.assessment_generation`
+    //     → `semantic_plan_is_stale` returns `true` → CB-007/CB-012 force
+    //     a re-diagnostic against the new cluster. Once that re-diagnostic
+    //     increments `RepairJob.assessment_generation`, the comparison
+    //     flips and the controller proceeds to repair the freshly-diagnosed
+    //     cluster (the liveness gap CB-015 closes).
+    //   * `AdvanceTrigger::DiagnosticSkip` — stamp with
+    //     `repair_job.assessment_generation.saturating_sub(1)`. The caller
+    //     has just landed a fresh diagnostic (post-bump
+    //     `job.assessment_generation`) and is only walking past an
+    //     already-exhausted cluster proposed by the LLM. The fresh
+    //     assessment in `job.assessment` already corresponds to the
+    //     new cluster, so the new plan must look **fresh**
+    //     (`plan.gen < job.gen`) — that lets CB-012 step out of the way
+    //     and the controller routes directly to `NeedFreshRead` /
+    //     `NeedEdit`.
+    let assessment_generation_at_creation = match trigger {
+        AdvanceTrigger::RerunNoProgress => repair_job.assessment_generation,
+        AdvanceTrigger::DiagnosticSkip => repair_job.assessment_generation.saturating_sub(1),
+    };
     repair_job.semantic_plan = Some(SemanticRepairPlan {
         semantic_cause: report.failure_kind,
         spec_authority,
@@ -797,7 +860,12 @@ pub(super) fn apply_semantic_repair_dispatch_after_rerun(
         return;
     };
 
-    let advanced = advance_to_next_cluster(repair_job, &report);
+    // CB-016: dispatch-after-rerun is the `RerunNoProgress` semantic — the
+    // verifier rerun returned no progress and we are walking to the next
+    // cluster with the still-stale assessment. The new plan must look stale
+    // so the controller routes through CB-012/CB-014 for a fresh
+    // diagnostic before attempting the next repair pass.
+    let advanced = advance_to_next_cluster(repair_job, &report, AdvanceTrigger::RerunNoProgress);
 
     if advanced {
         // Cluster transition → upgrade the outcome via the SSOT wrapper.
@@ -890,7 +958,13 @@ pub(super) fn assign_semantic_plan_preserving_exhausted(
     // report (it travels with the plan); fall back to the caller-supplied
     // `new_report` only if the caller explicitly passes a different one.
     let report = new_report.cloned().unwrap_or(embedded_report);
-    advance_to_next_cluster(repair_job, &report);
+    // CB-016: this path is the `DiagnosticSkip` semantic — a freshly-built
+    // plan from the diagnostic LLM targets an already-exhausted cluster,
+    // so we skip ahead with the **fresh** assessment in hand. The new
+    // plan must look fresh (plan.gen < job.gen) so the controller does
+    // NOT route back to `NeedDiagnostic` (which would be a livelock —
+    // we have already produced a fresh diagnostic this turn).
+    advance_to_next_cluster(repair_job, &report, AdvanceTrigger::DiagnosticSkip);
     // `advance_to_next_cluster` already mutates `semantic_plan`
     // (either to the next unexhausted cluster or to `None`) and updates the
     // ledger — no further bookkeeping required here.
@@ -1269,21 +1343,33 @@ mod tests {
         );
 
         // First advance: cluster 1 → cluster 2.
-        assert!(advance_to_next_cluster(&mut job, &report));
+        assert!(advance_to_next_cluster(
+            &mut job,
+            &report,
+            AdvanceTrigger::RerunNoProgress
+        ));
         assert_eq!(
             job.semantic_plan.as_ref().unwrap().failure_cluster_id,
             cluster_ids[1]
         );
 
         // Second advance: cluster 2 → cluster 3.
-        assert!(advance_to_next_cluster(&mut job, &report));
+        assert!(advance_to_next_cluster(
+            &mut job,
+            &report,
+            AdvanceTrigger::RerunNoProgress
+        ));
         assert_eq!(
             job.semantic_plan.as_ref().unwrap().failure_cluster_id,
             cluster_ids[2]
         );
 
         // Third advance: no more clusters — slot cleared, return false.
-        assert!(!advance_to_next_cluster(&mut job, &report));
+        assert!(!advance_to_next_cluster(
+            &mut job,
+            &report,
+            AdvanceTrigger::RerunNoProgress
+        ));
         assert!(job.semantic_plan.is_none());
     }
 
@@ -1305,7 +1391,11 @@ mod tests {
         assert!(job.exhausted_attempts.is_empty());
 
         // Advance 1: cluster 1 → cluster 2; ledger now holds cluster 1.
-        assert!(advance_to_next_cluster(&mut job, &report));
+        assert!(advance_to_next_cluster(
+            &mut job,
+            &report,
+            AdvanceTrigger::RerunNoProgress
+        ));
         assert_eq!(job.exhausted_attempts.len(), 1);
         assert_eq!(job.exhausted_attempts[0], (cluster_ids[0].clone(), role));
         // Slot now targets cluster 2.
@@ -1315,7 +1405,11 @@ mod tests {
         );
 
         // Advance 2: cluster 2 → cluster 3; ledger preserves cluster 1.
-        assert!(advance_to_next_cluster(&mut job, &report));
+        assert!(advance_to_next_cluster(
+            &mut job,
+            &report,
+            AdvanceTrigger::RerunNoProgress
+        ));
         assert_eq!(job.exhausted_attempts.len(), 2);
         assert_eq!(job.exhausted_attempts[0], (cluster_ids[0].clone(), role));
         assert_eq!(job.exhausted_attempts[1], (cluster_ids[1].clone(), role));
@@ -1328,7 +1422,11 @@ mod tests {
         // Advance 3: no more clusters; slot cleared, ledger still holds
         // both 1 and 2 (the cluster 3 attempt is recorded too because we
         // pushed it before searching).
-        assert!(!advance_to_next_cluster(&mut job, &report));
+        assert!(!advance_to_next_cluster(
+            &mut job,
+            &report,
+            AdvanceTrigger::RerunNoProgress
+        ));
         assert!(job.semantic_plan.is_none());
         assert_eq!(job.exhausted_attempts.len(), 3);
         assert_eq!(job.exhausted_attempts[2], (cluster_ids[2].clone(), role));
@@ -1344,12 +1442,20 @@ mod tests {
         let mut job = job_with_first_cluster_plan(&report);
 
         // First call: no other clusters → slot cleared, false returned.
-        assert!(!advance_to_next_cluster(&mut job, &report));
+        assert!(!advance_to_next_cluster(
+            &mut job,
+            &report,
+            AdvanceTrigger::RerunNoProgress
+        ));
         let after_first_len = job.exhausted_attempts.len();
         assert_eq!(after_first_len, 1);
 
         // Second call: semantic_plan is None, so no new ledger entry.
-        assert!(!advance_to_next_cluster(&mut job, &report));
+        assert!(!advance_to_next_cluster(
+            &mut job,
+            &report,
+            AdvanceTrigger::RerunNoProgress
+        ));
         assert_eq!(job.exhausted_attempts.len(), after_first_len);
     }
 
@@ -1507,10 +1613,22 @@ mod tests {
         let mut job = job_with_first_cluster_plan(&report);
 
         // Walk all three clusters via the Phase-E helper.
-        assert!(advance_to_next_cluster(&mut job, &report)); // 1 → 2
-        assert!(advance_to_next_cluster(&mut job, &report)); // 2 → 3
+        assert!(advance_to_next_cluster(
+            &mut job,
+            &report,
+            AdvanceTrigger::RerunNoProgress
+        )); // 1 → 2
+        assert!(advance_to_next_cluster(
+            &mut job,
+            &report,
+            AdvanceTrigger::RerunNoProgress
+        )); // 2 → 3
         // Third advance: no more clusters.
-        assert!(!advance_to_next_cluster(&mut job, &report));
+        assert!(!advance_to_next_cluster(
+            &mut job,
+            &report,
+            AdvanceTrigger::RerunNoProgress
+        ));
 
         // The Phase-E slot reuse path must not touch the legacy retry
         // counters — they remain at their fresh-job defaults so the
@@ -2126,7 +2244,11 @@ mod tests {
             ..RepairJob::new_for_test()
         };
 
-        assert!(advance_to_next_cluster(&mut job, &report));
+        assert!(advance_to_next_cluster(
+            &mut job,
+            &report,
+            AdvanceTrigger::RerunNoProgress
+        ));
 
         let advanced = job.semantic_plan.as_ref().expect("slot now holds plan B");
         assert_eq!(
@@ -2170,7 +2292,11 @@ mod tests {
             ..RepairJob::new_for_test()
         };
 
-        assert!(advance_to_next_cluster(&mut job, &report));
+        assert!(advance_to_next_cluster(
+            &mut job,
+            &report,
+            AdvanceTrigger::RerunNoProgress
+        ));
 
         let advanced = job.semantic_plan.as_ref().expect("slot now holds plan B");
         assert_eq!(advanced.failure_cluster_id, cluster_ids[1]);
@@ -2217,7 +2343,11 @@ mod tests {
         };
 
         // First advance: A → B. Authority must remain BehaviorContract.
-        assert!(advance_to_next_cluster(&mut job, &report));
+        assert!(advance_to_next_cluster(
+            &mut job,
+            &report,
+            AdvanceTrigger::RerunNoProgress
+        ));
         assert_eq!(
             job.semantic_plan.as_ref().unwrap().failure_cluster_id,
             cluster_ids[1],
@@ -2230,7 +2360,11 @@ mod tests {
 
         // Second advance: B → C. Authority must STILL remain BehaviorContract
         // (carry-forward survives chained slot reuse).
-        assert!(advance_to_next_cluster(&mut job, &report));
+        assert!(advance_to_next_cluster(
+            &mut job,
+            &report,
+            AdvanceTrigger::RerunNoProgress
+        ));
         assert_eq!(
             job.semantic_plan.as_ref().unwrap().failure_cluster_id,
             cluster_ids[2],
@@ -2468,7 +2602,11 @@ mod tests {
         // `assessment_generation_at_creation = job.assessment_generation = 1`
         // AND cluster A is pushed onto `exhausted_attempts`. The stale
         // predicate must fire.
-        assert!(advance_to_next_cluster(&mut job, &report));
+        assert!(advance_to_next_cluster(
+            &mut job,
+            &report,
+            AdvanceTrigger::RerunNoProgress
+        ));
         assert!(
             semantic_plan_is_stale(&job),
             "CB-015: post-advance, plan.gen == job.gen and exhausted non-empty → stale must be true",
@@ -2496,7 +2634,11 @@ mod tests {
         let mut job = job_with_first_cluster_plan(&report);
         job.assessment_generation = 1;
         // Advance to cluster B → stale precondition.
-        assert!(advance_to_next_cluster(&mut job, &report));
+        assert!(advance_to_next_cluster(
+            &mut job,
+            &report,
+            AdvanceTrigger::RerunNoProgress
+        ));
         assert!(semantic_plan_is_stale(&job));
 
         // Simulate `run_verifier_diagnostic_pass` writing a new assessment:
@@ -2672,6 +2814,300 @@ mod tests {
         let mut bumped = job.clone();
         bumped.assessment_generation = 8;
         assert_ne!(job, bumped);
+    }
+
+    // ---- Issue #647 (CB-016): AdvanceTrigger semantic distinction ---- //
+
+    /// CB-016 (helper unit): from the same initial job, `DiagnosticSkip`
+    /// stamps the new plan one generation behind the current job, while
+    /// `RerunNoProgress` stamps it equal to the current job — yielding a
+    /// stale plan for the latter and a fresh plan for the former.
+    #[test]
+    fn cb016_advance_trigger_stamps_correct_generation() {
+        let report =
+            multi_cluster_report_fixture(VerifierDiagnosticFailureKind::AssertionMismatch, 2);
+
+        // Use job.assessment_generation = 2 so we can distinguish the two
+        // stamps unambiguously (saturating_sub(1) yields 1, not the same
+        // value as the RerunNoProgress branch).
+        let mut job_rerun = job_with_first_cluster_plan(&report);
+        job_rerun.assessment_generation = 2;
+        assert!(advance_to_next_cluster(
+            &mut job_rerun,
+            &report,
+            AdvanceTrigger::RerunNoProgress,
+        ));
+        let rerun_plan = job_rerun.semantic_plan.as_ref().expect("rerun advanced");
+        assert_eq!(
+            rerun_plan.assessment_generation_at_creation, 2,
+            "RerunNoProgress must stamp plan.gen = job.gen (stale post-advance)",
+        );
+        assert!(
+            semantic_plan_is_stale(&job_rerun),
+            "RerunNoProgress post-advance must produce a stale plan",
+        );
+
+        let mut job_skip = job_with_first_cluster_plan(&report);
+        job_skip.assessment_generation = 2;
+        assert!(advance_to_next_cluster(
+            &mut job_skip,
+            &report,
+            AdvanceTrigger::DiagnosticSkip,
+        ));
+        let skip_plan = job_skip.semantic_plan.as_ref().expect("skip advanced");
+        assert_eq!(
+            skip_plan.assessment_generation_at_creation, 1,
+            "DiagnosticSkip must stamp plan.gen = job.gen - 1 (fresh post-advance)",
+        );
+        assert!(
+            !semantic_plan_is_stale(&job_skip),
+            "DiagnosticSkip post-advance must produce a fresh plan",
+        );
+    }
+
+    /// CB-016 (boundary): when `job.assessment_generation == 0`,
+    /// `DiagnosticSkip` saturates at 0 instead of underflowing. The plan
+    /// is then equal to the job (not less than), so the stale predicate
+    /// fires the same way as `RerunNoProgress` — defensive posture for a
+    /// caller that wires the new trigger in before the first
+    /// re-diagnostic bump has happened.
+    #[test]
+    fn cb016_diagnostic_skip_saturates_at_zero_generation() {
+        let report =
+            multi_cluster_report_fixture(VerifierDiagnosticFailureKind::AssertionMismatch, 2);
+        let mut job = job_with_first_cluster_plan(&report);
+        // job.assessment_generation defaults to 0 (RepairJob::new_for_test).
+        assert_eq!(job.assessment_generation, 0);
+
+        assert!(advance_to_next_cluster(
+            &mut job,
+            &report,
+            AdvanceTrigger::DiagnosticSkip,
+        ));
+        let plan = job.semantic_plan.as_ref().expect("advanced");
+        assert_eq!(
+            plan.assessment_generation_at_creation, 0,
+            "DiagnosticSkip with job.gen=0 must saturate at 0 (no underflow)",
+        );
+    }
+
+    /// CB-016.1 (production integration scenario): `assign_semantic_plan_preserving_exhausted`
+    /// is the `DiagnosticSkip` callsite. When a fresh diagnostic
+    /// re-proposes an already-exhausted cluster, the helper walks to the
+    /// next unexhausted cluster — and the new plan must look **fresh**
+    /// (plan.gen < job.gen) so the controller does NOT route back to
+    /// `NeedDiagnostic`. That would be a livelock: we just finished a
+    /// fresh diagnostic, and routing back would consume the diagnostic
+    /// budget for nothing.
+    #[test]
+    fn cb016_diagnostic_skip_advance_produces_fresh_plan() {
+        use tempfile::tempdir;
+        let temp = tempdir().unwrap();
+        let work_root = temp.path().to_path_buf();
+
+        let report =
+            multi_cluster_report_fixture(VerifierDiagnosticFailureKind::AssertionMismatch, 2);
+        let cluster_ids: Vec<_> = report
+            .failure_clusters
+            .iter()
+            .map(|c| c.cluster_key.clone())
+            .collect();
+        let role = report.preferred_repair_role;
+
+        // The work_root needs a file for `verifier_repair_context_target_path`
+        // / `latest_successful_read_existing_path` to resolve to it; we
+        // construct one matching the fresh repair_target_hint we will set
+        // on the assessment below. The essential CB-016.1 invariant is
+        // that the decision is NOT `NeedDiagnostic` / `DiagnosticUnavailable`
+        // post-advance.
+        let fresh_target = "app/cluster_b.py";
+        let fresh_target_path = work_root.join(fresh_target);
+        if let Some(parent) = fresh_target_path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(&fresh_target_path, "# fresh cluster B target\n").unwrap();
+
+        // Job posture: cluster A exhausted (verifier rerun no-progress
+        // pushed it onto the ledger and walked to cluster B on a prior
+        // turn). The fresh diagnostic just ran and bumped the assessment
+        // generation to 2. The assessment now corresponds to the freshly
+        // diagnosed (still) cluster A — the LLM re-proposed it.
+        let fresh_hint = super::super::task_contract::RecoveryTargetHint {
+            role: super::super::task_contract::ArtifactRole::Implementation,
+            path: fresh_target.to_string(),
+            reason: "fresh diagnostic re-proposed cluster A".to_string(),
+        };
+        let plan_b_before = SemanticRepairPlan {
+            semantic_report: report.clone(),
+            failure_cluster_id: cluster_ids[1].clone(),
+            semantic_cause: report.failure_kind,
+            spec_authority: SpecAuthority::ImplementationContract,
+            preferred_repair_role: role,
+            repair_hypothesis: report.repair_hypothesis.clone(),
+            expected_improvement: None,
+            // Plan was created at the previous gen (CB-015 RerunNoProgress
+            // path); pre-diagnostic generation = 1.
+            assessment_generation_at_creation: 1,
+        };
+        let mut job = RepairJob {
+            semantic_plan: Some(plan_b_before),
+            exhausted_attempts: vec![(cluster_ids[0].clone(), role)],
+            assessment: Some(super::super::VerifierRepairAssessment {
+                failure_kind: VerifierDiagnosticFailureKind::AssertionMismatch,
+                failure_type: VerifierFailureType::Unknown,
+                probable_cause_role: Some(role),
+                needed_reads: Vec::new(),
+                repair_target_hint: Some(fresh_hint.clone()),
+                repair_plan: vec![fresh_hint],
+                summary: None,
+                source: super::super::VerifierRepairAssessmentSource::DiagnosticPass,
+            }),
+            // Fresh diagnostic just landed → assessment_generation bumped to 2.
+            assessment_generation: 2,
+            ..RepairJob::new_for_test()
+        };
+
+        // Fresh diagnostic produced a plan that re-proposes cluster A
+        // (LLM has no memory of the previous turn's exhaustion). The
+        // plan's stamp matches the current generation (= 2) because
+        // `run_verifier_diagnostic_pass` threads the pre-bump value
+        // (which was 1) into the candidate plan after the assessment
+        // landed; but the precise stamp is what
+        // `build_semantic_repair_plan_from_report_with_authority_input`
+        // produces — we only need the (cluster_id, role) to be exhausted
+        // to drive the skip path.
+        let proposed_plan_a = SemanticRepairPlan {
+            semantic_report: report.clone(),
+            failure_cluster_id: cluster_ids[0].clone(),
+            semantic_cause: report.failure_kind,
+            spec_authority: SpecAuthority::ImplementationContract,
+            preferred_repair_role: role,
+            repair_hypothesis: report.repair_hypothesis.clone(),
+            expected_improvement: None,
+            assessment_generation_at_creation: 1,
+        };
+
+        // DiagnosticSkip path: the helper recognises cluster A is exhausted
+        // and walks to cluster B with the fresh assessment in hand.
+        assign_semantic_plan_preserving_exhausted(&mut job, Some(proposed_plan_a), Some(&report));
+
+        let advanced = job
+            .semantic_plan
+            .as_ref()
+            .expect("DiagnosticSkip must land on cluster B");
+        assert_eq!(
+            advanced.failure_cluster_id, cluster_ids[1],
+            "DiagnosticSkip must walk past exhausted cluster A to cluster B",
+        );
+        // CB-016 core invariant: the new plan looks fresh
+        // (plan.gen < job.gen) so the stale predicate does NOT fire.
+        assert!(
+            !semantic_plan_is_stale(&job),
+            "CB-016: DiagnosticSkip post-advance plan must be fresh (plan.gen < job.gen)",
+        );
+
+        // The decision must NOT route back to NeedDiagnostic /
+        // DiagnosticUnavailable — that would be the V8 livelock CB-016
+        // closes.
+        let dec = verifier_repair_decision(true, Some(&job), &[], &work_root, Some(0), 0);
+        assert_ne!(
+            dec,
+            VerifierRepairDecision::NeedDiagnostic,
+            "CB-016: post DiagnosticSkip, the controller must NOT re-route through NeedDiagnostic",
+        );
+        assert_ne!(
+            dec,
+            VerifierRepairDecision::DiagnosticUnavailable,
+            "CB-016: post DiagnosticSkip, the controller must NOT fail closed as DiagnosticUnavailable",
+        );
+    }
+
+    /// CB-016.2 (production integration scenario): the legacy `RerunNoProgress`
+    /// path through `apply_semantic_repair_dispatch_after_rerun` must keep
+    /// its stale-stamp behaviour intact — that is the precondition for
+    /// CB-012/CB-014 to force a fresh diagnostic between cluster A and
+    /// cluster B repair attempts.
+    #[test]
+    fn cb016_rerun_no_progress_advance_produces_stale_plan() {
+        use tempfile::tempdir;
+        let temp = tempdir().unwrap();
+        let work_root = temp.path().to_path_buf();
+
+        let report =
+            multi_cluster_report_fixture(VerifierDiagnosticFailureKind::AssertionMismatch, 2);
+        let cluster_ids: Vec<_> = report
+            .failure_clusters
+            .iter()
+            .map(|c| c.cluster_key.clone())
+            .collect();
+        let role = report.preferred_repair_role;
+
+        // Job posture: a successful diagnostic produced a plan targeting
+        // cluster A at generation 1; the assessment is in the slot too.
+        let stale_hint = super::super::task_contract::RecoveryTargetHint {
+            role: super::super::task_contract::ArtifactRole::Implementation,
+            path: "app/cluster_a.py".to_string(),
+            reason: "cluster A repair".to_string(),
+        };
+        let plan_a = SemanticRepairPlan {
+            semantic_report: report.clone(),
+            failure_cluster_id: cluster_ids[0].clone(),
+            semantic_cause: report.failure_kind,
+            spec_authority: SpecAuthority::ImplementationContract,
+            preferred_repair_role: role,
+            repair_hypothesis: report.repair_hypothesis.clone(),
+            expected_improvement: None,
+            assessment_generation_at_creation: 1,
+        };
+        let mut job = RepairJob {
+            semantic_plan: Some(plan_a),
+            assessment: Some(super::super::VerifierRepairAssessment {
+                failure_kind: VerifierDiagnosticFailureKind::AssertionMismatch,
+                failure_type: VerifierFailureType::Unknown,
+                probable_cause_role: Some(role),
+                needed_reads: Vec::new(),
+                repair_target_hint: Some(stale_hint.clone()),
+                repair_plan: vec![stale_hint],
+                summary: None,
+                source: super::super::VerifierRepairAssessmentSource::DiagnosticPass,
+            }),
+            assessment_generation: 1,
+            rerun_outcome: Some(VerifierRepairRerunOutcome::SameFailureRemaining),
+            ..RepairJob::new_for_test()
+        };
+
+        // RerunNoProgress path: dispatch advances the slot to cluster B
+        // with the stale assessment carried over.
+        apply_semantic_repair_dispatch_after_rerun(&mut job, Some(&cluster_ids[0]));
+
+        let advanced = job
+            .semantic_plan
+            .as_ref()
+            .expect("RerunNoProgress must land on cluster B");
+        assert_eq!(
+            advanced.failure_cluster_id, cluster_ids[1],
+            "RerunNoProgress must advance past cluster A to cluster B",
+        );
+        // CB-016 core invariant for the legacy path: the new plan is
+        // stale (plan.gen == job.gen) so CB-012 forces a fresh diagnostic.
+        assert_eq!(
+            advanced.assessment_generation_at_creation, job.assessment_generation,
+            "CB-016: RerunNoProgress post-advance must stamp plan.gen = job.gen",
+        );
+        assert!(
+            semantic_plan_is_stale(&job),
+            "CB-016: RerunNoProgress post-advance plan must be stale (CB-015 invariant)",
+        );
+
+        // The decision must route through NeedDiagnostic (CB-012 path) —
+        // that is the existing behaviour the legacy `RerunNoProgress`
+        // semantic preserves.
+        let dec = verifier_repair_decision(true, Some(&job), &[], &work_root, Some(0), 0);
+        assert_eq!(
+            dec,
+            VerifierRepairDecision::NeedDiagnostic,
+            "CB-016: post RerunNoProgress, controller must route to NeedDiagnostic (CB-012)",
+        );
     }
 
     // -- Phase G grep / structure tests (Issue #647 acceptance closure) -- //

--- a/src/agent/loop_run/repair_job.rs
+++ b/src/agent/loop_run/repair_job.rs
@@ -674,6 +674,85 @@ pub(super) fn apply_semantic_repair_dispatch_after_rerun(
     }
 }
 
+/// Issue #647 (MF2 V3.1): assign a freshly built `SemanticRepairPlan` into
+/// the `repair_job.semantic_plan` slot **while preserving the
+/// `exhausted_attempts` ledger**.
+///
+/// Background: when the diagnostic LLM is re-run after `apply_semantic_repair_dispatch_after_rerun`
+/// has already pushed a cluster onto `exhausted_attempts`, a naive
+/// `current.semantic_plan = new_plan` overwrite throws away the progress the
+/// dispatch made — even though the dispatch deliberately recorded the
+/// already-attacked cluster so it would be skipped. This helper bridges that
+/// gap by routing the assignment through the same Phase-E
+/// `advance_to_next_cluster` machinery the rerun dispatch uses.
+///
+/// Behaviour:
+///
+/// 1. `new_plan == None` → clear the slot (`semantic_plan = None`). This is
+///    the legacy / setup-repair fallback path; no ledger mutation occurs.
+/// 2. `new_plan == Some(plan)` whose `(failure_cluster_id,
+///    preferred_repair_role)` is **not** already in `exhausted_attempts` →
+///    write the new plan verbatim. Ledger untouched.
+/// 3. `new_plan == Some(plan)` whose `(failure_cluster_id,
+///    preferred_repair_role)` **is** already in `exhausted_attempts` →
+///    assign the new plan into the slot, then immediately call
+///    `advance_to_next_cluster` with `new_report` (the report carried by the
+///    new plan) so the helper walks past the already-exhausted entry to the
+///    first unexhausted cluster of the new report. If no cluster remains,
+///    the slot ends up as `None` (caller falls back to re-diagnostic /
+///    legacy mode — same posture as `advance_to_next_cluster` returning
+///    `false`).
+///
+/// `new_report` is accepted as a separate argument so callers that have a
+/// fresh report (e.g. after a re-diagnostic produced a new
+/// `SemanticFailureReport`) can pass it explicitly. When `new_plan` is
+/// `Some`, the report embedded in `new_plan.semantic_report` is used as the
+/// authoritative source for cluster walking; `new_report` is consulted only
+/// when the embedded report disagrees with the caller's intent — current
+/// callers should pass the same report instance as a defensive precondition.
+///
+/// The helper deliberately does **not** touch `assessment` /
+/// `assessment_attempts` / `repair_attempt` — those remain governed by the
+/// legacy diagnostic / repair-pass machinery (mirrors the S7-005 boundary
+/// in `apply_semantic_repair_dispatch_after_rerun`).
+pub(super) fn assign_semantic_plan_preserving_exhausted(
+    repair_job: &mut RepairJob,
+    new_plan: Option<SemanticRepairPlan>,
+    new_report: Option<&SemanticFailureReport>,
+) {
+    let Some(plan) = new_plan else {
+        // Legacy fallback / setup-repair path: clear the slot, leave the
+        // ledger and other fields untouched (matches the pre-MF2-V3
+        // overwrite semantics for the `None` case).
+        repair_job.semantic_plan = None;
+        return;
+    };
+
+    let role = plan.preferred_repair_role;
+    let cluster_id = plan.failure_cluster_id.clone();
+    let already_exhausted = repair_job.exhausted_attempts.contains(&(cluster_id, role));
+
+    // Assign the plan into the slot first. The embedded `semantic_report`
+    // becomes the authoritative source for cluster walking when we need to
+    // skip an already-exhausted entry.
+    let embedded_report = plan.semantic_report.clone();
+    repair_job.semantic_plan = Some(plan);
+
+    if !already_exhausted {
+        return;
+    }
+
+    // The newly proposed plan targets an already-exhausted (cluster, role)
+    // pair → ask the Phase-E walker to skip ahead. Prefer the embedded
+    // report (it travels with the plan); fall back to the caller-supplied
+    // `new_report` only if the caller explicitly passes a different one.
+    let report = new_report.cloned().unwrap_or(embedded_report);
+    advance_to_next_cluster(repair_job, &report);
+    // `advance_to_next_cluster` already mutates `semantic_plan`
+    // (either to the next unexhausted cluster or to `None`) and updates the
+    // ledger — no further bookkeeping required here.
+}
+
 /// Issue #647 (Phase E.3 / S3-014): wrap the existing
 /// `verifier_repair_rerun_outcome` (which is failure_count-based and
 /// cluster-agnostic) with a cluster-id transition rule.
@@ -1525,6 +1604,331 @@ mod tests {
         // repair_attempt is owned by the diagnostic / repair machinery and
         // is not touched by this dispatch helper.
         assert_eq!(job.repair_attempt, 0);
+    }
+
+    // ---- Issue #647 (MF2 V3): assign_semantic_plan_preserving_exhausted ---- //
+
+    /// MF2 V3.1: legacy / setup-repair fallback — `new_plan = None` clears the
+    /// slot without disturbing the `exhausted_attempts` ledger. This matches
+    /// the pre-V3 overwrite behaviour for the `None` case (turn.rs:9416).
+    #[test]
+    fn assign_semantic_plan_preserving_exhausted_none_clears_slot_only() {
+        let report =
+            multi_cluster_report_fixture(VerifierDiagnosticFailureKind::AssertionMismatch, 2);
+        let cluster_ids: Vec<_> = report
+            .failure_clusters
+            .iter()
+            .map(|c| c.cluster_key.clone())
+            .collect();
+        let role = report.preferred_repair_role;
+
+        let mut job = job_with_first_cluster_plan(&report);
+        job.exhausted_attempts = vec![(cluster_ids[0].clone(), role)];
+
+        assign_semantic_plan_preserving_exhausted(&mut job, None, None);
+
+        assert!(job.semantic_plan.is_none(), "None must clear the slot");
+        // Ledger preserved verbatim — legacy fallback never mutates it.
+        assert_eq!(job.exhausted_attempts, vec![(cluster_ids[0].clone(), role)]);
+    }
+
+    /// MF2 V3.1: when the new plan's `(cluster_id, role)` pair is NOT in the
+    /// ledger, the helper writes the plan verbatim. No ledger mutation.
+    #[test]
+    fn assign_semantic_plan_preserving_exhausted_writes_unexhausted_plan_verbatim() {
+        let report =
+            multi_cluster_report_fixture(VerifierDiagnosticFailureKind::AssertionMismatch, 2);
+        let cluster_ids: Vec<_> = report
+            .failure_clusters
+            .iter()
+            .map(|c| c.cluster_key.clone())
+            .collect();
+        let role = report.preferred_repair_role;
+
+        // Job state: no plan yet, empty ledger.
+        let mut job = RepairJob::new_for_test();
+        let new_plan = SemanticRepairPlan {
+            semantic_report: report.clone(),
+            failure_cluster_id: cluster_ids[0].clone(),
+            semantic_cause: report.failure_kind,
+            spec_authority: SpecAuthority::ImplementationContract,
+            preferred_repair_role: role,
+            repair_hypothesis: report.repair_hypothesis.clone(),
+            expected_improvement: None,
+        };
+
+        assign_semantic_plan_preserving_exhausted(&mut job, Some(new_plan), Some(&report));
+
+        assert_eq!(
+            job.semantic_plan.as_ref().unwrap().failure_cluster_id,
+            cluster_ids[0],
+            "unexhausted plan must be written verbatim",
+        );
+        assert!(job.exhausted_attempts.is_empty(), "ledger untouched");
+    }
+
+    /// MF2 V3.1 (core): when the new plan targets an already-exhausted
+    /// `(cluster_id, role)` pair, the helper walks to the next unexhausted
+    /// cluster instead of overwriting the slot with the doomed plan.
+    /// This is the SSOT defence against the turn.rs:9416 regression where
+    /// re-diagnostic could revive an already-burned cluster.
+    #[test]
+    fn assign_semantic_plan_preserving_exhausted_skips_to_next_when_proposed_is_exhausted() {
+        let report =
+            multi_cluster_report_fixture(VerifierDiagnosticFailureKind::AssertionMismatch, 2);
+        let cluster_ids: Vec<_> = report
+            .failure_clusters
+            .iter()
+            .map(|c| c.cluster_key.clone())
+            .collect();
+        let role = report.preferred_repair_role;
+
+        // Ledger already contains cluster A (we burned it on a prior turn).
+        let mut job = RepairJob {
+            exhausted_attempts: vec![(cluster_ids[0].clone(), role)],
+            ..RepairJob::new_for_test()
+        };
+        // Re-diagnostic proposes cluster A again (LLM duplicated the cluster
+        // it can no longer fix).
+        let doomed_plan = SemanticRepairPlan {
+            semantic_report: report.clone(),
+            failure_cluster_id: cluster_ids[0].clone(),
+            semantic_cause: report.failure_kind,
+            spec_authority: SpecAuthority::ImplementationContract,
+            preferred_repair_role: role,
+            repair_hypothesis: report.repair_hypothesis.clone(),
+            expected_improvement: None,
+        };
+
+        assign_semantic_plan_preserving_exhausted(&mut job, Some(doomed_plan), Some(&report));
+
+        // Walked past cluster A → slot targets cluster B.
+        assert_eq!(
+            job.semantic_plan.as_ref().unwrap().failure_cluster_id,
+            cluster_ids[1],
+            "slot must walk past the already-exhausted cluster to the next cluster",
+        );
+    }
+
+    /// MF2 V3.1: when ALL clusters in the new report are already exhausted,
+    /// the helper clears the slot (`semantic_plan = None`) so the caller can
+    /// fall back to the re-diagnostic / legacy path.
+    #[test]
+    fn assign_semantic_plan_preserving_exhausted_clears_slot_when_all_clusters_exhausted() {
+        let report =
+            multi_cluster_report_fixture(VerifierDiagnosticFailureKind::AssertionMismatch, 2);
+        let cluster_ids: Vec<_> = report
+            .failure_clusters
+            .iter()
+            .map(|c| c.cluster_key.clone())
+            .collect();
+        let role = report.preferred_repair_role;
+
+        // Ledger already contains BOTH clusters (the whole report is burnt).
+        let mut job = RepairJob {
+            exhausted_attempts: vec![
+                (cluster_ids[0].clone(), role),
+                (cluster_ids[1].clone(), role),
+            ],
+            ..RepairJob::new_for_test()
+        };
+        let any_plan = SemanticRepairPlan {
+            semantic_report: report.clone(),
+            failure_cluster_id: cluster_ids[0].clone(),
+            semantic_cause: report.failure_kind,
+            spec_authority: SpecAuthority::ImplementationContract,
+            preferred_repair_role: role,
+            repair_hypothesis: report.repair_hypothesis.clone(),
+            expected_improvement: None,
+        };
+
+        assign_semantic_plan_preserving_exhausted(&mut job, Some(any_plan), Some(&report));
+
+        assert!(
+            job.semantic_plan.is_none(),
+            "fully exhausted report must clear the slot (caller falls back to re-diagnostic)",
+        );
+    }
+
+    /// MF2 V3.1: helper does NOT touch legacy retry counters
+    /// (`assessment_attempts`, `repair_attempt`). Mirrors the S7-005 boundary
+    /// on `apply_semantic_repair_dispatch_after_rerun`.
+    #[test]
+    fn assign_semantic_plan_preserving_exhausted_never_bumps_retry_counters() {
+        let report =
+            multi_cluster_report_fixture(VerifierDiagnosticFailureKind::AssertionMismatch, 2);
+        let cluster_ids: Vec<_> = report
+            .failure_clusters
+            .iter()
+            .map(|c| c.cluster_key.clone())
+            .collect();
+        let role = report.preferred_repair_role;
+
+        let mut job = RepairJob {
+            exhausted_attempts: vec![(cluster_ids[0].clone(), role)],
+            assessment_attempts: 1,
+            repair_attempt: 2,
+            ..RepairJob::new_for_test()
+        };
+        let doomed = SemanticRepairPlan {
+            semantic_report: report.clone(),
+            failure_cluster_id: cluster_ids[0].clone(),
+            semantic_cause: report.failure_kind,
+            spec_authority: SpecAuthority::ImplementationContract,
+            preferred_repair_role: role,
+            repair_hypothesis: report.repair_hypothesis.clone(),
+            expected_improvement: None,
+        };
+
+        assign_semantic_plan_preserving_exhausted(&mut job, Some(doomed), Some(&report));
+
+        // Counters untouched even though we walked clusters.
+        assert_eq!(job.assessment_attempts, 1);
+        assert_eq!(job.repair_attempt, 2);
+    }
+
+    /// MF2 V3.4 (production integration scenario #1):
+    /// `mf2_v3_cluster_a_exhausted_after_no_progress_leads_to_cluster_b`.
+    ///
+    /// Simulates the failing production flow end-to-end at the helper layer:
+    ///   1. Diagnostic produces a plan targeting cluster A.
+    ///   2. Repair runs; rerun returns `SameFailureRemaining` (no progress).
+    ///   3. `apply_semantic_repair_dispatch_after_rerun` pushes A into the
+    ///      ledger and advances the slot to cluster B (legacy behaviour).
+    ///   4. The next turn's diagnostic re-proposes cluster A (the LLM has no
+    ///      memory of the previous turn) → without MF2 V3.1 this would
+    ///      overwrite cluster B with cluster A and burn the entire
+    ///      previous-turn progress.
+    ///   5. `assign_semantic_plan_preserving_exhausted` recognises cluster A
+    ///      is exhausted and walks back to cluster B — progress preserved.
+    #[test]
+    fn mf2_v3_cluster_a_exhausted_after_no_progress_leads_to_cluster_b() {
+        let report =
+            multi_cluster_report_fixture(VerifierDiagnosticFailureKind::AssertionMismatch, 2);
+        let cluster_ids: Vec<_> = report
+            .failure_clusters
+            .iter()
+            .map(|c| c.cluster_key.clone())
+            .collect();
+        let role = report.preferred_repair_role;
+
+        // (1) Initial diagnostic → plan targets cluster A.
+        let mut job = job_with_first_cluster_plan(&report);
+        let preserved_assessment = super::super::VerifierRepairAssessment {
+            failure_kind: VerifierDiagnosticFailureKind::AssertionMismatch,
+            failure_type: VerifierFailureType::Unknown,
+            probable_cause_role: Some(role),
+            needed_reads: Vec::new(),
+            repair_target_hint: None,
+            repair_plan: Vec::new(),
+            summary: None,
+            source: super::super::VerifierRepairAssessmentSource::DiagnosticPass,
+        };
+        job.assessment = Some(preserved_assessment.clone());
+
+        // (2/3) Repair → rerun SameFailureRemaining → dispatch advances to B.
+        job.rerun_outcome = Some(VerifierRepairRerunOutcome::SameFailureRemaining);
+        apply_semantic_repair_dispatch_after_rerun(&mut job, Some(&cluster_ids[0]));
+        assert_eq!(
+            job.semantic_plan.as_ref().unwrap().failure_cluster_id,
+            cluster_ids[1],
+            "dispatch must advance to cluster B after no-progress rerun",
+        );
+        assert_eq!(
+            job.exhausted_attempts,
+            vec![(cluster_ids[0].clone(), role)],
+            "ledger must record cluster A as exhausted",
+        );
+
+        // (4) New diagnostic produces a fresh plan that targets cluster A
+        // again (LLM doesn't remember cluster A is doomed).
+        let re_diagnostic_plan = SemanticRepairPlan {
+            semantic_report: report.clone(),
+            failure_cluster_id: cluster_ids[0].clone(),
+            semantic_cause: report.failure_kind,
+            spec_authority: SpecAuthority::ImplementationContract,
+            preferred_repair_role: role,
+            repair_hypothesis: report.repair_hypothesis.clone(),
+            expected_improvement: None,
+        };
+
+        // (5) MF2 V3.1 router → must skip A and land on B.
+        assign_semantic_plan_preserving_exhausted(
+            &mut job,
+            Some(re_diagnostic_plan),
+            Some(&report),
+        );
+        assert_eq!(
+            job.semantic_plan.as_ref().unwrap().failure_cluster_id,
+            cluster_ids[1],
+            "MF2 V3.1 must preserve cluster-B progress when re-diagnostic re-proposes cluster A",
+        );
+        // Ledger still records A as exhausted.
+        assert!(
+            job.exhausted_attempts
+                .contains(&(cluster_ids[0].clone(), role)),
+            "cluster A must remain in exhausted_attempts ledger after re-diagnostic",
+        );
+    }
+
+    /// MF2 V3.4 (production integration scenario #2):
+    /// `mf2_v3_exhausted_a_persists_after_re_diagnostic`.
+    ///
+    /// Stronger variant: after several re-diagnostic rounds that all
+    /// re-propose cluster A, the exhausted-A entry must persist and the
+    /// slot must continue to advance to cluster B (never regressing).
+    #[test]
+    fn mf2_v3_exhausted_a_persists_after_re_diagnostic() {
+        let report =
+            multi_cluster_report_fixture(VerifierDiagnosticFailureKind::AssertionMismatch, 2);
+        let cluster_ids: Vec<_> = report
+            .failure_clusters
+            .iter()
+            .map(|c| c.cluster_key.clone())
+            .collect();
+        let role = report.preferred_repair_role;
+
+        // Job state mirrors the snapshot after dispatch advanced once:
+        // cluster A in ledger, cluster B in slot.
+        let plan_b = SemanticRepairPlan {
+            semantic_report: report.clone(),
+            failure_cluster_id: cluster_ids[1].clone(),
+            semantic_cause: report.failure_kind,
+            spec_authority: SpecAuthority::ImplementationContract,
+            preferred_repair_role: role,
+            repair_hypothesis: report.repair_hypothesis.clone(),
+            expected_improvement: None,
+        };
+        let mut job = RepairJob {
+            semantic_plan: Some(plan_b),
+            exhausted_attempts: vec![(cluster_ids[0].clone(), role)],
+            ..RepairJob::new_for_test()
+        };
+
+        // Re-diagnostic loop: 3 successive calls all propose cluster A.
+        for _ in 0..3 {
+            let re_diag_plan = SemanticRepairPlan {
+                semantic_report: report.clone(),
+                failure_cluster_id: cluster_ids[0].clone(),
+                semantic_cause: report.failure_kind,
+                spec_authority: SpecAuthority::ImplementationContract,
+                preferred_repair_role: role,
+                repair_hypothesis: report.repair_hypothesis.clone(),
+                expected_improvement: None,
+            };
+            assign_semantic_plan_preserving_exhausted(&mut job, Some(re_diag_plan), Some(&report));
+            // After every router call, A remains exhausted; B is the slot.
+            assert!(
+                job.exhausted_attempts
+                    .contains(&(cluster_ids[0].clone(), role)),
+                "cluster A must persist in exhausted_attempts ledger across re-diagnostics",
+            );
+            assert_eq!(
+                job.semantic_plan.as_ref().unwrap().failure_cluster_id,
+                cluster_ids[1],
+                "slot must remain on cluster B (never regress to A)",
+            );
+        }
     }
 
     // -- Phase G grep / structure tests (Issue #647 acceptance closure) -- //

--- a/src/agent/loop_run/repair_job.rs
+++ b/src/agent/loop_run/repair_job.rs
@@ -713,13 +713,13 @@ pub(super) fn advance_to_next_cluster(
     });
 
     // 2. Find the next cluster in document order that is NOT exhausted
-    //    under the report's preferred_repair_role.
+    //    under the report's preferred_repair_role. CB-017 A''' (Commit 3,
+    //    CR-6 V2): route through `next_repairable_cluster` so targetless
+    //    clusters (admitted_cluster_targets empty after enrich) are skipped
+    //    and the ledger comparison uses `(cluster_key, RepairRole)` exact
+    //    pairs.
     let role = report.preferred_repair_role;
-    let next_cluster = report.failure_clusters.iter().find(|cluster| {
-        !repair_job
-            .exhausted_attempts
-            .contains(&(cluster.cluster_key.clone(), role))
-    });
+    let next_cluster = next_repairable_cluster(report, role, &repair_job.exhausted_attempts);
 
     let Some(next_cluster) = next_cluster else {
         // 3. No more clusters — clear the slot and signal no progress.
@@ -794,6 +794,46 @@ pub(super) fn should_re_diagnostic(repair_job: &RepairJob) -> bool {
     repair_job
         .exhausted_attempts
         .contains(&(plan.failure_cluster_id.clone(), plan.preferred_repair_role))
+}
+
+/// Issue #647 / CB-017 A''' (Commit 3, CR-6 V2): return the first cluster
+/// of `report` that is *repairable* — i.e. has a non-empty
+/// `admitted_cluster_targets` list. Targetless clusters (no LLM-supplied
+/// target_paths AND no merged legacy targets, or all candidates rejected by
+/// the admission gate) are skipped.
+///
+/// Used by `turn.rs::build_semantic_repair_plan_from_report_with_authority_input`
+/// to pick the initial cluster for the new plan.
+pub(super) fn first_repairable_cluster(
+    report: &SemanticFailureReport,
+) -> Option<&super::semantic_failure::FailureCluster> {
+    report
+        .failure_clusters
+        .iter()
+        .find(|c| !c.admitted_cluster_targets.is_empty())
+}
+
+/// Issue #647 / CB-017 A''' (Commit 3, CR-6 V2): return the next cluster
+/// that:
+///
+/// 1. Has a non-empty `admitted_cluster_targets` list (repairable), AND
+/// 2. Is not already in `exhausted` under the **exact** `(cluster_key,
+///    preferred_role)` pair.
+///
+/// CR-6 V2 distinguishes attacks on the same cluster under different
+/// roles: an entry `(cluster_A, Implementation)` in `exhausted` does NOT
+/// block a later attempt on `(cluster_A, Test)`.
+pub(super) fn next_repairable_cluster<'a>(
+    report: &'a SemanticFailureReport,
+    preferred_role: RepairRole,
+    exhausted: &[(FailureClusterKey, RepairRole)],
+) -> Option<&'a super::semantic_failure::FailureCluster> {
+    report.failure_clusters.iter().find(|c| {
+        !c.admitted_cluster_targets.is_empty()
+            && !exhausted
+                .iter()
+                .any(|(id, role)| id == &c.cluster_key && *role == preferred_role)
+    })
 }
 
 /// Issue #647 (MF2.3): production dispatch helper that wires the Phase-E
@@ -1287,8 +1327,23 @@ mod tests {
             "repair_hypothesis": "multi-cluster hypothesis",
             "failure_clusters": clusters,
         });
-        super::super::semantic_failure::parse_semantic_failure_report(&json)
-            .expect("multi-cluster fixture parses")
+        let mut report = super::super::semantic_failure::parse_semantic_failure_report(&json)
+            .expect("multi-cluster fixture parses");
+        // CB-017 A''' (Commit 3): seed every cluster with a synthetic admitted
+        // target so the new `next_repairable_cluster` skip rule does not
+        // accidentally drop clusters in pre-CB-017 fixtures. Production code
+        // fills this slot via `enrich_failure_clusters_with_admitted_targets`
+        // in `turn.rs`; tests that exercise the cluster-walker rely on the
+        // pre-Commit-3 "every cluster is repairable" expectation.
+        for (idx, cluster) in report.failure_clusters.iter_mut().enumerate() {
+            cluster.admitted_cluster_targets =
+                vec![super::super::task_contract::RecoveryTargetHint {
+                    role: super::super::task_contract::ArtifactRole::Implementation,
+                    path: format!("app/main_{idx}.py"),
+                    reason: "fixture-admitted target".to_string(),
+                }];
+        }
+        report
     }
 
     /// Build a fresh `RepairJob` whose `semantic_plan` slot targets the
@@ -3181,5 +3236,83 @@ mod tests {
                  (S1-011 / S3-006: SemanticFailureReport is turn-local)",
             );
         }
+    }
+
+    // ─── CB-017 A''' (Commit 3): first/next_repairable_cluster ─────────────
+
+    /// CR-6 V2: `first_repairable_cluster` skips clusters whose
+    /// `admitted_cluster_targets` is empty, returning the first cluster with
+    /// at least one admitted target.
+    #[test]
+    fn cb017_first_repairable_cluster_skips_targetless() {
+        // Build a 3-cluster fixture (every cluster pre-seeded with admitted
+        // targets), then clear the first cluster's admitted list. The helper
+        // must walk past the empty first cluster and return the second.
+        let mut report =
+            multi_cluster_report_fixture(VerifierDiagnosticFailureKind::AssertionMismatch, 3);
+        report.failure_clusters[0].admitted_cluster_targets.clear();
+        let chosen = super::first_repairable_cluster(&report).expect("second cluster repairable");
+        assert_eq!(chosen.cluster_key, report.failure_clusters[1].cluster_key);
+
+        // If we clear every cluster, the helper returns None.
+        for cluster in report.failure_clusters.iter_mut() {
+            cluster.admitted_cluster_targets.clear();
+        }
+        assert!(super::first_repairable_cluster(&report).is_none());
+    }
+
+    /// CR-6 V2: `next_repairable_cluster` distinguishes the same cluster
+    /// under different `RepairRole`s — an entry `(cluster_A, Implementation)`
+    /// does NOT block a later attempt on `(cluster_A, Test)`.
+    #[test]
+    fn cb017_next_repairable_distinguishes_same_cluster_different_role() {
+        let report =
+            multi_cluster_report_fixture(VerifierDiagnosticFailureKind::AssertionMismatch, 2);
+        let cluster_a = report.failure_clusters[0].cluster_key.clone();
+        // Cluster A exhausted under Implementation; query under Test should
+        // still admit Cluster A.
+        let exhausted = vec![(
+            cluster_a.clone(),
+            super::super::task_contract::ArtifactRole::Implementation,
+        )];
+        let chosen = super::next_repairable_cluster(
+            &report,
+            super::super::task_contract::ArtifactRole::Test,
+            &exhausted,
+        )
+        .expect("cluster A still repairable under Test role");
+        assert_eq!(chosen.cluster_key, cluster_a);
+        // Same query under Implementation must skip A and pick B.
+        let chosen = super::next_repairable_cluster(
+            &report,
+            super::super::task_contract::ArtifactRole::Implementation,
+            &exhausted,
+        )
+        .expect("cluster B repairable under Implementation");
+        assert_eq!(chosen.cluster_key, report.failure_clusters[1].cluster_key);
+    }
+
+    /// CR-6 V2 (fallback test): when every cluster of the report is targetless
+    /// (no LLM-supplied target_paths, no merged legacy targets, or all
+    /// candidates rejected by admission), the controller falls back to the
+    /// legacy assessment — represented here by `first_repairable_cluster`
+    /// returning `None`.
+    #[test]
+    fn cb017_all_clusters_targetless_falls_back_to_legacy_assessment() {
+        let mut report =
+            multi_cluster_report_fixture(VerifierDiagnosticFailureKind::AssertionMismatch, 3);
+        for cluster in report.failure_clusters.iter_mut() {
+            cluster.admitted_cluster_targets.clear();
+        }
+        assert!(super::first_repairable_cluster(&report).is_none());
+        assert!(
+            super::next_repairable_cluster(
+                &report,
+                super::super::task_contract::ArtifactRole::Implementation,
+                &[]
+            )
+            .is_none(),
+            "next_repairable_cluster must skip targetless clusters",
+        );
     }
 }

--- a/src/agent/loop_run/repair_job.rs
+++ b/src/agent/loop_run/repair_job.rs
@@ -1217,4 +1217,77 @@ mod tests {
         // bounded list, not a retry counter.
         assert_eq!(job.exhausted_attempts.len(), 3);
     }
+
+    // -- Phase G grep / structure tests (Issue #647 acceptance closure) -- //
+
+    /// Helper: split the module source into the production prefix
+    /// (everything before `#[cfg(test)]\nmod tests` at column 0).
+    fn production_source() -> &'static str {
+        let source = include_str!("repair_job.rs");
+        match source.find("\n#[cfg(test)]\nmod tests") {
+            Some(idx) => &source[..idx],
+            None => source,
+        }
+    }
+
+    #[test]
+    fn no_framework_literal_in_repair_job_production_code() {
+        // S1-012 (拡張): production code (everything before `mod tests`)
+        // must not embed framework-specific literals. Test-only literals
+        // (e.g. `command: "pytest"` inside #[cfg(test)] fixtures) are
+        // explicitly exempt.
+        let prod = production_source();
+        for lit in &[
+            "\"422\"",
+            "\"404\"",
+            "/items/nonexistent",
+            "FastAPI",
+            "\"pytest\"",
+        ] {
+            assert!(
+                !prod.contains(lit),
+                "repair_job.rs production code must not contain framework literal {lit:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn no_unsafe_in_repair_job_production_code() {
+        // DR4-003: no unsafe / FFI in new production code.
+        let prod = production_source();
+        assert!(
+            !prod.contains("unsafe "),
+            "repair_job.rs production code must not contain `unsafe `",
+        );
+        assert!(
+            !prod.contains("extern \"C\""),
+            "repair_job.rs production code must not declare FFI",
+        );
+    }
+
+    #[test]
+    fn session_store_does_not_serialize_semantic_failure_report() {
+        // S1-011 / S3-006 / DR3-002: SemanticFailureReport &
+        // FailureCluster are turn-local — they must not appear in the
+        // session persistence layer. If a future Issue moves them into
+        // `session::store`, this test forces an explicit review of the
+        // serialization + masking SSOT path.
+        let store_path =
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/session/store.rs");
+        let body = std::fs::read_to_string(&store_path)
+            .unwrap_or_else(|e| panic!("read {store_path:?}: {e}"));
+        for forbidden in &[
+            "SemanticFailureReport",
+            "FailureCluster",
+            "FailureClusterKey",
+            "SpecAuthority",
+            "SemanticRepairPlan",
+        ] {
+            assert!(
+                !body.contains(forbidden),
+                "src/session/store.rs must not reference turn-local type {forbidden:?} \
+                 (S1-011 / S3-006: SemanticFailureReport is turn-local)",
+            );
+        }
+    }
 }

--- a/src/agent/loop_run/repair_job.rs
+++ b/src/agent/loop_run/repair_job.rs
@@ -56,6 +56,17 @@ pub(super) struct SemanticRepairPlan {
     pub(super) repair_hypothesis: String,
     /// rerun 後に書き込まれる予測対比の結果。未 rerun 時は `None`。
     pub(super) expected_improvement: Option<VerifierRepairRerunOutcome>,
+    /// Issue #647 (CB-015): `RepairJob.assessment_generation` の値を、
+    /// この `SemanticRepairPlan` が構築された **時点** で coil した snapshot。
+    ///
+    /// re-diagnostic が完了して新しい assessment が書き込まれると
+    /// `RepairJob.assessment_generation` は `+1` される — それより前に
+    /// 作られた plan は `plan.assessment_generation_at_creation <
+    /// repair_job.assessment_generation` となり、stale ではなく
+    /// **fresh** assessment と組み合わさった "post re-diagnostic" 状態
+    /// として区別される (CB-007 / CB-012 / CB-013 / CB-014 ガードは
+    /// この比較で stale を判定する)。
+    pub(super) assessment_generation_at_creation: u32,
 }
 
 /// Issue #625 / #627 / #637: turn-local diagnostic context for a failed
@@ -96,6 +107,16 @@ pub(super) struct RepairJob {
     /// `slot reuse` でも保持される (per-cluster ではない) — 同じ
     /// `(FailureClusterKey, RepairRole)` 組み合わせを 2 度 attack しないため。
     pub(super) exhausted_attempts: Vec<(FailureClusterKey, RepairRole)>,
+    /// Issue #647 (CB-015): "assessment は何代目か" を first-class state に
+    /// した generation counter。`run_verifier_diagnostic_pass` が新 assessment
+    /// を書き込むたびに `+= 1`、`verifier_repair_context_from_failure` は
+    /// previous_context から carry over する。
+    ///
+    /// `SemanticRepairPlan.assessment_generation_at_creation` と比較する
+    /// ことで CB-007/CB-012/CB-013/CB-014 のガードは「plan は新 assessment
+    /// より古い (stale)」か「plan は新 assessment と同じ世代 (まだ re-diagnostic
+    /// が走っていない / advance 直後の stale state)」かを区別する。
+    pub(super) assessment_generation: u32,
 }
 
 /// Controller-internal decision used by `run_turn` to pick the next action
@@ -299,6 +320,7 @@ impl RepairJob {
             repair_attempt: 0,
             semantic_plan: None,
             exhausted_attempts: Vec::new(),
+            assessment_generation: 0,
         }
     }
 }
@@ -374,6 +396,47 @@ fn truncate_chars_with_ellipsis(s: &str, max_chars: usize) -> String {
     }
 }
 
+/// Issue #647 (CB-015): SSOT predicate for "the active `semantic_plan` is
+/// stale" — i.e. the plan was constructed under the *same* assessment that
+/// is currently sitting in `RepairJob.assessment`, and at least one cluster
+/// has already been pushed onto `exhausted_attempts`.
+///
+/// "Stale" means: the cluster pointer has advanced (e.g. cluster B is now in
+/// the slot after A was exhausted), but the assessment / repair-target hint
+/// was generated for the **previous** cluster and no re-diagnostic has run
+/// yet to refresh it. Returning `true` here is the precondition for CB-007
+/// (hint guard returns `None`), CB-012/CB-014 (decision routes to
+/// `NeedDiagnostic` / `DiagnosticUnavailable`), and CB-013 (diagnostic
+/// runner clears the stale assessment before its `Skipped` short-circuit
+/// fires).
+///
+/// "Fresh" means: after a re-diagnostic has bumped
+/// `RepairJob.assessment_generation`, the plan's
+/// `assessment_generation_at_creation` is strictly less than the job's
+/// generation — the assessment in the slot was rebuilt *after* the plan
+/// was last advanced, so the hint is no longer stale and CB-007 should
+/// step out of the way so the controller can route to `NeedFreshRead` /
+/// `NeedEdit` on cluster B.
+///
+/// Returns `false` when:
+/// - `semantic_plan` is `None` (legacy / SetupRepair path),
+/// - `exhausted_attempts` is empty (fresh first-cluster state, never advanced),
+/// - the plan's `assessment_generation_at_creation` is strictly less than
+///   `RepairJob.assessment_generation` (re-diagnostic produced a fresh
+///   assessment after the last advance).
+pub(super) fn semantic_plan_is_stale(job: &RepairJob) -> bool {
+    let Some(plan) = job.semantic_plan.as_ref() else {
+        return false;
+    };
+    if job.exhausted_attempts.is_empty() {
+        return false;
+    }
+    // Plan was created at or after the current assessment generation →
+    // no re-diagnostic has refreshed the assessment since the plan was
+    // advanced. The plan is stale relative to its own assessment.
+    plan.assessment_generation_at_creation >= job.assessment_generation
+}
+
 /// Pure function moved from `turn.rs`. Drives the verifier-repair state
 /// machine using `messages` (for fresh-read detection) and `work_root`
 /// (for target-path resolution). Behaviour and ordering are identical to
@@ -411,11 +474,11 @@ pub(super) fn verifier_repair_decision(
     if job.is_some_and(|job| job.assessment.is_none()) {
         return VerifierRepairDecision::DiagnosticUnavailable;
     }
-    // Issue #647 (CB-012 / CB-014): When semantic_plan is active but
-    // the assessment was constructed before exhausted_attempts grew
-    // (= the hint guard in `verifier_repair_context_target_path`
-    // returns `None` because exhausted_attempts is non-empty), the
-    // assessment is **stale**. Two branches:
+    // Issue #647 (CB-012 / CB-014 / CB-015): When semantic_plan is active
+    // but the assessment was constructed before the plan advanced to its
+    // current cluster (= `semantic_plan_is_stale` returns `true`), the
+    // assessment is stale and the repair-target hint guard in
+    // `verifier_repair_context_target_path` returns `None`. Two branches:
     //
     //   * **CB-012** (attempts remain): force a fresh diagnostic so
     //     the next assessment reflects the advanced cluster. Without
@@ -428,11 +491,17 @@ pub(super) fn verifier_repair_decision(
     //     boundary because `assessment.is_some()` keeps the earlier
     //     `assessment.is_none() -> DiagnosticUnavailable` arm from
     //     firing.
-    if job.is_some_and(|job| {
-        job.semantic_plan.is_some()
-            && !job.exhausted_attempts.is_empty()
-            && super::turn::verifier_repair_context_target_path(work_root, job).is_none()
-    }) {
+    //
+    // **CB-015** (architectural refactor): the stale-state predicate now
+    // uses `semantic_plan_is_stale` which compares
+    // `plan.assessment_generation_at_creation` against
+    // `RepairJob.assessment_generation`. After a re-diagnostic bumps the
+    // job's generation, the predicate flips to `false` (fresh state) and
+    // the controller can advance to `NeedFreshRead` / `NeedEdit` on the
+    // current cluster — closing the liveness gap where cluster B repair
+    // could never start because the same exhausted_attempts-based predicate
+    // kept routing back to `NeedDiagnostic`.
+    if job.is_some_and(semantic_plan_is_stale) {
         if job.is_some_and(|job| {
             job.assessment_attempts
                 < crate::agent::loop_run::turn::VERIFIER_DIAGNOSTIC_ATTEMPT_LIMIT
@@ -463,8 +532,8 @@ pub(super) fn verifier_repair_decision(
     }
 }
 
-/// Issue #647 (CB-013): detect the "advanced semantic_plan + stale
-/// assessment" state that CB-012 catches in the decision layer.
+/// Issue #647 (CB-013 / CB-015): detect the "advanced semantic_plan +
+/// stale assessment" state that CB-012 catches in the decision layer.
 ///
 /// The diagnostic runner (`run_verifier_diagnostic_pass` in `turn.rs`)
 /// consults this helper to know whether to clear the stale assessment
@@ -475,22 +544,22 @@ pub(super) fn verifier_repair_decision(
 /// to actually run because the stale assessment from the previous
 /// cluster is still in the slot.
 ///
-/// The predicate mirrors the CB-007 / CB-012 invariant:
-/// * `assessment.is_some()` — a stale assessment exists
-/// * `semantic_plan.is_some()` — we are inside a semantic plan
-/// * `!exhausted_attempts.is_empty()` — at least one cluster has been
-///   exhausted, i.e. the plan has advanced
-/// * `verifier_repair_context_target_path(...) == None` — the CB-007 hint
-///   guard is already returning None for this state, confirming the
-///   assessment is stale
+/// The predicate composes:
+/// * `assessment.is_some()` — a stale assessment exists to clear
+/// * `semantic_plan_is_stale(job)` — CB-015 generation-aware staleness
+///   (subsumes the legacy `semantic_plan.is_some() &&
+///   !exhausted_attempts.is_empty()` shape, and additionally flips to
+///   `false` once a re-diagnostic has refreshed the assessment).
+///
+/// `work_root` is no longer consulted: stale detection lives entirely
+/// on the `RepairJob` generation fields, so the predicate is now
+/// O(1) and independent of filesystem state. The argument is retained
+/// for the existing call-site signature; future cleanup may remove it.
 pub(super) fn has_stale_assessment_after_cluster_advance(
     job: &RepairJob,
-    work_root: &Path,
+    _work_root: &Path,
 ) -> bool {
-    job.assessment.is_some()
-        && job.semantic_plan.is_some()
-        && !job.exhausted_attempts.is_empty()
-        && super::turn::verifier_repair_context_target_path(work_root, job).is_none()
+    job.assessment.is_some() && semantic_plan_is_stale(job)
 }
 
 /// Adapter moved from `turn.rs::Agent::task_contract_repair_state()`. Pure
@@ -621,6 +690,16 @@ pub(super) fn advance_to_next_cluster(
     //    uses when no higher-authority signal fires.
     let spec_authority = carried_authority.unwrap_or(SpecAuthority::ImplementationContract);
 
+    // Issue #647 (CB-015): the new plan's generation snapshot is set to
+    // the **current** `RepairJob.assessment_generation`. This intentionally
+    // creates a "stale" state immediately after a cluster advance:
+    // `plan.assessment_generation_at_creation == job.assessment_generation`
+    // → `semantic_plan_is_stale` returns `true` → CB-007/CB-012 force a
+    // re-diagnostic against the new cluster. Once that re-diagnostic
+    // increments `RepairJob.assessment_generation`, the comparison
+    // flips and the controller proceeds to repair the freshly-diagnosed
+    // cluster (the liveness gap CB-015 closes).
+    let assessment_generation_at_creation = repair_job.assessment_generation;
     repair_job.semantic_plan = Some(SemanticRepairPlan {
         semantic_cause: report.failure_kind,
         spec_authority,
@@ -629,6 +708,7 @@ pub(super) fn advance_to_next_cluster(
         failure_cluster_id: next_cluster.cluster_key.clone(),
         expected_improvement: None,
         semantic_report: report.clone(),
+        assessment_generation_at_creation,
     });
     true
 }
@@ -959,6 +1039,7 @@ mod tests {
             preferred_repair_role: super::super::task_contract::ArtifactRole::Implementation,
             repair_hypothesis: "h".to_string(),
             expected_improvement: None,
+            assessment_generation_at_creation: 0,
         };
         let plan_b = SemanticRepairPlan {
             semantic_report: report,
@@ -968,6 +1049,7 @@ mod tests {
             preferred_repair_role: super::super::task_contract::ArtifactRole::Implementation,
             repair_hypothesis: "h".to_string(),
             expected_improvement: None,
+            assessment_generation_at_creation: 0,
         };
         assert_eq!(plan_a, plan_b);
     }
@@ -984,6 +1066,7 @@ mod tests {
             preferred_repair_role: super::super::task_contract::ArtifactRole::Implementation,
             repair_hypothesis: "h".to_string(),
             expected_improvement: None,
+            assessment_generation_at_creation: 0,
         };
         let mut different_authority = base.clone();
         different_authority.spec_authority = SpecAuthority::LlmGeneratedTest;
@@ -1060,6 +1143,7 @@ mod tests {
             preferred_repair_role: super::super::task_contract::ArtifactRole::Implementation,
             repair_hypothesis: "h".to_string(),
             expected_improvement: None,
+            assessment_generation_at_creation: 0,
         };
         let a = RepairJob {
             semantic_plan: Some(plan.clone()),
@@ -1149,6 +1233,7 @@ mod tests {
             preferred_repair_role: report.preferred_repair_role,
             repair_hypothesis: report.repair_hypothesis.clone(),
             expected_improvement: None,
+            assessment_generation_at_creation: 0,
         };
         RepairJob {
             semantic_plan: Some(plan),
@@ -1294,6 +1379,7 @@ mod tests {
             preferred_repair_role: role,
             repair_hypothesis: report.repair_hypothesis.clone(),
             expected_improvement: None,
+            assessment_generation_at_creation: 0,
         };
         let job = RepairJob {
             semantic_plan: Some(plan),
@@ -1311,6 +1397,7 @@ mod tests {
             preferred_repair_role: role,
             repair_hypothesis: report.repair_hypothesis.clone(),
             expected_improvement: None,
+            assessment_generation_at_creation: 0,
         };
         let job2 = RepairJob {
             semantic_plan: Some(plan2),
@@ -1517,6 +1604,7 @@ mod tests {
             preferred_repair_role: role,
             repair_hypothesis: report.repair_hypothesis.clone(),
             expected_improvement: None,
+            assessment_generation_at_creation: 0,
         };
         let mut job = RepairJob {
             semantic_plan: Some(plan),
@@ -1718,6 +1806,7 @@ mod tests {
             preferred_repair_role: role,
             repair_hypothesis: report.repair_hypothesis.clone(),
             expected_improvement: None,
+            assessment_generation_at_creation: 0,
         };
 
         assign_semantic_plan_preserving_exhausted(&mut job, Some(new_plan), Some(&report));
@@ -1761,6 +1850,7 @@ mod tests {
             preferred_repair_role: role,
             repair_hypothesis: report.repair_hypothesis.clone(),
             expected_improvement: None,
+            assessment_generation_at_creation: 0,
         };
 
         assign_semantic_plan_preserving_exhausted(&mut job, Some(doomed_plan), Some(&report));
@@ -1803,6 +1893,7 @@ mod tests {
             preferred_repair_role: role,
             repair_hypothesis: report.repair_hypothesis.clone(),
             expected_improvement: None,
+            assessment_generation_at_creation: 0,
         };
 
         assign_semantic_plan_preserving_exhausted(&mut job, Some(any_plan), Some(&report));
@@ -1841,6 +1932,7 @@ mod tests {
             preferred_repair_role: role,
             repair_hypothesis: report.repair_hypothesis.clone(),
             expected_improvement: None,
+            assessment_generation_at_creation: 0,
         };
 
         assign_semantic_plan_preserving_exhausted(&mut job, Some(doomed), Some(&report));
@@ -1913,6 +2005,7 @@ mod tests {
             preferred_repair_role: role,
             repair_hypothesis: report.repair_hypothesis.clone(),
             expected_improvement: None,
+            assessment_generation_at_creation: 0,
         };
 
         // (5) MF2 V3.1 router → must skip A and land on B.
@@ -1961,6 +2054,7 @@ mod tests {
             preferred_repair_role: role,
             repair_hypothesis: report.repair_hypothesis.clone(),
             expected_improvement: None,
+            assessment_generation_at_creation: 0,
         };
         let mut job = RepairJob {
             semantic_plan: Some(plan_b),
@@ -1978,6 +2072,7 @@ mod tests {
                 preferred_repair_role: role,
                 repair_hypothesis: report.repair_hypothesis.clone(),
                 expected_improvement: None,
+                assessment_generation_at_creation: 0,
             };
             assign_semantic_plan_preserving_exhausted(&mut job, Some(re_diag_plan), Some(&report));
             // After every router call, A remains exhausted; B is the slot.
@@ -2024,6 +2119,7 @@ mod tests {
             preferred_repair_role: role,
             repair_hypothesis: report.repair_hypothesis.clone(),
             expected_improvement: None,
+            assessment_generation_at_creation: 0,
         };
         let mut job = RepairJob {
             semantic_plan: Some(plan),
@@ -2067,6 +2163,7 @@ mod tests {
             preferred_repair_role: role,
             repair_hypothesis: report.repair_hypothesis.clone(),
             expected_improvement: None,
+            assessment_generation_at_creation: 0,
         };
         let mut job = RepairJob {
             semantic_plan: Some(plan),
@@ -2112,6 +2209,7 @@ mod tests {
             preferred_repair_role: role,
             repair_hypothesis: report.repair_hypothesis.clone(),
             expected_improvement: None,
+            assessment_generation_at_creation: 0,
         };
         let mut job = RepairJob {
             semantic_plan: Some(plan),
@@ -2185,6 +2283,7 @@ mod tests {
             preferred_repair_role: role,
             repair_hypothesis: report.repair_hypothesis.clone(),
             expected_improvement: None,
+            assessment_generation_at_creation: 0,
         };
         let stale_hint = RecoveryTargetHint {
             role: super::super::task_contract::ArtifactRole::Implementation,
@@ -2238,6 +2337,7 @@ mod tests {
             preferred_repair_role: role,
             repair_hypothesis: report.repair_hypothesis.clone(),
             expected_improvement: None,
+            assessment_generation_at_creation: 0,
         };
         let job = RepairJob {
             semantic_plan: Some(plan),
@@ -2285,6 +2385,7 @@ mod tests {
             preferred_repair_role: role,
             repair_hypothesis: report.repair_hypothesis.clone(),
             expected_improvement: None,
+            assessment_generation_at_creation: 0,
         };
         let job = RepairJob {
             semantic_plan: Some(plan),
@@ -2327,6 +2428,250 @@ mod tests {
             !has_stale_assessment_after_cluster_advance(&job, &work_root),
             "CB-013: semantic_plan None → helper must not fire",
         );
+    }
+
+    // ---- Issue #647 (CB-015): stale↔fresh distinction via assessment_generation ---- //
+
+    /// CB-015.1: a freshly-built RepairJob has `assessment_generation == 0`
+    /// and `semantic_plan_is_stale` is `false` (no plan, no exhausted
+    /// attempts). The legacy zero-init posture is preserved.
+    #[test]
+    fn cb015_new_job_starts_with_generation_zero_and_is_not_stale() {
+        let job = RepairJob::new_for_test();
+        assert_eq!(job.assessment_generation, 0);
+        assert!(!semantic_plan_is_stale(&job));
+    }
+
+    /// CB-015.2 (core stale state): after a cluster advance, the new plan is
+    /// `assessment_generation_at_creation == job.assessment_generation`
+    /// AND `!exhausted_attempts.is_empty()` → `semantic_plan_is_stale`
+    /// fires. This is the precondition where CB-007 / CB-012 must force
+    /// re-diagnostic.
+    #[test]
+    fn cb015_stale_state_after_cluster_advance_returns_true() {
+        let report =
+            multi_cluster_report_fixture(VerifierDiagnosticFailureKind::AssertionMismatch, 2);
+        let mut job = job_with_first_cluster_plan(&report);
+        // The fixture sets job.assessment_generation = 0 (default). The
+        // initial plan is also at generation 0 — but `exhausted_attempts`
+        // is empty, so the plan is not yet stale.
+        assert!(!semantic_plan_is_stale(&job));
+
+        // Simulate a "diagnostic landed at generation 1" baseline (so the
+        // initial plan from `job_with_first_cluster_plan` looks fresh
+        // post-bump). This mirrors the production sequencing in
+        // `run_verifier_diagnostic_pass`.
+        job.assessment_generation = 1;
+        assert!(!semantic_plan_is_stale(&job)); // empty exhausted_attempts
+
+        // Now advance to cluster B → the new plan is created with
+        // `assessment_generation_at_creation = job.assessment_generation = 1`
+        // AND cluster A is pushed onto `exhausted_attempts`. The stale
+        // predicate must fire.
+        assert!(advance_to_next_cluster(&mut job, &report));
+        assert!(
+            semantic_plan_is_stale(&job),
+            "CB-015: post-advance, plan.gen == job.gen and exhausted non-empty → stale must be true",
+        );
+        assert_eq!(
+            job.semantic_plan
+                .as_ref()
+                .unwrap()
+                .assessment_generation_at_creation,
+            1,
+            "advance must coil the current job.gen into the new plan",
+        );
+    }
+
+    /// CB-015.3 (fresh state): once a re-diagnostic bumps
+    /// `RepairJob.assessment_generation`, the plan's
+    /// `assessment_generation_at_creation` becomes strictly less than the
+    /// job's generation → `semantic_plan_is_stale` flips back to `false`.
+    /// This is the architectural change that lets CB-007 / CB-012 step
+    /// out of the way after a re-diagnostic has refreshed the assessment.
+    #[test]
+    fn cb015_post_re_diagnostic_fresh_state_is_not_stale() {
+        let report =
+            multi_cluster_report_fixture(VerifierDiagnosticFailureKind::AssertionMismatch, 2);
+        let mut job = job_with_first_cluster_plan(&report);
+        job.assessment_generation = 1;
+        // Advance to cluster B → stale precondition.
+        assert!(advance_to_next_cluster(&mut job, &report));
+        assert!(semantic_plan_is_stale(&job));
+
+        // Simulate `run_verifier_diagnostic_pass` writing a new assessment:
+        // bump `assessment_generation` by 1. The slot still holds the
+        // cluster-B plan with `assessment_generation_at_creation == 1`.
+        job.assessment_generation = 2;
+        assert!(
+            !semantic_plan_is_stale(&job),
+            "CB-015: after re-diagnostic bump, plan.gen < job.gen → stale must be false",
+        );
+    }
+
+    /// CB-015.4 (decision integration): the `verifier_repair_decision`
+    /// state machine routes a stale state through `NeedDiagnostic`, and a
+    /// fresh state (post-re-diagnostic) through the normal target
+    /// resolution path (`NeedTargetDiscovery` here because the test
+    /// fixture's `repair_target_hint` path does not exist on disk; the
+    /// essential invariant is "no longer `NeedDiagnostic`").
+    #[test]
+    fn cb015_decision_routes_fresh_state_past_need_diagnostic() {
+        use tempfile::tempdir;
+        let temp = tempdir().unwrap();
+        let work_root = temp.path().to_path_buf();
+
+        let report =
+            multi_cluster_report_fixture(VerifierDiagnosticFailureKind::AssertionMismatch, 2);
+        let cluster_ids: Vec<_> = report
+            .failure_clusters
+            .iter()
+            .map(|c| c.cluster_key.clone())
+            .collect();
+        let role = report.preferred_repair_role;
+
+        let stale_hint = super::super::task_contract::RecoveryTargetHint {
+            role: super::super::task_contract::ArtifactRole::Implementation,
+            path: "app/stale.py".to_string(),
+            reason: "stale".to_string(),
+        };
+
+        // Stale state: plan.gen == job.gen, exhausted non-empty.
+        let mut job = RepairJob {
+            semantic_plan: Some(SemanticRepairPlan {
+                semantic_report: report.clone(),
+                failure_cluster_id: cluster_ids[1].clone(),
+                semantic_cause: report.failure_kind,
+                spec_authority: SpecAuthority::ImplementationContract,
+                preferred_repair_role: role,
+                repair_hypothesis: report.repair_hypothesis.clone(),
+                expected_improvement: None,
+                assessment_generation_at_creation: 1,
+            }),
+            exhausted_attempts: vec![(cluster_ids[0].clone(), role)],
+            assessment: Some(super::super::VerifierRepairAssessment {
+                failure_kind: VerifierDiagnosticFailureKind::AssertionMismatch,
+                failure_type: VerifierFailureType::Unknown,
+                probable_cause_role: Some(role),
+                needed_reads: Vec::new(),
+                repair_target_hint: Some(stale_hint.clone()),
+                repair_plan: vec![stale_hint],
+                summary: None,
+                source: super::super::VerifierRepairAssessmentSource::DiagnosticPass,
+            }),
+            assessment_attempts: 0,
+            assessment_generation: 1,
+            ..RepairJob::new_for_test()
+        };
+
+        // Stale → NeedDiagnostic (CB-012 path via CB-015 predicate).
+        let dec = verifier_repair_decision(true, Some(&job), &[], &work_root, Some(1), 1);
+        assert_eq!(
+            dec,
+            VerifierRepairDecision::NeedDiagnostic,
+            "CB-015 stale state must route to NeedDiagnostic",
+        );
+
+        // Now simulate re-diagnostic bumping `assessment_generation` →
+        // plan becomes fresh.
+        job.assessment_generation = 2;
+        assert!(!semantic_plan_is_stale(&job));
+
+        // Fresh → no longer NeedDiagnostic. The decision falls through to
+        // the normal target-resolution branches.
+        let dec_fresh = verifier_repair_decision(true, Some(&job), &[], &work_root, Some(1), 1);
+        assert_ne!(
+            dec_fresh,
+            VerifierRepairDecision::NeedDiagnostic,
+            "CB-015 fresh state must NOT route to NeedDiagnostic — \
+             the controller can now proceed to NeedFreshRead/NeedEdit/etc.",
+        );
+        assert_ne!(
+            dec_fresh,
+            VerifierRepairDecision::DiagnosticUnavailable,
+            "CB-015 fresh state must NOT fail closed as DiagnosticUnavailable",
+        );
+    }
+
+    /// CB-015.5 (CB-013 helper integration): once the assessment is fresh
+    /// (post-re-diagnostic generation bump), `has_stale_assessment_after_cluster_advance`
+    /// no longer fires — the diagnostic runner's `Skipped` short-circuit
+    /// returns to its normal posture instead of being pre-empted.
+    #[test]
+    fn cb015_has_stale_assessment_fires_only_for_stale_generation() {
+        use tempfile::tempdir;
+        let temp = tempdir().unwrap();
+        let work_root = temp.path().to_path_buf();
+
+        let report =
+            multi_cluster_report_fixture(VerifierDiagnosticFailureKind::AssertionMismatch, 2);
+        let cluster_ids: Vec<_> = report
+            .failure_clusters
+            .iter()
+            .map(|c| c.cluster_key.clone())
+            .collect();
+        let role = report.preferred_repair_role;
+
+        let mut job = RepairJob {
+            semantic_plan: Some(SemanticRepairPlan {
+                semantic_report: report.clone(),
+                failure_cluster_id: cluster_ids[1].clone(),
+                semantic_cause: report.failure_kind,
+                spec_authority: SpecAuthority::ImplementationContract,
+                preferred_repair_role: role,
+                repair_hypothesis: report.repair_hypothesis.clone(),
+                expected_improvement: None,
+                assessment_generation_at_creation: 1,
+            }),
+            exhausted_attempts: vec![(cluster_ids[0].clone(), role)],
+            assessment: Some(super::super::VerifierRepairAssessment {
+                failure_kind: VerifierDiagnosticFailureKind::AssertionMismatch,
+                failure_type: VerifierFailureType::Unknown,
+                probable_cause_role: Some(role),
+                needed_reads: Vec::new(),
+                repair_target_hint: None,
+                repair_plan: Vec::new(),
+                summary: None,
+                source: super::super::VerifierRepairAssessmentSource::DiagnosticPass,
+            }),
+            assessment_generation: 1,
+            ..RepairJob::new_for_test()
+        };
+
+        // Stale: helper fires.
+        assert!(has_stale_assessment_after_cluster_advance(&job, &work_root));
+
+        // Fresh (re-diagnostic bumped gen): helper must NOT fire — the
+        // assessment now belongs to the current cluster, no need to
+        // clear it before the next diagnostic call.
+        job.assessment_generation = 2;
+        assert!(
+            !has_stale_assessment_after_cluster_advance(&job, &work_root),
+            "CB-015: post-re-diagnostic fresh assessment must NOT trigger the stale-clear helper",
+        );
+    }
+
+    /// CB-015.6 (carryover invariant): `verifier_repair_context_from_failure`
+    /// carries `assessment_generation` over the turn boundary. This pin
+    /// guards the SSOT carryover so a future refactor cannot silently
+    /// drop the generation field across slot reuse.
+    ///
+    /// The actual production carryover lives in `turn.rs`; we verify the
+    /// field shape here by constructing a job with a non-zero generation,
+    /// cloning the field through the public API, and asserting it survives.
+    #[test]
+    fn cb015_assessment_generation_field_is_copyable_and_survives_clone() {
+        let mut job = RepairJob::new_for_test();
+        job.assessment_generation = 7;
+        let cloned = job.clone();
+        assert_eq!(cloned.assessment_generation, 7);
+        // PartialEq still holds across the new field.
+        assert_eq!(job, cloned);
+        // Mutating the new field breaks equality, confirming the field
+        // participates in `PartialEq`.
+        let mut bumped = job.clone();
+        bumped.assessment_generation = 8;
+        assert_ne!(job, bumped);
     }
 
     // -- Phase G grep / structure tests (Issue #647 acceptance closure) -- //

--- a/src/agent/loop_run/semantic_failure.rs
+++ b/src/agent/loop_run/semantic_failure.rs
@@ -1,0 +1,1068 @@
+//! Issue #647 (Phase A.1): semantic repair planning — bounded failure report
+//! schema and deterministic cluster-key generation.
+//!
+//! Visibility: every export here is `pub(super)` and **must not** be
+//! re-exported from `src/agent/loop_run.rs` (CLAUDE.md DR3-001). The only
+//! in-crate consumers will be `super::turn` (parse / dispatch boundary) and
+//! `super::repair_job` (SemanticRepairPlan slot, arriving in Phase B).
+//!
+//! # Security: sanitize SSOT (DR1-001 / DR2-005)
+//!
+//! The two SSOT entry points (composed of the shared `mask_and_neutralize`
+//! prefix in `repair_job.rs::mask_secrets_headers_and_neutralize`) are:
+//!
+//! - `sanitize_repair_job_text` — byte-bounded by `SNAPSHOT_FIELD_BYTE_CAP`,
+//!   used by the snapshot store path.
+//! - `sanitize_repair_job_text_with_char_cap(s, max_chars)` — char-bounded for
+//!   parse-boundary fields with an explicit `max_chars`.
+//!
+//! Every `String` / `Vec<String>` field on `SemanticFailureReport` is run
+//! through entry **(b)** at the parse boundary
+//! (`parse_semantic_failure_report`) with `MAX_CLUSTER_TEXT_CHARS = 240`. The
+//! lower-level `mask_secrets_headers_and_neutralize` is the **internal
+//! prefix** of both entries and must **not** be called directly from a parse
+//! boundary (avoid SSOT duplication).
+//!
+//! # Cluster key (DR4-001 / DR1-010)
+//!
+//! `FailureClusterKey` is a derived value, computed locally by
+//! `build_failure_cluster_from_observation` over sanitized + shape-normalized
+//! inputs. LLM-supplied `cluster_key` values are ignored (DR4-001) so that
+//! diagnostic output cannot collide buckets, side-step `exhausted_attempts`
+//! ledgers, or inject secret-derived fingerprints.
+//!
+//! `cluster_key` is module-private and asserts the sanitize precondition with
+//! `debug_assert!` (caller contract enforced in dev/test, no-op in release).
+//!
+//! # Logging (DR4-004)
+//!
+//! Validation failures emit `tracing::warn!` payloads containing **only**
+//! metadata (error code / field name / cap value). Raw observed / expected /
+//! repair_hypothesis text never appears in log payloads.
+//!
+//! # Phase A.1 dead-code policy
+//!
+//! Phase A.1 lands the schema + parse + dispatch pieces ahead of their
+//! consumers (Phase D wires `parse_semantic_failure_report` into the
+//! diagnostic pipeline; Phase B stores `SemanticFailureReport` inside
+//! `SemanticRepairPlan`). Until those Phases land, the
+//! `pub(super)` surface is exercised only by in-module unit tests, so we
+//! silence `dead_code` at the module root rather than dropping the API.
+
+#![allow(dead_code)]
+
+use super::VerifierDiagnosticFailureKind;
+use super::repair_job::sanitize_repair_job_text_with_char_cap;
+use super::task_contract::ArtifactRole;
+
+/// Upper bound for `repair_hypothesis` after sanitize (chars, not bytes).
+/// Mirrors the diagnostic summary cap used elsewhere in the agent loop.
+pub(super) const MAX_REPAIR_HYPOTHESIS_CHARS: usize = 240;
+
+/// Upper bound for the number of `affected_cases` retained per cluster.
+pub(super) const MAX_AFFECTED_CASES: usize = 16;
+
+/// Upper bound (chars) for shape-normalized cluster text fields
+/// (`observed`, `expected`, `affected_cases[*]`, `ContractConflict.*`).
+pub(super) const MAX_CLUSTER_TEXT_CHARS: usize = 240;
+
+/// Bounded, sanitized representation of a diagnostic LLM failure report.
+///
+/// All `String` / `Vec<String>` fields are sanitized at the parse boundary
+/// so downstream consumers can read them without re-applying the SSOT
+/// pipeline. `Eq` is intentionally dropped because `confidence: f32` is not
+/// totally orderable (see `task_contract::TaskContract` for the same
+/// trade-off).
+#[derive(Debug, Clone, PartialEq)]
+pub(super) struct SemanticFailureReport {
+    pub(super) failure_kind: VerifierDiagnosticFailureKind,
+    pub(super) failure_clusters: Vec<FailureCluster>,
+    pub(super) contract_conflict: ContractConflict,
+    pub(super) preferred_repair_role: ArtifactRole,
+    /// Sanitized, char-capped to `MAX_REPAIR_HYPOTHESIS_CHARS`.
+    pub(super) repair_hypothesis: String,
+    /// Finite, in `[0.0, 1.0]` (validated at parse).
+    pub(super) confidence: f32,
+}
+
+/// Shape-normalized, role-tagged grouping of failure observations that share
+/// the same root cause. Cluster identity is encoded in `cluster_key`.
+#[derive(Debug, Clone, PartialEq)]
+pub(super) struct FailureCluster {
+    pub(super) cluster_key: FailureClusterKey,
+    pub(super) observed: String,
+    pub(super) expected: String,
+    pub(super) affected_cases: Vec<String>,
+    pub(super) involved_artifacts: Vec<ArtifactRole>,
+}
+
+/// Deterministic 16-hex (sha256 short) identifier for a failure cluster.
+///
+/// Constructed **only** by `cluster_key` over sanitized inputs. The newtype
+/// keeps the LLM-supplied raw string from ever escaping the parse boundary.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(super) struct FailureClusterKey(String);
+
+impl FailureClusterKey {
+    /// Read-only access to the 16-hex representation.
+    #[allow(dead_code)]
+    pub(super) fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Three-way contract conflict view: implementation vs. test vs. usage docs.
+/// Each field is sanitized to `MAX_CLUSTER_TEXT_CHARS` at the parse boundary.
+#[derive(Debug, Clone, PartialEq)]
+pub(super) struct ContractConflict {
+    pub(super) implementation: String,
+    pub(super) test: String,
+    pub(super) usage_docs: String,
+}
+
+/// Validation errors at the parse boundary.
+///
+/// Unit variants only — payloads (offending value, raw substrings) are
+/// **never** attached so that `tracing::warn!` callsites cannot leak
+/// secret-bearing text into logs (DR4-004). Eq derive is fine because no
+/// `f32` is carried.
+///
+/// `ClusterKeyMalformed` is a defensive variant: it covers the case where a
+/// locally generated key fails a debug invariant. It is **not** used to
+/// reject LLM-supplied keys — those are discarded silently per DR4-001 and
+/// regenerated by `build_failure_cluster_from_observation`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum SchemaError {
+    ConfidenceInvalid,
+    HypothesisTooLong,
+    AffectedCasesTooMany,
+    ClusterKeyMalformed,
+}
+
+impl SchemaError {
+    /// Stable string code used as the only payload in `tracing::warn!`
+    /// (DR4-004 — raw offending values must not be logged).
+    pub(super) fn code(self) -> &'static str {
+        match self {
+            SchemaError::ConfidenceInvalid => "confidence_invalid",
+            SchemaError::HypothesisTooLong => "hypothesis_too_long",
+            SchemaError::AffectedCasesTooMany => "affected_cases_too_many",
+            SchemaError::ClusterKeyMalformed => "cluster_key_malformed",
+        }
+    }
+}
+
+/// Dispatch target for a `SemanticFailureReport`.
+///
+/// `DependencyMissing` / `ConfigOrVerifierError` are routed to the existing
+/// setup-repair / `MissingVerifierJob` pipeline; everything else continues
+/// through semantic repair planning.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum SemanticDispatchTarget {
+    SemanticRepair,
+    SetupRepair,
+}
+
+/// Public entry point that guarantees the
+/// **sanitize → literal-to-shape normalize → cluster_key** invariant
+/// (DR1-010 + design judgment #6 §4.2): every string is first run through
+/// `sanitize_repair_job_text_with_char_cap` and then through
+/// [`normalize_to_shape`] before the hash input is assembled, so
+/// `cluster_key` only sees bounded, redacted, *shape-normalized* text.
+///
+/// The stored `observed` / `expected` on `FailureCluster` retain the
+/// sanitized (but unnormalized) text so operators can read the diagnostic
+/// in human form; only the hash-input variants are normalized.
+///
+/// `assertion_shape` is a caller-supplied label (e.g. the variant name of a
+/// closed enum). The function does not interpret its contents — it only
+/// participates in the cluster identity.
+pub(super) fn build_failure_cluster_from_observation(
+    raw_observed: &str,
+    raw_expected: &str,
+    raw_input_shape: &str,
+    assertion_shape: &str,
+    artifact_role_set: &[ArtifactRole],
+) -> FailureCluster {
+    let observed = sanitize_repair_job_text_with_char_cap(raw_observed, MAX_CLUSTER_TEXT_CHARS);
+    let expected = sanitize_repair_job_text_with_char_cap(raw_expected, MAX_CLUSTER_TEXT_CHARS);
+    let input_shape_signature =
+        sanitize_repair_job_text_with_char_cap(raw_input_shape, MAX_CLUSTER_TEXT_CHARS);
+    let assertion_shape_sig =
+        sanitize_repair_job_text_with_char_cap(assertion_shape, MAX_CLUSTER_TEXT_CHARS);
+
+    // CB-002: hash inputs are normalized to coarse shape so secret-like or
+    // identifier-like literals never form a stable fingerprint and don't
+    // fragment clusters that share the same shape.
+    let observed_shape = normalize_to_shape(&observed);
+    let expected_shape = normalize_to_shape(&expected);
+    let input_shape_shape = normalize_to_shape(&input_shape_signature);
+    let assertion_shape_shape = normalize_to_shape(&assertion_shape_sig);
+
+    let mut involved_artifacts: Vec<ArtifactRole> = artifact_role_set.to_vec();
+    involved_artifacts.sort();
+    involved_artifacts.dedup();
+
+    let key = cluster_key(
+        &observed_shape,
+        &expected_shape,
+        &input_shape_shape,
+        &assertion_shape_shape,
+        &involved_artifacts,
+    );
+
+    FailureCluster {
+        cluster_key: key,
+        observed,
+        expected,
+        affected_cases: Vec::new(),
+        involved_artifacts,
+    }
+}
+
+/// CB-002 / design §4.2: collapse literal values in `s` into coarse shape
+/// tokens so that hash inputs of different but structurally similar
+/// observations land in the same cluster (and so that secret-like values
+/// never form a stable fingerprint).
+///
+/// Order of replacements (each is order-dependent — earlier rules win):
+/// 1. UUID (8-4-4-4-12 hex) → `<uuid>`
+/// 2. Quoted literals (`"..."` / `'...'`) → `<str>`
+/// 3. Path segments (one or more `/segment/` runs) → `<path>`
+/// 4. Long opaque tokens (16+ contiguous alnum/`_`/`-`) → `<token>`
+/// 5. Decimal / hex / float number runs → `<num>`
+/// 6. The remaining raw text is truncated to `MAX_RAW_AFTER_SHAPE`
+///    characters so the hash input length is bounded.
+///
+/// Returned text is plain ASCII and contains no control characters (the
+/// inputs already passed `mask_and_neutralize` upstream).
+pub(super) fn normalize_to_shape(s: &str) -> String {
+    use regex::Regex;
+    use std::sync::OnceLock;
+
+    const MAX_RAW_AFTER_SHAPE: usize = 64;
+
+    // Static one-time compiled regexes.
+    static UUID_RE: OnceLock<Regex> = OnceLock::new();
+    static QSTR_RE: OnceLock<Regex> = OnceLock::new();
+    static PATH_RE: OnceLock<Regex> = OnceLock::new();
+    static TOKEN_RE: OnceLock<Regex> = OnceLock::new();
+    static NUM_RE: OnceLock<Regex> = OnceLock::new();
+
+    let uuid = UUID_RE.get_or_init(|| {
+        Regex::new(r"(?i)\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b")
+            .expect("uuid regex compiles")
+    });
+    let qstr = QSTR_RE.get_or_init(|| {
+        // Non-greedy quoted runs; allow escaped quotes.
+        Regex::new(r#""(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'"#).expect("qstr regex compiles")
+    });
+    let path = PATH_RE.get_or_init(|| {
+        // One or more `/<segment>` runs, where segment is non-whitespace
+        // and contains no `/`. Anchor: leading `/`.
+        Regex::new(r"(?:/[^/\s]+){1,}").expect("path regex compiles")
+    });
+    let token = TOKEN_RE.get_or_init(|| {
+        // 16+ contiguous alnum/_/- characters → opaque token.
+        Regex::new(r"[A-Za-z0-9_\-]{16,}").expect("token regex compiles")
+    });
+    let num = NUM_RE.get_or_init(|| {
+        // Integer / hex / decimal float run. (Order matters: this is last
+        // so numeric parts of larger tokens were already absorbed.)
+        Regex::new(r"\b(?:0x[0-9A-Fa-f]+|\d+(?:\.\d+)?)\b").expect("num regex compiles")
+    });
+
+    let stage1 = uuid.replace_all(s, "<uuid>");
+    let stage2 = qstr.replace_all(&stage1, "<str>");
+    let stage3 = path.replace_all(&stage2, "<path>");
+    let stage4 = token.replace_all(&stage3, "<token>");
+    let stage5 = num.replace_all(&stage4, "<num>");
+
+    // Truncate any remaining raw run to MAX_RAW_AFTER_SHAPE chars. We keep
+    // a `<...>` suffix when truncating so distinct over-cap inputs don't
+    // collide just because their first 64 chars matched.
+    let truncated: String = stage5.chars().take(MAX_RAW_AFTER_SHAPE).collect();
+    if stage5.chars().count() > MAX_RAW_AFTER_SHAPE {
+        format!("{truncated}<...>")
+    } else {
+        truncated
+    }
+}
+
+/// Module-private deterministic hash over sanitized + shape-normalized
+/// components. Returns a 16-hex (sha256 short, 8 leading bytes) identifier.
+///
+/// The function is intentionally private — its single caller is
+/// `build_failure_cluster_from_observation`, which is the only place where
+/// the sanitize precondition is enforced. `debug_assert!` is used to flag
+/// any future direct callers in dev/test builds.
+fn cluster_key(
+    observed_shape: &str,
+    expected_shape: &str,
+    input_shape_signature: &str,
+    assertion_shape: &str,
+    artifact_role_set: &[ArtifactRole],
+) -> FailureClusterKey {
+    use sha2::{Digest, Sha256};
+    use std::fmt::Write as _;
+
+    debug_assert!(
+        is_already_sanitized(observed_shape),
+        "cluster_key precondition: observed must be sanitized"
+    );
+    debug_assert!(
+        is_already_sanitized(expected_shape),
+        "cluster_key precondition: expected must be sanitized"
+    );
+    debug_assert!(
+        is_already_sanitized(input_shape_signature),
+        "cluster_key precondition: input_shape must be sanitized"
+    );
+    debug_assert!(
+        is_already_sanitized(assertion_shape),
+        "cluster_key precondition: assertion_shape must be sanitized"
+    );
+
+    let mut roles_sorted: Vec<&str> = artifact_role_set.iter().map(|r| r.label()).collect();
+    roles_sorted.sort();
+    roles_sorted.dedup();
+
+    let joined = format!(
+        "{}|{}|{}|{}|{}",
+        observed_shape,
+        expected_shape,
+        input_shape_signature,
+        assertion_shape,
+        roles_sorted.join(",")
+    );
+    let hash = Sha256::digest(joined.as_bytes());
+    let mut hex = String::with_capacity(16);
+    for byte in &hash[..8] {
+        // 2 hex chars per byte → 16 chars total.
+        let _ = write!(hex, "{:02x}", byte);
+    }
+    debug_assert_eq!(hex.len(), 16);
+    FailureClusterKey(hex)
+}
+
+/// `debug_assert!` helper: returns `true` when the input has already passed
+/// through the SSOT sanitize entry (no control chars, length ≤ cap).
+///
+/// This is a conservative invariant — it cannot prove that
+/// `mask_secrets`/`mask_header_family` ran, but it catches the most common
+/// programmer mistakes (raw control chars, oversized strings).
+fn is_already_sanitized(s: &str) -> bool {
+    if s.chars().count() > MAX_CLUSTER_TEXT_CHARS + 3 {
+        // +3 accounts for the trailing "..." ellipsis appended by
+        // `truncate_chars_with_ellipsis` when the input exceeded the cap.
+        return false;
+    }
+    !s.chars().any(|c| (c as u32) < 0x20 || c == '\x7f')
+}
+
+/// Parse + validate a diagnostic LLM JSON payload into a bounded
+/// `SemanticFailureReport`.
+///
+/// Returns `None` on any validation failure, after emitting a structured
+/// `tracing::warn!` event carrying only the error code, field name, and cap
+/// (DR4-004 — raw offending values are never logged).
+///
+/// LLM-supplied `failure_clusters[].cluster_key` values are ignored
+/// (DR4-001): clusters are reconstructed from sanitized components via
+/// `build_failure_cluster_from_observation`.
+pub(super) fn parse_semantic_failure_report(
+    json: &serde_json::Value,
+) -> Option<SemanticFailureReport> {
+    let obj = json.as_object()?;
+
+    let failure_kind = parse_failure_kind(obj.get("failure_kind")?)?;
+
+    // confidence: finite + within [0, 1].
+    let confidence = obj
+        .get("confidence")
+        .and_then(|v| v.as_f64())
+        .map(|v| v as f32)?;
+    if !confidence.is_finite() || !(0.0..=1.0).contains(&confidence) {
+        warn_schema_error(SchemaError::ConfidenceInvalid, "confidence", None);
+        return None;
+    }
+
+    // CB-005 (Codex review) / S1-014: do NOT reject the entire report when
+    // `repair_hypothesis` exceeds the cap. The SSOT sanitize entry
+    // (`sanitize_repair_job_text_with_char_cap`) already truncates with an
+    // ellipsis; rejecting here would throw away the whole diagnostic over a
+    // single overly long free-form field. We still emit a structured warn
+    // so operators can spot oversized hypotheses, but downstream consumers
+    // receive the truncated text.
+    let raw_hypothesis = obj
+        .get("repair_hypothesis")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    if raw_hypothesis.chars().count() > MAX_REPAIR_HYPOTHESIS_CHARS {
+        warn_schema_error(
+            SchemaError::HypothesisTooLong,
+            "repair_hypothesis",
+            Some(MAX_REPAIR_HYPOTHESIS_CHARS),
+        );
+    }
+    let repair_hypothesis =
+        sanitize_repair_job_text_with_char_cap(raw_hypothesis, MAX_REPAIR_HYPOTHESIS_CHARS);
+
+    // preferred_repair_role.
+    let preferred_repair_role = obj
+        .get("preferred_repair_role")
+        .and_then(|v| v.as_str())
+        .and_then(parse_artifact_role)?;
+
+    // contract_conflict.
+    let cc = obj.get("contract_conflict").and_then(|v| v.as_object());
+    let contract_conflict = ContractConflict {
+        implementation: sanitize_repair_job_text_with_char_cap(
+            cc.and_then(|o| o.get("implementation"))
+                .and_then(|v| v.as_str())
+                .unwrap_or(""),
+            MAX_CLUSTER_TEXT_CHARS,
+        ),
+        test: sanitize_repair_job_text_with_char_cap(
+            cc.and_then(|o| o.get("test"))
+                .and_then(|v| v.as_str())
+                .unwrap_or(""),
+            MAX_CLUSTER_TEXT_CHARS,
+        ),
+        usage_docs: sanitize_repair_job_text_with_char_cap(
+            cc.and_then(|o| o.get("usage_docs"))
+                .and_then(|v| v.as_str())
+                .unwrap_or(""),
+            MAX_CLUSTER_TEXT_CHARS,
+        ),
+    };
+
+    // failure_clusters: LLM-supplied cluster_key is ignored (DR4-001) and
+    // every cluster is rebuilt from sanitized components.
+    let mut failure_clusters: Vec<FailureCluster> = Vec::new();
+    if let Some(arr) = obj.get("failure_clusters").and_then(|v| v.as_array()) {
+        for cluster in arr {
+            let cluster_obj = match cluster.as_object() {
+                Some(o) => o,
+                None => continue,
+            };
+
+            // affected_cases: bounded count, each sanitized.
+            let mut affected_cases: Vec<String> = Vec::new();
+            if let Some(cases) = cluster_obj.get("affected_cases").and_then(|v| v.as_array()) {
+                if cases.len() > MAX_AFFECTED_CASES {
+                    warn_schema_error(
+                        SchemaError::AffectedCasesTooMany,
+                        "affected_cases",
+                        Some(MAX_AFFECTED_CASES),
+                    );
+                    return None;
+                }
+                for case in cases {
+                    if let Some(s) = case.as_str() {
+                        affected_cases.push(sanitize_repair_job_text_with_char_cap(
+                            s,
+                            MAX_CLUSTER_TEXT_CHARS,
+                        ));
+                    }
+                }
+            }
+
+            let involved_artifacts: Vec<ArtifactRole> = cluster_obj
+                .get("involved_artifacts")
+                .and_then(|v| v.as_array())
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|v| v.as_str().and_then(parse_artifact_role))
+                        .collect()
+                })
+                .unwrap_or_default();
+
+            let raw_observed = cluster_obj
+                .get("observed")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            let raw_expected = cluster_obj
+                .get("expected")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            let raw_input_shape = cluster_obj
+                .get("input_shape")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            let raw_assertion_shape = cluster_obj
+                .get("assertion_shape")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+
+            let mut rebuilt = build_failure_cluster_from_observation(
+                raw_observed,
+                raw_expected,
+                raw_input_shape,
+                raw_assertion_shape,
+                &involved_artifacts,
+            );
+            rebuilt.affected_cases = affected_cases;
+            failure_clusters.push(rebuilt);
+        }
+    }
+
+    Some(SemanticFailureReport {
+        failure_kind,
+        failure_clusters,
+        contract_conflict,
+        preferred_repair_role,
+        repair_hypothesis,
+        confidence,
+    })
+}
+
+/// Route a parsed report to the correct repair pipeline.
+///
+/// `DependencyMissing` / `ConfigOrVerifierError` short-circuit to setup
+/// repair (existing `MissingVerifierJob` / setup pipeline); every other
+/// failure kind continues through semantic repair planning.
+pub(super) fn dispatch_target(report: &SemanticFailureReport) -> SemanticDispatchTarget {
+    match report.failure_kind {
+        VerifierDiagnosticFailureKind::DependencyMissing
+        | VerifierDiagnosticFailureKind::ConfigOrVerifierError => {
+            SemanticDispatchTarget::SetupRepair
+        }
+        _ => SemanticDispatchTarget::SemanticRepair,
+    }
+}
+
+/// Parse the closed set of `VerifierDiagnosticFailureKind` labels from the
+/// existing SSOT (`loop_run.rs::VerifierDiagnosticFailureKind::as_str`).
+fn parse_failure_kind(v: &serde_json::Value) -> Option<VerifierDiagnosticFailureKind> {
+    Some(match v.as_str()? {
+        "dependency_missing" => VerifierDiagnosticFailureKind::DependencyMissing,
+        "local_import_contract_mismatch" => {
+            VerifierDiagnosticFailureKind::LocalImportContractMismatch
+        }
+        "compile_or_syntax_error" => VerifierDiagnosticFailureKind::CompileOrSyntaxError,
+        "assertion_mismatch" => VerifierDiagnosticFailureKind::AssertionMismatch,
+        "runtime_error" => VerifierDiagnosticFailureKind::RuntimeError,
+        "test_bug" => VerifierDiagnosticFailureKind::TestBug,
+        "config_or_verifier_error" => VerifierDiagnosticFailureKind::ConfigOrVerifierError,
+        "unknown" => VerifierDiagnosticFailureKind::Unknown,
+        _ => return None,
+    })
+}
+
+/// Parse the closed set of `ArtifactRole` labels from
+/// `task_contract::ArtifactRole::label`.
+fn parse_artifact_role(s: &str) -> Option<ArtifactRole> {
+    Some(match s {
+        "implementation" => ArtifactRole::Implementation,
+        "test" => ArtifactRole::Test,
+        "usage_docs" => ArtifactRole::UsageDocs,
+        "setup" => ArtifactRole::Setup,
+        _ => return None,
+    })
+}
+
+/// Emit a `SchemaError` validation failure with **metadata only** — never the
+/// offending raw value (DR4-004).
+fn warn_schema_error(err: SchemaError, field: &'static str, cap: Option<usize>) {
+    tracing::warn!(
+        event = "agent.semantic_failure.schema_error",
+        error_code = err.code(),
+        field = field,
+        cap = cap,
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn role_set(roles: &[ArtifactRole]) -> Vec<ArtifactRole> {
+        roles.to_vec()
+    }
+
+    #[test]
+    fn cluster_key_is_deterministic_for_same_inputs() {
+        let a = build_failure_cluster_from_observation(
+            "observed text",
+            "expected text",
+            "input shape",
+            "AssertEq",
+            &role_set(&[ArtifactRole::Test, ArtifactRole::Implementation]),
+        );
+        let b = build_failure_cluster_from_observation(
+            "observed text",
+            "expected text",
+            "input shape",
+            "AssertEq",
+            &role_set(&[ArtifactRole::Implementation, ArtifactRole::Test]),
+        );
+        assert_eq!(a.cluster_key, b.cluster_key);
+        assert_eq!(a.cluster_key.as_str().len(), 16);
+    }
+
+    #[test]
+    fn cluster_key_changes_when_inputs_change() {
+        let a = build_failure_cluster_from_observation(
+            "observed",
+            "expected",
+            "shape",
+            "AssertEq",
+            &role_set(&[ArtifactRole::Test]),
+        );
+        let b = build_failure_cluster_from_observation(
+            "observed",
+            "expected DIFFERENT",
+            "shape",
+            "AssertEq",
+            &role_set(&[ArtifactRole::Test]),
+        );
+        assert_ne!(a.cluster_key, b.cluster_key);
+    }
+
+    #[test]
+    fn cluster_key_uses_sanitized_inputs() {
+        // raw secret-like material should be masked before reaching cluster_key.
+        let raw_with_secret =
+            "Authorization: Bearer sk-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+        let cluster = build_failure_cluster_from_observation(
+            raw_with_secret,
+            "expected",
+            "shape",
+            "AssertEq",
+            &role_set(&[ArtifactRole::Test]),
+        );
+        // The sanitized observed text should not be byte-for-byte identical
+        // to the raw secret-bearing input (mask_header_family / mask_secrets
+        // applied at the boundary).
+        assert_ne!(cluster.observed, raw_with_secret);
+        // No control chars in the stored observed text.
+        assert!(!cluster.observed.chars().any(|c| (c as u32) < 0x20));
+    }
+
+    #[test]
+    fn cluster_key_role_order_does_not_change_identity() {
+        // ArtifactRole input order must not affect the cluster identity.
+        let key_a = build_failure_cluster_from_observation(
+            "o",
+            "e",
+            "s",
+            "AssertEq",
+            &role_set(&[ArtifactRole::UsageDocs, ArtifactRole::Implementation]),
+        )
+        .cluster_key;
+        let key_b = build_failure_cluster_from_observation(
+            "o",
+            "e",
+            "s",
+            "AssertEq",
+            &role_set(&[ArtifactRole::Implementation, ArtifactRole::UsageDocs]),
+        )
+        .cluster_key;
+        assert_eq!(key_a, key_b);
+    }
+
+    #[test]
+    fn parse_rejects_nan_and_inf_confidence() {
+        let nan = serde_json::json!({
+            "failure_kind": "assertion_mismatch",
+            "confidence": f64::NAN,
+            "preferred_repair_role": "implementation",
+            "repair_hypothesis": "",
+        });
+        assert!(parse_semantic_failure_report(&nan).is_none());
+
+        let inf = serde_json::json!({
+            "failure_kind": "assertion_mismatch",
+            "confidence": f64::INFINITY,
+            "preferred_repair_role": "implementation",
+            "repair_hypothesis": "",
+        });
+        assert!(parse_semantic_failure_report(&inf).is_none());
+    }
+
+    #[test]
+    fn parse_rejects_confidence_outside_unit_interval() {
+        let low = serde_json::json!({
+            "failure_kind": "assertion_mismatch",
+            "confidence": -0.1,
+            "preferred_repair_role": "implementation",
+            "repair_hypothesis": "",
+        });
+        assert!(parse_semantic_failure_report(&low).is_none());
+
+        let high = serde_json::json!({
+            "failure_kind": "assertion_mismatch",
+            "confidence": 1.1,
+            "preferred_repair_role": "implementation",
+            "repair_hypothesis": "",
+        });
+        assert!(parse_semantic_failure_report(&high).is_none());
+    }
+
+    #[test]
+    fn parse_accepts_confidence_at_boundary() {
+        for c in [0.0_f64, 1.0_f64] {
+            let v = serde_json::json!({
+                "failure_kind": "assertion_mismatch",
+                "confidence": c,
+                "preferred_repair_role": "implementation",
+                "repair_hypothesis": "",
+            });
+            let parsed = parse_semantic_failure_report(&v).expect("boundary accepted");
+            assert_eq!(parsed.confidence, c as f32);
+        }
+    }
+
+    #[test]
+    fn parse_truncates_hypothesis_longer_than_cap_cb005() {
+        // CB-005 acceptance (S1-014): an over-cap repair_hypothesis must be
+        // truncated via the SSOT sanitize entry, not cause the whole report
+        // to be rejected. 300 chars → ≤ MAX_REPAIR_HYPOTHESIS_CHARS + ellipsis.
+        let long = "a".repeat(300);
+        let v = serde_json::json!({
+            "failure_kind": "assertion_mismatch",
+            "confidence": 0.5,
+            "preferred_repair_role": "implementation",
+            "repair_hypothesis": long,
+        });
+        let parsed = parse_semantic_failure_report(&v)
+            .expect("CB-005: long hypothesis must not reject the report");
+        // Truncated length: cap + at most 3 trailing ellipsis chars
+        // (truncate_chars_with_ellipsis convention).
+        let n = parsed.repair_hypothesis.chars().count();
+        assert!(
+            n <= MAX_REPAIR_HYPOTHESIS_CHARS + 3,
+            "truncated length {n} exceeded cap+ellipsis",
+        );
+        // And the truncated text must be a strict prefix of the raw "a"-run
+        // (modulo the trailing ellipsis).
+        assert!(parsed.repair_hypothesis.starts_with("aaa"));
+    }
+
+    #[test]
+    fn parse_rejects_affected_cases_over_cap() {
+        let cases: Vec<&str> = (0..(MAX_AFFECTED_CASES + 1)).map(|_| "case").collect();
+        let v = serde_json::json!({
+            "failure_kind": "assertion_mismatch",
+            "confidence": 0.5,
+            "preferred_repair_role": "implementation",
+            "repair_hypothesis": "h",
+            "failure_clusters": [
+                {
+                    "observed": "o",
+                    "expected": "e",
+                    "input_shape": "s",
+                    "assertion_shape": "AssertEq",
+                    "involved_artifacts": ["test"],
+                    "affected_cases": cases,
+                }
+            ],
+        });
+        assert!(parse_semantic_failure_report(&v).is_none());
+    }
+
+    #[test]
+    fn parse_ignores_llm_supplied_cluster_key_and_regenerates() {
+        let v = serde_json::json!({
+            "failure_kind": "assertion_mismatch",
+            "confidence": 0.5,
+            "preferred_repair_role": "implementation",
+            "repair_hypothesis": "h",
+            "failure_clusters": [
+                {
+                    "cluster_key": "deadbeefdeadbeef", // attacker-supplied
+                    "observed": "o",
+                    "expected": "e",
+                    "input_shape": "s",
+                    "assertion_shape": "AssertEq",
+                    "involved_artifacts": ["test"],
+                    "affected_cases": ["case1"],
+                }
+            ],
+        });
+        let parsed = parse_semantic_failure_report(&v).expect("parses");
+        assert_eq!(parsed.failure_clusters.len(), 1);
+        // The locally regenerated key must NOT equal the attacker payload.
+        assert_ne!(
+            parsed.failure_clusters[0].cluster_key.as_str(),
+            "deadbeefdeadbeef"
+        );
+        // And it must match a freshly computed key from the same components.
+        let regenerated = build_failure_cluster_from_observation(
+            "o",
+            "e",
+            "s",
+            "AssertEq",
+            &[ArtifactRole::Test],
+        );
+        assert_eq!(
+            parsed.failure_clusters[0].cluster_key,
+            regenerated.cluster_key
+        );
+    }
+
+    #[test]
+    fn parse_returns_none_for_unknown_failure_kind() {
+        let v = serde_json::json!({
+            "failure_kind": "totally_made_up",
+            "confidence": 0.5,
+            "preferred_repair_role": "implementation",
+            "repair_hypothesis": "h",
+        });
+        assert!(parse_semantic_failure_report(&v).is_none());
+    }
+
+    #[test]
+    fn parse_returns_none_for_unknown_repair_role() {
+        let v = serde_json::json!({
+            "failure_kind": "assertion_mismatch",
+            "confidence": 0.5,
+            "preferred_repair_role": "controller",
+            "repair_hypothesis": "h",
+        });
+        assert!(parse_semantic_failure_report(&v).is_none());
+    }
+
+    #[test]
+    fn parse_returns_none_when_top_level_not_object() {
+        let v = serde_json::json!([1, 2, 3]);
+        assert!(parse_semantic_failure_report(&v).is_none());
+    }
+
+    #[test]
+    fn dispatch_target_routes_setup_for_dependency_and_config() {
+        let mut report = SemanticFailureReport {
+            failure_kind: VerifierDiagnosticFailureKind::DependencyMissing,
+            failure_clusters: Vec::new(),
+            contract_conflict: ContractConflict {
+                implementation: String::new(),
+                test: String::new(),
+                usage_docs: String::new(),
+            },
+            preferred_repair_role: ArtifactRole::Setup,
+            repair_hypothesis: String::new(),
+            confidence: 0.5,
+        };
+        assert_eq!(
+            dispatch_target(&report),
+            SemanticDispatchTarget::SetupRepair
+        );
+
+        report.failure_kind = VerifierDiagnosticFailureKind::ConfigOrVerifierError;
+        assert_eq!(
+            dispatch_target(&report),
+            SemanticDispatchTarget::SetupRepair
+        );
+    }
+
+    #[test]
+    fn dispatch_target_routes_semantic_for_other_kinds() {
+        for kind in [
+            VerifierDiagnosticFailureKind::AssertionMismatch,
+            VerifierDiagnosticFailureKind::RuntimeError,
+            VerifierDiagnosticFailureKind::TestBug,
+            VerifierDiagnosticFailureKind::CompileOrSyntaxError,
+            VerifierDiagnosticFailureKind::LocalImportContractMismatch,
+            VerifierDiagnosticFailureKind::Unknown,
+        ] {
+            let report = SemanticFailureReport {
+                failure_kind: kind,
+                failure_clusters: Vec::new(),
+                contract_conflict: ContractConflict {
+                    implementation: String::new(),
+                    test: String::new(),
+                    usage_docs: String::new(),
+                },
+                preferred_repair_role: ArtifactRole::Implementation,
+                repair_hypothesis: String::new(),
+                confidence: 0.5,
+            };
+            assert_eq!(
+                dispatch_target(&report),
+                SemanticDispatchTarget::SemanticRepair
+            );
+        }
+    }
+
+    #[test]
+    fn schema_error_codes_are_stable() {
+        assert_eq!(SchemaError::ConfidenceInvalid.code(), "confidence_invalid");
+        assert_eq!(SchemaError::HypothesisTooLong.code(), "hypothesis_too_long");
+        assert_eq!(
+            SchemaError::AffectedCasesTooMany.code(),
+            "affected_cases_too_many"
+        );
+        assert_eq!(
+            SchemaError::ClusterKeyMalformed.code(),
+            "cluster_key_malformed"
+        );
+    }
+
+    #[test]
+    fn parse_strips_control_chars_from_all_string_fields() {
+        let v = serde_json::json!({
+            "failure_kind": "assertion_mismatch",
+            "confidence": 0.5,
+            "preferred_repair_role": "implementation",
+            "repair_hypothesis": "hyp\x07with\x08bell",
+            "contract_conflict": {
+                "implementation": "impl\x01ctl",
+                "test": "test\x02ctl",
+                "usage_docs": "docs\x03ctl",
+            },
+            "failure_clusters": [
+                {
+                    "observed": "obs\x04",
+                    "expected": "exp\x05",
+                    "input_shape": "shp\x06",
+                    "assertion_shape": "AssertEq",
+                    "involved_artifacts": ["test"],
+                    "affected_cases": ["case\x07one"],
+                }
+            ],
+        });
+        let parsed = parse_semantic_failure_report(&v).expect("parses");
+        for s in [
+            &parsed.repair_hypothesis,
+            &parsed.contract_conflict.implementation,
+            &parsed.contract_conflict.test,
+            &parsed.contract_conflict.usage_docs,
+            &parsed.failure_clusters[0].observed,
+            &parsed.failure_clusters[0].expected,
+            &parsed.failure_clusters[0].affected_cases[0],
+        ] {
+            assert!(
+                !s.chars().any(|c| (c as u32) < 0x20),
+                "control char leaked into parsed field: {s:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn is_already_sanitized_rejects_control_chars() {
+        assert!(is_already_sanitized("ok ascii"));
+        assert!(!is_already_sanitized("has \x07 bell"));
+        assert!(!is_already_sanitized("has \x7f del"));
+    }
+
+    // ---- CB-002 (literal-to-shape normalization) ---- //
+
+    #[test]
+    fn normalize_to_shape_collapses_numbers() {
+        assert_eq!(
+            normalize_to_shape("got 12345 want 0"),
+            "got <num> want <num>"
+        );
+    }
+
+    #[test]
+    fn normalize_to_shape_collapses_uuid() {
+        let s = "trace-id 550e8400-e29b-41d4-a716-446655440000 failed";
+        assert!(normalize_to_shape(s).contains("<uuid>"));
+        assert!(!normalize_to_shape(s).contains("550e8400"));
+    }
+
+    #[test]
+    fn normalize_to_shape_collapses_quoted_string() {
+        assert_eq!(
+            normalize_to_shape("expected \"alice\" got 'bob'"),
+            "expected <str> got <str>"
+        );
+    }
+
+    #[test]
+    fn normalize_to_shape_collapses_path_segments() {
+        let s = "GET /users/12345/orders/77 not found";
+        let n = normalize_to_shape(s);
+        assert!(n.contains("<path>"), "expected <path> in {n:?}");
+        assert!(!n.contains("12345"), "raw number must not leak: {n:?}");
+    }
+
+    #[test]
+    fn normalize_to_shape_collapses_long_token() {
+        // AKIA-style key (24+ chars) collapses to <token>.
+        let s = "AWS key AKIAIOSFODNN7EXAMPLEXYZ rejected";
+        let n = normalize_to_shape(s);
+        assert!(n.contains("<token>"), "expected <token> in {n:?}");
+        assert!(!n.contains("AKIA"), "raw key prefix must not leak: {n:?}");
+    }
+
+    #[test]
+    fn normalize_to_shape_truncates_long_raw_tail() {
+        // No shape-collapsing match (each "ab " is short / has whitespace) →
+        // falls to the 64-char truncate path.
+        let raw: String = "ab ".repeat(100); // 300 chars total
+        let n = normalize_to_shape(&raw);
+        assert!(
+            n.chars().count() <= 64 + 6,
+            "len {} exceeded cap+marker",
+            n.chars().count()
+        );
+    }
+
+    #[test]
+    fn cluster_key_secret_like_values_collapse_to_same_shape_cb002() {
+        // CB-002 acceptance: different secret-like values that share the
+        // same shape (long token, number, etc.) must produce identical
+        // cluster keys, and the raw secret must NEVER appear in the hash
+        // input (verified indirectly via two distinct secrets → same key).
+        let a = build_failure_cluster_from_observation(
+            "auth failed for AKIAIOSFODNN7EXAMPLEXYZ on /users/12345",
+            "expected 200 got 401",
+            "shape",
+            "AssertEq",
+            &role_set(&[ArtifactRole::Test]),
+        );
+        let b = build_failure_cluster_from_observation(
+            "auth failed for tok_abc123def456ghi789 on /users/67890",
+            "expected 999 got 401",
+            "shape",
+            "AssertEq",
+            &role_set(&[ArtifactRole::Test]),
+        );
+        assert_eq!(
+            a.cluster_key, b.cluster_key,
+            "secret-like values must collapse to the same shape key"
+        );
+    }
+
+    #[test]
+    fn cluster_key_does_not_embed_raw_secret_cb002() {
+        // CB-002: raw secret values must not appear in `cluster_key`'s hex.
+        let secret = "AKIA0123456789ABCDEFGHIJ";
+        let cluster = build_failure_cluster_from_observation(
+            &format!("denied for {secret}"),
+            "expected ok",
+            "shape",
+            "AssertEq",
+            &role_set(&[ArtifactRole::Test]),
+        );
+        // Hex key is 16 chars — verify it's not a substring of the secret
+        // and the secret is not a substring of the hash inputs by
+        // recomputing with a *different* secret of the same shape: keys
+        // must agree (covered by the previous test) and neither key must
+        // textually contain the secret.
+        assert!(!cluster.cluster_key.as_str().contains(secret));
+    }
+
+    #[test]
+    fn cluster_key_different_shapes_yield_different_keys_cb002() {
+        // CB-002 sanity: shapes that genuinely differ must NOT collide.
+        let assertion_failure = build_failure_cluster_from_observation(
+            "assertion x == 1 failed",
+            "got 2",
+            "shape",
+            "AssertEq",
+            &role_set(&[ArtifactRole::Test]),
+        );
+        let runtime_failure = build_failure_cluster_from_observation(
+            "panic: divide by zero",
+            "no panic expected",
+            "shape",
+            "Panic",
+            &role_set(&[ArtifactRole::Test]),
+        );
+        assert_ne!(assertion_failure.cluster_key, runtime_failure.cluster_key);
+    }
+}

--- a/src/agent/loop_run/semantic_failure.rs
+++ b/src/agent/loop_run/semantic_failure.rs
@@ -54,6 +54,7 @@
 use super::VerifierDiagnosticFailureKind;
 use super::repair_job::sanitize_repair_job_text_with_char_cap;
 use super::task_contract::ArtifactRole;
+use super::task_contract::RecoveryTargetHint;
 
 /// Upper bound for `repair_hypothesis` after sanitize (chars, not bytes).
 /// Mirrors the diagnostic summary cap used elsewhere in the agent loop.
@@ -65,6 +66,40 @@ pub(super) const MAX_AFFECTED_CASES: usize = 16;
 /// Upper bound (chars) for shape-normalized cluster text fields
 /// (`observed`, `expected`, `affected_cases[*]`, `ContractConflict.*`).
 pub(super) const MAX_CLUSTER_TEXT_CHARS: usize = 240;
+
+/// CB-017 A''': upper bound on the number of LLM-supplied raw target
+/// candidates retained per cluster after parse. Anything beyond this is
+/// truncated at the parse boundary so the rest of the pipeline operates on
+/// a bounded list.
+pub(super) const MAX_PROPOSED_TARGETS_PER_CLUSTER: usize = 8;
+
+/// CB-017 A''': char-cap applied to each `RawClusterTargetCandidate.raw_path`
+/// and `RawClusterTargetCandidate.reason` at the parse boundary via the
+/// SSOT `sanitize_repair_job_text_with_char_cap` entry.
+pub(super) const MAX_RAW_PATH_CHARS: usize = 240;
+
+/// CB-017 A''': parse-stage advisory record for one LLM-proposed repair
+/// target. Sanitized to bounded char caps but **not** Owned-validated — the
+/// downstream `recovery_target_hint_for_diagnostic_path` SSOT decides
+/// admission and is the source of truth for the resolved role.
+///
+/// `role_hint` is advisory only: it may be used as a tie-breaker in the
+/// admission sort, or as debug/log metadata, but it never overrides the
+/// path-classification role of an admitted hint (Invariant 2 in the design
+/// policy).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct RawClusterTargetCandidate {
+    /// LLM-supplied `target_path` (sanitized, char-capped to
+    /// `MAX_RAW_PATH_CHARS`; Owned admission is decided downstream).
+    pub(super) raw_path: String,
+    /// LLM-supplied `role`. Advisory only — admitted hint role is decided
+    /// by `recovery_target_hint_for_existing_path` path classification.
+    pub(super) role_hint: Option<ArtifactRole>,
+    /// LLM-supplied raw diagnostic `reason` (sanitized + char-capped to
+    /// `MAX_RAW_PATH_CHARS`). Must not be conflated with cluster id / role /
+    /// authority strings.
+    pub(super) reason: String,
+}
 
 /// Bounded, sanitized representation of a diagnostic LLM failure report.
 ///
@@ -87,6 +122,15 @@ pub(super) struct SemanticFailureReport {
 
 /// Shape-normalized, role-tagged grouping of failure observations that share
 /// the same root cause. Cluster identity is encoded in `cluster_key`.
+///
+/// CB-017 A''' adds two `pub(super)` fields:
+///   * `proposed_target_candidates` — parse-stage raw advisory candidates
+///     (Owned-unvalidated). DR1-010: **not** included in the `cluster_key`
+///     hash input.
+///   * `admitted_cluster_targets` — Owned-validated `RecoveryTargetHint`s
+///     produced by the turn.rs admission enrich step. Always empty at parse
+///     time (`Vec::new()`); the turn.rs boundary fills this after
+///     `recovery_target_hint_for_diagnostic_path` admission.
 #[derive(Debug, Clone, PartialEq)]
 pub(super) struct FailureCluster {
     pub(super) cluster_key: FailureClusterKey,
@@ -94,6 +138,13 @@ pub(super) struct FailureCluster {
     pub(super) expected: String,
     pub(super) affected_cases: Vec<String>,
     pub(super) involved_artifacts: Vec<ArtifactRole>,
+    /// CB-017 A''': LLM-supplied raw target candidates (advisory).
+    /// **Excluded from `cluster_key` hash input** (DR1-010).
+    pub(super) proposed_target_candidates: Vec<RawClusterTargetCandidate>,
+    /// CB-017 A''': admitted, Owned-validated targets filled in by the
+    /// turn.rs enrich boundary. **Always empty at parse time**; downstream
+    /// admission writes path-classification-derived roles here.
+    pub(super) admitted_cluster_targets: Vec<RecoveryTargetHint>,
 }
 
 /// Deterministic 16-hex (sha256 short) identifier for a failure cluster.
@@ -183,6 +234,7 @@ pub(super) fn build_failure_cluster_from_observation(
     raw_input_shape: &str,
     assertion_shape: &str,
     artifact_role_set: &[ArtifactRole],
+    proposed_target_candidates: Vec<RawClusterTargetCandidate>,
 ) -> FailureCluster {
     let observed = sanitize_repair_job_text_with_char_cap(raw_observed, MAX_CLUSTER_TEXT_CHARS);
     let expected = sanitize_repair_job_text_with_char_cap(raw_expected, MAX_CLUSTER_TEXT_CHARS);
@@ -194,6 +246,10 @@ pub(super) fn build_failure_cluster_from_observation(
     // CB-002: hash inputs are normalized to coarse shape so secret-like or
     // identifier-like literals never form a stable fingerprint and don't
     // fragment clusters that share the same shape.
+    //
+    // DR1-010 (CB-017 A'''): `proposed_target_candidates` are **not** fed
+    // into `cluster_key` — cluster identity stays a pure function of the
+    // shape-normalized observation, not LLM-supplied advisory paths.
     let observed_shape = normalize_to_shape(&observed);
     let expected_shape = normalize_to_shape(&expected);
     let input_shape_shape = normalize_to_shape(&input_shape_signature);
@@ -217,6 +273,10 @@ pub(super) fn build_failure_cluster_from_observation(
         expected,
         affected_cases: Vec::new(),
         involved_artifacts,
+        // CB-017 A''': proposed candidates flow through as-is (advisory);
+        // admitted targets are filled by the turn.rs enrich boundary.
+        proposed_target_candidates,
+        admitted_cluster_targets: Vec::new(),
     }
 }
 
@@ -495,12 +555,47 @@ pub(super) fn parse_semantic_failure_report(
                 .and_then(|v| v.as_str())
                 .unwrap_or("");
 
+            // CB-017 A''': extract LLM-supplied `target_paths` advisory list.
+            // Sanitized + char-capped + bounded-count at the parse boundary.
+            // `admitted_cluster_targets` stays empty here — it is filled by
+            // the turn.rs enrich step which is the SSOT for Owned admission.
+            let proposed_target_candidates: Vec<RawClusterTargetCandidate> = cluster_obj
+                .get("target_paths")
+                .and_then(|v| v.as_array())
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|entry| entry.as_object())
+                        .take(MAX_PROPOSED_TARGETS_PER_CLUSTER)
+                        .map(|entry| {
+                            let raw_path = sanitize_repair_job_text_with_char_cap(
+                                entry.get("path").and_then(|v| v.as_str()).unwrap_or(""),
+                                MAX_RAW_PATH_CHARS,
+                            );
+                            let role_hint = entry
+                                .get("role")
+                                .and_then(|v| v.as_str())
+                                .and_then(parse_artifact_role);
+                            let reason = sanitize_repair_job_text_with_char_cap(
+                                entry.get("reason").and_then(|v| v.as_str()).unwrap_or(""),
+                                MAX_RAW_PATH_CHARS,
+                            );
+                            RawClusterTargetCandidate {
+                                raw_path,
+                                role_hint,
+                                reason,
+                            }
+                        })
+                        .collect()
+                })
+                .unwrap_or_default();
+
             let mut rebuilt = build_failure_cluster_from_observation(
                 raw_observed,
                 raw_expected,
                 raw_input_shape,
                 raw_assertion_shape,
                 &involved_artifacts,
+                proposed_target_candidates,
             );
             rebuilt.affected_cases = affected_cases;
             failure_clusters.push(rebuilt);
@@ -589,6 +684,7 @@ mod tests {
             "input shape",
             "AssertEq",
             &role_set(&[ArtifactRole::Test, ArtifactRole::Implementation]),
+            Vec::new(),
         );
         let b = build_failure_cluster_from_observation(
             "observed text",
@@ -596,6 +692,7 @@ mod tests {
             "input shape",
             "AssertEq",
             &role_set(&[ArtifactRole::Implementation, ArtifactRole::Test]),
+            Vec::new(),
         );
         assert_eq!(a.cluster_key, b.cluster_key);
         assert_eq!(a.cluster_key.as_str().len(), 16);
@@ -609,6 +706,7 @@ mod tests {
             "shape",
             "AssertEq",
             &role_set(&[ArtifactRole::Test]),
+            Vec::new(),
         );
         let b = build_failure_cluster_from_observation(
             "observed",
@@ -616,6 +714,7 @@ mod tests {
             "shape",
             "AssertEq",
             &role_set(&[ArtifactRole::Test]),
+            Vec::new(),
         );
         assert_ne!(a.cluster_key, b.cluster_key);
     }
@@ -631,6 +730,7 @@ mod tests {
             "shape",
             "AssertEq",
             &role_set(&[ArtifactRole::Test]),
+            Vec::new(),
         );
         // The sanitized observed text should not be byte-for-byte identical
         // to the raw secret-bearing input (mask_header_family / mask_secrets
@@ -649,6 +749,7 @@ mod tests {
             "s",
             "AssertEq",
             &role_set(&[ArtifactRole::UsageDocs, ArtifactRole::Implementation]),
+            Vec::new(),
         )
         .cluster_key;
         let key_b = build_failure_cluster_from_observation(
@@ -657,6 +758,7 @@ mod tests {
             "s",
             "AssertEq",
             &role_set(&[ArtifactRole::Implementation, ArtifactRole::UsageDocs]),
+            Vec::new(),
         )
         .cluster_key;
         assert_eq!(key_a, key_b);
@@ -795,6 +897,7 @@ mod tests {
             "s",
             "AssertEq",
             &[ArtifactRole::Test],
+            Vec::new(),
         );
         assert_eq!(
             parsed.failure_clusters[0].cluster_key,
@@ -1013,6 +1116,7 @@ mod tests {
             "shape",
             "AssertEq",
             &role_set(&[ArtifactRole::Test]),
+            Vec::new(),
         );
         let b = build_failure_cluster_from_observation(
             "auth failed for tok_abc123def456ghi789 on /users/67890",
@@ -1020,6 +1124,7 @@ mod tests {
             "shape",
             "AssertEq",
             &role_set(&[ArtifactRole::Test]),
+            Vec::new(),
         );
         assert_eq!(
             a.cluster_key, b.cluster_key,
@@ -1037,6 +1142,7 @@ mod tests {
             "shape",
             "AssertEq",
             &role_set(&[ArtifactRole::Test]),
+            Vec::new(),
         );
         // Hex key is 16 chars — verify it's not a substring of the secret
         // and the secret is not a substring of the hash inputs by
@@ -1055,6 +1161,7 @@ mod tests {
             "shape",
             "AssertEq",
             &role_set(&[ArtifactRole::Test]),
+            Vec::new(),
         );
         let runtime_failure = build_failure_cluster_from_observation(
             "panic: divide by zero",
@@ -1062,8 +1169,277 @@ mod tests {
             "shape",
             "Panic",
             &role_set(&[ArtifactRole::Test]),
+            Vec::new(),
         );
         assert_ne!(assertion_failure.cluster_key, runtime_failure.cluster_key);
+    }
+
+    // ---- CB-017 A''' (Commit 2): RawClusterTargetCandidate schema ---- //
+
+    #[test]
+    fn cb017_failure_cluster_carries_proposed_target_candidates() {
+        // The constructor accepts a Vec<RawClusterTargetCandidate> at parse
+        // time. `admitted_cluster_targets` stays empty until the turn.rs
+        // enrich step runs (Commit 3).
+        let candidates = vec![
+            RawClusterTargetCandidate {
+                raw_path: "src/main.rs".to_string(),
+                role_hint: Some(ArtifactRole::Implementation),
+                reason: "fix null check".to_string(),
+            },
+            RawClusterTargetCandidate {
+                raw_path: "tests/integration.rs".to_string(),
+                role_hint: Some(ArtifactRole::Test),
+                reason: "update fixture".to_string(),
+            },
+        ];
+        let cluster = build_failure_cluster_from_observation(
+            "observed",
+            "expected",
+            "shape",
+            "AssertEq",
+            &role_set(&[ArtifactRole::Implementation]),
+            candidates.clone(),
+        );
+        assert_eq!(cluster.proposed_target_candidates, candidates);
+        // Commit 2 invariant: admission is the turn.rs boundary's job.
+        assert!(
+            cluster.admitted_cluster_targets.is_empty(),
+            "admitted_cluster_targets must be empty at parse time",
+        );
+    }
+
+    #[test]
+    fn cb017_parse_extracts_target_paths_from_cluster_json() {
+        let v = serde_json::json!({
+            "failure_kind": "assertion_mismatch",
+            "confidence": 0.5,
+            "preferred_repair_role": "implementation",
+            "repair_hypothesis": "h",
+            "failure_clusters": [
+                {
+                    "observed": "o",
+                    "expected": "e",
+                    "input_shape": "s",
+                    "assertion_shape": "AssertEq",
+                    "involved_artifacts": ["implementation"],
+                    "affected_cases": [],
+                    "target_paths": [
+                        {
+                            "path": "src/main.rs",
+                            "role": "implementation",
+                            "reason": "fix null check",
+                        }
+                    ],
+                }
+            ],
+        });
+        let parsed = parse_semantic_failure_report(&v).expect("parses");
+        assert_eq!(parsed.failure_clusters.len(), 1);
+        let candidates = &parsed.failure_clusters[0].proposed_target_candidates;
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].raw_path, "src/main.rs");
+        assert_eq!(candidates[0].role_hint, Some(ArtifactRole::Implementation));
+        assert_eq!(candidates[0].reason, "fix null check");
+        // Commit 2 invariant.
+        assert!(
+            parsed.failure_clusters[0]
+                .admitted_cluster_targets
+                .is_empty(),
+            "parse must not populate admitted_cluster_targets",
+        );
+    }
+
+    #[test]
+    fn cb017_parse_truncates_target_paths_above_max() {
+        // 9 entries → truncated to MAX_PROPOSED_TARGETS_PER_CLUSTER = 8.
+        let entries: Vec<_> = (0..9)
+            .map(|i| {
+                serde_json::json!({
+                    "path": format!("src/file_{}.rs", i),
+                    "role": "implementation",
+                    "reason": "r",
+                })
+            })
+            .collect();
+        let v = serde_json::json!({
+            "failure_kind": "assertion_mismatch",
+            "confidence": 0.5,
+            "preferred_repair_role": "implementation",
+            "repair_hypothesis": "h",
+            "failure_clusters": [
+                {
+                    "observed": "o",
+                    "expected": "e",
+                    "input_shape": "s",
+                    "assertion_shape": "AssertEq",
+                    "involved_artifacts": ["implementation"],
+                    "affected_cases": [],
+                    "target_paths": entries,
+                }
+            ],
+        });
+        let parsed = parse_semantic_failure_report(&v).expect("parses");
+        assert_eq!(
+            parsed.failure_clusters[0].proposed_target_candidates.len(),
+            MAX_PROPOSED_TARGETS_PER_CLUSTER,
+            "parse must truncate to MAX_PROPOSED_TARGETS_PER_CLUSTER",
+        );
+    }
+
+    #[test]
+    fn cb017_parse_role_hint_invalid_returns_none() {
+        let v = serde_json::json!({
+            "failure_kind": "assertion_mismatch",
+            "confidence": 0.5,
+            "preferred_repair_role": "implementation",
+            "repair_hypothesis": "h",
+            "failure_clusters": [
+                {
+                    "observed": "o",
+                    "expected": "e",
+                    "input_shape": "s",
+                    "assertion_shape": "AssertEq",
+                    "involved_artifacts": ["implementation"],
+                    "affected_cases": [],
+                    "target_paths": [
+                        {
+                            "path": "src/main.rs",
+                            "role": "garbage",
+                            "reason": "r",
+                        }
+                    ],
+                }
+            ],
+        });
+        let parsed = parse_semantic_failure_report(&v).expect("parses");
+        let cand = &parsed.failure_clusters[0].proposed_target_candidates[0];
+        assert_eq!(cand.role_hint, None);
+        // raw_path / reason are still sanitized + retained.
+        assert_eq!(cand.raw_path, "src/main.rs");
+        assert_eq!(cand.reason, "r");
+    }
+
+    #[test]
+    fn cb017_parse_target_paths_absent_yields_empty() {
+        // No `target_paths` field at all → proposed_target_candidates empty,
+        // existing cluster fields preserved.
+        let v = serde_json::json!({
+            "failure_kind": "assertion_mismatch",
+            "confidence": 0.5,
+            "preferred_repair_role": "implementation",
+            "repair_hypothesis": "h",
+            "failure_clusters": [
+                {
+                    "observed": "o",
+                    "expected": "e",
+                    "input_shape": "s",
+                    "assertion_shape": "AssertEq",
+                    "involved_artifacts": ["implementation"],
+                    "affected_cases": [],
+                }
+            ],
+        });
+        let parsed = parse_semantic_failure_report(&v).expect("parses");
+        assert!(
+            parsed.failure_clusters[0]
+                .proposed_target_candidates
+                .is_empty(),
+            "absent target_paths must yield empty candidates",
+        );
+        assert!(
+            parsed.failure_clusters[0]
+                .admitted_cluster_targets
+                .is_empty(),
+            "admitted_cluster_targets must be empty at parse time",
+        );
+    }
+
+    #[test]
+    fn cb017_cluster_key_unchanged_by_target_candidates() {
+        // DR1-010: cluster_key hash inputs must not include
+        // proposed_target_candidates. Two clusters with identical
+        // observed/expected/role but different candidate lists must share a
+        // cluster_key.
+        let with_a = build_failure_cluster_from_observation(
+            "o",
+            "e",
+            "s",
+            "AssertEq",
+            &role_set(&[ArtifactRole::Implementation]),
+            vec![RawClusterTargetCandidate {
+                raw_path: "src/a.rs".to_string(),
+                role_hint: Some(ArtifactRole::Implementation),
+                reason: "r".to_string(),
+            }],
+        );
+        let with_b = build_failure_cluster_from_observation(
+            "o",
+            "e",
+            "s",
+            "AssertEq",
+            &role_set(&[ArtifactRole::Implementation]),
+            vec![RawClusterTargetCandidate {
+                raw_path: "src/b.rs".to_string(),
+                role_hint: Some(ArtifactRole::Test),
+                reason: "different".to_string(),
+            }],
+        );
+        assert_eq!(
+            with_a.cluster_key, with_b.cluster_key,
+            "cluster_key must be independent of proposed_target_candidates (DR1-010)",
+        );
+        let empty = build_failure_cluster_from_observation(
+            "o",
+            "e",
+            "s",
+            "AssertEq",
+            &role_set(&[ArtifactRole::Implementation]),
+            Vec::new(),
+        );
+        assert_eq!(
+            with_a.cluster_key, empty.cluster_key,
+            "cluster_key must be invariant when candidates are added",
+        );
+    }
+
+    #[test]
+    fn cb017_raw_path_sanitized_and_capped() {
+        // A 250-char raw_path is truncated to MAX_RAW_PATH_CHARS (240) at
+        // parse, via the SSOT sanitize entry (with trailing ellipsis ≤ +3).
+        let long_path: String = "a".repeat(250);
+        let v = serde_json::json!({
+            "failure_kind": "assertion_mismatch",
+            "confidence": 0.5,
+            "preferred_repair_role": "implementation",
+            "repair_hypothesis": "h",
+            "failure_clusters": [
+                {
+                    "observed": "o",
+                    "expected": "e",
+                    "input_shape": "s",
+                    "assertion_shape": "AssertEq",
+                    "involved_artifacts": ["implementation"],
+                    "affected_cases": [],
+                    "target_paths": [
+                        {
+                            "path": long_path,
+                            "role": "implementation",
+                            "reason": "r",
+                        }
+                    ],
+                }
+            ],
+        });
+        let parsed = parse_semantic_failure_report(&v).expect("parses");
+        let cand = &parsed.failure_clusters[0].proposed_target_candidates[0];
+        let n = cand.raw_path.chars().count();
+        assert!(
+            n <= MAX_RAW_PATH_CHARS + 3,
+            "raw_path must be capped to MAX_RAW_PATH_CHARS (+ optional ellipsis); got {n}",
+        );
+        // No control chars leaked.
+        assert!(!cand.raw_path.chars().any(|c| (c as u32) < 0x20));
     }
 
     // -- Phase G grep / structure tests (Issue #647 acceptance closure) -- //

--- a/src/agent/loop_run/semantic_failure.rs
+++ b/src/agent/loop_run/semantic_failure.rs
@@ -1065,4 +1065,46 @@ mod tests {
         );
         assert_ne!(assertion_failure.cluster_key, runtime_failure.cluster_key);
     }
+
+    // -- Phase G grep / structure tests (Issue #647 acceptance closure) -- //
+
+    /// Helper: split the module source into the production prefix
+    /// (everything before `#[cfg(test)]\nmod tests`). Phase G grep tests
+    /// scrutinize production code only — test-only literals are exempt.
+    fn production_source() -> &'static str {
+        let source = include_str!("semantic_failure.rs");
+        // Match the canonical opener of this file's test module.
+        match source.find("#[cfg(test)]\nmod tests") {
+            Some(idx) => &source[..idx],
+            None => source,
+        }
+    }
+
+    #[test]
+    fn no_framework_literal_in_semantic_failure_module() {
+        // S1-012 (拡張): new production code must not embed
+        // framework-specific literals — those belong to evaluation
+        // fixtures, not the semantic repair planner.
+        let prod = production_source();
+        for lit in &["\"422\"", "\"404\"", "/items/nonexistent", "FastAPI"] {
+            assert!(
+                !prod.contains(lit),
+                "semantic_failure.rs production code must not contain framework literal {lit:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn no_unsafe_in_semantic_failure_module() {
+        // DR4-003: no unsafe / FFI in new production code.
+        let prod = production_source();
+        assert!(
+            !prod.contains("unsafe "),
+            "semantic_failure.rs production code must not contain `unsafe `",
+        );
+        assert!(
+            !prod.contains("extern \"C\""),
+            "semantic_failure.rs production code must not declare FFI",
+        );
+    }
 }

--- a/src/agent/loop_run/spec_authority.rs
+++ b/src/agent/loop_run/spec_authority.rs
@@ -1,0 +1,1067 @@
+//! Issue #647 (Phase A.2): spec-authority enum + tie-break scoring +
+//! deterministic test/impl weakening detectors.
+//!
+//! Visibility: every export here is `pub(super)` and **must not** be
+//! re-exported from `src/agent/loop_run.rs` (CLAUDE.md DR3-001). Future
+//! consumers (`super::repair_job` for `SemanticRepairPlan` and `super::turn`
+//! for the repair-editor admission boundary) reach in via sibling import.
+//!
+//! # Why an enum + scoring (design judgment #4)
+//!
+//! `SpecAuthority` represents *which single source of truth wins* at a
+//! decision point. The "three-artifact consensus" case is **not** an
+//! authority — it is a tie-break signal. Modelling it as a scoring layer
+//! (`ArtifactConsensus`) keeps the enum small (5 closed variants) and
+//! testable as pure functions.
+//!
+//! # `RepairRole` alias (DR1-009)
+//!
+//! `RepairRole` is a type alias for `task_contract::ArtifactRole`. The alias
+//! is used by **new semantic-repair callsites** in this and downstream
+//! modules so the reader knows "this `ArtifactRole` participates in repair
+//! planning". Existing modules (`task_contract.rs`, `artifact_ownership.rs`,
+//! `completion_evidence.rs`) keep the `ArtifactRole` name.
+//!
+//! # Weakening detectors (DR1-007 / S1-012)
+//!
+//! Each of the 9 patterns is implemented as an **independent pure function**
+//! (OCP: adding a new pattern is one new pure fn + one orchestration line —
+//! the existing detectors stay untouched). Detection is line-based string
+//! comparison; no framework-specific literals are hard-coded.
+//!
+//! # Phase A.2 dead-code policy
+//!
+//! Phase A.2 lands the enum + scoring + detectors ahead of their consumers
+//! (Phase D wires `select_authority` into the diagnostic pipeline; Phase F
+//! wires the weakening detectors into the repair-editor admission boundary).
+//! Until those Phases land, the `pub(super)` surface is exercised only by
+//! in-module unit tests, so we silence `dead_code` at the module root rather
+//! than dropping the API.
+
+#![allow(dead_code)]
+
+use super::repair_job::sanitize_repair_job_text_with_char_cap;
+use super::task_contract::ArtifactRole;
+
+/// Maximum char cap applied to user-supplied / LLM-supplied free-form
+/// `reason` text on `ArtifactConsensus` (DR4-004 mirror of the
+/// `semantic_failure.rs` cap).
+const MAX_CONSENSUS_REASON_CHARS: usize = 240;
+
+/// Ranked spec-authority levels. `PartialOrd` / `Ord` follow variant order,
+/// so `UserRequest < BehaviorContract < ... < LlmGeneratedTest` — **smaller
+/// is higher authority**.
+///
+/// `VerifiedPublicInterface` is a forward-extensibility placeholder
+/// (DR1-005): `select_authority` does not return it today. The variant exists
+/// so the API surface is stable when a later Issue wires the
+/// session/turn-local cache.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(super) enum SpecAuthority {
+    /// Highest authority — explicit human request.
+    UserRequest,
+    /// Derived deterministic behavior contract (`RequiredBehaviorContract`).
+    BehaviorContract,
+    /// Placeholder for "this interface already passed a verifier in scope"
+    /// (DR1-005 / S5-005). **Dead variant** in this Issue — `select_authority`
+    /// will not return it even if a caller passes it in.
+    VerifiedPublicInterface,
+    /// Type / schema / validation invariants in the implementation.
+    ImplementationContract,
+    /// Lowest authority — LLM-generated test assertions.
+    LlmGeneratedTest,
+}
+
+/// Type alias for `ArtifactRole` used by **new** semantic-repair-flavored
+/// callsites. The two names refer to the exact same type — no conversion
+/// is needed at the boundary (DR1-009).
+#[allow(dead_code)]
+pub(super) type RepairRole = ArtifactRole;
+
+/// Pairwise consensus signal among the three artifact roles
+/// (Implementation / Test / UsageDocs). When two agree and one disagrees,
+/// the agreeing side becomes the tie-break winner.
+///
+/// `reason` is sanitized at construction via
+/// [`ArtifactConsensus::new`] (DR4-004).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct ArtifactConsensus {
+    pub(super) agreeing: Vec<ArtifactRole>,
+    pub(super) dissenting: Vec<ArtifactRole>,
+    pub(super) reason: String,
+}
+
+impl ArtifactConsensus {
+    /// Construct an `ArtifactConsensus` with the `reason` text sanitized to
+    /// `MAX_CONSENSUS_REASON_CHARS` chars via the SSOT entry
+    /// (`sanitize_repair_job_text_with_char_cap`, DR1-001 / DR4-004).
+    #[allow(dead_code)] // consumer arrives in Phase D
+    pub(super) fn new(
+        agreeing: Vec<ArtifactRole>,
+        dissenting: Vec<ArtifactRole>,
+        raw_reason: &str,
+    ) -> Self {
+        Self {
+            agreeing,
+            dissenting,
+            reason: sanitize_repair_job_text_with_char_cap(raw_reason, MAX_CONSENSUS_REASON_CHARS),
+        }
+    }
+}
+
+/// Pick the highest-authority candidate, falling back to `consensus` only
+/// when (a) the candidate list yielded multiple *distinct* top-tier entries
+/// (genuine tie) or (b) the candidate list is empty.
+///
+/// `VerifiedPublicInterface` is filtered out before scoring (DR1-005) so it
+/// never wins the selection in this Issue.
+///
+/// CB-001 (Codex review): duplicate same-variant candidates are **not** a tie.
+/// Since `SpecAuthority` has a strict total order, the only way `top_count > 1`
+/// could trigger the consensus branch previously was when the same variant
+/// appeared multiple times — that should resolve to that variant, not be
+/// demoted to a weaker authority via consensus. We dedup before tie-checking,
+/// and we additionally guard consensus output from demoting the top: the
+/// consensus winner is only adopted if it is at least as strong as `top`.
+#[allow(dead_code)] // consumer arrives in Phase D
+pub(super) fn select_authority(
+    candidates: &[SpecAuthority],
+    consensus: Option<&ArtifactConsensus>,
+) -> Option<SpecAuthority> {
+    // DR1-005 / S5-005: VerifiedPublicInterface is a dead variant in this Issue.
+    let mut filtered: Vec<SpecAuthority> = candidates
+        .iter()
+        .copied()
+        .filter(|c| *c != SpecAuthority::VerifiedPublicInterface)
+        .collect();
+
+    if filtered.is_empty() {
+        // No usable candidates → fall back to consensus if available.
+        return consensus_to_authority(consensus);
+    }
+
+    filtered.sort();
+    let top = filtered[0];
+
+    // CB-001: dedup duplicates of the *same* variant — these are not a tie.
+    // After dedup, a "tie" means two *distinct* variants share the top rank
+    // (impossible today because variant order is total, but we keep the
+    // dedup as defence-in-depth for future variant additions).
+    let mut distinct = filtered.clone();
+    distinct.dedup();
+    let top_count = distinct.iter().filter(|c| **c == top).count();
+    if top_count > 1
+        && let Some(c) = consensus_to_authority(consensus)
+        && c <= top
+    {
+        // Adopt consensus only when it does NOT demote the top authority
+        // (smaller variant index = higher authority).
+        return Some(c);
+    }
+    Some(top)
+}
+
+/// Map an `ArtifactConsensus` to the spec authority that the agreeing roles
+/// imply. Implementation-agreeing → `ImplementationContract`; otherwise the
+/// consensus alone is not enough to elect a higher authority and we return
+/// `None`.
+fn consensus_to_authority(consensus: Option<&ArtifactConsensus>) -> Option<SpecAuthority> {
+    let c = consensus?;
+    if c.agreeing.is_empty() {
+        return None;
+    }
+    if c.agreeing.contains(&ArtifactRole::Implementation) {
+        Some(SpecAuthority::ImplementationContract)
+    } else {
+        // Test- or docs-only consensus is weaker than ImplementationContract
+        // and isn't enough on its own to win — defer the decision back to the
+        // caller, which can fall back to LlmGeneratedTest if nothing else is
+        // available.
+        Some(SpecAuthority::LlmGeneratedTest)
+    }
+}
+
+/// Closed list of test/impl weakening patterns detected at the repair
+/// editor's admission boundary (S1-004 / S1-007). Each variant is produced
+/// by a dedicated pure-function detector (`detect_*`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(super) enum WeakeningPattern {
+    // Test patterns (5).
+    AssertionDeleted,
+    SkipMarkerAdded,
+    AssertTrueWeakening,
+    TestFunctionDeleted,
+    LiteralOnlyExpectedChange,
+    // Implementation patterns (4).
+    ValidatorDeleted,
+    ErrorSwallowed,
+    EarlyReturnBypass,
+    TypeAnnotationWeakened,
+}
+
+/// Orchestration: aggregate every test-side detector for `(before, after)`.
+///
+/// Each detector is independent (OCP) and the orchestrator is just a flatten
+/// over their `Option<WeakeningPattern>` outputs.
+#[allow(dead_code)] // consumer arrives in Phase F
+pub(super) fn detect_test_weakening(
+    relative_path: &str,
+    before: &str,
+    after: &str,
+) -> Vec<WeakeningPattern> {
+    [
+        detect_assertion_deleted(relative_path, before, after),
+        detect_skip_marker_added(relative_path, before, after),
+        detect_assert_true_weakening(relative_path, before, after),
+        detect_test_function_deleted(relative_path, before, after),
+        detect_literal_only_expected_change(relative_path, before, after),
+    ]
+    .into_iter()
+    .flatten()
+    .collect()
+}
+
+/// Orchestration: aggregate every impl-side detector for `(before, after)`.
+#[allow(dead_code)] // consumer arrives in Phase F
+pub(super) fn detect_impl_weakening(
+    relative_path: &str,
+    before: &str,
+    after: &str,
+) -> Vec<WeakeningPattern> {
+    [
+        detect_validator_deleted(relative_path, before, after),
+        detect_error_swallowed(relative_path, before, after),
+        detect_early_return_bypass(relative_path, before, after),
+        detect_type_annotation_weakened(relative_path, before, after),
+    ]
+    .into_iter()
+    .flatten()
+    .collect()
+}
+
+// ---------- helpers ---------- //
+
+/// Return the set of trimmed non-empty lines in `s` (multiset preserving
+/// the first occurrence, not full bag semantics). Used by detectors that
+/// reason about "line X exists in before but not in after".
+fn line_set(s: &str) -> Vec<String> {
+    s.lines().map(|l| l.trim().to_string()).collect()
+}
+
+/// Build a multiset (line → count) of trimmed non-empty lines.
+fn line_multiset(s: &str) -> std::collections::HashMap<String, isize> {
+    let mut m = std::collections::HashMap::new();
+    for line in line_set(s) {
+        if line.is_empty() {
+            continue;
+        }
+        *m.entry(line).or_insert(0) += 1;
+    }
+    m
+}
+
+/// CB-003: lines whose count in `before` strictly exceeds their count in
+/// `after`. The returned `Vec` repeats a line `n` times when `n` extra
+/// occurrences were deleted, so detectors that scan it see every deleted
+/// occurrence rather than a single deduped representative.
+fn lines_only_in_before(before: &str, after: &str) -> Vec<String> {
+    let after_counts = line_multiset(after);
+    let before_counts = line_multiset(before);
+    let mut out: Vec<String> = Vec::new();
+    for (line, before_n) in before_counts {
+        let after_n = after_counts.get(&line).copied().unwrap_or(0);
+        let delta = before_n - after_n;
+        if delta > 0 {
+            for _ in 0..delta {
+                out.push(line.clone());
+            }
+        }
+    }
+    out
+}
+
+/// CB-003: lines whose count in `after` strictly exceeds their count in
+/// `before`. Multiset semantics mirror [`lines_only_in_before`].
+fn lines_only_in_after(before: &str, after: &str) -> Vec<String> {
+    let before_counts = line_multiset(before);
+    let after_counts = line_multiset(after);
+    let mut out: Vec<String> = Vec::new();
+    for (line, after_n) in after_counts {
+        let before_n = before_counts.get(&line).copied().unwrap_or(0);
+        let delta = after_n - before_n;
+        if delta > 0 {
+            for _ in 0..delta {
+                out.push(line.clone());
+            }
+        }
+    }
+    out
+}
+
+// ---------- test-side detectors (5) ---------- //
+
+/// AssertionDeleted: any `assert*`-prefixed line present in `before` but
+/// missing in `after` (pure deletion).
+fn detect_assertion_deleted(
+    _relative_path: &str,
+    before: &str,
+    after: &str,
+) -> Option<WeakeningPattern> {
+    let deleted = lines_only_in_before(before, after);
+    if deleted.iter().any(|l| l.starts_with("assert")) {
+        Some(WeakeningPattern::AssertionDeleted)
+    } else {
+        None
+    }
+}
+
+/// SkipMarkerAdded: a skip / ignore / expected-failure marker appears in
+/// `after` that wasn't in `before`. Language-level markers only — no
+/// framework-specific hardcode beyond the generic marker tokens themselves.
+fn detect_skip_marker_added(
+    _relative_path: &str,
+    before: &str,
+    after: &str,
+) -> Option<WeakeningPattern> {
+    const MARKERS: &[&str] = &[
+        "@pytest.mark.skip",
+        "@pytest.mark.xfail",
+        "#[ignore]",
+        "#[should_panic]",
+    ];
+    let added = lines_only_in_after(before, after);
+    if added.iter().any(|l| MARKERS.iter().any(|m| l.contains(m))) {
+        Some(WeakeningPattern::SkipMarkerAdded)
+    } else {
+        None
+    }
+}
+
+/// AssertTrueWeakening: lines added in `after` that are bare "assert True"
+/// / "assert!(true)" / "pass" — common assertion-bypass shapes.
+fn detect_assert_true_weakening(
+    _relative_path: &str,
+    before: &str,
+    after: &str,
+) -> Option<WeakeningPattern> {
+    let before_had_assert = line_set(before).iter().any(|l| l.starts_with("assert"));
+    if !before_had_assert {
+        return None;
+    }
+    let added = lines_only_in_after(before, after);
+    let matched = added.iter().any(|l| {
+        let t = l.trim_end_matches(';').trim();
+        t == "assert True" || t == "assert!(true)" || t == "pass" || t == "assert true"
+    });
+    matched.then_some(WeakeningPattern::AssertTrueWeakening)
+}
+
+/// TestFunctionDeleted: a `def test_*` / `fn test_*` start line present in
+/// `before` but missing in `after`.
+fn detect_test_function_deleted(
+    _relative_path: &str,
+    before: &str,
+    after: &str,
+) -> Option<WeakeningPattern> {
+    let deleted = lines_only_in_before(before, after);
+    let hit = deleted.iter().any(|l| {
+        let t = l.trim_start();
+        t.starts_with("def test_") || t.starts_with("fn test_")
+    });
+    hit.then_some(WeakeningPattern::TestFunctionDeleted)
+}
+
+/// LiteralOnlyExpectedChange: an `assert`-line in `before` has been replaced
+/// by an `assert`-line in `after` where the literal RHS differs, and no
+/// other non-assertion lines moved (= test inputs / setup untouched).
+fn detect_literal_only_expected_change(
+    _relative_path: &str,
+    before: &str,
+    after: &str,
+) -> Option<WeakeningPattern> {
+    let before_asserts: Vec<String> = line_set(before)
+        .into_iter()
+        .filter(|l| l.starts_with("assert"))
+        .collect();
+    let after_asserts: Vec<String> = line_set(after)
+        .into_iter()
+        .filter(|l| l.starts_with("assert"))
+        .collect();
+    let before_non_assert: Vec<String> = line_set(before)
+        .into_iter()
+        .filter(|l| !l.is_empty() && !l.starts_with("assert"))
+        .collect();
+    let after_non_assert: Vec<String> = line_set(after)
+        .into_iter()
+        .filter(|l| !l.is_empty() && !l.starts_with("assert"))
+        .collect();
+
+    let asserts_changed = before_asserts != after_asserts && !before_asserts.is_empty();
+    let non_assert_unchanged = before_non_assert == after_non_assert;
+    (asserts_changed && non_assert_unchanged).then_some(WeakeningPattern::LiteralOnlyExpectedChange)
+}
+
+// ---------- impl-side detectors (4) ---------- //
+
+/// ValidatorDeleted: `assert` / `if .* raise` / `?` propagation / bare
+/// `raise` / `throw` / `return Err` / `bail!` deleted from implementation
+/// code.
+///
+/// CB-004 (Codex review): a multiline validator
+/// ```text
+/// if invalid:
+///     raise ValueError(...)
+/// ```
+/// can be silently weakened by deleting only the `raise` line. We therefore
+/// treat any standalone validator-terminal line (`raise`, `throw`,
+/// `return Err`, `bail!`, `anyhow::bail!`) as a deleted validator, not just
+/// the same-line `if ... raise` shape.
+fn detect_validator_deleted(
+    _relative_path: &str,
+    before: &str,
+    after: &str,
+) -> Option<WeakeningPattern> {
+    let deleted = lines_only_in_before(before, after);
+    let hit = deleted.iter().any(|l| {
+        let t = l.trim_start();
+        t.starts_with("assert")
+            || (t.starts_with("if ") && l.contains("raise"))
+            // `?` propagation lines like `let x = foo()?;` — bare `?` operator.
+            || (l.contains("?;") && !l.contains("if "))
+            // CB-004: standalone validator-terminal lines (multiline validators).
+            || is_validator_terminal_line(t)
+    });
+    hit.then_some(WeakeningPattern::ValidatorDeleted)
+}
+
+/// CB-004: is `t` (already trim_start'd) a standalone validator-terminal
+/// statement (`raise ...`, `throw ...`, `return Err(...)`, `bail!(...)`,
+/// `anyhow::bail!(...)`)?
+fn is_validator_terminal_line(t: &str) -> bool {
+    t.starts_with("raise ")
+        || t == "raise"
+        || t.starts_with("throw ")
+        || t.starts_with("throw new ")
+        || t.starts_with("return Err(")
+        || t == "return Err()"
+        || t.starts_with("bail!(")
+        || t.starts_with("anyhow::bail!(")
+}
+
+/// ErrorSwallowed: new code in `after` that drops error information
+/// (`try / except: pass`, `Result::ok()` chain that discards the error,
+/// `let _ = x?` is *not* covered — that's still propagation).
+fn detect_error_swallowed(
+    _relative_path: &str,
+    before: &str,
+    after: &str,
+) -> Option<WeakeningPattern> {
+    let added = lines_only_in_after(before, after);
+
+    // Pattern 1: bare `except: pass` style added.
+    let bare_except = added.iter().any(|l| {
+        let t = l.trim();
+        t == "except: pass" || t == "except Exception: pass" || t.starts_with("except:")
+    });
+    if bare_except {
+        return Some(WeakeningPattern::ErrorSwallowed);
+    }
+
+    // Pattern 2: `.ok();` (discards the error half of Result) newly added.
+    let ok_discard = added.iter().any(|l| {
+        let t = l.trim();
+        t.ends_with(".ok();") || t.ends_with(".ok().unwrap_or_default();")
+    });
+    if ok_discard {
+        return Some(WeakeningPattern::ErrorSwallowed);
+    }
+
+    // Pattern 3: a multiline try block (`try:` then `except: pass` later)
+    // can also be detected as a holistic before/after change.
+    let after_text = after;
+    let before_text = before;
+    if after_text.contains("except:")
+        && after_text.contains("pass")
+        && !(before_text.contains("except:") && before_text.contains("pass"))
+    {
+        return Some(WeakeningPattern::ErrorSwallowed);
+    }
+
+    None
+}
+
+/// EarlyReturnBypass: `return` / `return Ok(())` newly added near the top of
+/// a function body in `after` (= short-circuits the rest of the body).
+fn detect_early_return_bypass(
+    _relative_path: &str,
+    before: &str,
+    after: &str,
+) -> Option<WeakeningPattern> {
+    let added = lines_only_in_after(before, after);
+    let hit = added.iter().any(|l| {
+        let t = l.trim();
+        t == "return"
+            || t == "return;"
+            || t == "return None"
+            || t == "return None;"
+            || t == "return Ok(())"
+            || t == "return Ok(());"
+            || t == "return True"
+            || t == "return True;"
+            || t == "return None,"
+    });
+    hit.then_some(WeakeningPattern::EarlyReturnBypass)
+}
+
+/// TypeAnnotationWeakened: structural weakening of type annotations on the
+/// **same** identifier (`item_id: int` → `item_id: str`, `x: int` →
+/// `x: Any`, `&str` → `&dyn Any`).
+///
+/// CB-006 (Codex review): the previous string-contains heuristic fired on
+/// unrelated lines (e.g. adding `unrelated: Any` to a file that already had
+/// `x: int`). We now extract `identifier: annotation` pairs per line and
+/// only fire when the same identifier's annotation moved from a
+/// strong-typed token to a weak-typed token across `(before, after)`.
+fn detect_type_annotation_weakened(
+    _relative_path: &str,
+    before: &str,
+    after: &str,
+) -> Option<WeakeningPattern> {
+    let before_map = collect_identifier_annotations(before);
+    let after_map = collect_identifier_annotations(after);
+
+    for (ident, before_anns) in &before_map {
+        let Some(after_anns) = after_map.get(ident) else {
+            continue;
+        };
+        // For each annotation the identifier had in `before`, see if any
+        // matching annotation in `after` is a strict weakening of it.
+        for ba in before_anns {
+            for aa in after_anns {
+                if is_annotation_weakening(ba, aa) {
+                    return Some(WeakeningPattern::TypeAnnotationWeakened);
+                }
+            }
+        }
+    }
+    None
+}
+
+/// CB-006: collect `identifier -> [annotations]` from every line in `src`.
+///
+/// Captures the simple shapes covered by Phase A.2:
+/// - Python: `ident: TYPE` (parameter / variable / field; TYPE up to `,` `)` `=` end-of-line)
+/// - Rust: `ident: TYPE` in `let` / fn params / struct fields (same delimiters)
+///
+/// More exotic constructs (generic bounds, nested generics with `,`, etc.)
+/// are intentionally out-of-scope — under-detection is acceptable; the goal
+/// here is to remove the false-positive on unrelated identifiers.
+fn collect_identifier_annotations(src: &str) -> std::collections::HashMap<String, Vec<String>> {
+    use std::collections::HashMap;
+    // identifier is [A-Za-z_][A-Za-z0-9_]*
+    // annotation captures non-greedy up to a delimiter.
+    let re = regex::Regex::new(r"(?P<id>[A-Za-z_][A-Za-z0-9_]*)\s*:\s*(?P<ann>[^,)=\n;{]+)")
+        .expect("static regex must compile");
+    let mut out: HashMap<String, Vec<String>> = HashMap::new();
+    for line in src.lines() {
+        let trimmed = line.trim();
+        // Skip Python dict-literal / JSON-ish lines (`"key": value`) — those
+        // are not type annotations. A line starting with a `"` or `'`
+        // usually indicates a dict / mapping literal.
+        if trimmed.starts_with('"') || trimmed.starts_with('\'') {
+            continue;
+        }
+        for caps in re.captures_iter(line) {
+            let id = caps.name("id").unwrap().as_str().to_string();
+            let ann = caps.name("ann").unwrap().as_str().trim().to_string();
+            // Skip noise: empty / annotation that is a bare keyword like "in".
+            if ann.is_empty() {
+                continue;
+            }
+            out.entry(id).or_default().push(ann);
+        }
+    }
+    out
+}
+
+/// CB-006: classify `strong → weak` pairwise.
+///
+/// Returns `true` iff `before_ann` is a strictly stronger type than
+/// `after_ann`. Conservative: unknown pairs return `false`.
+fn is_annotation_weakening(before_ann: &str, after_ann: &str) -> bool {
+    if before_ann == after_ann {
+        return false;
+    }
+    let strong_to_weak: &[(&str, &[&str])] = &[
+        // Python — concrete primitives → Any / object / generic dynamic.
+        ("int", &["Any", "str", "object", "Optional[Any]"]),
+        ("str", &["Any", "object", "Optional[Any]"]),
+        ("bool", &["Any", "object", "int"]),
+        ("float", &["Any", "object"]),
+        // Rust — concrete → dynamic.
+        (
+            "&str",
+            &["&dyn Any", "&dyn std::any::Any", "&dyn core::any::Any"],
+        ),
+        ("u32", &["Box<dyn Any>", "Box<dyn std::any::Any>"]),
+        ("i32", &["Box<dyn Any>", "Box<dyn std::any::Any>"]),
+    ];
+    for (strong, weak_list) in strong_to_weak {
+        if before_ann == *strong && weak_list.contains(&after_ann) {
+            return true;
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -- SpecAuthority ordering / select -- //
+
+    #[test]
+    fn spec_authority_ordering_is_user_first_llm_last() {
+        let mut variants = [
+            SpecAuthority::LlmGeneratedTest,
+            SpecAuthority::ImplementationContract,
+            SpecAuthority::UserRequest,
+            SpecAuthority::BehaviorContract,
+        ];
+        variants.sort();
+        assert_eq!(variants[0], SpecAuthority::UserRequest);
+        assert_eq!(variants[1], SpecAuthority::BehaviorContract);
+        assert_eq!(variants[2], SpecAuthority::ImplementationContract);
+        assert_eq!(variants[3], SpecAuthority::LlmGeneratedTest);
+    }
+
+    #[test]
+    fn select_authority_returns_highest_priority_candidate() {
+        let picked = select_authority(
+            &[
+                SpecAuthority::LlmGeneratedTest,
+                SpecAuthority::UserRequest,
+                SpecAuthority::ImplementationContract,
+            ],
+            None,
+        );
+        assert_eq!(picked, Some(SpecAuthority::UserRequest));
+    }
+
+    #[test]
+    fn select_authority_ignores_verified_public_interface_as_dead_variant() {
+        // Even when listed first, VerifiedPublicInterface must not be picked.
+        let picked = select_authority(
+            &[
+                SpecAuthority::VerifiedPublicInterface,
+                SpecAuthority::ImplementationContract,
+            ],
+            None,
+        );
+        assert_eq!(picked, Some(SpecAuthority::ImplementationContract));
+    }
+
+    #[test]
+    fn select_authority_returns_none_when_only_dead_variant() {
+        let picked = select_authority(&[SpecAuthority::VerifiedPublicInterface], None);
+        assert!(picked.is_none());
+    }
+
+    #[test]
+    fn select_authority_duplicate_top_variant_is_not_tie_cb001() {
+        // CB-001 regression: [UserRequest, UserRequest] with a test/docs-only
+        // consensus must NOT demote to LlmGeneratedTest. Duplicate same-variant
+        // candidates are dedup'd before tie checks.
+        let consensus = ArtifactConsensus::new(
+            vec![ArtifactRole::Test, ArtifactRole::UsageDocs],
+            vec![ArtifactRole::Implementation],
+            "test+docs agree (impl dissents)",
+        );
+        let picked = select_authority(
+            &[SpecAuthority::UserRequest, SpecAuthority::UserRequest],
+            Some(&consensus),
+        );
+        assert_eq!(
+            picked,
+            Some(SpecAuthority::UserRequest),
+            "duplicate UserRequest must not be demoted to a weaker authority"
+        );
+    }
+
+    #[test]
+    fn select_authority_consensus_cannot_demote_top_cb001() {
+        // CB-001 guard: even if the consensus branch is somehow reached, the
+        // consensus winner must not be weaker than the existing top.
+        // Here `LlmGeneratedTest` is the bottom rank; consensus would suggest
+        // `ImplementationContract` (a stronger authority), which is allowed.
+        // Conversely, a stronger top (e.g., UserRequest) must never be demoted
+        // even if consensus suggested `ImplementationContract`.
+        let consensus_impl = ArtifactConsensus::new(
+            vec![ArtifactRole::Implementation, ArtifactRole::UsageDocs],
+            vec![ArtifactRole::Test],
+            "impl and docs agree",
+        );
+        // UserRequest top + impl-consensus → top wins (no demotion).
+        let picked = select_authority(
+            &[SpecAuthority::UserRequest, SpecAuthority::UserRequest],
+            Some(&consensus_impl),
+        );
+        assert_eq!(picked, Some(SpecAuthority::UserRequest));
+    }
+
+    #[test]
+    fn select_authority_returns_none_for_empty_input() {
+        assert_eq!(select_authority(&[], None), None);
+    }
+
+    #[test]
+    fn artifact_consensus_sanitizes_reason() {
+        let c = ArtifactConsensus::new(
+            vec![ArtifactRole::Implementation],
+            vec![ArtifactRole::Test],
+            "reason\x07with\x08ctl",
+        );
+        assert!(
+            !c.reason.chars().any(|ch| (ch as u32) < 0x20),
+            "control chars must be neutralized: {:?}",
+            c.reason
+        );
+    }
+
+    #[test]
+    fn artifact_consensus_truncates_long_reason() {
+        let raw = "x".repeat(MAX_CONSENSUS_REASON_CHARS + 50);
+        let c = ArtifactConsensus::new(vec![ArtifactRole::Implementation], vec![], &raw);
+        assert!(c.reason.chars().count() <= MAX_CONSENSUS_REASON_CHARS + 3); // +"..."
+    }
+
+    // -- Test detectors -- //
+
+    #[test]
+    fn detect_assertion_deleted_positive() {
+        let before = "def test_x():\n    assert foo() == 1\n    do_setup()\n";
+        let after = "def test_x():\n    do_setup()\n";
+        assert_eq!(
+            detect_assertion_deleted("t.py", before, after),
+            Some(WeakeningPattern::AssertionDeleted)
+        );
+    }
+
+    #[test]
+    fn detect_assertion_deleted_negative_when_assert_preserved() {
+        let before = "def test_x():\n    assert foo() == 1\n";
+        let after = "def test_x():\n    assert foo() == 1\n    extra()\n";
+        assert!(detect_assertion_deleted("t.py", before, after).is_none());
+    }
+
+    #[test]
+    fn detect_assertion_deleted_cb003_duplicate_row_one_removed() {
+        // CB-003 regression: before has the same assert twice, after has it
+        // once → 1 occurrence was deleted, AssertionDeleted must fire.
+        let before = "def test_x():\n    assert foo() == 1\n    assert foo() == 1\n";
+        let after = "def test_x():\n    assert foo() == 1\n";
+        assert_eq!(
+            detect_assertion_deleted("t.py", before, after),
+            Some(WeakeningPattern::AssertionDeleted),
+            "multiset semantics: deleting one of two duplicate asserts must fire"
+        );
+    }
+
+    #[test]
+    fn detect_skip_marker_added_positive_python() {
+        let before = "def test_x():\n    assert foo()\n";
+        let after = "@pytest.mark.skip\ndef test_x():\n    assert foo()\n";
+        assert_eq!(
+            detect_skip_marker_added("t.py", before, after),
+            Some(WeakeningPattern::SkipMarkerAdded)
+        );
+    }
+
+    #[test]
+    fn detect_skip_marker_added_positive_rust() {
+        let before = "#[test]\nfn test_x() { assert!(true); }\n";
+        let after = "#[ignore]\n#[test]\nfn test_x() { assert!(true); }\n";
+        assert_eq!(
+            detect_skip_marker_added("t.rs", before, after),
+            Some(WeakeningPattern::SkipMarkerAdded)
+        );
+    }
+
+    #[test]
+    fn detect_skip_marker_added_negative_when_unchanged() {
+        let s = "fn test_x() {}\n";
+        assert!(detect_skip_marker_added("t.rs", s, s).is_none());
+    }
+
+    #[test]
+    fn detect_assert_true_weakening_positive() {
+        let before = "def test_x():\n    assert foo() == 1\n";
+        let after = "def test_x():\n    assert True\n";
+        assert_eq!(
+            detect_assert_true_weakening("t.py", before, after),
+            Some(WeakeningPattern::AssertTrueWeakening)
+        );
+    }
+
+    #[test]
+    fn detect_assert_true_weakening_negative_when_no_prior_assert() {
+        let before = "def test_x():\n    pass\n";
+        let after = "def test_x():\n    pass\n    assert True\n";
+        // No prior real assert → not a weakening of an existing assertion.
+        assert!(detect_assert_true_weakening("t.py", before, after).is_none());
+    }
+
+    #[test]
+    fn detect_test_function_deleted_positive_python() {
+        let before = "def test_x():\n    assert foo()\n\ndef test_y():\n    assert bar()\n";
+        let after = "def test_x():\n    assert foo()\n";
+        assert_eq!(
+            detect_test_function_deleted("t.py", before, after),
+            Some(WeakeningPattern::TestFunctionDeleted)
+        );
+    }
+
+    #[test]
+    fn detect_test_function_deleted_positive_rust() {
+        let before = "fn test_a() { assert!(true); }\nfn test_b() { assert!(true); }\n";
+        let after = "fn test_a() { assert!(true); }\n";
+        assert_eq!(
+            detect_test_function_deleted("t.rs", before, after),
+            Some(WeakeningPattern::TestFunctionDeleted)
+        );
+    }
+
+    #[test]
+    fn detect_literal_only_expected_change_positive() {
+        let before = "def test_x():\n    x = compute()\n    assert x == 1\n";
+        let after = "def test_x():\n    x = compute()\n    assert x == 99\n";
+        assert_eq!(
+            detect_literal_only_expected_change("t.py", before, after),
+            Some(WeakeningPattern::LiteralOnlyExpectedChange)
+        );
+    }
+
+    #[test]
+    fn detect_literal_only_expected_change_negative_when_inputs_changed() {
+        let before = "def test_x():\n    x = compute(1)\n    assert x == 1\n";
+        let after = "def test_x():\n    x = compute(2)\n    assert x == 99\n";
+        // Both inputs and expected changed → not "literal only".
+        assert!(detect_literal_only_expected_change("t.py", before, after).is_none());
+    }
+
+    // -- Impl detectors -- //
+
+    #[test]
+    fn detect_validator_deleted_positive_assert() {
+        let before = "fn run(x: i32) -> i32 {\n    assert!(x > 0);\n    x * 2\n}\n";
+        let after = "fn run(x: i32) -> i32 {\n    x * 2\n}\n";
+        assert_eq!(
+            detect_validator_deleted("m.rs", before, after),
+            Some(WeakeningPattern::ValidatorDeleted)
+        );
+    }
+
+    #[test]
+    fn detect_validator_deleted_positive_question_mark() {
+        let before = "fn run() -> Result<i32, E> {\n    let x = step()?;\n    Ok(x)\n}\n";
+        let after =
+            "fn run() -> Result<i32, E> {\n    let x = step().unwrap_or_default();\n    Ok(x)\n}\n";
+        assert_eq!(
+            detect_validator_deleted("m.rs", before, after),
+            Some(WeakeningPattern::ValidatorDeleted)
+        );
+    }
+
+    #[test]
+    fn detect_validator_deleted_negative() {
+        let s = "fn run() -> i32 { 1 }\n";
+        assert!(detect_validator_deleted("m.rs", s, s).is_none());
+    }
+
+    #[test]
+    fn detect_validator_deleted_cb004_python_multiline_raise() {
+        // CB-004 acceptance: multiline validator (`if invalid:` next line
+        // `raise ValueError`) where only the `raise` line is deleted must
+        // fire as ValidatorDeleted.
+        let before = "def run(x):\n    if not x:\n        raise ValueError('bad')\n    return x\n";
+        let after = "def run(x):\n    if not x:\n        pass\n    return x\n";
+        assert_eq!(
+            detect_validator_deleted("m.py", before, after),
+            Some(WeakeningPattern::ValidatorDeleted)
+        );
+    }
+
+    #[test]
+    fn detect_validator_deleted_cb004_rust_return_err_deleted() {
+        // CB-004: `return Err(...)` deletion is a validator removal.
+        let before = "fn run(x: i32) -> Result<i32, E> {\n    if x < 0 {\n        return Err(E::Neg);\n    }\n    Ok(x)\n}\n";
+        let after = "fn run(x: i32) -> Result<i32, E> {\n    if x < 0 {\n    }\n    Ok(x)\n}\n";
+        assert_eq!(
+            detect_validator_deleted("m.rs", before, after),
+            Some(WeakeningPattern::ValidatorDeleted)
+        );
+    }
+
+    #[test]
+    fn detect_validator_deleted_cb004_rust_bail_deleted() {
+        // CB-004: bail!() terminal removed → ValidatorDeleted.
+        let before = "fn run(x: i32) -> anyhow::Result<i32> {\n    if x < 0 {\n        bail!(\"negative\");\n    }\n    Ok(x)\n}\n";
+        let after =
+            "fn run(x: i32) -> anyhow::Result<i32> {\n    if x < 0 {\n    }\n    Ok(x)\n}\n";
+        assert_eq!(
+            detect_validator_deleted("m.rs", before, after),
+            Some(WeakeningPattern::ValidatorDeleted)
+        );
+    }
+
+    #[test]
+    fn detect_validator_deleted_cb004_ts_throw_deleted() {
+        // CB-004: `throw new ...` terminal removed → ValidatorDeleted.
+        let before = "function run(x: number) {\n  if (x < 0) {\n    throw new Error('neg');\n  }\n  return x;\n}\n";
+        let after = "function run(x: number) {\n  if (x < 0) {\n  }\n  return x;\n}\n";
+        assert_eq!(
+            detect_validator_deleted("m.ts", before, after),
+            Some(WeakeningPattern::ValidatorDeleted)
+        );
+    }
+
+    #[test]
+    fn detect_error_swallowed_positive_python() {
+        let before = "def run():\n    do_thing()\n";
+        let after = "def run():\n    try:\n        do_thing()\n    except: pass\n";
+        assert_eq!(
+            detect_error_swallowed("m.py", before, after),
+            Some(WeakeningPattern::ErrorSwallowed)
+        );
+    }
+
+    #[test]
+    fn detect_error_swallowed_positive_rust_ok() {
+        let before = "fn run() -> Result<(), E> {\n    step()?;\n    Ok(())\n}\n";
+        let after = "fn run() -> Result<(), E> {\n    step().ok();\n    Ok(())\n}\n";
+        assert_eq!(
+            detect_error_swallowed("m.rs", before, after),
+            Some(WeakeningPattern::ErrorSwallowed)
+        );
+    }
+
+    #[test]
+    fn detect_error_swallowed_negative_when_propagation_kept() {
+        let s = "fn run() -> Result<(), E> { step()?; Ok(()) }\n";
+        assert!(detect_error_swallowed("m.rs", s, s).is_none());
+    }
+
+    #[test]
+    fn detect_early_return_bypass_positive() {
+        let before = "fn run(flag: bool) -> i32 {\n    let x = compute();\n    x\n}\n";
+        let after =
+            "fn run(flag: bool) -> i32 {\n    return Ok(());\n    let x = compute();\n    x\n}\n";
+        assert_eq!(
+            detect_early_return_bypass("m.rs", before, after),
+            Some(WeakeningPattern::EarlyReturnBypass)
+        );
+    }
+
+    #[test]
+    fn detect_early_return_bypass_negative_when_no_added_return() {
+        let s = "fn run() -> i32 { compute() }\n";
+        assert!(detect_early_return_bypass("m.rs", s, s).is_none());
+    }
+
+    #[test]
+    fn detect_type_annotation_weakened_python_same_ident() {
+        // CB-006: same identifier `x` moved from `int` to `Any` → fire.
+        let before = "def f(x: int) -> int:\n    return x\n";
+        let after = "def f(x: Any) -> int:\n    return x\n";
+        assert_eq!(
+            detect_type_annotation_weakened("m.py", before, after),
+            Some(WeakeningPattern::TypeAnnotationWeakened)
+        );
+    }
+
+    #[test]
+    fn detect_type_annotation_weakened_rust_same_ident() {
+        // CB-006: same param `x` moved from `&str` to `&dyn Any` → fire.
+        let before = "fn run(x: &str) -> String { x.to_owned() }\n";
+        let after = "fn run(x: &dyn Any) -> String { format!(\"{:?}\", x) }\n";
+        assert_eq!(
+            detect_type_annotation_weakened("m.rs", before, after),
+            Some(WeakeningPattern::TypeAnnotationWeakened)
+        );
+    }
+
+    #[test]
+    fn detect_type_annotation_weakened_negative() {
+        let s = "fn run(x: &str) -> String { x.to_owned() }\n";
+        assert!(detect_type_annotation_weakened("m.rs", s, s).is_none());
+    }
+
+    #[test]
+    fn detect_type_annotation_weakened_cb006_item_id_int_to_str() {
+        // CB-006 acceptance (a): item_id: int → item_id: str must fire.
+        let before = "def f(item_id: int) -> int:\n    return item_id\n";
+        let after = "def f(item_id: str) -> int:\n    return item_id\n";
+        assert_eq!(
+            detect_type_annotation_weakened("m.py", before, after),
+            Some(WeakeningPattern::TypeAnnotationWeakened)
+        );
+    }
+
+    #[test]
+    fn detect_type_annotation_weakened_cb006_unrelated_any_no_fire() {
+        // CB-006 acceptance (b): adding an unrelated `unrelated: Any`
+        // variable must NOT fire — only existing identifiers count.
+        let before = "def f(item_id: int) -> int:\n    return item_id\n";
+        let after = "def f(item_id: int) -> int:\n    unrelated: Any = 0\n    return item_id\n";
+        assert!(
+            detect_type_annotation_weakened("m.py", before, after).is_none(),
+            "unrelated `: Any` addition must not be reported as weakening"
+        );
+    }
+
+    // -- Orchestration -- //
+
+    #[test]
+    fn detect_test_weakening_aggregates_independent_detectors() {
+        // Both AssertionDeleted and SkipMarkerAdded fire at once.
+        let before = "def test_x():\n    assert foo() == 1\n";
+        let after = "@pytest.mark.skip\ndef test_x():\n    pass\n";
+        let mut patterns = detect_test_weakening("t.py", before, after);
+        patterns.sort_by_key(|p| format!("{p:?}"));
+        assert!(patterns.contains(&WeakeningPattern::AssertionDeleted));
+        assert!(patterns.contains(&WeakeningPattern::SkipMarkerAdded));
+    }
+
+    #[test]
+    fn detect_test_weakening_empty_for_identical_input() {
+        let s = "def test_x():\n    assert foo() == 1\n";
+        assert!(detect_test_weakening("t.py", s, s).is_empty());
+    }
+
+    #[test]
+    fn detect_impl_weakening_aggregates_independent_detectors() {
+        let before = "fn run() -> Result<i32, E> {\n    let x = step()?;\n    Ok(x)\n}\n";
+        let after =
+            "fn run() -> Result<i32, E> {\n    step().ok();\n    return Ok(());\n    Ok(0)\n}\n";
+        let patterns = detect_impl_weakening("m.rs", before, after);
+        assert!(patterns.contains(&WeakeningPattern::ValidatorDeleted));
+        assert!(patterns.contains(&WeakeningPattern::ErrorSwallowed));
+        assert!(patterns.contains(&WeakeningPattern::EarlyReturnBypass));
+    }
+
+    #[test]
+    fn detect_impl_weakening_empty_for_identical_input() {
+        let s = "fn run() -> i32 { 1 }\n";
+        assert!(detect_impl_weakening("m.rs", s, s).is_empty());
+    }
+
+    // -- RepairRole alias -- //
+
+    #[test]
+    fn repair_role_is_artifact_role_alias() {
+        // Same type → assignable both ways without conversion.
+        let r: RepairRole = ArtifactRole::Implementation;
+        let a: ArtifactRole = r;
+        assert_eq!(a, ArtifactRole::Implementation);
+    }
+}

--- a/src/agent/loop_run/spec_authority.rs
+++ b/src/agent/loop_run/spec_authority.rs
@@ -227,24 +227,62 @@ const EXPLICIT_SPEC_MIN_DISTINCT_HITS: usize = 2;
 
 /// Issue #647 (SF1 V3.1): cheap heuristic that classifies an
 /// `active_request` as "carries an explicit specification" iff at least
-/// `EXPLICIT_SPEC_MIN_DISTINCT_HITS` distinct keywords from
-/// `EXPLICIT_SPEC_KEYWORDS` appear in the request.
+/// `EXPLICIT_SPEC_MIN_DISTINCT_HITS` distinct, **non-overlapping** keyword
+/// spans from `EXPLICIT_SPEC_KEYWORDS` appear in the request.
 ///
 /// Pure function — no I/O, no LLM dependency. Matching is case-insensitive
 /// on the ascii side; the Japanese keywords are matched verbatim (Japanese
 /// has no case fold to apply).
+///
+/// CB-010 (Issue #647 V3 iteration-4): the keyword table intentionally
+/// contains overlapping prefixes ("must " vs. "must return", "should "
+/// vs. "should return", …) so a single phrase like "must return 404" used
+/// to be counted twice and crossed the 2-hit threshold on its own — a
+/// false positive. We now collect every match position, sort by start,
+/// and greedily drop spans whose `[start, end)` overlaps the previously
+/// accepted span. The resulting count is the number of **distinct
+/// linguistic occurrences**, not the number of matching keywords.
 pub(super) fn detect_explicit_spec_in_user_request(active_request: &str) -> bool {
     if active_request.trim().is_empty() {
         return false;
     }
     let lowered = active_request.to_ascii_lowercase();
-    let mut hits = 0usize;
+
+    // CB-010: gather every keyword match as a byte-span and dedup
+    // overlapping spans so a single phrase only counts once.
+    let mut spans: Vec<(usize, usize)> = Vec::new();
     for keyword in EXPLICIT_SPEC_KEYWORDS {
-        // Ascii keywords are stored in lower-case; Japanese keywords are
-        // ascii-only-insensitive (they have no ascii letters anyway).
-        if lowered.contains(keyword) {
-            hits += 1;
-            if hits >= EXPLICIT_SPEC_MIN_DISTINCT_HITS {
+        let kw_len = keyword.len();
+        if kw_len == 0 {
+            continue;
+        }
+        // Walk non-overlapping occurrences of this single keyword.
+        // We advance by `kw_len` (safe char-boundary for ascii + multibyte
+        // because keywords are stored as whole UTF-8 sequences). Cross-
+        // keyword overlap is still caught by the span-dedup step below.
+        let mut search_from = 0;
+        while let Some(rel) = lowered[search_from..].find(keyword) {
+            let start = search_from + rel;
+            let end = start + kw_len;
+            spans.push((start, end));
+            search_from = end;
+        }
+    }
+
+    if spans.len() < EXPLICIT_SPEC_MIN_DISTINCT_HITS {
+        return false;
+    }
+
+    // Greedy non-overlapping span count: sort by start, accept a span
+    // only if its start is at or beyond the previously accepted end.
+    spans.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| b.1.cmp(&a.1)));
+    let mut deduped_hits = 0usize;
+    let mut last_end = 0usize;
+    for (start, end) in spans {
+        if start >= last_end {
+            deduped_hits += 1;
+            last_end = end;
+            if deduped_hits >= EXPLICIT_SPEC_MIN_DISTINCT_HITS {
                 return true;
             }
         }
@@ -1212,6 +1250,47 @@ mod tests {
         // Two distinct Japanese prescriptive keywords are enough.
         let request = "本仕様の API は必ず 404 を返すこと。";
         assert!(detect_explicit_spec_in_user_request(request));
+    }
+
+    // -- Issue #647 CB-010: span-dedup against overlapping keyword hits -- //
+
+    #[test]
+    fn cb010_single_must_return_does_not_trigger_user_request_match() {
+        // Regression: "must " (with trailing space) and "must return" both
+        // appear in EXPLICIT_SPEC_KEYWORDS. Before span dedup, the single
+        // phrase "must return 404" produced **two** hits and crossed the
+        // 2-hit threshold — a false positive. After dedup the overlapping
+        // spans collapse to one and the detector returns `false`.
+        let request = "the endpoint must return 404 when item not found";
+        assert!(!detect_explicit_spec_in_user_request(request));
+    }
+
+    #[test]
+    fn cb010_two_distinct_keywords_still_trigger_match() {
+        // Regression guard for CB-010 fix: two **non-overlapping** keyword
+        // spans ("must " and "specification") must still cross the threshold.
+        let request = "must return 404; this is the specification";
+        assert!(detect_explicit_spec_in_user_request(request));
+    }
+
+    #[test]
+    fn cb010_overlapping_must_and_must_return_dedup_to_one_hit() {
+        // Pure span-dedup check: only "must " and "must return" overlap on
+        // a single phrase, so the detector must see exactly one distinct
+        // span and return `false`.
+        let request = "must return 200";
+        assert!(!detect_explicit_spec_in_user_request(request));
+    }
+
+    #[test]
+    fn cb010_japanese_keyword_dedup() {
+        // Japanese: "返すこと" is a substring of "返さなければならない"-style
+        // phrases is not the case here, but "返すこと" alone, plus the
+        // overlapping case where "仕様" appears only once, must not be
+        // double-counted. A single Japanese phrase containing only
+        // "返すこと" must NOT trigger the detector.
+        let request = "API は 404 を返すこと。";
+        assert!(!detect_explicit_spec_in_user_request(request));
     }
 
     // -- SF1 V3.3: consensus heuristic -- //

--- a/src/agent/loop_run/spec_authority.rs
+++ b/src/agent/loop_run/spec_authority.rs
@@ -360,17 +360,39 @@ fn normalize_consensus_text(text: &str) -> String {
     out
 }
 
-/// Issue #647 (SF1 V3.2): "verified public interface" detector that wires
-/// the existing turn-local `verifier_passed_in_loop` signal into the
-/// `SpecAuthorityInput`. This is the **real but bounded** detector
-/// referenced in S5-005: it never lies (the bit is observed, not stubbed)
-/// and it never reaches outside the current actor-loop iteration.
+/// Issue #647 (SF1 V3.2 + CB-011): "verified public interface" detector.
 ///
-/// Pure function — `hint` is the only input. Lives next to the consensus
-/// / explicit-spec detectors so a future Issue widening the history
-/// surface has a single growth point.
-pub(super) fn detect_verified_public_interface_from_history(hint: AgentHistoryHint) -> bool {
-    hint.verifier_passed_in_loop
+/// **Dead variant placeholder until artifact identity is bound** (CB-011).
+/// Earlier iterations returned `hint.verifier_passed_in_loop` directly, but
+/// the `verifier_passed_in_loop` bit is *turn-local* (S5-005) without being
+/// *artifact-specific*: it tells us "some artifact passed the verifier in
+/// this actor-loop iteration", not "the artifact implicated by the current
+/// `SemanticFailureReport` passed the verifier". The current
+/// `SemanticFailureReport` schema does not carry path / interface identifiers
+/// in `affected_cases` / `involved_artifacts` / `contract_conflict`, so there
+/// is no safe way to prove path overlap. Lifting authority on the bit alone
+/// would let an unrelated verifier success elevate `VerifiedPublicInterface`
+/// over `ImplementationContract` for a failure that has nothing to do with
+/// the verified artifact — a false-positive authority elevation.
+///
+/// We therefore keep the detector **constant `false`** in this Issue. The
+/// `VerifiedPublicInterface` variant remains in the [`SpecAuthority`] enum
+/// (DR1-005 forward-extensibility), the [`AgentHistoryHint`] struct keeps
+/// `verifier_passed_in_loop` as a placeholder field, and the production
+/// resolve path can never reach the variant. A future Issue that plumbs
+/// artifact identity (e.g. failing path / interface identifier on the
+/// `SemanticFailureReport`) into the hint will be the single growth point:
+/// it can add a `passed_artifact_paths: Vec<String>` field on
+/// `AgentHistoryHint`, take a `&SemanticFailureReport` here, and flip the
+/// return to `true` only when path overlap is provable.
+///
+/// Pure function — `hint` is currently unused but kept on the signature to
+/// preserve the call-site shape (`turn.rs::build_spec_authority_input_for_active_request`)
+/// and to make the future-extension growth point obvious.
+pub(super) fn detect_verified_public_interface_from_history(_hint: AgentHistoryHint) -> bool {
+    // CB-011: hold the line at `false` until artifact identity is bound.
+    // See doc comment for the full rationale.
+    false
 }
 
 /// Issue #647 (SF1): aggregated input passed by `turn.rs` to [`resolve`]
@@ -1356,12 +1378,68 @@ mod tests {
         assert!(!detect_verified_public_interface_from_history(hint));
     }
 
+    // CB-011: the prior `sf1_v3_verified_public_interface_true_when_verifier_passed_in_loop`
+    // test asserted the detector returned `true` when `verifier_passed_in_loop = true`.
+    // That route is now dead per CB-011 (artifact identity is not bound to the
+    // current `SemanticFailureReport`), so the new behavior is exercised by
+    // `cb011_verified_public_interface_detector_returns_false_when_artifact_identity_not_bound`
+    // immediately below — there is no replacement positive test for the
+    // pre-CB-011 path.
+
+    // -- CB-011: VerifiedPublicInterface must stay a dead variant
+    //    placeholder until artifact identity is bound to the failing
+    //    `SemanticFailureReport`. The detector must NOT lift authority
+    //    based on `verifier_passed_in_loop` alone (Issue #647 CB-011). --
+
     #[test]
-    fn sf1_v3_verified_public_interface_true_when_verifier_passed_in_loop() {
+    fn cb011_verified_public_interface_detector_returns_false_when_artifact_identity_not_bound() {
+        // CB-011: even when the turn-local verifier-passed bit is set,
+        // we have no signal proving the verified artifact matches the
+        // *current* failure (SemanticFailureReport does not carry
+        // path/interface identifiers). The detector must therefore
+        // remain a dead placeholder and never lift the bit on its own.
         let hint = AgentHistoryHint {
             verifier_passed_in_loop: true,
         };
-        assert!(detect_verified_public_interface_from_history(hint));
+        assert!(
+            !detect_verified_public_interface_from_history(hint),
+            "verifier_passed_in_loop alone must not light VerifiedPublicInterface (CB-011)"
+        );
+    }
+
+    #[test]
+    fn cb011_resolve_does_not_elect_verified_public_interface_in_production() {
+        // CB-011 integration: even if the production callsite passes a
+        // hint where `verifier_passed_in_loop = true`, the detector
+        // returns `false`, so the resulting `SpecAuthorityInput` has
+        // `has_verified_public_interface = false` and `resolve` cannot
+        // elect `VerifiedPublicInterface`. We exercise the detector +
+        // resolve chain directly here (the production builder lives in
+        // `turn.rs`; the parallel integration test lives there too).
+        let hint = AgentHistoryHint {
+            verifier_passed_in_loop: true,
+        };
+        let has_verified_public_interface = detect_verified_public_interface_from_history(hint);
+        assert!(
+            !has_verified_public_interface,
+            "production hint with verifier_passed_in_loop=true must NOT light the flag"
+        );
+        let input = SpecAuthorityInput {
+            has_user_request_match: false,
+            has_behavior_contract: false,
+            has_verified_public_interface,
+            is_newly_generated_task: false,
+            consensus: None,
+        };
+        // With no other signal lit, `resolve` falls through to the
+        // ImplementationContract default — VerifiedPublicInterface is
+        // unreachable in production.
+        assert_ne!(
+            resolve(&input),
+            SpecAuthority::VerifiedPublicInterface,
+            "VerifiedPublicInterface must stay a dead variant in production (CB-011)"
+        );
+        assert_eq!(resolve(&input), SpecAuthority::ImplementationContract);
     }
 
     // -- Test detectors -- //

--- a/src/agent/loop_run/spec_authority.rs
+++ b/src/agent/loop_run/spec_authority.rs
@@ -161,6 +161,180 @@ pub(super) fn select_authority(
     Some(top)
 }
 
+/// Issue #647 (SF1 V3): minimal cross-turn history hint that the
+/// `SpecAuthorityInput` builder can read to decide whether
+/// `has_verified_public_interface` should fire.
+///
+/// Kept deliberately small (one bool) — wider session-store history is out
+/// of scope for SF1 V3 (S5-005 dead-variant policy still applies on the
+/// resolver side). When future Issues plumb richer history, this struct is
+/// the only growth point for the builder signature.
+///
+/// `Default::default()` is the safe production fallback when no caller
+/// context is available (e.g. test wrappers or fresh sessions).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(super) struct AgentHistoryHint {
+    /// True iff the agent already observed a verifier success for the
+    /// active task *within this run-actor-loop iteration*. Mirrors the
+    /// local `task_contract_verifier_passed_in_loop` flag in
+    /// `Agent::handle_user_message`.
+    pub(super) verifier_passed_in_loop: bool,
+}
+
+/// Issue #647 (SF1 V3.1): explicit-spec keyword set used by
+/// [`detect_explicit_spec_in_user_request`]. Ascii + Japanese kept in one
+/// table so the detector is a pure-string match. Each entry encodes a
+/// determinate, prescriptive expression — vague guidance (e.g. "please",
+/// "could you") is intentionally excluded.
+const EXPLICIT_SPEC_KEYWORDS: &[&str] = &[
+    // Ascii: prescriptive modal verbs and contract phrasing.
+    "must ",
+    "must return",
+    "must accept",
+    "must raise",
+    "must not",
+    "should ",
+    "should return",
+    "should accept",
+    "should not",
+    "shall ",
+    "shall return",
+    "specification",
+    "spec:",
+    "expects exactly",
+    "expects:",
+    "api contract",
+    "contract:",
+    // Japanese: prescriptive phrasing.
+    "仕様",
+    "必須",
+    "必ず",
+    "返却すること",
+    "返すこと",
+    "返さなければならない",
+    "してはならない",
+    "とすること",
+];
+
+/// Minimum count of distinct explicit-spec keywords that must appear in
+/// `active_request` for the detector to declare a "user-request match".
+///
+/// SF1 V3 design judgment: a single occurrence of "should" is too noisy
+/// (it often appears in conversational filler). Two distinct hits raise
+/// the bar high enough that the request is plausibly *prescriptive*
+/// without forcing the user to write a formal grammar.
+const EXPLICIT_SPEC_MIN_DISTINCT_HITS: usize = 2;
+
+/// Issue #647 (SF1 V3.1): cheap heuristic that classifies an
+/// `active_request` as "carries an explicit specification" iff at least
+/// `EXPLICIT_SPEC_MIN_DISTINCT_HITS` distinct keywords from
+/// `EXPLICIT_SPEC_KEYWORDS` appear in the request.
+///
+/// Pure function — no I/O, no LLM dependency. Matching is case-insensitive
+/// on the ascii side; the Japanese keywords are matched verbatim (Japanese
+/// has no case fold to apply).
+pub(super) fn detect_explicit_spec_in_user_request(active_request: &str) -> bool {
+    if active_request.trim().is_empty() {
+        return false;
+    }
+    let lowered = active_request.to_ascii_lowercase();
+    let mut hits = 0usize;
+    for keyword in EXPLICIT_SPEC_KEYWORDS {
+        // Ascii keywords are stored in lower-case; Japanese keywords are
+        // ascii-only-insensitive (they have no ascii letters anyway).
+        if lowered.contains(keyword) {
+            hits += 1;
+            if hits >= EXPLICIT_SPEC_MIN_DISTINCT_HITS {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Issue #647 (SF1 V3.3): consensus heuristic computed from the
+/// `ContractConflict` fields of a `SemanticFailureReport`. Returns
+/// `Some(ArtifactConsensus { agreeing, dissenting, reason })` when exactly
+/// two of the three roles agree (after normalization) and the third
+/// disagrees; otherwise returns `None` (covers both "all three agree" and
+/// "all three differ").
+///
+/// Normalization is intentionally cheap: lower-case + collapsed-whitespace
+/// trim. The Issue spec explicitly forbids NLP — this stays a pure string
+/// match.
+pub(super) fn detect_consensus_from_contract_conflict(
+    implementation: &str,
+    test: &str,
+    usage_docs: &str,
+) -> Option<ArtifactConsensus> {
+    let impl_norm = normalize_consensus_text(implementation);
+    let test_norm = normalize_consensus_text(test);
+    let docs_norm = normalize_consensus_text(usage_docs);
+    if impl_norm.is_empty() || test_norm.is_empty() || docs_norm.is_empty() {
+        return None;
+    }
+    let impl_test = impl_norm == test_norm;
+    let impl_docs = impl_norm == docs_norm;
+    let test_docs = test_norm == docs_norm;
+    // Exactly two roles agree → tie-break consensus.
+    match (impl_test, impl_docs, test_docs) {
+        (true, false, false) => Some(ArtifactConsensus::new(
+            vec![ArtifactRole::Implementation, ArtifactRole::Test],
+            vec![ArtifactRole::UsageDocs],
+            "impl and test agree; usage_docs dissents",
+        )),
+        (false, true, false) => Some(ArtifactConsensus::new(
+            vec![ArtifactRole::Implementation, ArtifactRole::UsageDocs],
+            vec![ArtifactRole::Test],
+            "impl and usage_docs agree; test dissents",
+        )),
+        (false, false, true) => Some(ArtifactConsensus::new(
+            vec![ArtifactRole::Test, ArtifactRole::UsageDocs],
+            vec![ArtifactRole::Implementation],
+            "test and usage_docs agree; impl dissents",
+        )),
+        // All three agree, or all three differ → no usable tie-break.
+        _ => None,
+    }
+}
+
+/// Normalize a `ContractConflict` field for consensus comparison.
+///
+/// Lower-case + collapse all whitespace runs to a single space + trim.
+fn normalize_consensus_text(text: &str) -> String {
+    let lowered = text.to_ascii_lowercase();
+    let mut out = String::with_capacity(lowered.len());
+    let mut last_was_ws = true; // suppress leading whitespace
+    for ch in lowered.chars() {
+        if ch.is_whitespace() {
+            if !last_was_ws {
+                out.push(' ');
+                last_was_ws = true;
+            }
+        } else {
+            out.push(ch);
+            last_was_ws = false;
+        }
+    }
+    if out.ends_with(' ') {
+        out.pop();
+    }
+    out
+}
+
+/// Issue #647 (SF1 V3.2): "verified public interface" detector that wires
+/// the existing turn-local `verifier_passed_in_loop` signal into the
+/// `SpecAuthorityInput`. This is the **real but bounded** detector
+/// referenced in S5-005: it never lies (the bit is observed, not stubbed)
+/// and it never reaches outside the current actor-loop iteration.
+///
+/// Pure function — `hint` is the only input. Lives next to the consensus
+/// / explicit-spec detectors so a future Issue widening the history
+/// surface has a single growth point.
+pub(super) fn detect_verified_public_interface_from_history(hint: AgentHistoryHint) -> bool {
+    hint.verifier_passed_in_loop
+}
+
 /// Issue #647 (SF1): aggregated input passed by `turn.rs` to [`resolve`]
 /// when constructing a `SemanticRepairPlan`. Each flag is computed by the
 /// caller from a different source (the user request, the
@@ -923,6 +1097,108 @@ mod tests {
         let raw = "x".repeat(MAX_CONSENSUS_REASON_CHARS + 50);
         let c = ArtifactConsensus::new(vec![ArtifactRole::Implementation], vec![], &raw);
         assert!(c.reason.chars().count() <= MAX_CONSENSUS_REASON_CHARS + 3); // +"..."
+    }
+
+    // -- SF1 V3.1: explicit-spec detector -- //
+
+    #[test]
+    fn sf1_v3_explicit_spec_positive_two_distinct_keywords() {
+        // Two distinct prescriptive keywords ("must return", "should")
+        // → user-request match fires.
+        let request = "The endpoint must return 404 when the item is missing. \
+                       The response should also include a JSON error body.";
+        assert!(detect_explicit_spec_in_user_request(request));
+    }
+
+    #[test]
+    fn sf1_v3_explicit_spec_negative_single_should() {
+        // A single "should" hit is below the threshold (2 distinct hits).
+        let request = "You should probably add a test for the create flow.";
+        assert!(!detect_explicit_spec_in_user_request(request));
+    }
+
+    #[test]
+    fn sf1_v3_explicit_spec_negative_empty_request() {
+        assert!(!detect_explicit_spec_in_user_request(""));
+        assert!(!detect_explicit_spec_in_user_request("   \n  "));
+    }
+
+    #[test]
+    fn sf1_v3_explicit_spec_positive_japanese_keywords() {
+        // Two distinct Japanese prescriptive keywords are enough.
+        let request = "本仕様の API は必ず 404 を返すこと。";
+        assert!(detect_explicit_spec_in_user_request(request));
+    }
+
+    // -- SF1 V3.3: consensus heuristic -- //
+
+    #[test]
+    fn sf1_v3_consensus_impl_and_docs_agree_test_dissents() {
+        let consensus = detect_consensus_from_contract_conflict(
+            "returns 404 when missing",
+            "expects 200",
+            "Returns 404 when missing",
+        );
+        let consensus = consensus.expect("two-vs-one agreement must yield consensus");
+        assert!(consensus.agreeing.contains(&ArtifactRole::Implementation));
+        assert!(consensus.agreeing.contains(&ArtifactRole::UsageDocs));
+        assert_eq!(consensus.dissenting, vec![ArtifactRole::Test]);
+    }
+
+    #[test]
+    fn sf1_v3_consensus_test_and_docs_agree_impl_dissents() {
+        let consensus =
+            detect_consensus_from_contract_conflict("returns 200", "expects 404", "expects 404");
+        let consensus = consensus.expect("two-vs-one agreement must yield consensus");
+        assert_eq!(consensus.dissenting, vec![ArtifactRole::Implementation]);
+        assert!(consensus.agreeing.contains(&ArtifactRole::Test));
+        assert!(consensus.agreeing.contains(&ArtifactRole::UsageDocs));
+    }
+
+    #[test]
+    fn sf1_v3_consensus_all_three_agree_returns_none() {
+        // Full agreement is not a tie-break signal.
+        let consensus = detect_consensus_from_contract_conflict("foo", "foo", "foo");
+        assert!(consensus.is_none());
+    }
+
+    #[test]
+    fn sf1_v3_consensus_all_three_differ_returns_none() {
+        let consensus = detect_consensus_from_contract_conflict("alpha", "beta", "gamma");
+        assert!(consensus.is_none());
+    }
+
+    #[test]
+    fn sf1_v3_consensus_empty_field_returns_none() {
+        // If any field is empty after normalize, consensus can't fire.
+        let consensus = detect_consensus_from_contract_conflict("foo", "foo", "");
+        assert!(consensus.is_none());
+    }
+
+    #[test]
+    fn sf1_v3_consensus_whitespace_and_case_insensitive() {
+        // Normalize: lower-case + whitespace collapse → still agreement.
+        let consensus =
+            detect_consensus_from_contract_conflict("Returns   404", "expects 200", "returns 404");
+        let consensus = consensus.expect("normalize must allow case/ws-tolerant match");
+        assert!(consensus.agreeing.contains(&ArtifactRole::Implementation));
+        assert!(consensus.agreeing.contains(&ArtifactRole::UsageDocs));
+    }
+
+    // -- SF1 V3.2: verified-public-interface from history -- //
+
+    #[test]
+    fn sf1_v3_verified_public_interface_false_by_default() {
+        let hint = AgentHistoryHint::default();
+        assert!(!detect_verified_public_interface_from_history(hint));
+    }
+
+    #[test]
+    fn sf1_v3_verified_public_interface_true_when_verifier_passed_in_loop() {
+        let hint = AgentHistoryHint {
+            verifier_passed_in_loop: true,
+        };
+        assert!(detect_verified_public_interface_from_history(hint));
     }
 
     // -- Test detectors -- //

--- a/src/agent/loop_run/spec_authority.rs
+++ b/src/agent/loop_run/spec_authority.rs
@@ -161,6 +161,85 @@ pub(super) fn select_authority(
     Some(top)
 }
 
+/// Issue #647 (SF1): aggregated input passed by `turn.rs` to [`resolve`]
+/// when constructing a `SemanticRepairPlan`. Each flag is computed by the
+/// caller from a different source (the user request, the
+/// `RequiredBehaviorContract`, the turn-local task state, etc.); collecting
+/// them in a single struct lets the resolution rules stay declarative and
+/// keeps the production callsite a single line.
+///
+/// Fields:
+/// - `has_user_request_match`: the failing artifact lines up with an
+///   *explicit* spec in the user request (detection is a future Issue —
+///   today the caller passes `false`).
+/// - `has_behavior_contract`: a `RequiredBehaviorContract` has actionable
+///   signal in scope (operations / domain_terms / etc.).
+/// - `has_verified_public_interface`: a public interface that already
+///   passed verification is in scope. **Dead variant** (S5-005); the
+///   production caller passes `false`.
+/// - `is_newly_generated_task`: this turn produced new implementation /
+///   test / README artifacts. When `true` and no `consensus` exists, the
+///   resolution returns `LlmGeneratedTest` so test edits get suppressed
+///   (test cannot be the lone source of truth on a brand-new task).
+/// - `consensus`: optional 2-vs-1 agreement signal across the three
+///   artifacts. When present, [`select_authority`] handles tie-break.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct SpecAuthorityInput {
+    pub(super) has_user_request_match: bool,
+    pub(super) has_behavior_contract: bool,
+    pub(super) has_verified_public_interface: bool,
+    pub(super) is_newly_generated_task: bool,
+    pub(super) consensus: Option<ArtifactConsensus>,
+}
+
+/// Resolve a [`SpecAuthority`] from `input`.
+///
+/// Decision order (Issue #647 acceptance):
+/// 1. `has_user_request_match` → [`SpecAuthority::UserRequest`] (highest).
+/// 2. `has_behavior_contract` → [`SpecAuthority::BehaviorContract`].
+/// 3. `has_verified_public_interface` →
+///    [`SpecAuthority::VerifiedPublicInterface`]. **Dead variant** in this
+///    Issue — the production caller passes `false`, so this branch is only
+///    reachable from in-module unit tests.
+/// 4. `is_newly_generated_task && consensus.is_none()` →
+///    [`SpecAuthority::LlmGeneratedTest`] (the *lowest* authority). Issue
+///    acceptance treats impl/test/README as equally authoritative on a
+///    brand-new task, but if we elected `ImplementationContract` here the
+///    repair editor would happily rewrite the test to match buggy impl.
+///    Returning the lowest authority instead is the safe default — the
+///    weakening detectors get a chance to block test edits before we
+///    decide impl is the source of truth.
+/// 5. `consensus.is_some()` → delegate to [`select_authority`] with the
+///    full candidate set so 2-vs-1 tie-break logic applies.
+/// 6. Default fallback → [`SpecAuthority::ImplementationContract`].
+pub(super) fn resolve(input: &SpecAuthorityInput) -> SpecAuthority {
+    if input.has_user_request_match {
+        return SpecAuthority::UserRequest;
+    }
+    if input.has_behavior_contract {
+        return SpecAuthority::BehaviorContract;
+    }
+    if input.has_verified_public_interface {
+        return SpecAuthority::VerifiedPublicInterface;
+    }
+    if input.is_newly_generated_task && input.consensus.is_none() {
+        return SpecAuthority::LlmGeneratedTest;
+    }
+    if let Some(consensus) = input.consensus.as_ref() {
+        // Pass the full candidate set so `select_authority` can apply its
+        // tie-break logic. We include `ImplementationContract` and
+        // `LlmGeneratedTest` as the default candidate base.
+        let candidates = [
+            SpecAuthority::ImplementationContract,
+            SpecAuthority::LlmGeneratedTest,
+        ];
+        if let Some(picked) = select_authority(&candidates, Some(consensus)) {
+            return picked;
+        }
+    }
+    SpecAuthority::ImplementationContract
+}
+
 /// Map an `ArtifactConsensus` to the spec authority that the agreeing roles
 /// imply. Implementation-agreeing → `ImplementationContract`; otherwise the
 /// consensus alone is not enough to elect a higher authority and we return
@@ -712,6 +791,117 @@ mod tests {
     #[test]
     fn select_authority_returns_none_for_empty_input() {
         assert_eq!(select_authority(&[], None), None);
+    }
+
+    // -- SF1: resolve() unit tests (Issue #647) -- //
+
+    /// Helper: build a `SpecAuthorityInput` with all flags off and no
+    /// consensus, so individual tests can flip exactly one field.
+    fn empty_input() -> SpecAuthorityInput {
+        SpecAuthorityInput {
+            has_user_request_match: false,
+            has_behavior_contract: false,
+            has_verified_public_interface: false,
+            is_newly_generated_task: false,
+            consensus: None,
+        }
+    }
+
+    #[test]
+    fn sf1_resolve_user_request_wins_when_request_matches() {
+        // SF1-resolve-user-request: any user-request match short-circuits
+        // to the highest authority, even when other flags are on.
+        let input = SpecAuthorityInput {
+            has_user_request_match: true,
+            has_behavior_contract: true,
+            has_verified_public_interface: true,
+            is_newly_generated_task: true,
+            consensus: None,
+        };
+        assert_eq!(resolve(&input), SpecAuthority::UserRequest);
+    }
+
+    #[test]
+    fn sf1_resolve_behavior_contract_when_only_contract_present() {
+        // SF1-resolve-behavior-contract: BehaviorContract wins when only it
+        // is set (user_request flag off).
+        let input = SpecAuthorityInput {
+            has_behavior_contract: true,
+            ..empty_input()
+        };
+        assert_eq!(resolve(&input), SpecAuthority::BehaviorContract);
+    }
+
+    #[test]
+    fn sf1_resolve_newly_generated_with_no_consensus_returns_llm_generated_test() {
+        // SF1-resolve-newly-generated-equality: a brand-new task with no
+        // consensus must NOT promote ImplementationContract — we elect the
+        // lowest authority (LlmGeneratedTest) so the repair editor's
+        // weakening detectors get to suppress test edits before impl wins.
+        let input = SpecAuthorityInput {
+            is_newly_generated_task: true,
+            ..empty_input()
+        };
+        assert_eq!(resolve(&input), SpecAuthority::LlmGeneratedTest);
+    }
+
+    #[test]
+    fn sf1_resolve_implementation_default_when_nothing_set() {
+        // SF1-resolve-implementation-default: the empty fallback path
+        // returns ImplementationContract (pre-SF1 production behavior).
+        let input = empty_input();
+        assert_eq!(resolve(&input), SpecAuthority::ImplementationContract);
+    }
+
+    #[test]
+    fn sf1_resolve_consensus_tiebreak_when_consensus_present() {
+        // SF1-resolve-consensus-tiebreak: when consensus is present (and the
+        // newly-generated short-circuit does not fire), resolution delegates
+        // to select_authority. Implementation-agreeing consensus elects
+        // ImplementationContract via that path.
+        let consensus = ArtifactConsensus::new(
+            vec![ArtifactRole::Implementation, ArtifactRole::UsageDocs],
+            vec![ArtifactRole::Test],
+            "impl and docs agree",
+        );
+        let input = SpecAuthorityInput {
+            consensus: Some(consensus),
+            ..empty_input()
+        };
+        assert_eq!(resolve(&input), SpecAuthority::ImplementationContract);
+    }
+
+    #[test]
+    fn sf1_resolve_verified_public_interface_when_only_that_flag_set() {
+        // Forward-extensibility: even though the production caller passes
+        // `false` for `has_verified_public_interface` (S5-005 dead-variant
+        // policy), the resolver itself must respect the flag so a future
+        // Issue wiring the session/turn-local cache can flip it.
+        let input = SpecAuthorityInput {
+            has_verified_public_interface: true,
+            ..empty_input()
+        };
+        assert_eq!(resolve(&input), SpecAuthority::VerifiedPublicInterface);
+    }
+
+    #[test]
+    fn sf1_resolve_newly_generated_short_circuits_before_consensus_only_when_consensus_absent() {
+        // Boundary: newly_generated_task takes effect only when consensus
+        // is None. If consensus is provided, we fall through to the
+        // select_authority tie-break.
+        let consensus = ArtifactConsensus::new(
+            vec![ArtifactRole::Implementation],
+            vec![ArtifactRole::Test],
+            "impl alone",
+        );
+        let input = SpecAuthorityInput {
+            is_newly_generated_task: true,
+            consensus: Some(consensus),
+            ..empty_input()
+        };
+        // Consensus is present → resolve() takes the tie-break path and
+        // elects ImplementationContract, *not* LlmGeneratedTest.
+        assert_eq!(resolve(&input), SpecAuthority::ImplementationContract);
     }
 
     #[test]

--- a/src/agent/loop_run/spec_authority.rs
+++ b/src/agent/loop_run/spec_authority.rs
@@ -1064,4 +1064,113 @@ mod tests {
         let a: ArtifactRole = r;
         assert_eq!(a, ArtifactRole::Implementation);
     }
+
+    // -- Phase G grep / structure tests (Issue #647 acceptance closure) -- //
+
+    /// Helper: split the module source into the production prefix
+    /// (everything before `#[cfg(test)]\nmod tests`).
+    fn production_source() -> &'static str {
+        let source = include_str!("spec_authority.rs");
+        match source.find("#[cfg(test)]\nmod tests") {
+            Some(idx) => &source[..idx],
+            None => source,
+        }
+    }
+
+    #[test]
+    fn spec_authority_enum_has_exactly_5_variants() {
+        // S1-005: SpecAuthority is fixed to 5 variants — adding a sixth
+        // variant must be a deliberate design decision and force this
+        // test to be updated (which serves as a review trigger).
+        let all = [
+            SpecAuthority::UserRequest,
+            SpecAuthority::BehaviorContract,
+            SpecAuthority::VerifiedPublicInterface,
+            SpecAuthority::ImplementationContract,
+            SpecAuthority::LlmGeneratedTest,
+        ];
+        // Each variant matches exactly itself — exhaustive `match` here
+        // is the structural lock: if a 6th variant is added, the `match`
+        // below becomes non-exhaustive and the test fails to compile.
+        for v in &all {
+            let label: &'static str = match v {
+                SpecAuthority::UserRequest => "user_request",
+                SpecAuthority::BehaviorContract => "behavior_contract",
+                SpecAuthority::VerifiedPublicInterface => "verified_public_interface",
+                SpecAuthority::ImplementationContract => "implementation_contract",
+                SpecAuthority::LlmGeneratedTest => "llm_generated_test",
+            };
+            assert!(!label.is_empty());
+        }
+        assert_eq!(all.len(), 5);
+    }
+
+    #[test]
+    fn no_framework_literal_in_spec_authority_module() {
+        // S1-012 (拡張): new production code must not embed
+        // framework-specific literals.
+        let prod = production_source();
+        for lit in &["\"422\"", "\"404\"", "/items/nonexistent", "FastAPI"] {
+            assert!(
+                !prod.contains(lit),
+                "spec_authority.rs production code must not contain framework literal {lit:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn no_unsafe_in_spec_authority_module() {
+        // DR4-003: no unsafe / FFI in new production code.
+        let prod = production_source();
+        assert!(
+            !prod.contains("unsafe "),
+            "spec_authority.rs production code must not contain `unsafe `",
+        );
+        assert!(
+            !prod.contains("extern \"C\""),
+            "spec_authority.rs production code must not declare FFI",
+        );
+    }
+
+    #[test]
+    fn photon_layer_does_not_import_semantic_repair_types() {
+        // DR3-002: photon → session → agent is the only allowed direction.
+        // The semantic-repair planner lives in `agent/loop_run/` and must
+        // never leak into the photon sidecar layer.
+        let photon_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/photon");
+        assert!(
+            photon_dir.is_dir(),
+            "src/photon must exist for DR3-002 to be meaningful",
+        );
+        let mut visited_files = 0usize;
+        let entries =
+            std::fs::read_dir(&photon_dir).expect("read_dir src/photon for DR3-002 grep test");
+        for entry in entries {
+            let entry = entry.expect("photon dir entry");
+            let path = entry.path();
+            if path.extension().and_then(|s| s.to_str()) != Some("rs") {
+                continue;
+            }
+            let body =
+                std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {path:?}: {e}"));
+            for forbidden in &[
+                "SemanticFailureReport",
+                "SpecAuthority",
+                "FailureCluster",
+                "FailureClusterKey",
+                "semantic_failure",
+                "spec_authority",
+            ] {
+                assert!(
+                    !body.contains(forbidden),
+                    "DR3-002 violated: {path:?} contains forbidden symbol {forbidden:?}",
+                );
+            }
+            visited_files += 1;
+        }
+        assert!(
+            visited_files > 0,
+            "photon layer scan must visit at least one .rs file"
+        );
+    }
 }

--- a/src/agent/loop_run/spec_authority.rs
+++ b/src/agent/loop_run/spec_authority.rs
@@ -383,8 +383,13 @@ pub(super) struct SpecAuthorityInput {
 ///    Returning the lowest authority instead is the safe default — the
 ///    weakening detectors get a chance to block test edits before we
 ///    decide impl is the source of truth.
-/// 5. `consensus.is_some()` → delegate to [`select_authority`] with the
-///    full candidate set so 2-vs-1 tie-break logic applies.
+/// 5. `consensus.is_some()` → apply [`consensus_to_authority_for_resolve`]
+///    directly so the agreeing roles drive authority selection (CB-008).
+///    The previous implementation delegated to [`select_authority`] with a
+///    fixed candidate base `[ImplementationContract, LlmGeneratedTest]`,
+///    which always returned `ImplementationContract` by ordered-enum top
+///    even when test + usage_docs agreed against impl — the consensus
+///    signal became a dead path.
 /// 6. Default fallback → [`SpecAuthority::ImplementationContract`].
 pub(super) fn resolve(input: &SpecAuthorityInput) -> SpecAuthority {
     if input.has_user_request_match {
@@ -400,16 +405,12 @@ pub(super) fn resolve(input: &SpecAuthorityInput) -> SpecAuthority {
         return SpecAuthority::LlmGeneratedTest;
     }
     if let Some(consensus) = input.consensus.as_ref() {
-        // Pass the full candidate set so `select_authority` can apply its
-        // tie-break logic. We include `ImplementationContract` and
-        // `LlmGeneratedTest` as the default candidate base.
-        let candidates = [
-            SpecAuthority::ImplementationContract,
-            SpecAuthority::LlmGeneratedTest,
-        ];
-        if let Some(picked) = select_authority(&candidates, Some(consensus)) {
-            return picked;
-        }
+        // CB-008: apply the agreeing-role mapping directly. We deliberately
+        // do NOT route through `select_authority` here — its `[Impl,
+        // LlmGenTest]` candidate base always returns `Impl` by ordered-enum
+        // top, which silently bypassed the consensus signal for the
+        // test + usage_docs case.
+        return consensus_to_authority_for_resolve(consensus);
     }
     SpecAuthority::ImplementationContract
 }
@@ -432,6 +433,42 @@ fn consensus_to_authority(consensus: Option<&ArtifactConsensus>) -> Option<SpecA
         // available.
         Some(SpecAuthority::LlmGeneratedTest)
     }
+}
+
+/// CB-008: map an `ArtifactConsensus` to a `SpecAuthority` from `resolve`'s
+/// point of view. Unlike [`consensus_to_authority`] (used by
+/// [`select_authority`] as a fallback that must not demote an existing
+/// candidate top), this mapping is the **primary** decision when no
+/// higher-authority signal is available: the agreeing roles drive the
+/// outcome, not the ordered-enum top of a fixed candidate base.
+///
+/// Mapping (closed, deterministic):
+/// - agreeing contains `Implementation` → `ImplementationContract`
+///   (canonical "stale test" case).
+/// - agreeing is `Test` + `UsageDocs` (no `Implementation`) →
+///   `BehaviorContract` — the spec-side (test assertions + user-facing
+///   docs) agrees against the impl, so we elect the spec-side authority
+///   rather than letting the repair editor weaken the test toward buggy
+///   impl. This is the CB-008 bug fix's central case.
+/// - any other agreeing layout (incl. empty / `Test`-only / `UsageDocs`-only)
+///   → `ImplementationContract` as the safe default. A lone Test or lone
+///   docs is too thin to elect `BehaviorContract`; the empty case is
+///   already filtered out at the caller, but we guard it defensively.
+fn consensus_to_authority_for_resolve(consensus: &ArtifactConsensus) -> SpecAuthority {
+    let has_impl = consensus.agreeing.contains(&ArtifactRole::Implementation);
+    let has_test = consensus.agreeing.contains(&ArtifactRole::Test);
+    let has_docs = consensus.agreeing.contains(&ArtifactRole::UsageDocs);
+
+    if has_impl {
+        return SpecAuthority::ImplementationContract;
+    }
+    if has_test && has_docs {
+        // Spec-side 2-vs-1: test assertions and user-facing docs agree
+        // against the implementation. Elect BehaviorContract so the repair
+        // editor cannot weaken the test toward buggy impl.
+        return SpecAuthority::BehaviorContract;
+    }
+    SpecAuthority::ImplementationContract
 }
 
 /// Closed list of test/impl weakening patterns detected at the repair
@@ -1075,6 +1112,53 @@ mod tests {
         };
         // Consensus is present → resolve() takes the tie-break path and
         // elects ImplementationContract, *not* LlmGeneratedTest.
+        assert_eq!(resolve(&input), SpecAuthority::ImplementationContract);
+    }
+
+    // -- CB-008: consensus must not be bypassed by select_authority ordering -- //
+
+    #[test]
+    fn cb008_resolve_honors_consensus_when_test_and_usage_docs_agree_against_impl() {
+        // CB-008 regression: test+usage_docs agreeing, impl dissenting.
+        // Pre-fix: resolve() called select_authority(&[Impl, LlmGenTest], …)
+        // which always returns Impl by ordered-enum top, silently bypassing
+        // the consensus signal. Post-fix: the spec-side agreement (test +
+        // docs) elects BehaviorContract so the repair editor cannot rewrite
+        // the test to match buggy impl.
+        let consensus = ArtifactConsensus::new(
+            vec![ArtifactRole::Test, ArtifactRole::UsageDocs],
+            vec![ArtifactRole::Implementation],
+            "test and docs agree on spec",
+        );
+        let input = SpecAuthorityInput {
+            consensus: Some(consensus),
+            ..empty_input()
+        };
+        assert_eq!(resolve(&input), SpecAuthority::BehaviorContract);
+    }
+
+    #[test]
+    fn cb008_resolve_honors_consensus_when_impl_and_usage_docs_agree_against_test() {
+        // CB-008 regression: impl+usage_docs agreeing → ImplementationContract.
+        // This is the most common 2-vs-1 case (stale test); the agreeing side
+        // contains Implementation so the canonical mapping wins.
+        let consensus = ArtifactConsensus::new(
+            vec![ArtifactRole::Implementation, ArtifactRole::UsageDocs],
+            vec![ArtifactRole::Test],
+            "impl and docs agree",
+        );
+        let input = SpecAuthorityInput {
+            consensus: Some(consensus),
+            ..empty_input()
+        };
+        assert_eq!(resolve(&input), SpecAuthority::ImplementationContract);
+    }
+
+    #[test]
+    fn cb008_resolve_falls_through_to_implementation_default_when_consensus_is_none() {
+        // CB-008 regression: existing fallback behavior must be preserved
+        // when consensus is None (and no higher-authority flag is set).
+        let input = empty_input();
         assert_eq!(resolve(&input), SpecAuthority::ImplementationContract);
     }
 

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -14700,6 +14700,33 @@ fn validate_verifier_repair_intents(
             result.updated_contents
         };
     }
+    // Issue #647 (Phase F / S1-004 / S1-007 / S3-011): apply the deterministic
+    // test/impl weakening detectors at the repair editor's admission
+    // boundary. `original_contents` is the pre-edit `before` snapshot and
+    // `contents` is the post-edit `after`. Both are simultaneously available
+    // here (DR3-002), unlike inside `apply_validated_verifier_repair_edit`
+    // which only sees pre/post hashes. Test-side and impl-side detectors are
+    // dispatched by `file_classify` so each path is judged by the relevant
+    // closed pattern list (5 test patterns / 4 impl patterns). A non-empty
+    // pattern vec rejects the intent — this implements the AND coupling with
+    // the legacy `do_not_edit_tests_without_evidence` reject (which lives
+    // separately at hint admission via `diagnostic_target_allowed_by_confidence`):
+    // any weakening detected here is rejected unconditionally, while the
+    // evidence-required gate remains the independent first line of defence.
+    let weakening_path = Path::new(&relative_path);
+    let weakening = if is_test_file(weakening_path) {
+        super::spec_authority::detect_test_weakening(&relative_path, &original_contents, &contents)
+    } else if is_implementation_file(weakening_path) {
+        super::spec_authority::detect_impl_weakening(&relative_path, &original_contents, &contents)
+    } else {
+        Vec::new()
+    };
+    if !weakening.is_empty() {
+        return Err(CheapCheckOutcome::Failed(format!(
+            "repair intent rejected: test/impl weakening detected ({:?})",
+            weakening
+        )));
+    }
     validate_verifier_repair_candidate_contents(
         &relative_path,
         &contents,
@@ -18117,14 +18144,14 @@ mod progress_tests {
         classify_verifier_failure_type, deterministic_empty_framework_app_files,
         deterministic_empty_framework_game_files, deterministic_framework_app_files_needed,
         deterministic_framework_game_files_needed, deterministic_support_target_relative,
-        effective_tool_batch_action, effective_tool_policy_error_for_call,
-        effective_tool_policy_error_for_call_with_scope, existing_workspace_candidate_for_role,
-        existing_workspace_candidate_for_role_in_scope, extract_page_copy_block_from_numbered_read,
-        first_existing_impl_target, focused_edit_compact_anchor_note,
-        focused_edit_compact_recovery_anchor, focused_edit_exact_anchor_history,
-        focused_edit_exact_recovery_anchor, focused_edit_first_slice_note,
-        focused_edit_first_slice_uses_exact_anchor, focused_edit_guidance_note,
-        focused_edit_guidance_note_for_policy, focused_edit_history,
+        diagnostic_target_allowed_by_confidence, effective_tool_batch_action,
+        effective_tool_policy_error_for_call, effective_tool_policy_error_for_call_with_scope,
+        existing_workspace_candidate_for_role, existing_workspace_candidate_for_role_in_scope,
+        extract_page_copy_block_from_numbered_read, first_existing_impl_target,
+        focused_edit_compact_anchor_note, focused_edit_compact_recovery_anchor,
+        focused_edit_exact_anchor_history, focused_edit_exact_recovery_anchor,
+        focused_edit_first_slice_note, focused_edit_first_slice_uses_exact_anchor,
+        focused_edit_guidance_note, focused_edit_guidance_note_for_policy, focused_edit_history,
         focused_edit_max_predict_override, focused_edit_minimal_history,
         focused_edit_policy_violation_feedback_note, focused_edit_second_slice_note,
         focused_edit_target_already_read, focused_edit_timeout_override_secs,
@@ -19542,6 +19569,452 @@ mod progress_tests {
         let err =
             validate_verifier_repair_intent(work_root, &context, &target, intent).unwrap_err();
         assert!(err.contains("duplicate"));
+    }
+
+    // ---- Issue #647 (Phase F): weakening detector at validate_verifier_repair_intents ---- //
+
+    /// Helper: build a test-targeting `RepairJob` whose `target_hint` /
+    /// `assessment.repair_target_hint` point at a test-file path (so
+    /// `verifier_repair_path_input_is_safe` accepts it and the hint role is
+    /// coherent with the test path that `is_test_file` will classify).
+    fn verifier_test_context_for(path: &str) -> super::super::repair_job::RepairJob {
+        let hint = super::super::task_contract::RecoveryTargetHint {
+            role: super::super::task_contract::ArtifactRole::Test,
+            path: path.to_string(),
+            reason: "test".to_string(),
+        };
+        super::super::repair_job::RepairJob {
+            command: "python3 -m pytest".to_string(),
+            output_excerpt: "failure".to_string(),
+            failure_type: super::super::VerifierFailureType::AssertionFailure,
+            target_hint: Some(hint.clone()),
+            repair_target_hint: Some(hint.clone()),
+            changed_file_hints: vec![hint.clone()],
+            assessment: Some(super::super::VerifierRepairAssessment {
+                failure_kind: super::super::VerifierDiagnosticFailureKind::AssertionMismatch,
+                failure_type: super::super::VerifierFailureType::AssertionFailure,
+                probable_cause_role: Some(super::super::task_contract::ArtifactRole::Test),
+                needed_reads: vec![hint.clone()],
+                repair_target_hint: Some(hint.clone()),
+                repair_plan: vec![hint.clone()],
+                summary: Some("test helper assessment".to_string()),
+                source: super::super::VerifierRepairAssessmentSource::DiagnosticPass,
+            }),
+            diagnostic_attempted: true,
+            error_kind: Some("AssertionError".to_string()),
+            failure_signature: format!("{path} AssertionError"),
+            failure_count: Some(1),
+            repair_attempt: 1,
+            ..super::super::repair_job::RepairJob::new_for_test()
+        }
+    }
+
+    /// S1-004: any of the 5 closed test-side weakening patterns detected on a
+    /// path classified as a test file by `is_test_file` must reject the
+    /// intent at `validate_verifier_repair_intents`.
+    #[test]
+    fn validate_verifier_repair_intents_rejects_assertion_deletion_in_test() {
+        let temp = tempdir().unwrap();
+        let work_root = temp.path();
+        std::fs::create_dir_all(work_root.join("tests")).unwrap();
+        let original = "def test_x():\n    assert foo() == 1\n    do_setup()\n";
+        std::fs::write(work_root.join("tests/test_main.py"), original).unwrap();
+        let context = verifier_test_context_for("tests/test_main.py");
+        let target = context
+            .assessment
+            .as_ref()
+            .unwrap()
+            .repair_target_hint
+            .as_ref()
+            .unwrap()
+            .clone();
+        // Deleting the `assert foo() == 1` line is AssertionDeleted.
+        let intent = VerifierRepairIntent {
+            path: "tests/test_main.py".to_string(),
+            old_string: "    assert foo() == 1\n    do_setup()\n".to_string(),
+            new_string: "    do_setup()\n".to_string(),
+            reason: "remove failing assert".to_string(),
+            replace_all: false,
+        };
+        let err =
+            validate_verifier_repair_intent(work_root, &context, &target, intent).unwrap_err();
+        assert!(
+            err.contains("weakening detected"),
+            "expected weakening rejection, got: {err}"
+        );
+        assert!(err.contains("AssertionDeleted"), "got: {err}");
+        // File on disk must remain untouched.
+        assert_eq!(
+            std::fs::read_to_string(work_root.join("tests/test_main.py")).unwrap(),
+            original
+        );
+    }
+
+    /// S1-004 / SkipMarkerAdded.
+    #[test]
+    fn validate_verifier_repair_intents_rejects_skip_marker_added_in_test() {
+        let temp = tempdir().unwrap();
+        let work_root = temp.path();
+        std::fs::create_dir_all(work_root.join("tests")).unwrap();
+        let original = "def test_x():\n    assert foo()\n";
+        std::fs::write(work_root.join("tests/test_main.py"), original).unwrap();
+        let context = verifier_test_context_for("tests/test_main.py");
+        let target = context
+            .assessment
+            .as_ref()
+            .unwrap()
+            .repair_target_hint
+            .as_ref()
+            .unwrap()
+            .clone();
+        let intent = VerifierRepairIntent {
+            path: "tests/test_main.py".to_string(),
+            old_string: "def test_x():\n    assert foo()\n".to_string(),
+            new_string: "@pytest.mark.skip\ndef test_x():\n    assert foo()\n".to_string(),
+            reason: "skip failing test".to_string(),
+            replace_all: false,
+        };
+        let err =
+            validate_verifier_repair_intent(work_root, &context, &target, intent).unwrap_err();
+        assert!(err.contains("SkipMarkerAdded"), "got: {err}");
+    }
+
+    /// S1-004 / AssertTrueWeakening.
+    #[test]
+    fn validate_verifier_repair_intents_rejects_assert_true_weakening_in_test() {
+        let temp = tempdir().unwrap();
+        let work_root = temp.path();
+        std::fs::create_dir_all(work_root.join("tests")).unwrap();
+        let original = "def test_x():\n    assert foo() == 1\n";
+        std::fs::write(work_root.join("tests/test_main.py"), original).unwrap();
+        let context = verifier_test_context_for("tests/test_main.py");
+        let target = context
+            .assessment
+            .as_ref()
+            .unwrap()
+            .repair_target_hint
+            .as_ref()
+            .unwrap()
+            .clone();
+        let intent = VerifierRepairIntent {
+            path: "tests/test_main.py".to_string(),
+            old_string: "    assert foo() == 1\n".to_string(),
+            new_string: "    assert True\n".to_string(),
+            reason: "bypass assert".to_string(),
+            replace_all: false,
+        };
+        let err =
+            validate_verifier_repair_intent(work_root, &context, &target, intent).unwrap_err();
+        assert!(err.contains("AssertTrueWeakening"), "got: {err}");
+    }
+
+    /// S1-004 / TestFunctionDeleted.
+    #[test]
+    fn validate_verifier_repair_intents_rejects_test_function_deleted() {
+        let temp = tempdir().unwrap();
+        let work_root = temp.path();
+        std::fs::create_dir_all(work_root.join("tests")).unwrap();
+        let original = "def test_x():\n    assert foo()\n\ndef test_y():\n    assert bar()\n";
+        std::fs::write(work_root.join("tests/test_main.py"), original).unwrap();
+        let context = verifier_test_context_for("tests/test_main.py");
+        let target = context
+            .assessment
+            .as_ref()
+            .unwrap()
+            .repair_target_hint
+            .as_ref()
+            .unwrap()
+            .clone();
+        let intent = VerifierRepairIntent {
+            path: "tests/test_main.py".to_string(),
+            old_string: "\ndef test_y():\n    assert bar()\n".to_string(),
+            new_string: "".to_string(),
+            reason: "drop failing test".to_string(),
+            replace_all: false,
+        };
+        let err =
+            validate_verifier_repair_intent(work_root, &context, &target, intent).unwrap_err();
+        assert!(err.contains("TestFunctionDeleted"), "got: {err}");
+    }
+
+    /// S1-004 / LiteralOnlyExpectedChange.
+    #[test]
+    fn validate_verifier_repair_intents_rejects_literal_only_expected_change() {
+        let temp = tempdir().unwrap();
+        let work_root = temp.path();
+        std::fs::create_dir_all(work_root.join("tests")).unwrap();
+        let original = "def test_x():\n    x = compute()\n    assert x == 1\n";
+        std::fs::write(work_root.join("tests/test_main.py"), original).unwrap();
+        let context = verifier_test_context_for("tests/test_main.py");
+        let target = context
+            .assessment
+            .as_ref()
+            .unwrap()
+            .repair_target_hint
+            .as_ref()
+            .unwrap()
+            .clone();
+        let intent = VerifierRepairIntent {
+            path: "tests/test_main.py".to_string(),
+            old_string: "    assert x == 1\n".to_string(),
+            new_string: "    assert x == 99\n".to_string(),
+            reason: "move goalposts".to_string(),
+            replace_all: false,
+        };
+        let err =
+            validate_verifier_repair_intent(work_root, &context, &target, intent).unwrap_err();
+        assert!(err.contains("LiteralOnlyExpectedChange"), "got: {err}");
+    }
+
+    /// S1-007 / ValidatorDeleted (impl-side, `assert!` deletion in Rust).
+    #[test]
+    fn validate_verifier_repair_intents_rejects_validator_deleted_in_impl() {
+        let temp = tempdir().unwrap();
+        let work_root = temp.path();
+        std::fs::create_dir_all(work_root.join("app")).unwrap();
+        let original = "fn run(x: i32) -> i32 {\n    assert!(x > 0);\n    x * 2\n}\n";
+        std::fs::write(work_root.join("app/lib.rs"), original).unwrap();
+        let context = verifier_context_for("app/lib.rs");
+        let target = context
+            .assessment
+            .as_ref()
+            .unwrap()
+            .repair_target_hint
+            .as_ref()
+            .unwrap()
+            .clone();
+        let intent = VerifierRepairIntent {
+            path: "app/lib.rs".to_string(),
+            old_string: "    assert!(x > 0);\n    x * 2\n".to_string(),
+            new_string: "    x * 2\n".to_string(),
+            reason: "remove guard".to_string(),
+            replace_all: false,
+        };
+        let err =
+            validate_verifier_repair_intent(work_root, &context, &target, intent).unwrap_err();
+        assert!(err.contains("ValidatorDeleted"), "got: {err}");
+    }
+
+    /// S1-007 / ErrorSwallowed (impl-side).
+    #[test]
+    fn validate_verifier_repair_intents_rejects_error_swallowed_in_impl() {
+        let temp = tempdir().unwrap();
+        let work_root = temp.path();
+        std::fs::create_dir_all(work_root.join("app")).unwrap();
+        let original = "def run():\n    do_thing()\n";
+        std::fs::write(work_root.join("app/main.py"), original).unwrap();
+        let context = verifier_context_for("app/main.py");
+        let target = context
+            .assessment
+            .as_ref()
+            .unwrap()
+            .repair_target_hint
+            .as_ref()
+            .unwrap()
+            .clone();
+        let intent = VerifierRepairIntent {
+            path: "app/main.py".to_string(),
+            old_string: "def run():\n    do_thing()\n".to_string(),
+            new_string: "def run():\n    try:\n        do_thing()\n    except: pass\n".to_string(),
+            reason: "swallow errors".to_string(),
+            replace_all: false,
+        };
+        let err =
+            validate_verifier_repair_intent(work_root, &context, &target, intent).unwrap_err();
+        assert!(err.contains("ErrorSwallowed"), "got: {err}");
+    }
+
+    /// S1-007 / EarlyReturnBypass (impl-side).
+    #[test]
+    fn validate_verifier_repair_intents_rejects_early_return_bypass_in_impl() {
+        let temp = tempdir().unwrap();
+        let work_root = temp.path();
+        std::fs::create_dir_all(work_root.join("app")).unwrap();
+        let original = "fn run(flag: bool) -> i32 {\n    let x = compute();\n    x\n}\n";
+        std::fs::write(work_root.join("app/lib.rs"), original).unwrap();
+        let context = verifier_context_for("app/lib.rs");
+        let target = context
+            .assessment
+            .as_ref()
+            .unwrap()
+            .repair_target_hint
+            .as_ref()
+            .unwrap()
+            .clone();
+        let intent = VerifierRepairIntent {
+            path: "app/lib.rs".to_string(),
+            old_string: "fn run(flag: bool) -> i32 {\n    let x = compute();\n    x\n}\n"
+                .to_string(),
+            new_string: "fn run(flag: bool) -> i32 {\n    return Ok(());\n    let x = compute();\n    x\n}\n"
+                .to_string(),
+            reason: "early return".to_string(),
+            replace_all: false,
+        };
+        let err =
+            validate_verifier_repair_intent(work_root, &context, &target, intent).unwrap_err();
+        assert!(err.contains("EarlyReturnBypass"), "got: {err}");
+    }
+
+    /// DR3-002 + false-positive guard: a benign refactor on an impl file
+    /// (renaming a local) must NOT be classified as weakening.
+    #[test]
+    fn validate_verifier_repair_intents_accepts_benign_impl_edit() {
+        let temp = tempdir().unwrap();
+        let work_root = temp.path();
+        std::fs::create_dir_all(work_root.join("app")).unwrap();
+        let original = "def run():\n    value = 1\n    return value\n";
+        std::fs::write(work_root.join("app/main.py"), original).unwrap();
+        let context = verifier_context_for("app/main.py");
+        let target = context
+            .assessment
+            .as_ref()
+            .unwrap()
+            .repair_target_hint
+            .as_ref()
+            .unwrap()
+            .clone();
+        let intent = VerifierRepairIntent {
+            path: "app/main.py".to_string(),
+            old_string: "    value = 1\n    return value\n".to_string(),
+            new_string: "    value = 2\n    return value\n".to_string(),
+            reason: "fix constant".to_string(),
+            replace_all: false,
+        };
+        let edit = validate_verifier_repair_intent(work_root, &context, &target, intent).unwrap();
+        assert!(edit.updated_contents.contains("value = 2"));
+    }
+
+    /// DR3-002: non-test / non-impl file paths (e.g. JSON) must not invoke
+    /// either detector and must pass cleanly.
+    #[test]
+    fn validate_verifier_repair_intents_skips_detector_for_non_code_paths() {
+        let temp = tempdir().unwrap();
+        let work_root = temp.path();
+        std::fs::create_dir_all(work_root.join("app")).unwrap();
+        let original = "{\n  \"a\": 1\n}\n";
+        std::fs::write(work_root.join("app/data.json"), original).unwrap();
+        let context = verifier_context_for("app/data.json");
+        let target = context
+            .assessment
+            .as_ref()
+            .unwrap()
+            .repair_target_hint
+            .as_ref()
+            .unwrap()
+            .clone();
+        // Mimic a literal-value change that *would* fire `LiteralOnlyExpectedChange`
+        // on a `.py` file because of the leading `assert`-like prefix — but on a
+        // JSON path neither detector runs.
+        let intent = VerifierRepairIntent {
+            path: "app/data.json".to_string(),
+            old_string: "  \"a\": 1\n".to_string(),
+            new_string: "  \"a\": 2\n".to_string(),
+            reason: "tweak data".to_string(),
+            replace_all: false,
+        };
+        let edit = validate_verifier_repair_intent(work_root, &context, &target, intent).unwrap();
+        assert!(edit.updated_contents.contains("\"a\": 2"));
+    }
+
+    /// S3-011: AND coupling — when `do_not_edit_tests_without_evidence` is
+    /// asserted, weakening detection at `validate_verifier_repair_intents`
+    /// still rejects unconditionally. The evidence-required gate lives at
+    /// hint admission (`diagnostic_target_allowed_by_confidence`) and stays
+    /// independent. This test pins both halves: the weakening reject fires
+    /// here, while `diagnostic_target_allowed_by_confidence` continues to
+    /// gate hint admission via confidence.
+    #[test]
+    fn validate_verifier_repair_intents_weakening_reject_compounds_evidence_gate() {
+        let temp = tempdir().unwrap();
+        let work_root = temp.path();
+        std::fs::create_dir_all(work_root.join("tests")).unwrap();
+        let original = "def test_x():\n    assert foo() == 1\n";
+        std::fs::write(work_root.join("tests/test_main.py"), original).unwrap();
+        let context = verifier_test_context_for("tests/test_main.py");
+        let target = context
+            .assessment
+            .as_ref()
+            .unwrap()
+            .repair_target_hint
+            .as_ref()
+            .unwrap()
+            .clone();
+        // Weakening edit (assert True replacement) must reject regardless of
+        // how the evidence flag would have ruled at hint admission.
+        let intent = VerifierRepairIntent {
+            path: "tests/test_main.py".to_string(),
+            old_string: "    assert foo() == 1\n".to_string(),
+            new_string: "    assert True\n".to_string(),
+            reason: "bypass".to_string(),
+            replace_all: false,
+        };
+        let err =
+            validate_verifier_repair_intent(work_root, &context, &target, intent).unwrap_err();
+        assert!(err.contains("weakening detected"), "got: {err}");
+
+        // Independent half: with evidence required + Test hint, low-confidence
+        // hint admission is rejected by the legacy gate.
+        let evidence_required = true;
+        let test_hint = super::super::task_contract::RecoveryTargetHint {
+            role: super::super::task_contract::ArtifactRole::Test,
+            path: "tests/test_main.py".to_string(),
+            reason: "low-conf test edit".to_string(),
+        };
+        assert!(!diagnostic_target_allowed_by_confidence(
+            &test_hint,
+            0.10,
+            super::super::VerifierDiagnosticFailureKind::AssertionMismatch,
+            Some(super::super::task_contract::ArtifactRole::Test),
+            evidence_required,
+        ));
+    }
+
+    /// DR3-002: detector input is `(original_contents, post-edit contents)`.
+    /// A weakening pattern that only emerges when **two** edits are applied
+    /// in sequence (each individually benign) must still fire because the
+    /// detector runs after the full intent list is applied to `contents`.
+    #[test]
+    fn validate_verifier_repair_intents_detects_weakening_across_multi_edit() {
+        let temp = tempdir().unwrap();
+        let work_root = temp.path();
+        std::fs::create_dir_all(work_root.join("tests")).unwrap();
+        // Two asserts. Edit 1 deletes assert #1, edit 2 deletes assert #2.
+        // Neither in isolation is the only edit visible to the detector —
+        // it sees `before` vs `after-everything-applied`.
+        let original = "def test_x():\n    assert a == 1\n    assert b == 2\n    do_more()\n";
+        std::fs::write(work_root.join("tests/test_main.py"), original).unwrap();
+        let context = verifier_test_context_for("tests/test_main.py");
+        let target = context
+            .assessment
+            .as_ref()
+            .unwrap()
+            .repair_target_hint
+            .as_ref()
+            .unwrap()
+            .clone();
+        let err = validate_verifier_repair_intents(
+            work_root,
+            &context,
+            &target,
+            vec![
+                VerifierRepairIntent {
+                    path: "tests/test_main.py".to_string(),
+                    old_string: "    assert a == 1\n".to_string(),
+                    new_string: "".to_string(),
+                    reason: "drop assert a".to_string(),
+                    replace_all: false,
+                },
+                VerifierRepairIntent {
+                    path: "tests/test_main.py".to_string(),
+                    old_string: "    assert b == 2\n".to_string(),
+                    new_string: "".to_string(),
+                    reason: "drop assert b".to_string(),
+                    replace_all: false,
+                },
+            ],
+        )
+        .unwrap_err();
+        assert!(err.contains("AssertionDeleted"), "got: {err}");
     }
 
     #[test]

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -15745,6 +15745,11 @@ fn build_semantic_failure_report_from_legacy(
         "",
         "",
         &[preferred_repair_role],
+        // CB-017 A''' (Commit 2): legacy fallback synthesizes a cluster with
+        // **no** proposed target candidates; the merge step (Commit 3) will
+        // append legacy `parsed.repair_targets` here under the all-empty
+        // policy. Keep `Vec::new()` to preserve existing behavior.
+        Vec::new(),
     );
 
     // contract_conflict is sourced from the legacy summary — it lives in the
@@ -20060,6 +20065,7 @@ mod progress_tests {
             "shape",
             "AssertEq",
             &[super::super::task_contract::ArtifactRole::Test],
+            Vec::new(),
         );
         let cluster_id = cluster.cluster_key.clone();
         let report = super::super::semantic_failure::SemanticFailureReport {
@@ -22061,6 +22067,7 @@ E   assert [{'id': 1}] == []\n";
                 super::super::task_contract::ArtifactRole::Implementation,
                 super::super::task_contract::ArtifactRole::Test,
             ],
+            Vec::new(),
         );
         let cluster_id = cluster.cluster_key.clone();
         let report = SemanticFailureReport {
@@ -22880,6 +22887,7 @@ E   assert [{'id': 1}] == []\n";
             "POST /todos",
             "AssertEq",
             &[super::super::task_contract::ArtifactRole::Implementation],
+            Vec::new(),
         );
         let cluster_b = build_failure_cluster_from_observation(
             "missing field",
@@ -22887,6 +22895,7 @@ E   assert [{'id': 1}] == []\n";
             "GET /todos",
             "AssertContains",
             &[super::super::task_contract::ArtifactRole::Implementation],
+            Vec::new(),
         );
         let cluster_a_id = cluster_a.cluster_key.clone();
         let cluster_b_id = cluster_b.cluster_key.clone();
@@ -22978,6 +22987,7 @@ E   assert [{'id': 1}] == []\n";
             "POST /todos",
             "AssertEq",
             &[super::super::task_contract::ArtifactRole::Implementation],
+            Vec::new(),
         );
         let cluster_a_id = cluster_a.cluster_key.clone();
         let report = SemanticFailureReport {

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -9411,6 +9411,45 @@ impl Agent {
             semantic_report.as_ref(),
             agent_history_hint,
         );
+        // Issue #647 / CB-017 A''' (Commit 3): build the path-local admission
+        // context **before** semantic enrich so `enrich_failure_clusters_with_admitted_targets`
+        // can route every LLM-supplied target_path through the SSOT
+        // `recovery_target_hint_for_diagnostic_path` (syntactic safety +
+        // Owned admission). This is the same admission context used by the
+        // legacy `model_assessment_to_verifier_repair_assessment` below.
+        let scope = self.current_workspace_scope();
+        let turn_edited = self.turn_edited_relative_paths.clone();
+        let edited_predicate = |path: &str| turn_edited.contains(path);
+        let scaffold_predicate = |path: &str| self.repo_edit_has_post_scaffold_delta(path);
+        let admission = RepairTargetAdmissionContext {
+            work_root: &self.work_root,
+            scope: &scope,
+            edited_this_session_for: &edited_predicate,
+            scaffold_changed_for: &scaffold_predicate,
+        };
+        // CB-017 A''' (Commit 3): merge + enrich each report so every cluster
+        // carries `admitted_cluster_targets` derived from the SSOT admission
+        // gate. If every cluster ends up targetless, drop the semantic report
+        // so the legacy assessment path is used unchanged.
+        let semantic_report = semantic_report.and_then(|mut report| {
+            merge_legacy_targets_into_clusters(&mut report, &parsed);
+            let spec_authority = super::spec_authority::resolve(&authority_input);
+            enrich_failure_clusters_with_admitted_targets(
+                &mut report,
+                &self.work_root,
+                &admission,
+                spec_authority,
+            );
+            if report
+                .failure_clusters
+                .iter()
+                .all(|c| c.admitted_cluster_targets.is_empty())
+            {
+                None
+            } else {
+                Some(report)
+            }
+        });
         // Issue #647 (CB-015): the new plan's generation snapshot uses the
         // **pre-bump** `assessment_generation`. The live `RepairJob.assessment_generation`
         // is incremented below in lock-step with the new assessment landing
@@ -9430,21 +9469,6 @@ impl Agent {
                 pre_bump_assessment_generation,
             )
         });
-        // Issue #647 (§5.1 SSOT plumbing): build the path-local admission
-        // context from the agent's current scope + edit signals so every
-        // hint promoted by `model_assessment_to_verifier_repair_assessment`
-        // (and its sibling helpers) routes through `admit_repair_target_hint`
-        // for the *hint's own path*, not a turn-global signal.
-        let scope = self.current_workspace_scope();
-        let turn_edited = self.turn_edited_relative_paths.clone();
-        let edited_predicate = |path: &str| turn_edited.contains(path);
-        let scaffold_predicate = |path: &str| self.repo_edit_has_post_scaffold_delta(path);
-        let admission = RepairTargetAdmissionContext {
-            work_root: &self.work_root,
-            scope: &scope,
-            edited_this_session_for: &edited_predicate,
-            scaffold_changed_for: &scaffold_predicate,
-        };
         // -------- END semantic-boundary (Issue #647 / S3-005 / SF3) --------
         // Re-entering the legacy assessment pipeline: the call below builds
         // `super::VerifierRepairAssessment` only. `semantic_plan` lives on
@@ -14525,21 +14549,21 @@ fn verifier_repair_changed_file_hints(
 }
 
 #[derive(Debug, Clone, PartialEq)]
-struct ParsedVerifierRepairAssessment {
-    failure_kind: super::VerifierDiagnosticFailureKind,
-    probable_cause_role: Option<super::task_contract::ArtifactRole>,
-    repair_targets: Vec<ParsedVerifierRepairTarget>,
-    repair_plan: Vec<ParsedVerifierRepairTarget>,
-    secondary_targets: Vec<String>,
-    do_not_edit_tests_without_evidence: bool,
-    summary: Option<String>,
+pub(super) struct ParsedVerifierRepairAssessment {
+    pub(super) failure_kind: super::VerifierDiagnosticFailureKind,
+    pub(super) probable_cause_role: Option<super::task_contract::ArtifactRole>,
+    pub(super) repair_targets: Vec<ParsedVerifierRepairTarget>,
+    pub(super) repair_plan: Vec<ParsedVerifierRepairTarget>,
+    pub(super) secondary_targets: Vec<String>,
+    pub(super) do_not_edit_tests_without_evidence: bool,
+    pub(super) summary: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
-struct ParsedVerifierRepairTarget {
-    path: String,
-    confidence: f64,
-    reason: String,
+pub(super) struct ParsedVerifierRepairTarget {
+    pub(super) path: String,
+    pub(super) confidence: f64,
+    pub(super) reason: String,
 }
 
 fn parse_verifier_repair_assessment_reply(reply: &str) -> Option<ParsedVerifierRepairAssessment> {
@@ -15539,6 +15563,199 @@ fn recovery_target_hint_for_diagnostic_path(
     admit_repair_target_hint(hint, admission)
 }
 
+/// Issue #647 / CB-017 A''' (Commit 3, CR-2 V2): merge legacy
+/// `ParsedVerifierRepairAssessment` targets into the first cluster of a
+/// `SemanticFailureReport` **only when every cluster is targetless**.
+///
+/// Policy (all-or-nothing): partial output (some clusters target_paths, some
+/// not) is never merged — targetless clusters are skipped downstream by
+/// `first_repairable_cluster` / `next_repairable_cluster`. Merging into a
+/// random "first" cluster on partial output would break the LLM-supplied
+/// cluster ↔ path binding.
+///
+/// `role_hint` is always `None` because `ParsedVerifierRepairTarget` does
+/// not carry a role; the admitted hint's role is decided later by
+/// `recovery_target_hint_for_existing_path` (CR-3 V2). Each appended
+/// candidate's `raw_path` / `reason` is sanitized via
+/// `sanitize_repair_job_text_with_char_cap` so the parse-boundary invariant
+/// (same SSOT as `parse_semantic_failure_report`) holds.
+pub(super) fn merge_legacy_targets_into_clusters(
+    report: &mut super::semantic_failure::SemanticFailureReport,
+    parsed: &ParsedVerifierRepairAssessment,
+) {
+    let all_empty = report
+        .failure_clusters
+        .iter()
+        .all(|c| c.proposed_target_candidates.is_empty());
+    if !all_empty {
+        return;
+    }
+    let Some(first_cluster) = report.failure_clusters.first_mut() else {
+        return;
+    };
+    for target in &parsed.repair_targets {
+        if first_cluster.proposed_target_candidates.len()
+            >= super::semantic_failure::MAX_PROPOSED_TARGETS_PER_CLUSTER
+        {
+            break;
+        }
+        first_cluster.proposed_target_candidates.push(
+            super::semantic_failure::RawClusterTargetCandidate {
+                raw_path: super::repair_job::sanitize_repair_job_text_with_char_cap(
+                    &target.path,
+                    super::semantic_failure::MAX_RAW_PATH_CHARS,
+                ),
+                role_hint: None,
+                reason: super::repair_job::sanitize_repair_job_text_with_char_cap(
+                    &target.reason,
+                    240,
+                ),
+            },
+        );
+    }
+    for entry in &parsed.repair_plan {
+        if first_cluster.proposed_target_candidates.len()
+            >= super::semantic_failure::MAX_PROPOSED_TARGETS_PER_CLUSTER
+        {
+            break;
+        }
+        // Dedup-by-path: a path already appended via `repair_targets` is not
+        // re-appended via `repair_plan`. We compare against the sanitized
+        // entry that was pushed (the same SSOT is applied to the new entry
+        // below) so a path string that differs only in trailing whitespace /
+        // control chars still dedupes correctly.
+        let sanitized_path = super::repair_job::sanitize_repair_job_text_with_char_cap(
+            &entry.path,
+            super::semantic_failure::MAX_RAW_PATH_CHARS,
+        );
+        if first_cluster
+            .proposed_target_candidates
+            .iter()
+            .any(|c| c.raw_path == sanitized_path)
+        {
+            continue;
+        }
+        first_cluster.proposed_target_candidates.push(
+            super::semantic_failure::RawClusterTargetCandidate {
+                raw_path: sanitized_path,
+                role_hint: None,
+                reason: super::repair_job::sanitize_repair_job_text_with_char_cap(
+                    &entry.reason,
+                    240,
+                ),
+            },
+        );
+    }
+}
+
+/// Issue #647 / CB-017 A''' (Commit 3, CR-1 V2 / CR-3 V2 / CR-5):
+/// for every failure cluster, admit each `proposed_target_candidate` via
+/// the SSOT `recovery_target_hint_for_diagnostic_path` (which composes
+/// syntactic safety + Owned admission + setup-target gating), dedup the
+/// admitted hints by `(role, path)`, and sort them with the
+/// authority/failure-kind decision table in
+/// [`sort_admitted_by_authority_role_priority`].
+///
+/// CR-3 V2: `candidate.role_hint` is **advisory only** — it is never passed
+/// to the admission helper. The admitted hint's role is decided by
+/// `recovery_target_hint_for_existing_path`'s path classification.
+///
+/// CR-1 V2: the admission SSOT is invoked exactly once per candidate. We do
+/// NOT additionally call `admit_repair_target_hint` after the fact (that
+/// would double-gate Owned).
+pub(super) fn enrich_failure_clusters_with_admitted_targets(
+    report: &mut super::semantic_failure::SemanticFailureReport,
+    work_root: &Path,
+    admission_ctx: &RepairTargetAdmissionContext<'_>,
+    spec_authority: super::spec_authority::SpecAuthority,
+) {
+    let failure_kind = report.failure_kind;
+    for cluster in report.failure_clusters.iter_mut() {
+        let mut admitted: Vec<super::task_contract::RecoveryTargetHint> = Vec::new();
+        for candidate in cluster.proposed_target_candidates.iter() {
+            // recovery_target_hint_for_diagnostic_path is the SSOT — it
+            // composes syntactic safety + Owned admission via
+            // admit_repair_target_hint. role_hint is intentionally not
+            // forwarded (CR-3 V2).
+            if let Some(hint) = recovery_target_hint_for_diagnostic_path(
+                work_root,
+                &candidate.raw_path,
+                &candidate.reason,
+                failure_kind,
+                admission_ctx,
+            ) {
+                admitted.push(hint);
+            }
+        }
+        // (role, path) dedup — Codex nice-to-have 2.
+        admitted.sort_by(|a, b| (a.role, &a.path).cmp(&(b.role, &b.path)));
+        admitted.dedup_by(|a, b| a.role == b.role && a.path == b.path);
+        // Role priority sort (TestBug override / SetupRepair defensive /
+        // default impl-first). Stable sort with (rank, path) tie-breaker.
+        sort_admitted_by_authority_role_priority(&mut admitted, spec_authority, failure_kind);
+        cluster.admitted_cluster_targets = admitted;
+    }
+}
+
+/// Issue #647 / CB-017 A''' (Commit 3, CR-5 V2): stable role-priority sort
+/// for an `admitted_cluster_targets` slice.
+///
+/// Decision table:
+///
+/// | `failure_kind`                                            | Order                                          |
+/// |-----------------------------------------------------------|------------------------------------------------|
+/// | `TestBug` (override)                                      | Test > Impl > UsageDocs > Setup                |
+/// | `DependencyMissing` / `ConfigOrVerifierError` (defensive) | Setup > Impl > UsageDocs > Test                |
+/// | everything else                                           | Impl > UsageDocs > Setup > Test (test suppress)|
+///
+/// `spec_authority` is currently advisory at this layer — the table above
+/// is independent of authority. The parameter is retained for forward
+/// compatibility (a future Issue may introduce authority-conditional
+/// branches without touching the call sites).
+///
+/// The sort is stable and uses `(rank, path)` as the sort key so ties (two
+/// targets of the same role) resolve in deterministic path order.
+pub(super) fn sort_admitted_by_authority_role_priority(
+    admitted: &mut [super::task_contract::RecoveryTargetHint],
+    spec_authority: super::spec_authority::SpecAuthority,
+    failure_kind: super::VerifierDiagnosticFailureKind,
+) {
+    let _ = spec_authority; // explicit no-op for clarity (CR-5 V2 decision table).
+    let primary_rank_for = |role: super::task_contract::ArtifactRole| -> u8 {
+        if matches!(failure_kind, super::VerifierDiagnosticFailureKind::TestBug) {
+            return match role {
+                super::task_contract::ArtifactRole::Test => 0,
+                super::task_contract::ArtifactRole::Implementation => 1,
+                super::task_contract::ArtifactRole::UsageDocs => 2,
+                super::task_contract::ArtifactRole::Setup => 3,
+            };
+        }
+        if matches!(
+            failure_kind,
+            super::VerifierDiagnosticFailureKind::DependencyMissing
+                | super::VerifierDiagnosticFailureKind::ConfigOrVerifierError
+        ) {
+            return match role {
+                super::task_contract::ArtifactRole::Setup => 0,
+                super::task_contract::ArtifactRole::Implementation => 1,
+                super::task_contract::ArtifactRole::UsageDocs => 2,
+                super::task_contract::ArtifactRole::Test => 3,
+            };
+        }
+        match role {
+            super::task_contract::ArtifactRole::Implementation => 0,
+            super::task_contract::ArtifactRole::UsageDocs => 1,
+            super::task_contract::ArtifactRole::Setup => 2,
+            super::task_contract::ArtifactRole::Test => 3,
+        }
+    };
+    admitted.sort_by(|a, b| {
+        let pa = primary_rank_for(a.role);
+        let pb = primary_rank_for(b.role);
+        pa.cmp(&pb).then_with(|| a.path.cmp(&b.path))
+    });
+}
+
 fn diagnostic_target_allowed_by_confidence(
     hint: &super::task_contract::RecoveryTargetHint,
     confidence: f64,
@@ -15934,10 +16151,17 @@ fn build_semantic_repair_plan_from_report_with_authority_input(
     {
         return None;
     }
-    // 1 RepairJob = 1 cluster (slot reuse, Phase E). Pick the first cluster
-    // as the attack target; if no clusters were reported, the plan cannot
-    // be built (caller keeps `semantic_plan = None`).
-    let failure_cluster_id = report.failure_clusters.first()?.cluster_key.clone();
+    // 1 RepairJob = 1 cluster (slot reuse, Phase E). Pick the first
+    // **repairable** cluster — CB-017 A''' (Commit 3, CR-6 V2) skips
+    // targetless clusters (admitted_cluster_targets empty) so the plan is
+    // always anchored to a cluster the controller can actually attack.
+    // When tests build a fixture report *without* running the enrich step,
+    // every cluster looks targetless; fall back to the legacy "first cluster"
+    // behavior in that case so the existing test suite stays green.
+    let failure_cluster_id = super::repair_job::first_repairable_cluster(&report)
+        .or_else(|| report.failure_clusters.first())?
+        .cluster_key
+        .clone();
     // Issue #647 (SF1): SpecAuthority is now resolved through the
     // structured `resolve()` SSOT so impl/test/README are treated as
     // equally authoritative on newly generated tasks. Pre-SF1 the
@@ -27752,6 +27976,421 @@ export default function App() {
         // The plan must carry a non-empty hypothesis (MF3 admission guard
         // for test edits requires this).
         assert!(!plan.repair_hypothesis.trim().is_empty());
+    }
+
+    // ─── CB-017 A''' (Commit 3): merge + enrich + sort production helpers ───
+
+    /// Build a single-cluster `SemanticFailureReport` whose
+    /// `proposed_target_candidates` list is supplied by the caller. Bypasses
+    /// JSON parsing so we can inject candidates with arbitrary role hints
+    /// (including ones that disagree with the path classification).
+    fn cb017_single_cluster_report_with_candidates(
+        failure_kind: super::super::VerifierDiagnosticFailureKind,
+        candidates: Vec<super::super::semantic_failure::RawClusterTargetCandidate>,
+    ) -> super::super::semantic_failure::SemanticFailureReport {
+        let cluster = super::super::semantic_failure::build_failure_cluster_from_observation(
+            "observed",
+            "expected",
+            "shape",
+            "AssertEq",
+            &[super::super::task_contract::ArtifactRole::Implementation],
+            candidates,
+        );
+        super::super::semantic_failure::SemanticFailureReport {
+            failure_kind,
+            failure_clusters: vec![cluster],
+            contract_conflict: super::super::semantic_failure::ContractConflict {
+                implementation: String::new(),
+                test: String::new(),
+                usage_docs: String::new(),
+            },
+            preferred_repair_role: super::super::task_contract::ArtifactRole::Implementation,
+            repair_hypothesis: "hypothesis".to_string(),
+            confidence: 0.7,
+        }
+    }
+
+    fn cb017_admission_for_test<'a>(
+        work_root: &'a std::path::Path,
+        scope: &'a super::super::task_workspace_scope::TaskWorkspaceScope,
+    ) -> super::RepairTargetAdmissionContext<'a> {
+        super::RepairTargetAdmissionContext::owned_for_test(work_root, scope)
+    }
+
+    /// CR-2 V2: partial output (some clusters have target_paths, some not)
+    /// must NOT be merged with legacy targets. Targetless clusters are left
+    /// untouched and the downstream walker skips them.
+    #[test]
+    fn cb017_mixed_reply_partial_semantic_does_not_merge_legacy() {
+        let cluster_with_targets =
+            super::super::semantic_failure::build_failure_cluster_from_observation(
+                "obs_a",
+                "exp_a",
+                "shape_a",
+                "AssertEq",
+                &[super::super::task_contract::ArtifactRole::Implementation],
+                vec![super::super::semantic_failure::RawClusterTargetCandidate {
+                    raw_path: "src/a.rs".to_string(),
+                    role_hint: None,
+                    reason: "from llm".to_string(),
+                }],
+            );
+        let cluster_without_targets =
+            super::super::semantic_failure::build_failure_cluster_from_observation(
+                "obs_b",
+                "exp_b",
+                "shape_b",
+                "AssertEq",
+                &[super::super::task_contract::ArtifactRole::Implementation],
+                Vec::new(),
+            );
+        let mut report = super::super::semantic_failure::SemanticFailureReport {
+            failure_kind: super::super::VerifierDiagnosticFailureKind::AssertionMismatch,
+            failure_clusters: vec![cluster_with_targets, cluster_without_targets],
+            contract_conflict: super::super::semantic_failure::ContractConflict {
+                implementation: String::new(),
+                test: String::new(),
+                usage_docs: String::new(),
+            },
+            preferred_repair_role: super::super::task_contract::ArtifactRole::Implementation,
+            repair_hypothesis: "h".to_string(),
+            confidence: 0.7,
+        };
+        let parsed = super::ParsedVerifierRepairAssessment {
+            failure_kind: super::super::VerifierDiagnosticFailureKind::AssertionMismatch,
+            probable_cause_role: None,
+            repair_targets: vec![super::ParsedVerifierRepairTarget {
+                path: "legacy/path.rs".to_string(),
+                confidence: 0.5,
+                reason: "legacy".to_string(),
+            }],
+            repair_plan: Vec::new(),
+            secondary_targets: Vec::new(),
+            do_not_edit_tests_without_evidence: false,
+            summary: None,
+        };
+        super::merge_legacy_targets_into_clusters(&mut report, &parsed);
+        // Partial output policy: nothing merged.
+        assert_eq!(
+            report.failure_clusters[0].proposed_target_candidates.len(),
+            1
+        );
+        assert_eq!(
+            report.failure_clusters[0].proposed_target_candidates[0].raw_path,
+            "src/a.rs"
+        );
+        assert!(
+            report.failure_clusters[1]
+                .proposed_target_candidates
+                .is_empty(),
+            "CR-2 V2: targetless cluster must NOT be filled by legacy merge under partial output"
+        );
+    }
+
+    /// CR-2 V2 fallback: every cluster targetless → first cluster gets the
+    /// legacy targets appended (role_hint=None — ParsedVerifierRepairTarget
+    /// has no role).
+    #[test]
+    fn cb017_all_clusters_targetless_merges_legacy_into_first() {
+        let cluster_a = super::super::semantic_failure::build_failure_cluster_from_observation(
+            "obs_a",
+            "exp_a",
+            "shape_a",
+            "AssertEq",
+            &[super::super::task_contract::ArtifactRole::Implementation],
+            Vec::new(),
+        );
+        let cluster_b = super::super::semantic_failure::build_failure_cluster_from_observation(
+            "obs_b",
+            "exp_b",
+            "shape_b",
+            "AssertEq",
+            &[super::super::task_contract::ArtifactRole::Implementation],
+            Vec::new(),
+        );
+        let mut report = super::super::semantic_failure::SemanticFailureReport {
+            failure_kind: super::super::VerifierDiagnosticFailureKind::AssertionMismatch,
+            failure_clusters: vec![cluster_a, cluster_b],
+            contract_conflict: super::super::semantic_failure::ContractConflict {
+                implementation: String::new(),
+                test: String::new(),
+                usage_docs: String::new(),
+            },
+            preferred_repair_role: super::super::task_contract::ArtifactRole::Implementation,
+            repair_hypothesis: "h".to_string(),
+            confidence: 0.7,
+        };
+        let parsed = super::ParsedVerifierRepairAssessment {
+            failure_kind: super::super::VerifierDiagnosticFailureKind::AssertionMismatch,
+            probable_cause_role: None,
+            repair_targets: vec![super::ParsedVerifierRepairTarget {
+                path: "legacy/from_targets.rs".to_string(),
+                confidence: 0.5,
+                reason: "from targets list".to_string(),
+            }],
+            repair_plan: vec![
+                super::ParsedVerifierRepairTarget {
+                    path: "legacy/from_plan.rs".to_string(),
+                    confidence: 0.4,
+                    reason: "from plan".to_string(),
+                },
+                // duplicate path must be deduped by merge.
+                super::ParsedVerifierRepairTarget {
+                    path: "legacy/from_targets.rs".to_string(),
+                    confidence: 0.4,
+                    reason: "duplicate".to_string(),
+                },
+            ],
+            secondary_targets: Vec::new(),
+            do_not_edit_tests_without_evidence: false,
+            summary: None,
+        };
+        super::merge_legacy_targets_into_clusters(&mut report, &parsed);
+        let first = &report.failure_clusters[0].proposed_target_candidates;
+        assert_eq!(first.len(), 2, "duplicate path must be deduped");
+        assert_eq!(first[0].raw_path, "legacy/from_targets.rs");
+        assert_eq!(
+            first[0].role_hint, None,
+            "ParsedVerifierRepairTarget has no role"
+        );
+        assert_eq!(first[1].raw_path, "legacy/from_plan.rs");
+        assert!(
+            report.failure_clusters[1]
+                .proposed_target_candidates
+                .is_empty(),
+            "merge only touches the first cluster (slot reuse handles the rest)"
+        );
+    }
+
+    /// CR-1 V2 grep test: `enrich_failure_clusters_with_admitted_targets`
+    /// must invoke `recovery_target_hint_for_diagnostic_path` (SSOT) and
+    /// must NOT directly invoke `admit_repair_target_hint` (which would
+    /// double-gate Owned).
+    #[test]
+    fn cb017_enrich_calls_admission_ssot_exactly_once_per_candidate() {
+        let src = include_str!("turn.rs");
+        let fn_pos = src
+            .find("pub(super) fn enrich_failure_clusters_with_admitted_targets(")
+            .expect("enrich function must exist");
+        // Take a generous slice of the function body (up to the next top-level
+        // `pub(super) fn` / `fn ` declaration).
+        let after = &src[fn_pos..];
+        let next_fn = after[1..]
+            .find("\npub(super) fn ")
+            .or_else(|| after[1..].find("\nfn "))
+            .map(|n| n + 1)
+            .unwrap_or(after.len());
+        let body = &after[..next_fn];
+        assert!(
+            body.contains("recovery_target_hint_for_diagnostic_path"),
+            "enrich must route every candidate through recovery_target_hint_for_diagnostic_path (CR-1 V2 SSOT)"
+        );
+        assert!(
+            !body.contains("admit_repair_target_hint("),
+            "enrich must NOT call admit_repair_target_hint directly — recovery_target_hint_for_diagnostic_path already composes it (CR-1 V2)"
+        );
+    }
+
+    /// CR-3 V2: even when the LLM-supplied `role_hint` disagrees with the
+    /// path classification (here: role_hint=Test but raw_path resolves to an
+    /// implementation file), the admitted hint's role MUST come from the
+    /// path classification.
+    #[test]
+    fn cb017_admitted_role_comes_from_path_classification_not_role_hint() {
+        let temp = tempdir().unwrap();
+        let work_root = temp.path().to_path_buf();
+        // Create an implementation file at app/main.py (classified as
+        // Implementation by `classify_repo_edit_path`).
+        let impl_file = work_root.join("app").join("main.py");
+        std::fs::create_dir_all(impl_file.parent().unwrap()).unwrap();
+        std::fs::write(&impl_file, "def f(): pass\n").unwrap();
+
+        let mut report = cb017_single_cluster_report_with_candidates(
+            super::super::VerifierDiagnosticFailureKind::AssertionMismatch,
+            vec![super::super::semantic_failure::RawClusterTargetCandidate {
+                raw_path: "app/main.py".to_string(),
+                // Deliberately misleading hint:
+                role_hint: Some(super::super::task_contract::ArtifactRole::Test),
+                reason: "fix it".to_string(),
+            }],
+        );
+        let scope = super::super::task_workspace_scope::TaskWorkspaceScope::detect(&work_root, "");
+        let admission = cb017_admission_for_test(&work_root, &scope);
+        super::enrich_failure_clusters_with_admitted_targets(
+            &mut report,
+            &work_root,
+            &admission,
+            super::super::spec_authority::SpecAuthority::UserRequest,
+        );
+        let admitted = &report.failure_clusters[0].admitted_cluster_targets;
+        assert_eq!(admitted.len(), 1);
+        assert_eq!(
+            admitted[0].role,
+            super::super::task_contract::ArtifactRole::Implementation,
+            "CR-3 V2: admitted role must come from path classification, NOT from role_hint"
+        );
+        assert_eq!(admitted[0].path, "app/main.py");
+    }
+
+    /// CR-5: under UserRequest authority + AssertionMismatch failure, the
+    /// default decision-table ordering places Implementation before Test.
+    #[test]
+    fn cb017_sort_impl_first_under_user_request_authority() {
+        let mut admitted = vec![
+            super::super::task_contract::RecoveryTargetHint {
+                role: super::super::task_contract::ArtifactRole::Test,
+                path: "tests/test_a.py".to_string(),
+                reason: String::new(),
+            },
+            super::super::task_contract::RecoveryTargetHint {
+                role: super::super::task_contract::ArtifactRole::Implementation,
+                path: "app/main.py".to_string(),
+                reason: String::new(),
+            },
+        ];
+        super::sort_admitted_by_authority_role_priority(
+            &mut admitted,
+            super::super::spec_authority::SpecAuthority::UserRequest,
+            super::super::VerifierDiagnosticFailureKind::AssertionMismatch,
+        );
+        assert_eq!(
+            admitted[0].role,
+            super::super::task_contract::ArtifactRole::Implementation,
+            "default table: impl-first"
+        );
+        assert_eq!(
+            admitted[1].role,
+            super::super::task_contract::ArtifactRole::Test
+        );
+    }
+
+    /// CR-5: TestBug override flips the order — Test must come first.
+    #[test]
+    fn cb017_sort_test_first_when_failure_kind_is_test_bug() {
+        let mut admitted = vec![
+            super::super::task_contract::RecoveryTargetHint {
+                role: super::super::task_contract::ArtifactRole::Implementation,
+                path: "app/main.py".to_string(),
+                reason: String::new(),
+            },
+            super::super::task_contract::RecoveryTargetHint {
+                role: super::super::task_contract::ArtifactRole::Test,
+                path: "tests/test_a.py".to_string(),
+                reason: String::new(),
+            },
+        ];
+        super::sort_admitted_by_authority_role_priority(
+            &mut admitted,
+            super::super::spec_authority::SpecAuthority::UserRequest,
+            super::super::VerifierDiagnosticFailureKind::TestBug,
+        );
+        assert_eq!(
+            admitted[0].role,
+            super::super::task_contract::ArtifactRole::Test,
+            "TestBug override: test-first"
+        );
+    }
+
+    /// CR-5 defensive: under DependencyMissing, Setup comes first (even
+    /// though SetupRepair dispatch normally short-circuits before sort is
+    /// reached, the branch must exist).
+    #[test]
+    fn cb017_sort_setup_first_for_dependency_missing_defensive() {
+        let mut admitted = vec![
+            super::super::task_contract::RecoveryTargetHint {
+                role: super::super::task_contract::ArtifactRole::Implementation,
+                path: "app/main.py".to_string(),
+                reason: String::new(),
+            },
+            super::super::task_contract::RecoveryTargetHint {
+                role: super::super::task_contract::ArtifactRole::Setup,
+                path: "requirements.txt".to_string(),
+                reason: String::new(),
+            },
+        ];
+        super::sort_admitted_by_authority_role_priority(
+            &mut admitted,
+            super::super::spec_authority::SpecAuthority::ImplementationContract,
+            super::super::VerifierDiagnosticFailureKind::DependencyMissing,
+        );
+        assert_eq!(
+            admitted[0].role,
+            super::super::task_contract::ArtifactRole::Setup,
+            "DependencyMissing defensive: setup-first"
+        );
+    }
+
+    /// CR-5 V2: ties are broken by path order so the sort is deterministic
+    /// across runs.
+    #[test]
+    fn cb017_sort_is_stable_with_path_tiebreaker() {
+        let mut admitted = vec![
+            super::super::task_contract::RecoveryTargetHint {
+                role: super::super::task_contract::ArtifactRole::Implementation,
+                path: "app/z.py".to_string(),
+                reason: String::new(),
+            },
+            super::super::task_contract::RecoveryTargetHint {
+                role: super::super::task_contract::ArtifactRole::Implementation,
+                path: "app/a.py".to_string(),
+                reason: String::new(),
+            },
+        ];
+        super::sort_admitted_by_authority_role_priority(
+            &mut admitted,
+            super::super::spec_authority::SpecAuthority::UserRequest,
+            super::super::VerifierDiagnosticFailureKind::AssertionMismatch,
+        );
+        assert_eq!(
+            admitted[0].path, "app/a.py",
+            "tie-break must be path-sorted"
+        );
+        assert_eq!(admitted[1].path, "app/z.py");
+    }
+
+    /// Security: `../`, absolute path, embedded NUL all rejected by
+    /// `verifier_diagnostic_path_input_is_safe` (which the SSOT
+    /// `recovery_target_hint_for_diagnostic_path` calls). After enrich, no
+    /// admitted target should land in the cluster.
+    #[test]
+    fn cb017_security_unsafe_paths_rejected_by_enrich() {
+        let temp = tempdir().unwrap();
+        let work_root = temp.path().to_path_buf();
+        // Create a real file so the path-validation step has an existing
+        // file at every "safe" baseline — we want to be sure rejection
+        // happens for the unsafe shapes, not for "file does not exist".
+        let safe = work_root.join("app").join("safe.py");
+        std::fs::create_dir_all(safe.parent().unwrap()).unwrap();
+        std::fs::write(&safe, "x = 1\n").unwrap();
+
+        let cand = |raw_path: &str| super::super::semantic_failure::RawClusterTargetCandidate {
+            raw_path: raw_path.to_string(),
+            role_hint: None,
+            reason: "test".to_string(),
+        };
+        let candidates = vec![
+            cand("../etc/passwd"),
+            cand("/etc/passwd"),
+            cand("app/with\0nul.py"),
+        ];
+        let mut report = cb017_single_cluster_report_with_candidates(
+            super::super::VerifierDiagnosticFailureKind::AssertionMismatch,
+            candidates,
+        );
+        let scope = super::super::task_workspace_scope::TaskWorkspaceScope::detect(&work_root, "");
+        let admission = cb017_admission_for_test(&work_root, &scope);
+        super::enrich_failure_clusters_with_admitted_targets(
+            &mut report,
+            &work_root,
+            &admission,
+            super::super::spec_authority::SpecAuthority::UserRequest,
+        );
+        assert!(
+            report.failure_clusters[0]
+                .admitted_cluster_targets
+                .is_empty(),
+            "unsafe paths (../, absolute, control chars) must NOT survive enrich admission"
+        );
     }
 }
 

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -14166,6 +14166,14 @@ fn verifier_repair_context_from_failure(
         previous_failure_count,
         rerun_outcome,
         repair_attempt,
+        // Issue #647 (Phase B): semantic-repair planning fields are populated
+        // by Phase D (`model_assessment_to_verifier_repair_assessment` end).
+        // At this construction point we have not yet parsed the diagnostic
+        // LLM payload into a `SemanticFailureReport`, so both slots start
+        // empty. `exhausted_attempts` is the per-job ledger that survives
+        // slot reuse — it has no prior entries when the job is first built.
+        semantic_plan: None,
+        exhausted_attempts: Vec::new(),
     }
 }
 
@@ -18794,20 +18802,12 @@ mod progress_tests {
                 summary: Some("test helper assessment".to_string()),
                 source: super::super::VerifierRepairAssessmentSource::DiagnosticPass,
             }),
-            assessment_attempts: 0,
             diagnostic_attempted: true,
-            diagnostic_unavailable: false,
-            diagnostic_error: None,
-            repair_error: None,
-            applied_repair_intents: Vec::new(),
-            target_line: None,
             error_kind: Some("TypeError".to_string()),
             failure_signature: format!("{path} TypeError"),
             failure_count: Some(1),
-            previous_failure_signature: None,
-            previous_failure_count: None,
-            rerun_outcome: None,
             repair_attempt: 1,
+            ..super::super::repair_job::RepairJob::new_for_test()
         }
     }
 
@@ -23547,25 +23547,11 @@ export default function App() {
         let mut context = super::super::repair_job::RepairJob {
             command: "python3 -m pytest".to_string(),
             output_excerpt: "ImportError: cannot import name 'store' from 'app.main'".to_string(),
-            failure_type: super::super::VerifierFailureType::Unknown,
             target_hint: Some(hint.clone()),
-            repair_target_hint: None,
-            changed_file_hints: vec![],
-            assessment: None,
-            assessment_attempts: 0,
-            diagnostic_attempted: false,
-            diagnostic_unavailable: false,
-            diagnostic_error: None,
-            repair_error: None,
-            applied_repair_intents: vec![],
-            target_line: None,
-            error_kind: None,
             failure_signature: "app/main.py import_error".to_string(),
             failure_count: Some(1),
-            previous_failure_signature: None,
-            previous_failure_count: None,
-            rerun_outcome: None,
             repair_attempt: 1,
+            ..super::super::repair_job::RepairJob::new_for_test()
         };
 
         // With Unknown (parser-only), the helper must NOT fire.
@@ -23614,25 +23600,11 @@ export default function App() {
         let context = super::super::repair_job::RepairJob {
             command: "python3 -m pytest".to_string(),
             output_excerpt: "ImportError: cannot import name 'store' from 'app.main'".to_string(),
-            failure_type: super::super::VerifierFailureType::Unknown,
             target_hint: Some(hint.clone()),
-            repair_target_hint: None,
-            changed_file_hints: vec![],
-            assessment: None,
-            assessment_attempts: 0,
-            diagnostic_attempted: false,
-            diagnostic_unavailable: false,
-            diagnostic_error: None,
-            repair_error: None,
-            applied_repair_intents: vec![],
-            target_line: None,
-            error_kind: None,
             failure_signature: "app/main.py import_error".to_string(),
             failure_count: Some(1),
-            previous_failure_signature: None,
-            previous_failure_count: None,
-            rerun_outcome: None,
             repair_attempt: 1,
+            ..super::super::repair_job::RepairJob::new_for_test()
         };
         // parser-origin Unknown → both helpers must early-return
         assert!(
@@ -23969,25 +23941,12 @@ export default function App() {
         let context = super::super::repair_job::RepairJob {
             command: "python3 -m pytest".to_string(),
             output_excerpt: "error".to_string(),
-            failure_type: super::super::VerifierFailureType::Unknown,
             target_hint: Some(hint),
-            repair_target_hint: None,
-            changed_file_hints: vec![],
-            assessment: None,
-            assessment_attempts: 0,
-            diagnostic_attempted: false,
-            diagnostic_unavailable: false,
-            diagnostic_error: None,
-            repair_error: None,
-            applied_repair_intents: vec![],
             target_line: Some(1),
-            error_kind: None,
             failure_signature: "app/main.py error".to_string(),
             failure_count: Some(1),
-            previous_failure_signature: None,
-            previous_failure_count: None,
-            rerun_outcome: None,
             repair_attempt: 1,
+            ..super::super::repair_job::RepairJob::new_for_test()
         };
         let messages = verifier_diagnostic_messages(&work_root, &context, "fix bug");
         let payload = messages

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -20657,6 +20657,93 @@ mod progress_tests {
         );
     }
 
+    /// Issue #647 (CB-012): when `semantic_plan` is active and
+    /// `exhausted_attempts` is non-empty, the `verifier_repair_effective_target_hint`
+    /// guard returns `None` for stale assessments. The repair-decision
+    /// state machine must then return `NeedDiagnostic` instead of
+    /// falling through to `latest_successful_read_existing_path` / a
+    /// `NeedTargetDiscovery` fallback that would route the repair pass
+    /// to an unrelated turn-local read target.
+    #[test]
+    fn cb012_advanced_semantic_plan_with_stale_assessment_forces_need_diagnostic() {
+        use super::super::repair_job::{
+            RepairJob, VerifierRepairDecision, verifier_repair_decision as decision_fn,
+        };
+        let temp = tempdir().unwrap();
+        let work_root = temp.path().to_path_buf();
+        // Create an unrelated file so `latest_successful_read_existing_path`
+        // *could* return a fallback target. Without CB-012 the decision
+        // would route to that fallback; with CB-012 it must force a
+        // fresh diagnostic instead.
+        let unrelated = work_root.join("unrelated.txt");
+        std::fs::write(&unrelated, "irrelevant\n").unwrap();
+
+        // Build a RepairJob in the "advanced semantic_plan + stale
+        // assessment" state: semantic_plan is Some (= we have an
+        // active cluster B), exhausted_attempts is non-empty (= cluster
+        // A is already exhausted), and `assessment` still points at the
+        // stale cluster-A hint via `repair_target_hint`. The CB-007
+        // guard makes `verifier_repair_context_target_path` return None
+        // for this state; CB-012 must then return `NeedDiagnostic`.
+        let mut context: RepairJob = verifier_context_for("app/main.py");
+        // The stale assessment must exist (assessment.is_some()) — that
+        // is the precondition where CB-012 fires.
+        assert!(context.assessment.is_some(), "fixture invariant");
+        context.semantic_plan = Some(semantic_plan_for_test_fixture());
+        // One exhausted (cluster_id, role) tuple is enough to trigger
+        // the guard.
+        let any_cluster_id = context
+            .semantic_plan
+            .as_ref()
+            .unwrap()
+            .failure_cluster_id
+            .clone();
+        context.exhausted_attempts.push((
+            any_cluster_id,
+            super::super::task_contract::ArtifactRole::Implementation,
+        ));
+        context.assessment_attempts = 0;
+        context.diagnostic_attempted = true;
+        // No pending read target message — `latest_successful_read_existing_path`
+        // would still walk message history; with CB-012 we bypass it.
+
+        let dec = decision_fn(true, Some(&context), &[], &work_root, Some(1), 1);
+        assert_eq!(
+            dec,
+            VerifierRepairDecision::NeedDiagnostic,
+            "CB-012: advanced semantic_plan with stale assessment must force NeedDiagnostic"
+        );
+    }
+
+    /// Issue #647 (CB-012): the new guard must NOT fire when
+    /// `exhausted_attempts` is empty — i.e., legacy / fresh diagnostic
+    /// flow is unaffected.
+    #[test]
+    fn cb012_advanced_semantic_plan_without_exhausted_attempts_is_unaffected() {
+        use super::super::repair_job::{
+            RepairJob, VerifierRepairDecision, verifier_repair_decision as decision_fn,
+        };
+        let temp = tempdir().unwrap();
+        let work_root = temp.path().to_path_buf();
+        let app_dir = work_root.join("app");
+        std::fs::create_dir_all(&app_dir).unwrap();
+        std::fs::write(app_dir.join("main.py"), "def main():\n    return 1\n").unwrap();
+
+        let mut context: RepairJob = verifier_context_for("app/main.py");
+        context.semantic_plan = Some(semantic_plan_for_test_fixture());
+        // No exhausted attempts → CB-012 must NOT engage.
+        assert!(context.exhausted_attempts.is_empty(), "fixture invariant");
+
+        let dec = decision_fn(true, Some(&context), &[], &work_root, Some(1), 1);
+        // Fresh state should route to NeedFreshRead/NeedEdit (target
+        // resolves), not the new NeedDiagnostic shortcut.
+        assert_ne!(
+            dec,
+            VerifierRepairDecision::NeedDiagnostic,
+            "CB-012: guard must NOT fire when exhausted_attempts is empty"
+        );
+    }
+
     #[test]
     fn verifier_diagnostic_attempt_spec_uses_sidecar_then_main_fallback() {
         let first = verifier_diagnostic_attempt_spec("main-model", Some("sidecar-model"), 0)

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -4959,6 +4959,13 @@ impl Agent {
         self.task_contract_excerpts.clear();
         self.current_artifact_recovery_target = None;
         self.task_contract_verifier_repair_pending = false;
+        // Issue #647 (SF1 V3.2): mirror reset for the verifier-passed
+        // hint that backs `SpecAuthorityInput.has_verified_public_interface`.
+        // Lives at the same per-turn reset boundary as the
+        // `task_contract_verifier_repair_pending` flag so a previous turn's
+        // verifier success cannot leak into the current turn's
+        // SpecAuthority resolution.
+        self.task_contract_verifier_passed_this_actor_loop = false;
         self.repair_job = None;
         // Issue #637 (CB-001): reset the artifact-recovery retry counter at
         // the same per-turn boundary as `repair_job` so a previous turn's
@@ -7553,6 +7560,12 @@ impl Agent {
                 // cycle restarts at 1/3.
                 self.repair_job_artifact_attempts = 0;
                 *args.task_contract_verifier_passed_in_loop = true;
+                // Issue #647 (SF1 V3.2): mirror the local flag onto the
+                // Agent so `run_verifier_diagnostic_pass` (called later
+                // in the same actor-loop iteration on re-failure) can
+                // wire `has_verified_public_interface = true` into the
+                // SpecAuthorityInput.
+                self.task_contract_verifier_passed_this_actor_loop = true;
                 TaskContractVerifierFlowOutcome::Done {
                     final_prose: format!(
                         "Completed requested repository changes and verified them with `{safe_command}`."
@@ -9356,15 +9369,24 @@ impl Agent {
         // responsibility split.
         let semantic_report = parse_semantic_failure_report_from_reply(&reply.content)
             .or_else(|| build_semantic_failure_report_from_legacy(&parsed, &context));
-        // Issue #647 (SF1): build the `SpecAuthorityInput` from the active
-        // request's `RequiredBehaviorContract` (when actionable signal is
-        // present, the resolver elects `BehaviorContract`). All other
-        // detectors (`has_user_request_match`, consensus) are still default
-        // until later Issues wire them in; `is_newly_generated_task` is
-        // initialized to `true` per the SF1 acceptance until a real
-        // newly-generated detector lands.
-        let authority_input =
-            build_spec_authority_input_for_active_request(self.active_request_text().as_deref());
+        // Issue #647 (SF1 / V3): build the `SpecAuthorityInput` from the
+        // four real detectors wired in V3:
+        //   * BehaviorContract — from `TaskContract::from_request`.
+        //   * UserRequest match — from the explicit-spec keyword detector.
+        //   * VerifiedPublicInterface — from the turn-local
+        //     `task_contract_verifier_passed_this_actor_loop` flag
+        //     (S5-005: real-but-bounded detector).
+        //   * Consensus — from the V3.3 contract-conflict heuristic over
+        //     the just-parsed `SemanticFailureReport`.
+        // `is_newly_generated_task` stays `true` per the SF1 acceptance.
+        let agent_history_hint = super::spec_authority::AgentHistoryHint {
+            verifier_passed_in_loop: self.task_contract_verifier_passed_this_actor_loop,
+        };
+        let authority_input = build_spec_authority_input_for_active_request(
+            self.active_request_text().as_deref(),
+            semantic_report.as_ref(),
+            agent_history_hint,
+        );
         let semantic_plan = semantic_report.and_then(|report| {
             build_semantic_repair_plan_from_report_with_authority_input(
                 report,
@@ -15723,19 +15745,38 @@ fn build_semantic_failure_report_from_legacy(
 ///
 /// `expected_improvement` is initialized to `None` — Phase E fills it after
 /// the verifier rerun.
-/// Issue #647 (SF1): construct a `SpecAuthorityInput` for the production
-/// diagnostic pass by inspecting `active_request` for actionable behavior
-/// signal. When the request yields a `RequiredBehaviorContract` with
-/// operations / domain_terms, the resolver will elect `BehaviorContract`;
-/// otherwise we fall through to the newly-generated-task path (which
-/// returns `LlmGeneratedTest`, suppressing test edits on a brand-new
-/// task — see [`spec_authority::resolve`]).
+/// Issue #647 (SF1 / V3): construct a `SpecAuthorityInput` for the
+/// production diagnostic pass by funneling four independent signals into
+/// the resolver:
+///
+/// 1. `has_behavior_contract` — derived from
+///    `task_contract::TaskContract::from_request` on the active request.
+/// 2. `has_user_request_match` — derived from the SF1 V3.1 explicit-spec
+///    keyword detector ([`spec_authority::detect_explicit_spec_in_user_request`]).
+/// 3. `has_verified_public_interface` — derived from the SF1 V3.2
+///    history hint detector
+///    ([`spec_authority::detect_verified_public_interface_from_history`]),
+///    which today reads the turn-local "verifier already passed once"
+///    bit and never reaches outside the current actor-loop iteration.
+/// 4. `consensus` — derived from the SF1 V3.3 string-match heuristic
+///    ([`spec_authority::detect_consensus_from_contract_conflict`]) over
+///    the parsed `SemanticFailureReport.contract_conflict` fields. `None`
+///    when no report is available yet (e.g. legacy parse).
+///
+/// `is_newly_generated_task` stays `true` per the SF1 acceptance — Issue
+/// #647 treats every turn as "newly generated" until a future Issue
+/// plumbs a real detector. The resolver's newly-generated short-circuit
+/// only fires when `consensus` is `None`, so the V3.3 detector
+/// automatically demotes the short-circuit when a real tie-break exists.
 ///
 /// The helper lives here (not in `spec_authority.rs`) because it crosses
-/// the `task_contract` / `spec_authority` module boundary; the resolver
-/// itself stays input-only and decoupled from `TaskContract`.
+/// the `task_contract` / `spec_authority` / `semantic_failure` module
+/// boundaries; the resolver itself stays input-only and decoupled from
+/// `TaskContract` and `SemanticFailureReport`.
 fn build_spec_authority_input_for_active_request(
     active_request: Option<&str>,
+    semantic_report: Option<&super::semantic_failure::SemanticFailureReport>,
+    agent_history_hint: super::spec_authority::AgentHistoryHint,
 ) -> super::spec_authority::SpecAuthorityInput {
     let has_behavior_contract = active_request
         .map(|request| {
@@ -15744,12 +15785,24 @@ fn build_spec_authority_input_for_active_request(
                 || contract.required_behavior.domain_terms.is_some()
         })
         .unwrap_or(false);
+    let has_user_request_match = active_request
+        .map(super::spec_authority::detect_explicit_spec_in_user_request)
+        .unwrap_or(false);
+    let has_verified_public_interface =
+        super::spec_authority::detect_verified_public_interface_from_history(agent_history_hint);
+    let consensus = semantic_report.and_then(|report| {
+        super::spec_authority::detect_consensus_from_contract_conflict(
+            &report.contract_conflict.implementation,
+            &report.contract_conflict.test,
+            &report.contract_conflict.usage_docs,
+        )
+    });
     super::spec_authority::SpecAuthorityInput {
-        has_user_request_match: false,
+        has_user_request_match,
         has_behavior_contract,
-        has_verified_public_interface: false,
+        has_verified_public_interface,
         is_newly_generated_task: true,
-        consensus: None,
+        consensus,
     }
 }
 
@@ -21289,9 +21342,16 @@ E   assert [{'id': 1}] == []\n";
         // A request that names an operation keyword ("create") + a domain
         // term should yield `has_behavior_contract: true`. The exact
         // detection is owned by `task_contract::TaskContract::from_request`
-        // — we only assert the routing here.
+        // — we only assert the routing here. (V3) We also pass
+        // `semantic_report = None` and a default history hint so the new
+        // V3 detectors stay neutral and we exercise the same routing as
+        // pre-V3 production.
         let request = "Create a TODO API: implement POST /todos to create a new todo item, then add a pytest that POSTs and asserts 201.";
-        let input = super::build_spec_authority_input_for_active_request(Some(request));
+        let input = super::build_spec_authority_input_for_active_request(
+            Some(request),
+            None,
+            super::super::spec_authority::AgentHistoryHint::default(),
+        );
         assert!(
             input.has_behavior_contract,
             "actionable request must set has_behavior_contract=true"
@@ -21302,9 +21362,200 @@ E   assert [{'id': 1}] == []\n";
         assert!(input.consensus.is_none());
 
         // Empty / missing request → behavior contract flag stays false.
-        let empty_input = super::build_spec_authority_input_for_active_request(None);
+        let empty_input = super::build_spec_authority_input_for_active_request(
+            None,
+            None,
+            super::super::spec_authority::AgentHistoryHint::default(),
+        );
         assert!(!empty_input.has_behavior_contract);
         assert!(empty_input.is_newly_generated_task);
+    }
+
+    // -- SF1 V3 production integration tests (Issue #647 / SF1 V3.5) -- //
+    //
+    // These tests close the Codex SF1 V3 finding: prior to V3 the
+    // production builder hard-coded `has_user_request_match`, `consensus`,
+    // and `has_verified_public_interface` to neutral values regardless of
+    // input. V3 wires three real detectors plus the
+    // `SemanticFailureReport` + `AgentHistoryHint` parameters; the tests
+    // below exercise each detector through the production helper.
+
+    /// SF1 V3.1: an active request that carries two or more distinct
+    /// explicit-spec keywords (e.g. "must return 404", "must accept")
+    /// must flip `has_user_request_match = true` via the production
+    /// builder.
+    #[test]
+    fn sf1_v3_user_request_match_detected_from_explicit_spec_keywords() {
+        let request = "The endpoint must return 404 when the item is missing. \
+                       The handler must accept a JSON body with an `id` field.";
+        let input = super::build_spec_authority_input_for_active_request(
+            Some(request),
+            None,
+            super::super::spec_authority::AgentHistoryHint::default(),
+        );
+        assert!(
+            input.has_user_request_match,
+            "explicit-spec keywords (>=2 distinct hits) must flip has_user_request_match"
+        );
+
+        // Conversational guidance (one "should") must NOT trip the detector.
+        let conversational = "You should maybe add a test here.";
+        let input2 = super::build_spec_authority_input_for_active_request(
+            Some(conversational),
+            None,
+            super::super::spec_authority::AgentHistoryHint::default(),
+        );
+        assert!(
+            !input2.has_user_request_match,
+            "single-keyword conversational request must NOT flip the flag"
+        );
+    }
+
+    /// SF1 V3.3: when the `SemanticFailureReport.contract_conflict` shows
+    /// two roles agreeing and one dissenting, the production builder must
+    /// surface a non-`None` `consensus` value (with the right agreeing /
+    /// dissenting role layout).
+    #[test]
+    fn sf1_v3_consensus_detected_when_two_artifacts_agree() {
+        let reply = r#"{
+            "failure_kind": "assertion_mismatch",
+            "failure_clusters": [{
+                "observed": "200",
+                "expected": "404",
+                "affected_cases": ["read missing item"],
+                "involved_artifacts": ["implementation", "test"]
+            }],
+            "contract_conflict": {
+                "implementation": "returns 404 when missing",
+                "test": "expects 200",
+                "usage_docs": "Returns 404 when missing"
+            },
+            "preferred_repair_role": "test",
+            "repair_hypothesis": "test expects the pre-spec 200 response",
+            "confidence": 0.8
+        }"#;
+        let report =
+            super::parse_semantic_failure_report_from_reply(reply).expect("sample report parses");
+        let input = super::build_spec_authority_input_for_active_request(
+            None,
+            Some(&report),
+            super::super::spec_authority::AgentHistoryHint::default(),
+        );
+        let consensus = input
+            .consensus
+            .as_ref()
+            .expect("two-vs-one agreement in contract_conflict must surface a consensus");
+        assert!(
+            consensus
+                .agreeing
+                .contains(&super::super::task_contract::ArtifactRole::Implementation),
+            "impl/docs agreed in the fixture"
+        );
+        assert!(
+            consensus
+                .agreeing
+                .contains(&super::super::task_contract::ArtifactRole::UsageDocs),
+            "impl/docs agreed in the fixture"
+        );
+        assert_eq!(
+            consensus.dissenting,
+            vec![super::super::task_contract::ArtifactRole::Test],
+            "test was the dissenting role"
+        );
+    }
+
+    /// SF1 V3 acceptance: when the production builder is called with
+    /// rich inputs (explicit-spec request, a real
+    /// `SemanticFailureReport` with two-vs-one consensus, and a verifier
+    /// history hint), the resulting `SpecAuthorityInput` is **not**
+    /// all-neutral. At least one of the three V3 detectors must light up.
+    #[test]
+    fn sf1_v3_production_input_is_not_all_false() {
+        let request = "The API must return 404 when missing. The body must accept JSON.";
+        let reply = r#"{
+            "failure_kind": "assertion_mismatch",
+            "failure_clusters": [{
+                "observed": "200",
+                "expected": "404",
+                "affected_cases": ["missing item"],
+                "involved_artifacts": ["implementation", "test"]
+            }],
+            "contract_conflict": {
+                "implementation": "returns 404 when missing",
+                "test": "expects 200",
+                "usage_docs": "returns 404 when missing"
+            },
+            "preferred_repair_role": "test",
+            "repair_hypothesis": "stale test assertion",
+            "confidence": 0.9
+        }"#;
+        let report =
+            super::parse_semantic_failure_report_from_reply(reply).expect("sample report parses");
+        let hint = super::super::spec_authority::AgentHistoryHint {
+            verifier_passed_in_loop: true,
+        };
+        let input = super::build_spec_authority_input_for_active_request(
+            Some(request),
+            Some(&report),
+            hint,
+        );
+        // Pre-V3 production hard-coded all three to neutral. V3 must
+        // light at least one detector when real inputs exist; here all
+        // three light up.
+        assert!(
+            input.has_user_request_match,
+            "explicit-spec request must light has_user_request_match"
+        );
+        assert!(
+            input.has_verified_public_interface,
+            "verifier_passed_in_loop=true must light has_verified_public_interface"
+        );
+        assert!(
+            input.consensus.is_some(),
+            "two-vs-one contract_conflict must surface a consensus"
+        );
+    }
+
+    /// SF1 V3 acceptance end-to-end: an explicit-spec user request flows
+    /// all the way through the production builder + `resolve()` and
+    /// elects `SpecAuthority::UserRequest` on the resulting plan.
+    #[test]
+    fn sf1_v3_resolver_elects_user_request_when_match_detected() {
+        let request = "The API must return 404 when missing. The body must accept JSON.";
+        let reply = r#"{
+            "failure_kind": "assertion_mismatch",
+            "failure_clusters": [{
+                "observed": "200",
+                "expected": "404",
+                "affected_cases": ["missing item"],
+                "involved_artifacts": ["implementation", "test"]
+            }],
+            "contract_conflict": {
+                "implementation": "returns 200",
+                "test": "expects 404",
+                "usage_docs": "returns 404"
+            },
+            "preferred_repair_role": "implementation",
+            "repair_hypothesis": "impl returns the wrong status",
+            "confidence": 0.85
+        }"#;
+        let report =
+            super::parse_semantic_failure_report_from_reply(reply).expect("sample report parses");
+        let input = super::build_spec_authority_input_for_active_request(
+            Some(request),
+            Some(&report),
+            super::super::spec_authority::AgentHistoryHint::default(),
+        );
+        let plan = super::build_semantic_repair_plan_from_report_with_authority_input(
+            report.clone(),
+            input,
+        )
+        .expect("plan must build for assertion_mismatch");
+        assert_eq!(
+            plan.spec_authority,
+            super::super::spec_authority::SpecAuthority::UserRequest,
+            "an explicit-spec user request must dominate downstream authority resolution"
+        );
     }
 
     /// Phase D / D.3 (S1-010): `DependencyMissing` dispatches to the

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -14732,6 +14732,34 @@ fn validate_verifier_repair_intents(
             result.updated_contents
         };
     }
+    // Issue #647 (MF3 / codex final review): SemanticRepairPlan gate for test
+    // edits. Test files (`is_test_file`) may only be edited when the
+    // RepairJob carries a `SemanticRepairPlan` with both a determined
+    // `spec_authority` (enum closed set, never None) and a non-empty
+    // `repair_hypothesis`. Issue 受入条件: "test edit is allowed only when
+    // SpecAuthority and RepairHypothesis exist" / "test edit must preserve
+    // verification intent". This pre-gate runs before the weakening detector
+    // so that semantic_plan = None always rejects regardless of whether the
+    // edit text itself appears benign. Impl edits remain unaffected (impl
+    // repair has wider latitude — only test edits are gated here).
+    let relative_path_classified = Path::new(&relative_path);
+    if is_test_file(relative_path_classified) {
+        let plan = context.semantic_plan.as_ref().ok_or_else(|| {
+            CheapCheckOutcome::Failed(
+                "repair intent rejected: test edit requires SemanticRepairPlan \
+                 (spec_authority + repair_hypothesis); none was constructed"
+                    .to_string(),
+            )
+        })?;
+        if plan.repair_hypothesis.trim().is_empty() {
+            return Err(CheapCheckOutcome::Failed(
+                "repair intent rejected: test edit requires a non-empty \
+                 repair_hypothesis in the SemanticRepairPlan"
+                    .to_string(),
+            ));
+        }
+    }
+
     // Issue #647 (Phase F / S1-004 / S1-007 / S3-011): apply the deterministic
     // test/impl weakening detectors at the repair editor's admission
     // boundary. `original_contents` is the pre-edit `before` snapshot and
@@ -19712,10 +19740,54 @@ mod progress_tests {
 
     // ---- Issue #647 (Phase F): weakening detector at validate_verifier_repair_intents ---- //
 
+    /// Issue #647 (MF3): build a valid `SemanticRepairPlan` for test-path
+    /// fixtures. Existing weakening tests target test files, which now go
+    /// through the MF3 admission gate before the weakening detector — so the
+    /// fixture must carry a non-empty `repair_hypothesis` and a determined
+    /// `SpecAuthority` for those tests to keep exercising the weakening
+    /// detector path.
+    fn semantic_plan_for_test_fixture() -> super::super::repair_job::SemanticRepairPlan {
+        use super::super::semantic_failure::build_failure_cluster_from_observation;
+        let cluster = build_failure_cluster_from_observation(
+            "obs",
+            "exp",
+            "shape",
+            "AssertEq",
+            &[super::super::task_contract::ArtifactRole::Test],
+        );
+        let cluster_id = cluster.cluster_key.clone();
+        let report = super::super::semantic_failure::SemanticFailureReport {
+            failure_kind: super::super::VerifierDiagnosticFailureKind::AssertionMismatch,
+            failure_clusters: vec![cluster],
+            contract_conflict: super::super::semantic_failure::ContractConflict {
+                implementation: String::new(),
+                test: String::new(),
+                usage_docs: String::new(),
+            },
+            preferred_repair_role: super::super::task_contract::ArtifactRole::Test,
+            repair_hypothesis: "test fixture hypothesis".to_string(),
+            confidence: 0.8,
+        };
+        super::super::repair_job::SemanticRepairPlan {
+            semantic_report: report,
+            failure_cluster_id: cluster_id,
+            semantic_cause: super::super::VerifierDiagnosticFailureKind::AssertionMismatch,
+            spec_authority: super::super::spec_authority::SpecAuthority::UserRequest,
+            preferred_repair_role: super::super::task_contract::ArtifactRole::Test,
+            repair_hypothesis: "test fixture hypothesis".to_string(),
+            expected_improvement: None,
+        }
+    }
+
     /// Helper: build a test-targeting `RepairJob` whose `target_hint` /
     /// `assessment.repair_target_hint` point at a test-file path (so
     /// `verifier_repair_path_input_is_safe` accepts it and the hint role is
     /// coherent with the test path that `is_test_file` will classify).
+    ///
+    /// Issue #647 (MF3): the fixture attaches a valid `SemanticRepairPlan`
+    /// by default so weakening tests continue to reach the weakening
+    /// detector (the MF3 admission gate rejects test edits whose RepairJob
+    /// has no semantic plan, before the weakening detector ever runs).
     fn verifier_test_context_for(path: &str) -> super::super::repair_job::RepairJob {
         let hint = super::super::task_contract::RecoveryTargetHint {
             role: super::super::task_contract::ArtifactRole::Test,
@@ -19744,6 +19816,7 @@ mod progress_tests {
             failure_signature: format!("{path} AssertionError"),
             failure_count: Some(1),
             repair_attempt: 1,
+            semantic_plan: Some(semantic_plan_for_test_fixture()),
             ..super::super::repair_job::RepairJob::new_for_test()
         }
     }
@@ -20154,6 +20227,181 @@ mod progress_tests {
         )
         .unwrap_err();
         assert!(err.contains("AssertionDeleted"), "got: {err}");
+    }
+
+    // ---- Issue #647 (MF3): SemanticRepairPlan gate for test edits ---- //
+
+    /// MF3-test-edit-without-plan: a benign (non-weakening) edit on a test
+    /// file must be rejected by `validate_verifier_repair_intents` when the
+    /// RepairJob carries `semantic_plan = None`. Without a SemanticRepairPlan
+    /// the agent cannot identify SpecAuthority / RepairHypothesis, so test
+    /// edits are categorically refused (Issue 受入条件: "test edit は
+    /// SpecAuthority と RepairHypothesis がある場合のみ許可").
+    #[test]
+    fn mf3_test_edit_without_semantic_plan_is_rejected() {
+        let temp = tempdir().unwrap();
+        let work_root = temp.path();
+        std::fs::create_dir_all(work_root.join("tests")).unwrap();
+        let original = "def test_x():\n    assert foo() == 1\n    assert bar() == 2\n";
+        std::fs::write(work_root.join("tests/test_main.py"), original).unwrap();
+        // Start from the (now plan-bearing) test fixture and clear the
+        // semantic_plan slot — this mirrors the pre-MF1 legacy null case.
+        let mut context = verifier_test_context_for("tests/test_main.py");
+        context.semantic_plan = None;
+        let target = context
+            .assessment
+            .as_ref()
+            .unwrap()
+            .repair_target_hint
+            .as_ref()
+            .unwrap()
+            .clone();
+        // Benign edit: append a new assertion (NOT a weakening). With no
+        // semantic plan, the MF3 admission gate must still reject.
+        let intent = VerifierRepairIntent {
+            path: "tests/test_main.py".to_string(),
+            old_string: "    assert bar() == 2\n".to_string(),
+            new_string: "    assert bar() == 2\n    assert baz() == 3\n".to_string(),
+            reason: "add coverage".to_string(),
+            replace_all: false,
+        };
+        let err =
+            validate_verifier_repair_intent(work_root, &context, &target, intent).unwrap_err();
+        assert!(
+            err.contains("SemanticRepairPlan"),
+            "expected MF3 rejection for missing semantic plan, got: {err}"
+        );
+        // The on-disk file must remain untouched.
+        assert_eq!(
+            std::fs::read_to_string(work_root.join("tests/test_main.py")).unwrap(),
+            original
+        );
+    }
+
+    /// MF3-test-edit-without-hypothesis: a SemanticRepairPlan is present but
+    /// its `repair_hypothesis` is empty (whitespace only). The MF3 gate must
+    /// reject because "test edit must preserve verification intent", which
+    /// requires an articulated hypothesis.
+    #[test]
+    fn mf3_test_edit_with_empty_hypothesis_is_rejected() {
+        let temp = tempdir().unwrap();
+        let work_root = temp.path();
+        std::fs::create_dir_all(work_root.join("tests")).unwrap();
+        let original = "def test_x():\n    assert foo() == 1\n    assert bar() == 2\n";
+        std::fs::write(work_root.join("tests/test_main.py"), original).unwrap();
+        let mut context = verifier_test_context_for("tests/test_main.py");
+        // Replace the fixture plan with one whose repair_hypothesis is empty.
+        let mut empty_hyp_plan = semantic_plan_for_test_fixture();
+        empty_hyp_plan.repair_hypothesis = "   ".to_string();
+        context.semantic_plan = Some(empty_hyp_plan);
+        let target = context
+            .assessment
+            .as_ref()
+            .unwrap()
+            .repair_target_hint
+            .as_ref()
+            .unwrap()
+            .clone();
+        let intent = VerifierRepairIntent {
+            path: "tests/test_main.py".to_string(),
+            old_string: "    assert bar() == 2\n".to_string(),
+            new_string: "    assert bar() == 2\n    assert baz() == 3\n".to_string(),
+            reason: "add coverage".to_string(),
+            replace_all: false,
+        };
+        let err =
+            validate_verifier_repair_intent(work_root, &context, &target, intent).unwrap_err();
+        assert!(
+            err.contains("repair_hypothesis"),
+            "expected MF3 rejection for empty hypothesis, got: {err}"
+        );
+    }
+
+    /// MF3-impl-edit-allowed-without-plan: the MF3 admission gate must NOT
+    /// fire on implementation paths. Impl repair has wider latitude (it can
+    /// reason from compile errors, runtime traces, etc.) and is gated only
+    /// by the weakening detector. A benign impl edit with `semantic_plan
+    /// = None` must therefore still pass admission.
+    #[test]
+    fn mf3_impl_edit_without_semantic_plan_is_accepted() {
+        let temp = tempdir().unwrap();
+        let work_root = temp.path();
+        std::fs::create_dir_all(work_root.join("app")).unwrap();
+        let original = "def run():\n    value = 1\n    return value\n";
+        std::fs::write(work_root.join("app/main.py"), original).unwrap();
+        let mut context = verifier_context_for("app/main.py");
+        // Explicitly assert the pre-condition: impl fixture has no plan.
+        assert!(context.semantic_plan.is_none());
+        // Belt-and-suspenders: drop any incidental plan a future refactor
+        // might attach to the impl fixture.
+        context.semantic_plan = None;
+        let target = context
+            .assessment
+            .as_ref()
+            .unwrap()
+            .repair_target_hint
+            .as_ref()
+            .unwrap()
+            .clone();
+        let intent = VerifierRepairIntent {
+            path: "app/main.py".to_string(),
+            old_string: "    value = 1\n    return value\n".to_string(),
+            new_string: "    value = 2\n    return value\n".to_string(),
+            reason: "fix constant".to_string(),
+            replace_all: false,
+        };
+        let edit = validate_verifier_repair_intent(work_root, &context, &target, intent)
+            .expect("impl edit must pass without a semantic plan");
+        assert!(edit.updated_contents.contains("value = 2"));
+    }
+
+    /// MF3-test-edit-with-full-plan: a test edit must pass admission when
+    /// the RepairJob carries a SemanticRepairPlan with a determined
+    /// `SpecAuthority::UserRequest` and a non-empty `repair_hypothesis`, and
+    /// the edit itself does not trigger the weakening detector. This is the
+    /// positive path the MF3 gate guards — it must not over-reject benign
+    /// test additions that strengthen verification intent.
+    #[test]
+    fn mf3_test_edit_with_full_semantic_plan_is_accepted() {
+        let temp = tempdir().unwrap();
+        let work_root = temp.path();
+        std::fs::create_dir_all(work_root.join("tests")).unwrap();
+        // The repair adds a brand-new test function — strictly strengthens,
+        // and weakening detectors stay silent because pre-existing asserts /
+        // non-asserts are untouched.
+        let original = "def test_x():\n    assert foo() == 1\n";
+        std::fs::write(work_root.join("tests/test_main.py"), original).unwrap();
+        let context = verifier_test_context_for("tests/test_main.py");
+        // Pre-condition: the fixture attaches a full plan (MF3 admission
+        // input). Spot-check the SpecAuthority / repair_hypothesis fields
+        // since they are the gate's explicit inputs.
+        let plan = context.semantic_plan.as_ref().expect("fixture has plan");
+        assert_eq!(
+            plan.spec_authority,
+            super::super::spec_authority::SpecAuthority::UserRequest
+        );
+        assert!(!plan.repair_hypothesis.trim().is_empty());
+        let target = context
+            .assessment
+            .as_ref()
+            .unwrap()
+            .repair_target_hint
+            .as_ref()
+            .unwrap()
+            .clone();
+        let intent = VerifierRepairIntent {
+            path: "tests/test_main.py".to_string(),
+            old_string: "def test_x():\n    assert foo() == 1\n".to_string(),
+            new_string:
+                "def test_x():\n    assert foo() == 1\n\ndef test_y():\n    assert bar() == 2\n"
+                    .to_string(),
+            reason: "add new test case".to_string(),
+            replace_all: false,
+        };
+        let edit = validate_verifier_repair_intent(work_root, &context, &target, intent)
+            .expect("test edit with full plan and no weakening must pass");
+        assert!(edit.updated_contents.contains("def test_y()"));
+        assert!(edit.updated_contents.contains("assert bar() == 2"));
     }
 
     #[test]

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -9413,7 +9413,26 @@ impl Agent {
             // SemanticRepairPlan slot. `None` is the legacy-compatible
             // value when semantic parse failed or dispatch routed to
             // setup repair (D.3).
-            current.semantic_plan = semantic_plan;
+            //
+            // Issue #647 (MF2 V3.1): route the assignment through the
+            // exhausted-aware helper so re-diagnostic cannot revive a
+            // cluster that the previous turn already pushed onto
+            // `exhausted_attempts`. Without this, every fresh diagnostic
+            // would blindly overwrite the slot with whatever cluster the
+            // LLM picked first — discarding the dispatch helper's progress
+            // (`apply_semantic_repair_dispatch_after_rerun` in
+            // `drive_task_contract_verifier`) and forcing the same doomed
+            // cluster to be re-attacked. The new helper skips ahead to the
+            // next unexhausted cluster of the embedded report (or clears
+            // the slot for legacy fallback when none remain).
+            let new_report = semantic_plan
+                .as_ref()
+                .map(|plan| plan.semantic_report.clone());
+            super::repair_job::assign_semantic_plan_preserving_exhausted(
+                current,
+                semantic_plan,
+                new_report.as_ref(),
+            );
         }
         log_llm_event(
             "agent.verifier_diagnostic.completed",

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -16349,6 +16349,31 @@ pub(super) fn verifier_repair_context_target_path(
 pub(super) fn verifier_repair_effective_target_hint(
     context: &super::repair_job::RepairJob,
 ) -> Option<&super::task_contract::RecoveryTargetHint> {
+    // Issue #647 (CB-007): when a `SemanticRepairPlan` is active and the
+    // job has already exhausted at least one prior cluster, the freshly
+    // re-built `assessment.repair_target_hint` can be stale — the
+    // re-diagnostic LLM commonly re-proposes the just-exhausted cluster
+    // because the same failure text is still visible. `assign_semantic_plan_preserving_exhausted`
+    // walks the new plan past the exhausted entry, but nothing rebuilds
+    // the assessment hint to follow that walk. Returning the stale hint
+    // would make the repair editor keep attacking the exhausted cluster.
+    //
+    // We deliberately do NOT try to map `assessment.repair_target_hint.path`
+    // to a `FailureClusterKey` (no such mapping is recorded by the parser),
+    // and we keep the legacy `semantic_plan = None` path bit-for-bit
+    // identical so SetupRepair / pre-semantic flows are unaffected
+    // (DR3-001 / "semantic_plan = None 経路は既存挙動" constraint).
+    //
+    // The conservative rule:
+    //   semantic_plan = Some AND exhausted_attempts non-empty
+    //     → return None (force re-diagnostic against the current cluster).
+    //   semantic_plan = Some AND exhausted_attempts empty
+    //     → plan is fresh, legacy behaviour stands.
+    //   semantic_plan = None
+    //     → legacy behaviour (unchanged).
+    if context.semantic_plan.is_some() && !context.exhausted_attempts.is_empty() {
+        return None;
+    }
     if let Some(assessment) = context.assessment.as_ref() {
         if let Some(next) = assessment
             .repair_plan
@@ -22424,6 +22449,242 @@ E   assert [{'id': 1}] == []\n";
             verifier_repair_decision(true, Some(&context), &[], &work_root, Some(2), 3),
             VerifierRepairDecision::ReadyToVerify
         );
+    }
+
+    // ---- Issue #647 (CB-007): selected_target must follow semantic_plan ---- //
+    //
+    // Background: `verifier_repair_effective_target_hint` historically read
+    // `assessment.repair_plan` / `assessment.repair_target_hint` only, and
+    // ignored the active `semantic_plan`. After Phase E slot reuse pushes a
+    // cluster into `exhausted_attempts` and advances the plan to a new
+    // cluster, a re-diagnostic LLM call can re-propose the exhausted cluster
+    // (it sees the same failure text). `assign_semantic_plan_preserving_exhausted`
+    // walks the new plan past the exhausted entry, but the freshly built
+    // `assessment.repair_target_hint` still points at the old cluster's path.
+    // Without CB-007's guard, the repair editor keeps attacking the exhausted
+    // cluster (CB-007).
+    //
+    // CB-007 fix: when `semantic_plan` is `Some` and the job has already
+    // exhausted at least one prior cluster, the legacy assessment hint is
+    // potentially stale (the diagnostic that produced it cannot be linked
+    // back to a specific cluster id). The conservative behaviour is to
+    // return `None` so the controller forces a re-diagnostic pass instead
+    // of reusing the stale hint. Tests below pin both branches.
+
+    /// CB-007.2 — selected_target follows semantic_plan advancement.
+    ///
+    /// Scenario: cluster A repair attempt failed, was pushed onto
+    /// `exhausted_attempts`, and `semantic_plan` was advanced to cluster B.
+    /// The freshly re-built `assessment.repair_target_hint` still references
+    /// cluster A's path. `verifier_repair_effective_target_hint` MUST NOT
+    /// return that stale hint — it MUST return `None` so the controller
+    /// re-runs diagnostic against the new cluster instead of attacking the
+    /// exhausted one again.
+    #[test]
+    fn cb007_selected_target_follows_semantic_plan_advancement() {
+        use super::super::repair_job::{RepairJob, SemanticRepairPlan};
+        use super::super::semantic_failure::{
+            ContractConflict, SemanticFailureReport, build_failure_cluster_from_observation,
+        };
+        use super::super::spec_authority::SpecAuthority;
+
+        // Build a 2-cluster report (A then B) with the same preferred role.
+        let cluster_a = build_failure_cluster_from_observation(
+            "200 OK",
+            "201 Created",
+            "POST /todos",
+            "AssertEq",
+            &[super::super::task_contract::ArtifactRole::Implementation],
+        );
+        let cluster_b = build_failure_cluster_from_observation(
+            "missing field",
+            "field present",
+            "GET /todos",
+            "AssertContains",
+            &[super::super::task_contract::ArtifactRole::Implementation],
+        );
+        let cluster_a_id = cluster_a.cluster_key.clone();
+        let cluster_b_id = cluster_b.cluster_key.clone();
+        assert_ne!(
+            cluster_a_id, cluster_b_id,
+            "fixture sanity: distinct cluster ids"
+        );
+
+        let report = SemanticFailureReport {
+            failure_kind: super::super::VerifierDiagnosticFailureKind::AssertionMismatch,
+            failure_clusters: vec![cluster_a, cluster_b],
+            contract_conflict: ContractConflict {
+                implementation: "returns 200".to_string(),
+                test: "expects 201".to_string(),
+                usage_docs: String::new(),
+            },
+            preferred_repair_role: super::super::task_contract::ArtifactRole::Implementation,
+            repair_hypothesis: "impl mismatch".to_string(),
+            confidence: 0.9,
+        };
+
+        // semantic_plan now targets cluster B (after advance_to_next_cluster).
+        let plan_b = SemanticRepairPlan {
+            semantic_cause: super::super::VerifierDiagnosticFailureKind::AssertionMismatch,
+            spec_authority: SpecAuthority::ImplementationContract,
+            preferred_repair_role: super::super::task_contract::ArtifactRole::Implementation,
+            repair_hypothesis: "impl mismatch".to_string(),
+            failure_cluster_id: cluster_b_id.clone(),
+            expected_improvement: None,
+            semantic_report: report,
+        };
+
+        // Stale assessment from the re-diagnostic re-points at cluster A's path.
+        let stale_hint_a = super::super::task_contract::RecoveryTargetHint {
+            role: super::super::task_contract::ArtifactRole::Implementation,
+            path: "app/todos.py".to_string(),
+            reason: "re-diagnostic re-proposed cluster A".to_string(),
+        };
+        let job = RepairJob {
+            assessment: Some(super::super::VerifierRepairAssessment {
+                failure_kind: super::super::VerifierDiagnosticFailureKind::AssertionMismatch,
+                failure_type: super::super::VerifierFailureType::AssertionFailure,
+                probable_cause_role: Some(
+                    super::super::task_contract::ArtifactRole::Implementation,
+                ),
+                needed_reads: vec![stale_hint_a.clone()],
+                repair_target_hint: Some(stale_hint_a.clone()),
+                repair_plan: vec![stale_hint_a.clone()],
+                summary: Some("re-diagnostic".to_string()),
+                source: super::super::VerifierRepairAssessmentSource::DiagnosticPass,
+            }),
+            semantic_plan: Some(plan_b),
+            // ledger holds the previously attacked (cluster_a, Implementation):
+            exhausted_attempts: vec![(
+                cluster_a_id.clone(),
+                super::super::spec_authority::RepairRole::Implementation,
+            )],
+            ..RepairJob::new_for_test()
+        };
+
+        // CB-007: the stale assessment hint must NOT be surfaced when the
+        // semantic_plan has advanced past an exhausted cluster — the
+        // function must return None so the controller forces re-diagnostic.
+        assert!(
+            verifier_repair_effective_target_hint(&job).is_none(),
+            "CB-007: stale assessment.repair_target_hint (cluster A path) must \
+             not be returned after semantic_plan advanced to cluster B; \
+             expected None (force re-diagnostic), got Some",
+        );
+    }
+
+    /// CB-007.2 — regression guard: when `semantic_plan` is `Some` and no
+    /// cluster has been exhausted yet (the plan is freshly built and matches
+    /// the assessment), the function MUST keep returning the assessment hint
+    /// unchanged. This pins the "matching cluster" branch so the CB-007 guard
+    /// does not over-fire.
+    #[test]
+    fn cb007_selected_target_uses_assessment_when_cluster_matches() {
+        use super::super::repair_job::{RepairJob, SemanticRepairPlan};
+        use super::super::semantic_failure::{
+            ContractConflict, SemanticFailureReport, build_failure_cluster_from_observation,
+        };
+        use super::super::spec_authority::SpecAuthority;
+
+        let cluster_a = build_failure_cluster_from_observation(
+            "200 OK",
+            "201 Created",
+            "POST /todos",
+            "AssertEq",
+            &[super::super::task_contract::ArtifactRole::Implementation],
+        );
+        let cluster_a_id = cluster_a.cluster_key.clone();
+        let report = SemanticFailureReport {
+            failure_kind: super::super::VerifierDiagnosticFailureKind::AssertionMismatch,
+            failure_clusters: vec![cluster_a],
+            contract_conflict: ContractConflict {
+                implementation: "returns 200".to_string(),
+                test: "expects 201".to_string(),
+                usage_docs: String::new(),
+            },
+            preferred_repair_role: super::super::task_contract::ArtifactRole::Implementation,
+            repair_hypothesis: "impl mismatch".to_string(),
+            confidence: 0.9,
+        };
+        let plan_a = SemanticRepairPlan {
+            semantic_cause: super::super::VerifierDiagnosticFailureKind::AssertionMismatch,
+            spec_authority: SpecAuthority::ImplementationContract,
+            preferred_repair_role: super::super::task_contract::ArtifactRole::Implementation,
+            repair_hypothesis: "impl mismatch".to_string(),
+            failure_cluster_id: cluster_a_id,
+            expected_improvement: None,
+            semantic_report: report,
+        };
+
+        let hint_a = super::super::task_contract::RecoveryTargetHint {
+            role: super::super::task_contract::ArtifactRole::Implementation,
+            path: "app/todos.py".to_string(),
+            reason: "first diagnostic".to_string(),
+        };
+        let job = RepairJob {
+            assessment: Some(super::super::VerifierRepairAssessment {
+                failure_kind: super::super::VerifierDiagnosticFailureKind::AssertionMismatch,
+                failure_type: super::super::VerifierFailureType::AssertionFailure,
+                probable_cause_role: Some(
+                    super::super::task_contract::ArtifactRole::Implementation,
+                ),
+                needed_reads: vec![hint_a.clone()],
+                repair_target_hint: Some(hint_a.clone()),
+                repair_plan: vec![hint_a.clone()],
+                summary: Some("first diagnostic".to_string()),
+                source: super::super::VerifierRepairAssessmentSource::DiagnosticPass,
+            }),
+            semantic_plan: Some(plan_a),
+            // exhausted_attempts is empty: plan is fresh, no advancement yet.
+            exhausted_attempts: Vec::new(),
+            ..RepairJob::new_for_test()
+        };
+
+        // semantic_plan matches the assessment (no cluster has been exhausted
+        // yet) → assessment hint is returned unchanged.
+        let returned = verifier_repair_effective_target_hint(&job)
+            .expect("matching-cluster branch must return the assessment hint");
+        assert_eq!(returned.path, "app/todos.py");
+        assert_eq!(
+            returned.role,
+            super::super::task_contract::ArtifactRole::Implementation
+        );
+    }
+
+    /// CB-007.3 — legacy regression guard: `semantic_plan = None` callers
+    /// must keep the pre-CB-007 behaviour (return assessment.repair_target_hint
+    /// regardless of `exhausted_attempts`). This guards against the new branch
+    /// accidentally firing on the legacy / SetupRepair code paths.
+    #[test]
+    fn cb007_selected_target_legacy_path_unchanged_when_semantic_plan_none() {
+        use super::super::repair_job::RepairJob;
+
+        let hint = super::super::task_contract::RecoveryTargetHint {
+            role: super::super::task_contract::ArtifactRole::Implementation,
+            path: "app/main.py".to_string(),
+            reason: "legacy".to_string(),
+        };
+        let job = RepairJob {
+            assessment: Some(super::super::VerifierRepairAssessment {
+                failure_kind: super::super::VerifierDiagnosticFailureKind::RuntimeError,
+                failure_type: super::super::VerifierFailureType::RuntimeError,
+                probable_cause_role: Some(
+                    super::super::task_contract::ArtifactRole::Implementation,
+                ),
+                needed_reads: vec![hint.clone()],
+                repair_target_hint: Some(hint.clone()),
+                repair_plan: vec![hint.clone()],
+                summary: Some("legacy assessment".to_string()),
+                source: super::super::VerifierRepairAssessmentSource::DiagnosticPass,
+            }),
+            semantic_plan: None,
+            exhausted_attempts: Vec::new(),
+            ..RepairJob::new_for_test()
+        };
+
+        let returned = verifier_repair_effective_target_hint(&job)
+            .expect("legacy path must still return assessment hint when semantic_plan is None");
+        assert_eq!(returned.path, "app/main.py");
     }
 
     #[test]

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -9292,8 +9292,27 @@ impl Agent {
                 attempt_spec.role,
             );
         };
-        let assessment =
-            model_assessment_to_verifier_repair_assessment(&self.work_root, &context, parsed);
+        // Issue #647 (§5.1 SSOT plumbing): build the path-local admission
+        // context from the agent's current scope + edit signals so every
+        // hint promoted by `model_assessment_to_verifier_repair_assessment`
+        // (and its sibling helpers) routes through `admit_repair_target_hint`
+        // for the *hint's own path*, not a turn-global signal.
+        let scope = self.current_workspace_scope();
+        let turn_edited = self.turn_edited_relative_paths.clone();
+        let edited_predicate = |path: &str| turn_edited.contains(path);
+        let scaffold_predicate = |path: &str| self.repo_edit_has_post_scaffold_delta(path);
+        let admission = RepairTargetAdmissionContext {
+            work_root: &self.work_root,
+            scope: &scope,
+            edited_this_session_for: &edited_predicate,
+            scaffold_changed_for: &scaffold_predicate,
+        };
+        let assessment = model_assessment_to_verifier_repair_assessment(
+            &self.work_root,
+            &context,
+            parsed,
+            &admission,
+        );
         let has_target = assessment.repair_target_hint.is_some();
         if !has_target {
             return self.handle_verifier_diagnostic_failure(
@@ -15177,18 +15196,95 @@ fn recovery_target_hint_for_existing_path(
     })
 }
 
+/// Issue #647 (Phase C, §4.4 / §5.1): Owned admission context for every
+/// `RecoveryTargetHint` promotion path. Path-local predicates (DR3-001) so
+/// the SSOT gate evaluates `turn_edited_relative_paths.contains(path)` /
+/// `repo_edit_has_post_scaffold_delta(path)` for *the hint's own path*, not
+/// a turn-global signal that would falsely promote unrelated files.
+///
+/// `verifier_passed_in_scope` is omitted from the context per DR1-006:
+/// every callsite in this Issue is "trying to repair a hint" — by
+/// construction the verifier has not yet passed for the active scope, so
+/// `admit_repair_target_hint` fixes that flag to `false` literally. When a
+/// future Issue introduces post-success repair paths the field can be
+/// re-introduced on this struct without touching the SSOT function shape.
+pub(super) struct RepairTargetAdmissionContext<'a> {
+    pub(super) work_root: &'a Path,
+    pub(super) scope: &'a super::task_workspace_scope::TaskWorkspaceScope,
+    pub(super) edited_this_session_for: &'a dyn Fn(&str) -> bool,
+    pub(super) scaffold_changed_for: &'a dyn Fn(&str) -> bool,
+}
+
+#[cfg(test)]
+fn admission_always_true(_: &str) -> bool {
+    true
+}
+
+#[cfg(test)]
+fn admission_always_false(_: &str) -> bool {
+    false
+}
+
+impl<'a> RepairTargetAdmissionContext<'a> {
+    /// Test-only helper: build an admission context whose predicates always
+    /// promote the hint to `Owned` (edited_this_session=true). Lets fixtures
+    /// keep their existing repair-target assertions while still routing
+    /// through the SSOT gate (S7-004 / DR2-001).
+    #[cfg(test)]
+    pub(super) fn owned_for_test(
+        work_root: &'a Path,
+        scope: &'a super::task_workspace_scope::TaskWorkspaceScope,
+    ) -> Self {
+        Self {
+            work_root,
+            scope,
+            edited_this_session_for: &admission_always_true,
+            scaffold_changed_for: &admission_always_false,
+        }
+    }
+}
+
+/// Issue #647 (Phase C, §5.1 SSOT): Owned admission gate for any
+/// `RecoveryTargetHint` heading downstream into the repair-job pipeline.
+/// Every hint-promotion source category (6 categories in §5.1) routes
+/// through this single function so the `OwnershipInputs` invariants stay
+/// consistent (path-local predicates evaluated against `hint.path`,
+/// `verifier_passed_in_scope` fixed to `false` per DR1-006).
+pub(super) fn admit_repair_target_hint(
+    hint: super::task_contract::RecoveryTargetHint,
+    ctx: &RepairTargetAdmissionContext<'_>,
+) -> Option<super::task_contract::RecoveryTargetHint> {
+    let path = hint.path.clone();
+    let inputs = super::artifact_ownership::OwnershipInputs {
+        work_root: ctx.work_root,
+        relative_path: &path,
+        scope: ctx.scope,
+        edited_this_session: (ctx.edited_this_session_for)(&path),
+        scaffold_changed: (ctx.scaffold_changed_for)(&path),
+        verifier_passed_in_scope: false,
+    };
+    match super::artifact_ownership::classify_ownership(inputs) {
+        super::artifact_ownership::ArtifactOwnership::Owned => Some(hint),
+        super::artifact_ownership::ArtifactOwnership::CandidateOnly
+        | super::artifact_ownership::ArtifactOwnership::OutOfScope => None,
+    }
+}
+
 fn recovery_target_hint_for_diagnostic_path(
     work_root: &Path,
     raw_path: &str,
     reason: &str,
     failure_kind: super::VerifierDiagnosticFailureKind,
+    admission: &RepairTargetAdmissionContext<'_>,
 ) -> Option<super::task_contract::RecoveryTargetHint> {
     let hint = recovery_target_hint_for_existing_path(work_root, raw_path, reason)?;
     if hint.role == super::task_contract::ArtifactRole::Setup && !failure_kind.allows_setup_target()
     {
         return None;
     }
-    Some(hint)
+    // Issue #647 (§5.1 stage 2): Owned admission gate at the function exit.
+    // Path 1 of the 6 source categories: diagnostic LLM-proposed paths.
+    admit_repair_target_hint(hint, admission)
 }
 
 fn diagnostic_target_allowed_by_confidence(
@@ -15227,6 +15323,7 @@ fn verifier_repair_preferred_local_import_source(
     // after the parser scope reduction in Task 1.2). Production callers MUST pass
     // `verifier_failure_type_for_diagnostic_kind(failure_kind, context.failure_type)`.
     derived_failure_type: super::VerifierFailureType,
+    admission: &RepairTargetAdmissionContext<'_>,
 ) -> Option<super::task_contract::RecoveryTargetHint> {
     if derived_failure_type != super::VerifierFailureType::ImportOrDependency {
         return None;
@@ -15241,14 +15338,17 @@ fn verifier_repair_preferred_local_import_source(
         return None;
     }
     let hint = context.target_hint.as_ref()?;
-    if hint.role == super::task_contract::ArtifactRole::Implementation {
+    let promoted = if hint.role == super::task_contract::ArtifactRole::Implementation {
         Some(super::task_contract::RecoveryTargetHint {
             reason: "local import contract mismatch names this provider/source file".to_string(),
             ..hint.clone()
         })
     } else {
         None
-    }
+    }?;
+    // Issue #647 (§5.1 stage 2): Owned admission gate. Path 4 of the
+    // 6 source categories: local-import-contract-derived hints.
+    admit_repair_target_hint(promoted, admission)
 }
 
 fn verifier_repair_stale_assertion_test_target(
@@ -15259,6 +15359,7 @@ fn verifier_repair_stale_assertion_test_target(
     // after the parser scope reduction in Task 1.2). Production callers MUST pass
     // `verifier_failure_type_for_diagnostic_kind(failure_kind, context.failure_type)`.
     derived_failure_type: super::VerifierFailureType,
+    admission: &RepairTargetAdmissionContext<'_>,
 ) -> Option<super::task_contract::RecoveryTargetHint> {
     if derived_failure_type != super::VerifierFailureType::AssertionFailure {
         return None;
@@ -15287,16 +15388,20 @@ fn verifier_repair_stale_assertion_test_target(
     {
         return None;
     }
-    Some(super::task_contract::RecoveryTargetHint {
+    let promoted = super::task_contract::RecoveryTargetHint {
         reason: "same assertion failure remained after a non-test repair; inspect generated test setup or expectations".to_string(),
         ..failure_target.clone()
-    })
+    };
+    // Issue #647 (§5.1 stage 2): Owned admission gate. Path 5 of the
+    // 6 source categories: stale-assertion test re-target.
+    admit_repair_target_hint(promoted, admission)
 }
 
 fn model_assessment_to_verifier_repair_assessment(
     work_root: &Path,
     context: &super::repair_job::RepairJob,
     parsed: ParsedVerifierRepairAssessment,
+    admission: &RepairTargetAdmissionContext<'_>,
 ) -> super::VerifierRepairAssessment {
     let failure_kind = parsed.failure_kind;
     let failure_type =
@@ -15310,6 +15415,7 @@ fn model_assessment_to_verifier_repair_assessment(
                 &target.path,
                 &target.reason,
                 failure_kind,
+                admission,
             )
             .filter(|hint| {
                 diagnostic_target_allowed_by_confidence(
@@ -15332,6 +15438,7 @@ fn model_assessment_to_verifier_repair_assessment(
                 &target.path,
                 &target.reason,
                 failure_kind,
+                admission,
             )
             .filter(|hint| {
                 diagnostic_target_allowed_by_confidence(
@@ -15354,14 +15461,16 @@ fn model_assessment_to_verifier_repair_assessment(
     // Issue #638 (設計判断 #3): pass assessment-derived failure_type to helpers so
     // they gate on the diagnostic classification, not on context.failure_type
     // (which is Unknown after the parser scope reduction).
-    if let Some(preferred) = verifier_repair_preferred_local_import_source(context, failure_type) {
+    if let Some(preferred) =
+        verifier_repair_preferred_local_import_source(context, failure_type, admission)
+    {
         repair_plan.retain(|hint| hint.path != preferred.path);
         repair_plan.insert(0, preferred);
         repair_plan.truncate(3);
     }
     let selected_path = repair_plan.first().map(|hint| hint.path.as_str());
     if let Some(test_target) =
-        verifier_repair_stale_assertion_test_target(context, selected_path, failure_type)
+        verifier_repair_stale_assertion_test_target(context, selected_path, failure_type, admission)
     {
         repair_plan.retain(|hint| hint.path != test_target.path);
         repair_plan.insert(0, test_target);
@@ -15377,6 +15486,7 @@ fn model_assessment_to_verifier_repair_assessment(
                 path,
                 "diagnostic LLM suggested this secondary target",
                 failure_kind,
+                admission,
             )
         }))
         .take(3)
@@ -15391,6 +15501,13 @@ fn model_assessment_to_verifier_repair_assessment(
                 .map(|(hint, _)| hint.clone())
         })
         .or_else(|| {
+            // Issue #647 (§5.1): path 6 — `repair_target_hint` fallback from
+            // `probable_cause_role`. The candidates here come from
+            // `context.changed_file_hints` (path 3) and `needed_reads` (which
+            // were themselves already admitted via paths 1/4/5 above). Apply
+            // `admit_repair_target_hint` explicitly so the changed-file-hint
+            // branch is gated by the SSOT even when the inputs were copied
+            // straight off `RepairJob`.
             parsed.probable_cause_role.and_then(|role| {
                 needed_reads
                     .iter()
@@ -15401,6 +15518,7 @@ fn model_assessment_to_verifier_repair_assessment(
                                 || failure_kind.allows_setup_target())
                     })
                     .cloned()
+                    .and_then(|hint| admit_repair_target_hint(hint, admission))
             })
         });
 
@@ -19613,8 +19731,11 @@ E   assert [{'id': 1}] == []\n";
         )
         .expect("diagnostic json should parse");
 
-        let assessment =
-            super::model_assessment_to_verifier_repair_assessment(&work_root, &context, parsed);
+        let scope = super::super::task_workspace_scope::TaskWorkspaceScope::detect(&work_root, "");
+        let admission = super::RepairTargetAdmissionContext::owned_for_test(&work_root, &scope);
+        let assessment = super::model_assessment_to_verifier_repair_assessment(
+            &work_root, &context, parsed, &admission,
+        );
 
         assert_eq!(
             assessment
@@ -19677,8 +19798,11 @@ E   assert [{'id': 1}] == []\n";
         )
         .expect("diagnostic json should parse");
 
-        let assessment =
-            super::model_assessment_to_verifier_repair_assessment(&work_root, &context, parsed);
+        let scope = super::super::task_workspace_scope::TaskWorkspaceScope::detect(&work_root, "");
+        let admission = super::RepairTargetAdmissionContext::owned_for_test(&work_root, &scope);
+        let assessment = super::model_assessment_to_verifier_repair_assessment(
+            &work_root, &context, parsed, &admission,
+        );
 
         assert_eq!(
             assessment
@@ -19772,8 +19896,11 @@ E   assert [{'id': 1}] == []\n";
         )
         .expect("diagnostic json should parse");
 
-        let assessment =
-            super::model_assessment_to_verifier_repair_assessment(&work_root, &context, parsed);
+        let scope = super::super::task_workspace_scope::TaskWorkspaceScope::detect(&work_root, "");
+        let admission = super::RepairTargetAdmissionContext::owned_for_test(&work_root, &scope);
+        let assessment = super::model_assessment_to_verifier_repair_assessment(
+            &work_root, &context, parsed, &admission,
+        );
 
         assert_eq!(
             assessment
@@ -19816,8 +19943,11 @@ E   assert [{'id': 1}] == []\n";
         )
         .expect("diagnostic json should parse");
 
-        let assessment =
-            super::model_assessment_to_verifier_repair_assessment(&work_root, &context, parsed);
+        let scope = super::super::task_workspace_scope::TaskWorkspaceScope::detect(&work_root, "");
+        let admission = super::RepairTargetAdmissionContext::owned_for_test(&work_root, &scope);
+        let assessment = super::model_assessment_to_verifier_repair_assessment(
+            &work_root, &context, parsed, &admission,
+        );
 
         assert_eq!(
             assessment
@@ -19856,8 +19986,11 @@ E   assert [{'id': 1}] == []\n";
         )
         .expect("diagnostic json should parse");
 
-        let assessment =
-            super::model_assessment_to_verifier_repair_assessment(&work_root, &context, parsed);
+        let scope = super::super::task_workspace_scope::TaskWorkspaceScope::detect(&work_root, "");
+        let admission = super::RepairTargetAdmissionContext::owned_for_test(&work_root, &scope);
+        let assessment = super::model_assessment_to_verifier_repair_assessment(
+            &work_root, &context, parsed, &admission,
+        );
 
         assert_eq!(
             assessment
@@ -19901,8 +20034,11 @@ E   assert [{'id': 1}] == []\n";
         )
         .expect("diagnostic json should parse");
 
-        let assessment =
-            super::model_assessment_to_verifier_repair_assessment(&work_root, &context, parsed);
+        let scope = super::super::task_workspace_scope::TaskWorkspaceScope::detect(&work_root, "");
+        let admission = super::RepairTargetAdmissionContext::owned_for_test(&work_root, &scope);
+        let assessment = super::model_assessment_to_verifier_repair_assessment(
+            &work_root, &context, parsed, &admission,
+        );
 
         assert_eq!(
             assessment
@@ -19985,8 +20121,11 @@ E   assert [{'id': 1}] == []\n";
         )
         .expect("diagnostic json should parse");
 
-        let assessment =
-            super::model_assessment_to_verifier_repair_assessment(&work_root, &context, parsed);
+        let scope = super::super::task_workspace_scope::TaskWorkspaceScope::detect(&work_root, "");
+        let admission = super::RepairTargetAdmissionContext::owned_for_test(&work_root, &scope);
+        let assessment = super::model_assessment_to_verifier_repair_assessment(
+            &work_root, &context, parsed, &admission,
+        );
 
         assert!(assessment.repair_target_hint.is_none());
         assert!(assessment.needed_reads.is_empty());
@@ -20014,8 +20153,11 @@ E   assert [{'id': 1}] == []\n";
         )
         .expect("diagnostic json should parse");
 
-        let assessment =
-            super::model_assessment_to_verifier_repair_assessment(&work_root, &context, parsed);
+        let scope = super::super::task_workspace_scope::TaskWorkspaceScope::detect(&work_root, "");
+        let admission = super::RepairTargetAdmissionContext::owned_for_test(&work_root, &scope);
+        let assessment = super::model_assessment_to_verifier_repair_assessment(
+            &work_root, &context, parsed, &admission,
+        );
 
         assert!(assessment.repair_target_hint.is_none());
     }
@@ -21607,8 +21749,11 @@ export default function App() {
             }"#,
         )
         .expect("diagnostic json should parse");
-        let assessment =
-            super::model_assessment_to_verifier_repair_assessment(work_root, &context, parsed);
+        let scope = super::super::task_workspace_scope::TaskWorkspaceScope::detect(work_root, "");
+        let admission = super::RepairTargetAdmissionContext::owned_for_test(work_root, &scope);
+        let assessment = super::model_assessment_to_verifier_repair_assessment(
+            work_root, &context, parsed, &admission,
+        );
 
         // Issue #638 (設計判断 #3): LocalImportContractMismatch → ImportOrDependency,
         // so verifier_repair_preferred_local_import_source fires and promotes
@@ -23553,12 +23698,15 @@ export default function App() {
             repair_attempt: 1,
             ..super::super::repair_job::RepairJob::new_for_test()
         };
+        let scope = super::super::task_workspace_scope::TaskWorkspaceScope::detect(&work_root, "");
+        let admission = super::RepairTargetAdmissionContext::owned_for_test(&work_root, &scope);
 
         // With Unknown (parser-only), the helper must NOT fire.
         assert!(
             verifier_repair_preferred_local_import_source(
                 &context,
-                super::super::VerifierFailureType::Unknown
+                super::super::VerifierFailureType::Unknown,
+                &admission,
             )
             .is_none(),
             "helper must early-return for Unknown derived_failure_type"
@@ -23569,6 +23717,7 @@ export default function App() {
         let preferred = verifier_repair_preferred_local_import_source(
             &context,
             super::super::VerifierFailureType::ImportOrDependency,
+            &admission,
         );
         assert!(
             preferred.is_some(),
@@ -23583,6 +23732,7 @@ export default function App() {
         let preferred2 = verifier_repair_preferred_local_import_source(
             &context,
             super::super::VerifierFailureType::ImportOrDependency,
+            &admission,
         );
         assert!(preferred2.is_some());
     }
@@ -23606,11 +23756,16 @@ export default function App() {
             repair_attempt: 1,
             ..super::super::repair_job::RepairJob::new_for_test()
         };
+        let temp = tempdir().unwrap();
+        let work_root = temp.path().to_path_buf();
+        let scope = super::super::task_workspace_scope::TaskWorkspaceScope::detect(&work_root, "");
+        let admission = super::RepairTargetAdmissionContext::owned_for_test(&work_root, &scope);
         // parser-origin Unknown → both helpers must early-return
         assert!(
             verifier_repair_preferred_local_import_source(
                 &context,
-                super::super::VerifierFailureType::Unknown
+                super::super::VerifierFailureType::Unknown,
+                &admission,
             )
             .is_none()
         );
@@ -23618,7 +23773,8 @@ export default function App() {
             verifier_repair_stale_assertion_test_target(
                 &context,
                 None,
-                super::super::VerifierFailureType::Unknown
+                super::super::VerifierFailureType::Unknown,
+                &admission,
             )
             .is_none()
         );
@@ -24153,6 +24309,395 @@ export default function App() {
         assert!(
             agent.bounded_post_edit_excerpt("link.txt").is_none(),
             "symlink pointing outside the workspace must be rejected"
+        );
+    }
+
+    // ───────────────────────────────────────────────────────────────
+    // Issue #647 (Phase C, §4.4 / §5.1): `admit_repair_target_hint`
+    // SSOT unit & integration tests. Every hint promotion path must
+    // pass through the SSOT gate; only `Owned` hints are admitted.
+    // ───────────────────────────────────────────────────────────────
+
+    /// SSOT: an `Owned` hint passes through `admit_repair_target_hint`.
+    #[test]
+    fn admit_repair_target_hint_returns_owned_hint() {
+        let temp = tempdir().unwrap();
+        let work_root = temp.path().to_path_buf();
+        std::fs::create_dir_all(work_root.join("app")).unwrap();
+        std::fs::write(work_root.join("app/main.py"), "x = 1\n").unwrap();
+        let scope = super::super::task_workspace_scope::TaskWorkspaceScope::detect(&work_root, "");
+        let admission = super::RepairTargetAdmissionContext::owned_for_test(&work_root, &scope);
+
+        let hint = super::super::task_contract::RecoveryTargetHint {
+            role: super::super::task_contract::ArtifactRole::Implementation,
+            path: "app/main.py".to_string(),
+            reason: "test".to_string(),
+        };
+        let admitted = super::admit_repair_target_hint(hint.clone(), &admission);
+        assert_eq!(admitted, Some(hint));
+    }
+
+    /// SSOT: a `CandidateOnly` hint (in-scope, no edit/scaffold/explicit
+    /// signal) is rejected (S1-002 / S7-002).
+    #[test]
+    fn admit_repair_target_hint_rejects_candidate_only() {
+        let temp = tempdir().unwrap();
+        let work_root = temp.path().to_path_buf();
+        std::fs::write(work_root.join("README.md"), "# pre-existing\n").unwrap();
+        // SingleProjectRoot scope without explicit subtree → CandidateOnly
+        // when no edit signal is set on the predicate.
+        let scope = super::super::task_workspace_scope::TaskWorkspaceScope {
+            mode: super::super::task_workspace_scope::ScopeMode::SingleProjectRoot,
+        };
+        let admission = super::RepairTargetAdmissionContext {
+            work_root: &work_root,
+            scope: &scope,
+            edited_this_session_for: &super::admission_always_false,
+            scaffold_changed_for: &super::admission_always_false,
+        };
+        let hint = super::super::task_contract::RecoveryTargetHint {
+            role: super::super::task_contract::ArtifactRole::UsageDocs,
+            path: "README.md".to_string(),
+            reason: "test".to_string(),
+        };
+        let admitted = super::admit_repair_target_hint(hint, &admission);
+        assert_eq!(admitted, None);
+    }
+
+    /// SSOT: an `OutOfScope` hint (path traversal) is rejected (S7-002).
+    #[test]
+    fn admit_repair_target_hint_rejects_out_of_scope_traversal() {
+        let temp = tempdir().unwrap();
+        let work_root = temp.path().to_path_buf();
+        let scope = super::super::task_workspace_scope::TaskWorkspaceScope::detect(&work_root, "");
+        let admission = super::RepairTargetAdmissionContext::owned_for_test(&work_root, &scope);
+        let hint = super::super::task_contract::RecoveryTargetHint {
+            role: super::super::task_contract::ArtifactRole::Implementation,
+            path: "../sibling/escape.py".to_string(),
+            reason: "test".to_string(),
+        };
+        assert_eq!(super::admit_repair_target_hint(hint, &admission), None);
+    }
+
+    /// DR3-001: edited_this_session is evaluated **per-path**, so an edit
+    /// signal on path A must not promote a separate path B to Owned.
+    #[test]
+    fn admit_repair_target_hint_path_local_edited_signal() {
+        let temp = tempdir().unwrap();
+        let work_root = temp.path().to_path_buf();
+        std::fs::create_dir_all(work_root.join("app")).unwrap();
+        std::fs::write(work_root.join("app/edited.py"), "x = 1\n").unwrap();
+        std::fs::write(work_root.join("app/untouched.py"), "y = 2\n").unwrap();
+        let scope = super::super::task_workspace_scope::TaskWorkspaceScope {
+            mode: super::super::task_workspace_scope::ScopeMode::SingleProjectRoot,
+        };
+        let edited_for = |p: &str| p == "app/edited.py";
+        let scaffold_for = |_: &str| false;
+        let admission = super::RepairTargetAdmissionContext {
+            work_root: &work_root,
+            scope: &scope,
+            edited_this_session_for: &edited_for,
+            scaffold_changed_for: &scaffold_for,
+        };
+
+        let edited_hint = super::super::task_contract::RecoveryTargetHint {
+            role: super::super::task_contract::ArtifactRole::Implementation,
+            path: "app/edited.py".to_string(),
+            reason: "edited".to_string(),
+        };
+        let untouched_hint = super::super::task_contract::RecoveryTargetHint {
+            role: super::super::task_contract::ArtifactRole::Implementation,
+            path: "app/untouched.py".to_string(),
+            reason: "not edited".to_string(),
+        };
+
+        assert!(super::admit_repair_target_hint(edited_hint.clone(), &admission).is_some());
+        assert!(
+            super::admit_repair_target_hint(untouched_hint, &admission).is_none(),
+            "path-local edited signal must not promote a sibling path"
+        );
+    }
+
+    /// Integration: path 1 — diagnostic LLM-derived hints route through
+    /// `recovery_target_hint_for_diagnostic_path` → admission gate. A
+    /// CandidateOnly hint must drop out of the resulting assessment.
+    #[test]
+    fn model_assessment_paths_rejects_candidate_only_diagnostic_hint() {
+        let temp = tempdir().unwrap();
+        let work_root = temp.path().to_path_buf();
+        std::fs::create_dir_all(work_root.join("app")).unwrap();
+        std::fs::write(work_root.join("app/main.py"), "x = 1\n").unwrap();
+        // SingleProjectRoot + no edit/scaffold signal → CandidateOnly.
+        let scope = super::super::task_workspace_scope::TaskWorkspaceScope {
+            mode: super::super::task_workspace_scope::ScopeMode::SingleProjectRoot,
+        };
+        let admission = super::RepairTargetAdmissionContext {
+            work_root: &work_root,
+            scope: &scope,
+            edited_this_session_for: &super::admission_always_false,
+            scaffold_changed_for: &super::admission_always_false,
+        };
+        let context = verifier_context_for("app/main.py");
+        let parsed = parse_verifier_repair_assessment_reply(
+            r#"{
+                "failure_kind":"assertion_mismatch",
+                "probable_cause_role":"implementation",
+                "repair_targets":[
+                    {"path":"app/main.py","confidence":0.95,"reason":"diagnostic LLM picked this"}
+                ],
+                "summary":"diagnostic"
+            }"#,
+        )
+        .expect("diagnostic json should parse");
+
+        let assessment = super::model_assessment_to_verifier_repair_assessment(
+            &work_root, &context, parsed, &admission,
+        );
+
+        assert!(
+            assessment.repair_target_hint.is_none(),
+            "CandidateOnly diagnostic hint must not become a repair target"
+        );
+        assert!(
+            assessment.repair_plan.is_empty(),
+            "CandidateOnly diagnostic hint must not appear in repair_plan"
+        );
+    }
+
+    /// Integration: paths 2-3 — `context.target_hint` / `changed_file_hints`
+    /// surface into the fallback `repair_target_hint`. When admission is
+    /// CandidateOnly, the fallback must drop them too.
+    #[test]
+    fn model_assessment_paths_rejects_candidate_only_changed_file_fallback() {
+        let temp = tempdir().unwrap();
+        let work_root = temp.path().to_path_buf();
+        std::fs::create_dir_all(work_root.join("app")).unwrap();
+        std::fs::write(work_root.join("app/main.py"), "x = 1\n").unwrap();
+        let scope = super::super::task_workspace_scope::TaskWorkspaceScope {
+            mode: super::super::task_workspace_scope::ScopeMode::SingleProjectRoot,
+        };
+        let admission = super::RepairTargetAdmissionContext {
+            work_root: &work_root,
+            scope: &scope,
+            edited_this_session_for: &super::admission_always_false,
+            scaffold_changed_for: &super::admission_always_false,
+        };
+        // context.changed_file_hints carries app/main.py (path 3).
+        let context = verifier_context_for("app/main.py");
+        // Parsed JSON has *no* repair_targets / repair_plan, so the
+        // fallback at the end of model_assessment must fire.
+        let parsed = parse_verifier_repair_assessment_reply(
+            r#"{
+                "failure_kind":"unknown",
+                "probable_cause_role":"implementation",
+                "summary":"no diagnostic targets"
+            }"#,
+        )
+        .expect("diagnostic json should parse");
+
+        let assessment = super::model_assessment_to_verifier_repair_assessment(
+            &work_root, &context, parsed, &admission,
+        );
+
+        assert!(
+            assessment.repair_target_hint.is_none(),
+            "fallback must not promote a CandidateOnly changed_file_hint"
+        );
+    }
+
+    /// Integration: path 4 — `verifier_repair_preferred_local_import_source`
+    /// must apply admission gate at its exit. A CandidateOnly target hint
+    /// must not be promoted even when the local-import-mismatch pattern
+    /// fires.
+    #[test]
+    fn model_assessment_paths_path_4_admits_only_owned_local_import_source() {
+        let temp = tempdir().unwrap();
+        let work_root = temp.path().to_path_buf();
+        std::fs::create_dir_all(work_root.join("app")).unwrap();
+        std::fs::write(work_root.join("app/main.py"), "x = 1\n").unwrap();
+        // Build a context whose target_hint resolves to app/main.py and
+        // whose output looks like a local import mismatch.
+        let hint = super::super::task_contract::RecoveryTargetHint {
+            role: super::super::task_contract::ArtifactRole::Implementation,
+            path: "app/main.py".to_string(),
+            reason: "provider".to_string(),
+        };
+        let context = super::super::repair_job::RepairJob {
+            command: "python3 -m pytest".to_string(),
+            output_excerpt: "ImportError: cannot import name 'store' from 'app.main'".to_string(),
+            target_hint: Some(hint),
+            failure_signature: "app/main.py import_error".to_string(),
+            failure_count: Some(1),
+            repair_attempt: 1,
+            ..super::super::repair_job::RepairJob::new_for_test()
+        };
+        let scope = super::super::task_workspace_scope::TaskWorkspaceScope {
+            mode: super::super::task_workspace_scope::ScopeMode::SingleProjectRoot,
+        };
+        // CandidateOnly: no edit / scaffold signal.
+        let candidate_only = super::RepairTargetAdmissionContext {
+            work_root: &work_root,
+            scope: &scope,
+            edited_this_session_for: &super::admission_always_false,
+            scaffold_changed_for: &super::admission_always_false,
+        };
+        assert!(
+            verifier_repair_preferred_local_import_source(
+                &context,
+                super::super::VerifierFailureType::ImportOrDependency,
+                &candidate_only,
+            )
+            .is_none(),
+            "CandidateOnly local-import target must be rejected by SSOT gate"
+        );
+
+        // Owned: helper fires.
+        let owned = super::RepairTargetAdmissionContext::owned_for_test(&work_root, &scope);
+        assert!(
+            verifier_repair_preferred_local_import_source(
+                &context,
+                super::super::VerifierFailureType::ImportOrDependency,
+                &owned,
+            )
+            .is_some(),
+            "Owned local-import target must pass the SSOT gate"
+        );
+    }
+
+    /// Integration: path 5 — `verifier_repair_stale_assertion_test_target`
+    /// must apply admission gate at its exit.
+    #[test]
+    fn model_assessment_paths_path_5_admits_only_owned_stale_assertion_target() {
+        let temp = tempdir().unwrap();
+        let work_root = temp.path().to_path_buf();
+        std::fs::create_dir_all(work_root.join("app")).unwrap();
+        std::fs::create_dir_all(work_root.join("tests")).unwrap();
+        std::fs::write(work_root.join("app/main.py"), "x = 1\n").unwrap();
+        std::fs::write(
+            work_root.join("tests/test_health.py"),
+            "def test_x(): assert False\n",
+        )
+        .unwrap();
+
+        let app_hint = super::super::task_contract::RecoveryTargetHint {
+            role: super::super::task_contract::ArtifactRole::Implementation,
+            path: "app/main.py".to_string(),
+            reason: "impl".to_string(),
+        };
+        let test_hint = super::super::task_contract::RecoveryTargetHint {
+            role: super::super::task_contract::ArtifactRole::Test,
+            path: "tests/test_health.py".to_string(),
+            reason: "test".to_string(),
+        };
+        let context = super::super::repair_job::RepairJob {
+            command: "python3 -m pytest".to_string(),
+            output_excerpt: "AssertionError".to_string(),
+            target_hint: Some(test_hint),
+            repair_target_hint: Some(app_hint),
+            failure_signature: "stale-assertion".to_string(),
+            failure_count: Some(1),
+            repair_attempt: 2,
+            rerun_outcome: Some(super::super::VerifierRepairRerunOutcome::SameFailureRemaining),
+            ..super::super::repair_job::RepairJob::new_for_test()
+        };
+        let scope = super::super::task_workspace_scope::TaskWorkspaceScope {
+            mode: super::super::task_workspace_scope::ScopeMode::SingleProjectRoot,
+        };
+        let candidate_only = super::RepairTargetAdmissionContext {
+            work_root: &work_root,
+            scope: &scope,
+            edited_this_session_for: &super::admission_always_false,
+            scaffold_changed_for: &super::admission_always_false,
+        };
+        assert!(
+            verifier_repair_stale_assertion_test_target(
+                &context,
+                None,
+                super::super::VerifierFailureType::AssertionFailure,
+                &candidate_only,
+            )
+            .is_none(),
+            "CandidateOnly stale-assertion test target must be rejected by SSOT gate"
+        );
+        let owned = super::RepairTargetAdmissionContext::owned_for_test(&work_root, &scope);
+        assert!(
+            verifier_repair_stale_assertion_test_target(
+                &context,
+                None,
+                super::super::VerifierFailureType::AssertionFailure,
+                &owned,
+            )
+            .is_some(),
+            "Owned stale-assertion test target must pass the SSOT gate"
+        );
+    }
+
+    /// Integration: path 6 — `repair_target_hint` fallback from
+    /// `probable_cause_role`. When the only candidate is CandidateOnly
+    /// (changed_file_hint surfaced by `verifier_repair_context_from_failure`
+    /// but never edited / scaffolded this session), the fallback must not
+    /// promote it.
+    #[test]
+    fn model_assessment_paths_path_6_fallback_admits_only_owned() {
+        let temp = tempdir().unwrap();
+        let work_root = temp.path().to_path_buf();
+        std::fs::create_dir_all(work_root.join("app")).unwrap();
+        std::fs::write(work_root.join("app/main.py"), "x = 1\n").unwrap();
+        let scope = super::super::task_workspace_scope::TaskWorkspaceScope {
+            mode: super::super::task_workspace_scope::ScopeMode::SingleProjectRoot,
+        };
+        let admission = super::RepairTargetAdmissionContext {
+            work_root: &work_root,
+            scope: &scope,
+            edited_this_session_for: &super::admission_always_false,
+            scaffold_changed_for: &super::admission_always_false,
+        };
+        // verifier_context_for() seeds context.changed_file_hints with
+        // app/main.py and provides a probable_cause_role-style match below.
+        let context = verifier_context_for("app/main.py");
+        // No repair_targets/plan → forces fallback. probable_cause_role
+        // is set so the role-filter branch runs.
+        let parsed = parse_verifier_repair_assessment_reply(
+            r#"{
+                "failure_kind":"unknown",
+                "probable_cause_role":"implementation",
+                "summary":"force path 6 fallback"
+            }"#,
+        )
+        .expect("diagnostic json should parse");
+
+        let assessment = super::model_assessment_to_verifier_repair_assessment(
+            &work_root, &context, parsed, &admission,
+        );
+        assert!(
+            assessment.repair_target_hint.is_none(),
+            "path 6 fallback must drop CandidateOnly probable_cause_role hint"
+        );
+
+        // Same context with Owned admission → fallback promotes the hint.
+        let owned_admission =
+            super::RepairTargetAdmissionContext::owned_for_test(&work_root, &scope);
+        let parsed_owned = parse_verifier_repair_assessment_reply(
+            r#"{
+                "failure_kind":"unknown",
+                "probable_cause_role":"implementation",
+                "summary":"force path 6 fallback owned"
+            }"#,
+        )
+        .expect("diagnostic json should parse");
+        let assessment_owned = super::model_assessment_to_verifier_repair_assessment(
+            &work_root,
+            &context,
+            parsed_owned,
+            &owned_admission,
+        );
+        assert_eq!(
+            assessment_owned
+                .repair_target_hint
+                .as_ref()
+                .map(|hint| hint.path.as_str()),
+            Some("app/main.py"),
+            "Owned admission must allow path 6 fallback to promote the hint"
         );
     }
 }

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -21493,7 +21493,15 @@ E   assert [{'id': 1}] == []\n";
     /// rich inputs (explicit-spec request, a real
     /// `SemanticFailureReport` with two-vs-one consensus, and a verifier
     /// history hint), the resulting `SpecAuthorityInput` is **not**
-    /// all-neutral. At least one of the three V3 detectors must light up.
+    /// all-neutral. At least one of the V3 detectors must light up.
+    ///
+    /// CB-011 (Issue #647 iteration-4): the verifier-history detector is
+    /// pinned to `false` until artifact identity is bound to the failing
+    /// `SemanticFailureReport`. The two remaining V3 detectors
+    /// (`has_user_request_match` + `consensus`) must still light up on
+    /// this fixture so the production builder stays non-trivial; the
+    /// verifier flag is now asserted to stay `false` even when
+    /// `verifier_passed_in_loop = true` (CB-011).
     #[test]
     fn sf1_v3_production_input_is_not_all_false() {
         let request = "The API must return 404 when missing. The body must accept JSON.";
@@ -21524,16 +21532,16 @@ E   assert [{'id': 1}] == []\n";
             Some(&report),
             hint,
         );
-        // Pre-V3 production hard-coded all three to neutral. V3 must
-        // light at least one detector when real inputs exist; here all
-        // three light up.
+        // V3 must light at least one detector when real inputs exist.
+        // Post-CB-011: the user-request and consensus detectors light up,
+        // while the verifier-history detector stays a dead placeholder.
         assert!(
             input.has_user_request_match,
             "explicit-spec request must light has_user_request_match"
         );
         assert!(
-            input.has_verified_public_interface,
-            "verifier_passed_in_loop=true must light has_verified_public_interface"
+            !input.has_verified_public_interface,
+            "CB-011: verifier_passed_in_loop alone must NOT light has_verified_public_interface (dead variant placeholder)"
         );
         assert!(
             input.consensus.is_some(),

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -9345,6 +9345,15 @@ impl Agent {
         // when the LLM volunteered the extended schema. The legacy
         // `ParsedVerifierRepairAssessment` / `VerifierRepairAssessment` flow
         // below is **not** disturbed.
+        //
+        // -------- BEGIN semantic-boundary (Issue #647 / S3-005 / SF3) --------
+        // Everything between this marker and END semantic-boundary is
+        // *outside* the legacy assessment pipeline. The legacy struct-literal
+        // callsites for `super::VerifierRepairAssessment`
+        // (turn.rs:15399 / 18785 / 19477 / 19553 / 20230 / 23108 / 23133)
+        // remain unchanged by Issue #647. See the doc comment on
+        // `model_assessment_to_verifier_repair_assessment` for the full
+        // responsibility split.
         let semantic_report = parse_semantic_failure_report_from_reply(&reply.content)
             .or_else(|| build_semantic_failure_report_from_legacy(&parsed, &context));
         // Issue #647 (SF1): build the `SpecAuthorityInput` from the active
@@ -9377,6 +9386,10 @@ impl Agent {
             edited_this_session_for: &edited_predicate,
             scaffold_changed_for: &scaffold_predicate,
         };
+        // -------- END semantic-boundary (Issue #647 / S3-005 / SF3) --------
+        // Re-entering the legacy assessment pipeline: the call below builds
+        // `super::VerifierRepairAssessment` only. `semantic_plan` lives on
+        // the `RepairJob` it never touches.
         let assessment = model_assessment_to_verifier_repair_assessment(
             &self.work_root,
             &context,
@@ -15797,6 +15810,39 @@ fn build_semantic_repair_plan_from_report_with_authority_input(
     })
 }
 
+/// Boundary helper that converts a parsed diagnostic reply into the
+/// legacy `super::VerifierRepairAssessment` value used by the rest of the
+/// verifier-repair pipeline.
+///
+/// # Responsibility boundary (Issue #647 / S3-005 / SF3)
+///
+/// This function is **the** SSOT boundary for legacy-side assessment
+/// construction. The Issue #647 semantic-repair planning lives outside
+/// this boundary on purpose:
+///
+///   * **Legacy boundary (this function)**: builds
+///     `VerifierRepairAssessment { failure_kind, failure_type,
+///     probable_cause_role, needed_reads, repair_target_hint,
+///     repair_plan, summary, source }` only. The 7 existing
+///     `VerifierRepairAssessment` struct-literal callsites
+///     (turn.rs:15399 / 18785 / 19477 / 19553 / 20230 / 23108 / 23133)
+///     are unchanged by Issue #647 — none of them call into the
+///     semantic-repair helpers.
+///   * **Semantic boundary (outside this function, in
+///     [`run_verifier_diagnostic_pass`])**: after this function returns
+///     the legacy assessment, the caller separately runs:
+///       1. [`parse_semantic_failure_report_from_reply`] on the raw reply
+///       2. [`build_semantic_failure_report_from_legacy`] as a
+///          deterministic fallback (MF1) when (1) returns `None`
+///       3. [`build_semantic_repair_plan_from_report_with_authority_input`]
+///          to construct the `SemanticRepairPlan` and write it into
+///          `RepairJob.semantic_plan`
+///
+/// The two boundaries are intentionally kept separate so that:
+///   * existing tests pinning the legacy 7 struct-literal callsites
+///     remain unaffected (S3-005 unchanged-callsites invariant);
+///   * the semantic-repair pipeline can be evolved (new fallback paths,
+///     consensus detection, ...) without touching this function.
 fn model_assessment_to_verifier_repair_assessment(
     work_root: &Path,
     context: &super::repair_job::RepairJob,
@@ -26494,6 +26540,98 @@ export default function App() {
                 .map(|hint| hint.path.as_str()),
             Some("app/main.py"),
             "Owned admission must allow path 6 fallback to promote the hint"
+        );
+    }
+
+    // ─── Issue #647 (SF3 / S3-005): semantic-boundary invariant ────────
+    //
+    // Pin the two responsibility halves so future edits cannot silently
+    // erase the boundary markers we just installed.
+
+    #[test]
+    fn sf3_model_assessment_doc_comment_pins_legacy_boundary() {
+        let src = include_str!("turn.rs");
+        // Doc comment on the legacy boundary helper must label its role
+        // and explicitly state the unchanged-callsites invariant. We do
+        // NOT pin specific line numbers (those drift with surrounding
+        // edits); we pin the *contract* instead.
+        let fn_pos = src
+            .find("\nfn model_assessment_to_verifier_repair_assessment(")
+            .expect("function must exist");
+        let doc_start = fn_pos.saturating_sub(3000);
+        let doc = &src[doc_start..fn_pos];
+        assert!(
+            doc.contains("Legacy boundary") || doc.contains("legacy-side"),
+            "SF3: doc must label this helper as the legacy boundary"
+        );
+        assert!(
+            doc.contains("Semantic boundary") || doc.contains("semantic-repair planning"),
+            "SF3: doc must contrast with the semantic boundary"
+        );
+        assert!(
+            doc.contains("unchanged by Issue #647")
+                || doc.contains("are unchanged")
+                || doc.contains("unchanged-callsites"),
+            "SF3: doc must declare the unchanged-callsites invariant"
+        );
+        // Sanity: the 7 legacy callsites must still exist as struct
+        // literals in the file (literal count, not line-number pinning).
+        let struct_literal_count = src.matches("super::VerifierRepairAssessment {").count()
+            + src.matches("VerifierRepairAssessment {").count()
+            - src.matches("super::VerifierRepairAssessment {").count();
+        // We expect at least 7 occurrences of `VerifierRepairAssessment {`
+        // (the exact number can be 7+ because tests may add new ones,
+        // but never less than 7 — the boundary contract).
+        let total_literals = src.matches("VerifierRepairAssessment {").count();
+        assert!(
+            total_literals >= 7,
+            "SF3: at least 7 VerifierRepairAssessment struct literals must \
+             exist (legacy callsite invariant), found {total_literals}"
+        );
+        let _ = struct_literal_count; // keep variable for future tightening
+    }
+
+    #[test]
+    fn sf3_run_verifier_diagnostic_pass_uses_explicit_semantic_boundary_markers() {
+        let src = include_str!("turn.rs");
+        // Both BEGIN and END markers must exist *inside*
+        // `run_verifier_diagnostic_pass` so a reader can scan the function
+        // body and immediately see which lines are legacy vs. semantic.
+        assert!(
+            src.contains("BEGIN semantic-boundary (Issue #647 / S3-005 / SF3)"),
+            "SF3: BEGIN semantic-boundary marker must be present"
+        );
+        assert!(
+            src.contains("END semantic-boundary (Issue #647 / S3-005 / SF3)"),
+            "SF3: END semantic-boundary marker must be present"
+        );
+        // The BEGIN marker must appear *before* the semantic helpers
+        // are called, and the END marker must appear *after* the last
+        // semantic helper and *before* `model_assessment_to_verifier_repair_assessment`
+        // is invoked.
+        let begin = src
+            .find("BEGIN semantic-boundary (Issue #647 / S3-005 / SF3)")
+            .expect("BEGIN marker missing");
+        let end = src
+            .find("END semantic-boundary (Issue #647 / S3-005 / SF3)")
+            .expect("END marker missing");
+        let semantic_call = src
+            .find("build_semantic_repair_plan_from_report_with_authority_input(")
+            .expect("semantic helper call missing");
+        let legacy_call = src
+            .find("let assessment = model_assessment_to_verifier_repair_assessment(")
+            .expect("legacy helper call missing");
+        assert!(
+            begin < semantic_call,
+            "SF3: BEGIN marker must precede semantic helper call"
+        );
+        assert!(
+            semantic_call < end,
+            "SF3: semantic helper call must be inside the boundary"
+        );
+        assert!(
+            end < legacy_call,
+            "SF3: END marker must precede the legacy helper call"
         );
     }
 }

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -9411,10 +9411,23 @@ impl Agent {
             semantic_report.as_ref(),
             agent_history_hint,
         );
+        // Issue #647 (CB-015): the new plan's generation snapshot uses the
+        // **pre-bump** `assessment_generation`. The live `RepairJob.assessment_generation`
+        // is incremented below in lock-step with the new assessment landing
+        // in the slot, so after the bump:
+        //   plan.assessment_generation_at_creation == pre_bump_gen
+        //   job.assessment_generation              == pre_bump_gen + 1
+        // → `plan.gen < job.gen` → `semantic_plan_is_stale` returns `false`
+        // (fresh). This is the SSOT signal that the assessment in the slot
+        // is the one this plan was built against — the controller can route
+        // to NeedFreshRead/NeedEdit instead of looping back to
+        // NeedDiagnostic on the same cluster.
+        let pre_bump_assessment_generation = context.assessment_generation;
         let semantic_plan = semantic_report.and_then(|report| {
             build_semantic_repair_plan_from_report_with_authority_input(
                 report,
                 authority_input.clone(),
+                pre_bump_assessment_generation,
             )
         });
         // Issue #647 (§5.1 SSOT plumbing): build the path-local admission
@@ -9455,6 +9468,22 @@ impl Agent {
             current.diagnostic_error = None;
             current.diagnostic_unavailable = false;
             current.assessment = Some(assessment);
+            // Issue #647 (CB-015): bump `assessment_generation` in lock-step
+            // with the new assessment landing in the slot. Combined with the
+            // pre-bump generation threaded into the semantic plan above:
+            //   * stale (post-advance, pre-re-diagnostic):
+            //     `plan.assessment_generation_at_creation ==
+            //     job.assessment_generation` AND `exhausted_attempts`
+            //     non-empty → `semantic_plan_is_stale` = true →
+            //     CB-007/CB-012/CB-014 force re-diagnostic.
+            //   * fresh (post-re-diagnostic, ready to repair the new cluster):
+            //     `plan.assessment_generation_at_creation <
+            //     job.assessment_generation` →
+            //     `semantic_plan_is_stale` = false → controller routes to
+            //     NeedFreshRead/NeedEdit on the current cluster (closing the
+            //     liveness gap where the stale predicate kept looping back
+            //     to NeedDiagnostic after a cluster advance).
+            current.assessment_generation = pre_bump_assessment_generation.saturating_add(1);
             // Issue #647 (Phase D / D.2 / DR3-005): write the
             // SemanticRepairPlan slot. `None` is the legacy-compatible
             // value when semantic parse failed or dispatch routed to
@@ -14351,6 +14380,16 @@ fn verifier_repair_context_from_failure(
         exhausted_attempts: previous_context
             .map(|context| context.exhausted_attempts.clone())
             .unwrap_or_default(),
+        // Issue #647 (CB-015): carry `assessment_generation` over so the
+        // stale↔fresh distinction survives turn boundaries. The generation
+        // is monotonic across the job lifetime — every successful
+        // diagnostic write bumps it; cluster advances do not touch it.
+        // A new failure that builds a fresh `RepairJob` (no previous_context)
+        // resets the generation to 0, mirroring the `semantic_plan = None /
+        // exhausted_attempts = empty` defaults applied above.
+        assessment_generation: previous_context
+            .map(|context| context.assessment_generation)
+            .unwrap_or(0),
     }
 }
 
@@ -15841,9 +15880,14 @@ fn build_spec_authority_input_for_active_request(
 fn build_semantic_repair_plan_from_report(
     report: super::semantic_failure::SemanticFailureReport,
 ) -> Option<super::repair_job::SemanticRepairPlan> {
+    // Issue #647 (CB-015): test-only wrapper threads `0` as the
+    // generation snapshot — tests that pre-date CB-015 model a
+    // first-build "no prior re-diagnostic" state where the plan was
+    // created against generation 0.
     build_semantic_repair_plan_from_report_with_authority_input(
         report,
         default_spec_authority_input(),
+        0,
     )
 }
 
@@ -15876,6 +15920,7 @@ fn default_spec_authority_input() -> super::spec_authority::SpecAuthorityInput {
 fn build_semantic_repair_plan_from_report_with_authority_input(
     report: super::semantic_failure::SemanticFailureReport,
     authority_input: super::spec_authority::SpecAuthorityInput,
+    assessment_generation: u32,
 ) -> Option<super::repair_job::SemanticRepairPlan> {
     // D.3: DependencyMissing / ConfigOrVerifierError → setup repair path,
     // no semantic plan.
@@ -15903,6 +15948,11 @@ fn build_semantic_repair_plan_from_report_with_authority_input(
         failure_cluster_id,
         expected_improvement: None,
         semantic_report: report,
+        // Issue #647 (CB-015): coil the caller-provided generation. The
+        // production callsite in `run_verifier_diagnostic_pass` passes the
+        // RepairJob's pre-bump generation so this plan is fresh relative
+        // to the assessment we are about to write into the slot.
+        assessment_generation_at_creation: assessment_generation,
     })
 }
 
@@ -16373,9 +16423,9 @@ pub(super) fn verifier_repair_context_target_path(
 pub(super) fn verifier_repair_effective_target_hint(
     context: &super::repair_job::RepairJob,
 ) -> Option<&super::task_contract::RecoveryTargetHint> {
-    // Issue #647 (CB-007): when a `SemanticRepairPlan` is active and the
-    // job has already exhausted at least one prior cluster, the freshly
-    // re-built `assessment.repair_target_hint` can be stale — the
+    // Issue #647 (CB-007 / CB-015): when a `SemanticRepairPlan` is active
+    // and the job is in the stale state (per `semantic_plan_is_stale`), the
+    // freshly re-built `assessment.repair_target_hint` can be stale — the
     // re-diagnostic LLM commonly re-proposes the just-exhausted cluster
     // because the same failure text is still visible. `assign_semantic_plan_preserving_exhausted`
     // walks the new plan past the exhausted entry, but nothing rebuilds
@@ -16388,14 +16438,17 @@ pub(super) fn verifier_repair_effective_target_hint(
     // identical so SetupRepair / pre-semantic flows are unaffected
     // (DR3-001 / "semantic_plan = None 経路は既存挙動" constraint).
     //
-    // The conservative rule:
-    //   semantic_plan = Some AND exhausted_attempts non-empty
+    // The CB-015 generation-aware rule (subsumes the legacy
+    // `semantic_plan.is_some() && !exhausted_attempts.is_empty()`):
+    //   stale (plan.gen >= job.gen, exhausted non-empty)
     //     → return None (force re-diagnostic against the current cluster).
-    //   semantic_plan = Some AND exhausted_attempts empty
-    //     → plan is fresh, legacy behaviour stands.
+    //   fresh (plan.gen < job.gen, post-re-diagnostic)
+    //     → assessment has been refreshed for the current cluster; legacy
+    //       behaviour stands and the controller can route to NeedFreshRead /
+    //       NeedEdit.
     //   semantic_plan = None
     //     → legacy behaviour (unchanged).
-    if context.semantic_plan.is_some() && !context.exhausted_attempts.is_empty() {
+    if super::repair_job::semantic_plan_is_stale(context) {
         return None;
     }
     if let Some(assessment) = context.assessment.as_ref() {
@@ -20029,6 +20082,7 @@ mod progress_tests {
             preferred_repair_role: super::super::task_contract::ArtifactRole::Test,
             repair_hypothesis: "test fixture hypothesis".to_string(),
             expected_improvement: None,
+            assessment_generation_at_creation: 0,
         }
     }
 
@@ -21670,7 +21724,7 @@ E   assert [{'id': 1}] == []\n";
             consensus: None,
         };
         let plan2 =
-            super::build_semantic_repair_plan_from_report_with_authority_input(report2, input)
+            super::build_semantic_repair_plan_from_report_with_authority_input(report2, input, 0)
                 .expect("plan should be built");
         assert_eq!(
             plan2.spec_authority,
@@ -21903,6 +21957,7 @@ E   assert [{'id': 1}] == []\n";
         let plan = super::build_semantic_repair_plan_from_report_with_authority_input(
             report.clone(),
             input,
+            0,
         )
         .expect("plan must build for assertion_mismatch");
         assert_eq!(
@@ -22028,6 +22083,7 @@ E   assert [{'id': 1}] == []\n";
             failure_cluster_id: cluster_id.clone(),
             expected_improvement: None,
             semantic_report: report,
+            assessment_generation_at_creation: 0,
         };
 
         let target_hint = super::super::task_contract::RecoveryTargetHint {
@@ -22861,6 +22917,7 @@ E   assert [{'id': 1}] == []\n";
             failure_cluster_id: cluster_b_id.clone(),
             expected_improvement: None,
             semantic_report: report,
+            assessment_generation_at_creation: 0,
         };
 
         // Stale assessment from the re-diagnostic re-points at cluster A's path.
@@ -22943,6 +23000,7 @@ E   assert [{'id': 1}] == []\n";
             failure_cluster_id: cluster_a_id,
             expected_improvement: None,
             semantic_report: report,
+            assessment_generation_at_creation: 0,
         };
 
         let hint_a = super::super::task_contract::RecoveryTargetHint {
@@ -24572,6 +24630,7 @@ export default function App() {
             preferred_repair_role: report.preferred_repair_role,
             repair_hypothesis: report.repair_hypothesis.clone(),
             expected_improvement: None,
+            assessment_generation_at_creation: 0,
         };
         let mut previous = verifier_repair_context_from_failure(
             work_root,
@@ -24601,6 +24660,53 @@ export default function App() {
         assert_eq!(
             next.exhausted_attempts,
             vec![(cluster_a.clone(), ArtifactRole::Implementation)]
+        );
+    }
+
+    /// Issue #647 (CB-015): `verifier_repair_context_from_failure` must
+    /// also carry `assessment_generation` over the turn boundary so the
+    /// stale↔fresh distinction survives slot reuse. A new failure with no
+    /// `previous_context` resets the generation to 0; a follow-up failure
+    /// inherits whatever the previous turn's generation was.
+    #[test]
+    fn cb015_verifier_repair_context_carries_over_assessment_generation() {
+        let temp = tempdir().unwrap();
+        let work_root = temp.path();
+        std::fs::create_dir_all(work_root.join("app")).unwrap();
+        std::fs::write(work_root.join("app/main.py"), "def main(): pass\n").unwrap();
+        let changed = vec!["app/main.py".to_string()];
+        let output = "FAILED tests/test_api.py::test_x - AssertionError\n1 failed";
+
+        // First cycle: no previous context → generation defaults to 0.
+        let mut previous = verifier_repair_context_from_failure(
+            work_root,
+            "python3 -B -m pytest",
+            output,
+            &changed,
+            1,
+            None,
+        );
+        assert_eq!(
+            previous.assessment_generation, 0,
+            "CB-015: fresh RepairJob without previous_context starts at generation 0",
+        );
+
+        // Simulate `run_verifier_diagnostic_pass` bumping the generation
+        // after writing a fresh assessment.
+        previous.assessment_generation = 5;
+
+        // Second cycle: previous_context carries the generation forward.
+        let next = verifier_repair_context_from_failure(
+            work_root,
+            "python3 -B -m pytest",
+            output,
+            &changed,
+            2,
+            Some(&previous),
+        );
+        assert_eq!(
+            next.assessment_generation, 5,
+            "CB-015: assessment_generation must survive turn boundary via previous_context",
         );
     }
 
@@ -27540,7 +27646,7 @@ export default function App() {
             consensus: None,
         };
         let plan =
-            super::build_semantic_repair_plan_from_report_with_authority_input(report, input)
+            super::build_semantic_repair_plan_from_report_with_authority_input(report, input, 0)
                 .expect("plan must build");
         assert_eq!(
             plan.spec_authority,
@@ -27569,7 +27675,7 @@ export default function App() {
             consensus: None,
         };
         let plan =
-            super::build_semantic_repair_plan_from_report_with_authority_input(report, input)
+            super::build_semantic_repair_plan_from_report_with_authority_input(report, input, 0)
                 .expect("plan must build");
         assert_eq!(
             plan.spec_authority,
@@ -27604,7 +27710,7 @@ export default function App() {
             consensus: Some(consensus),
         };
         let plan =
-            super::build_semantic_repair_plan_from_report_with_authority_input(report, input)
+            super::build_semantic_repair_plan_from_report_with_authority_input(report, input, 0)
                 .expect("plan must build");
         assert_ne!(
             plan.spec_authority,
@@ -27628,7 +27734,7 @@ export default function App() {
             consensus: None,
         };
         let plan =
-            super::build_semantic_repair_plan_from_report_with_authority_input(report, input)
+            super::build_semantic_repair_plan_from_report_with_authority_input(report, input, 0)
                 .expect("plan must build");
         // Authority is resolved (any of the 5 enum variants is acceptable
         // — it is never None because the type itself has no None state).

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -9347,7 +9347,21 @@ impl Agent {
         // below is **not** disturbed.
         let semantic_report = parse_semantic_failure_report_from_reply(&reply.content)
             .or_else(|| build_semantic_failure_report_from_legacy(&parsed, &context));
-        let semantic_plan = semantic_report.and_then(build_semantic_repair_plan_from_report);
+        // Issue #647 (SF1): build the `SpecAuthorityInput` from the active
+        // request's `RequiredBehaviorContract` (when actionable signal is
+        // present, the resolver elects `BehaviorContract`). All other
+        // detectors (`has_user_request_match`, consensus) are still default
+        // until later Issues wire them in; `is_newly_generated_task` is
+        // initialized to `true` per the SF1 acceptance until a real
+        // newly-generated detector lands.
+        let authority_input =
+            build_spec_authority_input_for_active_request(self.active_request_text().as_deref());
+        let semantic_plan = semantic_report.and_then(|report| {
+            build_semantic_repair_plan_from_report_with_authority_input(
+                report,
+                authority_input.clone(),
+            )
+        });
         // Issue #647 (§5.1 SSOT plumbing): build the path-local admission
         // context from the agent's current scope + edit signals so every
         // hint promoted by `model_assessment_to_verifier_repair_assessment`
@@ -15677,8 +15691,82 @@ fn build_semantic_failure_report_from_legacy(
 ///
 /// `expected_improvement` is initialized to `None` — Phase E fills it after
 /// the verifier rerun.
+/// Issue #647 (SF1): construct a `SpecAuthorityInput` for the production
+/// diagnostic pass by inspecting `active_request` for actionable behavior
+/// signal. When the request yields a `RequiredBehaviorContract` with
+/// operations / domain_terms, the resolver will elect `BehaviorContract`;
+/// otherwise we fall through to the newly-generated-task path (which
+/// returns `LlmGeneratedTest`, suppressing test edits on a brand-new
+/// task — see [`spec_authority::resolve`]).
+///
+/// The helper lives here (not in `spec_authority.rs`) because it crosses
+/// the `task_contract` / `spec_authority` module boundary; the resolver
+/// itself stays input-only and decoupled from `TaskContract`.
+fn build_spec_authority_input_for_active_request(
+    active_request: Option<&str>,
+) -> super::spec_authority::SpecAuthorityInput {
+    let has_behavior_contract = active_request
+        .map(|request| {
+            let contract = super::task_contract::TaskContract::from_request(request);
+            contract.required_behavior.operations.is_some()
+                || contract.required_behavior.domain_terms.is_some()
+        })
+        .unwrap_or(false);
+    super::spec_authority::SpecAuthorityInput {
+        has_user_request_match: false,
+        has_behavior_contract,
+        has_verified_public_interface: false,
+        is_newly_generated_task: true,
+        consensus: None,
+    }
+}
+
+/// Issue #647 (SF1): test-only wrapper that builds the plan with the
+/// default `SpecAuthorityInput`. Production code passes its own
+/// `SpecAuthorityInput` directly to
+/// [`build_semantic_repair_plan_from_report_with_authority_input`] (so the
+/// `has_behavior_contract` flag can be derived from the active request);
+/// the test suite uses this convenience wrapper to keep older test
+/// fixtures unchanged.
+#[cfg(test)]
 fn build_semantic_repair_plan_from_report(
     report: super::semantic_failure::SemanticFailureReport,
+) -> Option<super::repair_job::SemanticRepairPlan> {
+    build_semantic_repair_plan_from_report_with_authority_input(
+        report,
+        default_spec_authority_input(),
+    )
+}
+
+/// Issue #647 (SF1): production default for `SpecAuthorityInput` when the
+/// build helper is called without explicit caller context.
+///
+/// - `has_user_request_match`: `false` (detection is a future Issue).
+/// - `has_behavior_contract`: `false` (the caller that has the
+///   `TaskContract` will pass an overridden input via
+///   `build_semantic_repair_plan_from_report_with_authority_input`).
+/// - `has_verified_public_interface`: `false` (S5-005 dead variant).
+/// - `is_newly_generated_task`: `true` — Issue acceptance treats every
+///   turn as "newly generated" until a future Issue plumbs a real
+///   detector.
+/// - `consensus`: `None` — consensus detection is a future Issue.
+#[cfg(test)]
+fn default_spec_authority_input() -> super::spec_authority::SpecAuthorityInput {
+    super::spec_authority::SpecAuthorityInput {
+        has_user_request_match: false,
+        has_behavior_contract: false,
+        has_verified_public_interface: false,
+        is_newly_generated_task: true,
+        consensus: None,
+    }
+}
+
+/// Issue #647 (SF1): variant that lets the caller pass an explicit
+/// `SpecAuthorityInput` (so a future Issue can wire the actual
+/// `RequiredBehaviorContract` / consensus detection signals).
+fn build_semantic_repair_plan_from_report_with_authority_input(
+    report: super::semantic_failure::SemanticFailureReport,
+    authority_input: super::spec_authority::SpecAuthorityInput,
 ) -> Option<super::repair_job::SemanticRepairPlan> {
     // D.3: DependencyMissing / ConfigOrVerifierError → setup repair path,
     // no semantic plan.
@@ -15691,15 +15779,13 @@ fn build_semantic_repair_plan_from_report(
     // as the attack target; if no clusters were reported, the plan cannot
     // be built (caller keeps `semantic_plan = None`).
     let failure_cluster_id = report.failure_clusters.first()?.cluster_key.clone();
-    // SpecAuthority candidates: Phase D wires the fallback set
-    // (ImplementationContract + LlmGeneratedTest) — a future Issue will pass
-    // BehaviorContract when a RequiredBehaviorContract is in scope. The
-    // result is deterministic (smaller variant index wins).
-    let candidates = [
-        super::spec_authority::SpecAuthority::ImplementationContract,
-        super::spec_authority::SpecAuthority::LlmGeneratedTest,
-    ];
-    let spec_authority = super::spec_authority::select_authority(&candidates, None)?;
+    // Issue #647 (SF1): SpecAuthority is now resolved through the
+    // structured `resolve()` SSOT so impl/test/README are treated as
+    // equally authoritative on newly generated tasks. Pre-SF1 the
+    // candidate set was hard-coded to `[ImplementationContract,
+    // LlmGeneratedTest]`, which always elected ImplementationContract and
+    // let the repair editor rewrite tests to match buggy impl.
+    let spec_authority = super::spec_authority::resolve(&authority_input);
     Some(super::repair_job::SemanticRepairPlan {
         semantic_cause: report.failure_kind,
         spec_authority,
@@ -21070,6 +21156,90 @@ E   assert [{'id': 1}] == []\n";
         );
         assert!(plan.repair_hypothesis.contains("returns 200"));
         assert!(plan.expected_improvement.is_none());
+    }
+
+    /// SF1-production-uses-resolve (Issue #647): the production builder
+    /// flows through `spec_authority::resolve` — verified end-to-end by
+    /// (a) the default-input wrapper electing `LlmGeneratedTest` on a
+    /// newly-generated task with no consensus, and (b) an explicit
+    /// `has_behavior_contract = true` input electing `BehaviorContract`.
+    /// Pre-SF1 the builder was hard-coded to `ImplementationContract`
+    /// regardless of input, so this asserts the new wiring.
+    #[test]
+    fn sf1_production_build_semantic_repair_plan_uses_resolve() {
+        let reply = r#"{
+            "failure_kind":"assertion_mismatch",
+            "confidence":0.91,
+            "preferred_repair_role":"implementation",
+            "repair_hypothesis":"impl returns 200, test expects 201",
+            "failure_clusters":[
+                {
+                    "observed":"200 OK",
+                    "expected":"201 Created",
+                    "input_shape":"POST /todos",
+                    "assertion_shape":"AssertEq",
+                    "involved_artifacts":["implementation","test"],
+                    "affected_cases":["test_create_todo"]
+                }
+            ]
+        }"#;
+        // Default-input path (newly-generated task, no consensus,
+        // no behavior contract) → resolve elects LlmGeneratedTest.
+        let report = super::parse_semantic_failure_report_from_reply(reply).expect("parses");
+        let plan = super::build_semantic_repair_plan_from_report(report)
+            .expect("plan should be built for AssertionMismatch with clusters");
+        assert_eq!(
+            plan.spec_authority,
+            super::super::spec_authority::SpecAuthority::LlmGeneratedTest,
+            "newly-generated task with no consensus must elect LlmGeneratedTest (SF1)"
+        );
+
+        // Explicit-input path with has_behavior_contract=true → resolve
+        // elects BehaviorContract, proving the production builder honors
+        // the resolver's decision rules end-to-end.
+        let report2 = super::parse_semantic_failure_report_from_reply(reply).expect("parses");
+        let input = super::super::spec_authority::SpecAuthorityInput {
+            has_user_request_match: false,
+            has_behavior_contract: true,
+            has_verified_public_interface: false,
+            is_newly_generated_task: true,
+            consensus: None,
+        };
+        let plan2 =
+            super::build_semantic_repair_plan_from_report_with_authority_input(report2, input)
+                .expect("plan should be built");
+        assert_eq!(
+            plan2.spec_authority,
+            super::super::spec_authority::SpecAuthority::BehaviorContract,
+            "has_behavior_contract=true must elect BehaviorContract via resolve()"
+        );
+    }
+
+    /// SF1: the production callsite helper
+    /// `build_spec_authority_input_for_active_request` flips
+    /// `has_behavior_contract` when the active request yields a
+    /// `RequiredBehaviorContract` with actionable signal.
+    #[test]
+    fn sf1_build_spec_authority_input_detects_behavior_contract_in_request() {
+        // A request that names an operation keyword ("create") + a domain
+        // term should yield `has_behavior_contract: true`. The exact
+        // detection is owned by `task_contract::TaskContract::from_request`
+        // — we only assert the routing here.
+        let request = "Create a TODO API: implement POST /todos to create a new todo item, then add a pytest that POSTs and asserts 201.";
+        let input = super::build_spec_authority_input_for_active_request(Some(request));
+        assert!(
+            input.has_behavior_contract,
+            "actionable request must set has_behavior_contract=true"
+        );
+        assert!(!input.has_user_request_match);
+        assert!(!input.has_verified_public_interface);
+        assert!(input.is_newly_generated_task);
+        assert!(input.consensus.is_none());
+
+        // Empty / missing request → behavior contract flag stays false.
+        let empty_input = super::build_spec_authority_input_for_active_request(None);
+        assert!(!empty_input.has_behavior_contract);
+        assert!(empty_input.is_newly_generated_task);
     }
 
     /// Phase D / D.3 (S1-010): `DependencyMissing` dispatches to the

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -26634,6 +26634,149 @@ export default function App() {
             "SF3: END marker must precede the legacy helper call"
         );
     }
+
+    // ─── Issue #647 joint-integration: BehaviorContract / UserRequest /
+    //     UsageDocs consensus × SemanticRepairPlan / SpecAuthority. ────────
+    //
+    // The user-orchestrator asked for joint tests covering the resolver's
+    // three production-relevant inputs (BehaviorContract, UserRequest,
+    // UsageDocs consensus tie-break) flowing end-to-end into a built
+    // SemanticRepairPlan.
+
+    fn joint_sample_report() -> super::super::semantic_failure::SemanticFailureReport {
+        // A minimal valid report that exercises the assertion-mismatch
+        // path with one cluster involving Implementation + Test.
+        let reply = r#"{
+            "failure_kind": "assertion_mismatch",
+            "failure_clusters": [{
+                "observed": "200",
+                "expected": "404",
+                "affected_cases": ["read missing item"],
+                "involved_artifacts": ["implementation", "test"]
+            }],
+            "contract_conflict": {
+                "implementation": "returns 200 instead of 404",
+                "test": "expects 404",
+                "usage_docs": "not specified"
+            },
+            "preferred_repair_role": "implementation",
+            "repair_hypothesis": "make the not-found branch return 404",
+            "confidence": 0.7
+        }"#;
+        super::parse_semantic_failure_report_from_reply(reply).expect("sample report must parse")
+    }
+
+    #[test]
+    fn joint_user_request_authority_flows_into_plan() {
+        // UserRequest is the top-priority authority; resolve() must
+        // elect it regardless of other flags, and the resulting plan
+        // must carry it verbatim.
+        let report = joint_sample_report();
+        let input = super::super::spec_authority::SpecAuthorityInput {
+            has_user_request_match: true,
+            has_behavior_contract: true,
+            has_verified_public_interface: false,
+            is_newly_generated_task: true,
+            consensus: None,
+        };
+        let plan =
+            super::build_semantic_repair_plan_from_report_with_authority_input(report, input)
+                .expect("plan must build");
+        assert_eq!(
+            plan.spec_authority,
+            super::super::spec_authority::SpecAuthority::UserRequest,
+            "UserRequest must dominate even when BehaviorContract is also present"
+        );
+        assert_eq!(
+            plan.preferred_repair_role,
+            super::super::task_contract::ArtifactRole::Implementation,
+            "preferred_repair_role carries through from the semantic report"
+        );
+        assert!(
+            !plan.repair_hypothesis.is_empty(),
+            "MF3 guard requires non-empty repair_hypothesis on the plan"
+        );
+    }
+
+    #[test]
+    fn joint_behavior_contract_authority_flows_into_plan() {
+        let report = joint_sample_report();
+        let input = super::super::spec_authority::SpecAuthorityInput {
+            has_user_request_match: false,
+            has_behavior_contract: true,
+            has_verified_public_interface: false,
+            is_newly_generated_task: true,
+            consensus: None,
+        };
+        let plan =
+            super::build_semantic_repair_plan_from_report_with_authority_input(report, input)
+                .expect("plan must build");
+        assert_eq!(
+            plan.spec_authority,
+            super::super::spec_authority::SpecAuthority::BehaviorContract,
+            "BehaviorContract is the chosen authority when UserRequest is absent"
+        );
+    }
+
+    #[test]
+    fn joint_usage_docs_consensus_tiebreaks_into_plan() {
+        // Newly generated task + impl/usage_docs agreement against test
+        // → consensus tie-break must elect ImplementationContract
+        // (or BehaviorContract, depending on the resolver wiring), and
+        // crucially must NOT elect LlmGeneratedTest (which would suppress
+        // test edits). The acceptance criterion here is that consensus
+        // tie-break engages instead of the bare "newly generated → test"
+        // fallback.
+        let report = joint_sample_report();
+        let consensus = super::super::spec_authority::ArtifactConsensus {
+            agreeing: vec![
+                super::super::task_contract::ArtifactRole::Implementation,
+                super::super::task_contract::ArtifactRole::UsageDocs,
+            ],
+            dissenting: vec![super::super::task_contract::ArtifactRole::Test],
+            reason: "impl and docs both say 404; only test says 200".to_string(),
+        };
+        let input = super::super::spec_authority::SpecAuthorityInput {
+            has_user_request_match: false,
+            has_behavior_contract: false,
+            has_verified_public_interface: false,
+            is_newly_generated_task: true,
+            consensus: Some(consensus),
+        };
+        let plan =
+            super::build_semantic_repair_plan_from_report_with_authority_input(report, input)
+                .expect("plan must build");
+        assert_ne!(
+            plan.spec_authority,
+            super::super::spec_authority::SpecAuthority::LlmGeneratedTest,
+            "Consensus tie-break must override the newly-generated→LlmGeneratedTest fallback"
+        );
+    }
+
+    #[test]
+    fn joint_test_edit_admission_requires_semantic_plan_built_from_authority() {
+        // MF3 + SF1 combined: an admission attempt against a test file
+        // succeeds only when a SemanticRepairPlan with a resolved
+        // SpecAuthority and a non-empty repair_hypothesis is present.
+        // Build the plan via the authority-aware production helper.
+        let report = joint_sample_report();
+        let input = super::super::spec_authority::SpecAuthorityInput {
+            has_user_request_match: false,
+            has_behavior_contract: true,
+            has_verified_public_interface: false,
+            is_newly_generated_task: true,
+            consensus: None,
+        };
+        let plan =
+            super::build_semantic_repair_plan_from_report_with_authority_input(report, input)
+                .expect("plan must build");
+        // Authority is resolved (any of the 5 enum variants is acceptable
+        // — it is never None because the type itself has no None state).
+        let _: super::super::spec_authority::SpecAuthority = plan.spec_authority;
+        // The plan must carry a non-empty hypothesis (MF3 admission guard
+        // for test edits requires this).
+        assert!(!plan.repair_hypothesis.trim().is_empty());
+    }
 }
 
 // ───────────────────────────────────────────────────────────────────────────

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -1849,6 +1849,27 @@ fn verifier_repair_pass_messages(
             "summary": assessment.summary,
         })
     });
+    // Issue #647 (Phase D / D.4 / DR4-002): pass `SemanticRepairPlan` to the
+    // repair editor as a structured JSON data field. The semantic_plan
+    // content is serialized via `serde_json::json!` (same envelope as the
+    // other untrusted-data fields) and never concatenated into system /
+    // developer instruction text or any shell command — the system message
+    // already declares verifier output as untrusted data.
+    let semantic_plan_payload = context.semantic_plan.as_ref().map(|plan| {
+        serde_json::json!({
+            "failure_cluster_id": plan.failure_cluster_id.as_str(),
+            "semantic_cause": plan.semantic_cause.as_str(),
+            "spec_authority": format!("{:?}", plan.spec_authority),
+            "preferred_repair_role": plan.preferred_repair_role.label(),
+            "repair_hypothesis": plan.repair_hypothesis,
+            "confidence": plan.semantic_report.confidence,
+            "contract_conflict": {
+                "implementation": plan.semantic_report.contract_conflict.implementation,
+                "test": plan.semantic_report.contract_conflict.test,
+                "usage_docs": plan.semantic_report.contract_conflict.usage_docs,
+            },
+        })
+    });
     let payload = serde_json::json!({
         "task_summary": compact_verifier_failure_text(active_request, 500),
         "command": context.command,
@@ -1856,6 +1877,7 @@ fn verifier_repair_pass_messages(
         "previous_repair_error": context.repair_error.as_deref(),
         "failure_signature": context.failure_signature,
         "diagnostic_assessment": assessment,
+        "semantic_plan": semantic_plan_payload,
         "selected_target": {
             "path": target_hint.path,
             "role": target_hint.role.label(),
@@ -9292,6 +9314,13 @@ impl Agent {
                 attempt_spec.role,
             );
         };
+        // Issue #647 (Phase D / D.1 / DR3-005): independently parse the
+        // semantic-failure report from the *same* reply. A `None` here
+        // collapses to `semantic_plan = None` (legacy fallback) without
+        // disturbing the legacy `ParsedVerifierRepairAssessment` /
+        // `VerifierRepairAssessment` flow above.
+        let semantic_report = parse_semantic_failure_report_from_reply(&reply.content);
+        let semantic_plan = semantic_report.and_then(build_semantic_repair_plan_from_report);
         // Issue #647 (§5.1 SSOT plumbing): build the path-local admission
         // context from the agent's current scope + edit signals so every
         // hint promoted by `model_assessment_to_verifier_repair_assessment`
@@ -9326,6 +9355,11 @@ impl Agent {
             current.diagnostic_error = None;
             current.diagnostic_unavailable = false;
             current.assessment = Some(assessment);
+            // Issue #647 (Phase D / D.2 / DR3-005): write the
+            // SemanticRepairPlan slot. `None` is the legacy-compatible
+            // value when semantic parse failed or dispatch routed to
+            // setup repair (D.3).
+            current.semantic_plan = semantic_plan;
         }
         log_llm_event(
             "agent.verifier_diagnostic.completed",
@@ -15397,6 +15431,92 @@ fn verifier_repair_stale_assertion_test_target(
     admit_repair_target_hint(promoted, admission)
 }
 
+/// Issue #647 (Phase D): extract the JSON object value from a diagnostic LLM
+/// reply, mirroring the SSOT preamble used by
+/// [`parse_verifier_repair_assessment_reply`] (strip `<think>` tags →
+/// trim/truncate → find the outermost `{ … }`). Returns `None` on any
+/// extraction or `serde_json` parse failure.
+///
+/// Phase D wires this helper into `run_verifier_diagnostic_pass` so the
+/// existing `ParsedVerifierRepairAssessment` parse and the new
+/// `parse_semantic_failure_report` parse share an identical JSON-extraction
+/// boundary. Keeping the extraction logic colocated avoids drift between
+/// the two parse paths.
+fn extract_diagnostic_reply_json_value(reply: &str) -> Option<serde_json::Value> {
+    let stripped = strip_think_tags(reply);
+    let trimmed = truncate(stripped.trim(), VERIFIER_DIAGNOSTIC_MAX_OUTPUT_BYTES);
+    let json_text = if trimmed.starts_with('{') && trimmed.ends_with('}') {
+        trimmed.clone()
+    } else {
+        let start = trimmed.find('{')?;
+        let end = trimmed.rfind('}')?;
+        if end <= start {
+            return None;
+        }
+        trimmed[start..=end].to_string()
+    };
+    serde_json::from_str(&json_text).ok()
+}
+
+/// Issue #647 (Phase D / D.1): parse a diagnostic LLM reply into an
+/// [`super::semantic_failure::SemanticFailureReport`]. Independent of the
+/// legacy `ParsedVerifierRepairAssessment` parse — a failure here returns
+/// `None` and the caller proceeds with `semantic_plan = None` (DR3-005), so
+/// the existing `VerifierRepairAssessment` / legacy repair-target selection
+/// is **not** disturbed.
+fn parse_semantic_failure_report_from_reply(
+    reply: &str,
+) -> Option<super::semantic_failure::SemanticFailureReport> {
+    let value = extract_diagnostic_reply_json_value(reply)?;
+    super::semantic_failure::parse_semantic_failure_report(&value)
+}
+
+/// Issue #647 (Phase D / D.2 + D.3): build a [`super::repair_job::SemanticRepairPlan`]
+/// from a parsed [`super::semantic_failure::SemanticFailureReport`].
+///
+/// Returns `None` when:
+/// - `dispatch_target(report) == SetupRepair` (D.3): DependencyMissing /
+///   ConfigOrVerifierError are routed to the existing setup-repair /
+///   `MissingVerifierJob` pipeline; no SemanticRepairPlan is constructed.
+/// - `report.failure_clusters` is empty (no cluster to attack; the caller
+///   keeps `semantic_plan = None`).
+///
+/// `expected_improvement` is initialized to `None` — Phase E fills it after
+/// the verifier rerun.
+fn build_semantic_repair_plan_from_report(
+    report: super::semantic_failure::SemanticFailureReport,
+) -> Option<super::repair_job::SemanticRepairPlan> {
+    // D.3: DependencyMissing / ConfigOrVerifierError → setup repair path,
+    // no semantic plan.
+    if super::semantic_failure::dispatch_target(&report)
+        == super::semantic_failure::SemanticDispatchTarget::SetupRepair
+    {
+        return None;
+    }
+    // 1 RepairJob = 1 cluster (slot reuse, Phase E). Pick the first cluster
+    // as the attack target; if no clusters were reported, the plan cannot
+    // be built (caller keeps `semantic_plan = None`).
+    let failure_cluster_id = report.failure_clusters.first()?.cluster_key.clone();
+    // SpecAuthority candidates: Phase D wires the fallback set
+    // (ImplementationContract + LlmGeneratedTest) — a future Issue will pass
+    // BehaviorContract when a RequiredBehaviorContract is in scope. The
+    // result is deterministic (smaller variant index wins).
+    let candidates = [
+        super::spec_authority::SpecAuthority::ImplementationContract,
+        super::spec_authority::SpecAuthority::LlmGeneratedTest,
+    ];
+    let spec_authority = super::spec_authority::select_authority(&candidates, None)?;
+    Some(super::repair_job::SemanticRepairPlan {
+        semantic_cause: report.failure_kind,
+        spec_authority,
+        preferred_repair_role: report.preferred_repair_role,
+        repair_hypothesis: report.repair_hypothesis.clone(),
+        failure_cluster_id,
+        expected_improvement: None,
+        semantic_report: report,
+    })
+}
+
 fn model_assessment_to_verifier_repair_assessment(
     work_root: &Path,
     context: &super::repair_job::RepairJob,
@@ -19959,6 +20079,335 @@ E   assert [{'id': 1}] == []\n";
         assert_eq!(
             assessment.repair_target_hint.as_ref().map(|hint| hint.role),
             Some(super::super::task_contract::ArtifactRole::Setup)
+        );
+    }
+
+    // ---- Issue #647 (Phase D): diagnostic 経路統合 ---- //
+
+    /// Phase D / D.1 (S1-009): a diagnostic reply that **does** carry a
+    /// well-formed semantic-failure payload parses into
+    /// `Some(SemanticFailureReport)` via the shared extraction boundary.
+    /// This is the positive path that gates D.2 plan construction.
+    #[test]
+    fn phase_d_parse_semantic_failure_report_from_diagnostic_reply_succeeds() {
+        let reply = r#"{
+            "failure_kind":"assertion_mismatch",
+            "confidence":0.84,
+            "preferred_repair_role":"implementation",
+            "repair_hypothesis":"todos list initialized incorrectly",
+            "failure_clusters":[
+                {
+                    "observed":"got 200 want 201",
+                    "expected":"201 Created",
+                    "input_shape":"POST /todos",
+                    "assertion_shape":"AssertEq",
+                    "involved_artifacts":["implementation","test"],
+                    "affected_cases":["test_create_todo"]
+                }
+            ],
+            "contract_conflict":{
+                "implementation":"returns 200",
+                "test":"expects 201",
+                "usage_docs":"unspecified"
+            },
+            "probable_cause_role":"implementation",
+            "summary":"http status mismatch"
+        }"#;
+
+        let report =
+            super::parse_semantic_failure_report_from_reply(reply).expect("semantic parse ok");
+
+        assert_eq!(
+            report.failure_kind,
+            super::super::VerifierDiagnosticFailureKind::AssertionMismatch
+        );
+        assert_eq!(report.failure_clusters.len(), 1);
+        assert_eq!(
+            report.preferred_repair_role,
+            super::super::task_contract::ArtifactRole::Implementation
+        );
+        assert!(report.repair_hypothesis.starts_with("todos list"));
+    }
+
+    /// Phase D / D.1 (S1-009 / DR3-005): a legacy diagnostic reply that
+    /// lacks the semantic-failure schema (no `confidence` /
+    /// `preferred_repair_role`) collapses to `None` at the semantic parse
+    /// boundary. The caller will leave `RepairJob.semantic_plan = None`
+    /// without disturbing the legacy `ParsedVerifierRepairAssessment`
+    /// parse — verified by the parallel `parse_verifier_repair_assessment_reply`
+    /// call.
+    #[test]
+    fn phase_d_legacy_reply_yields_none_semantic_report_but_legacy_parse_holds() {
+        let reply = r#"{
+            "failure_kind":"assertion_mismatch",
+            "probable_cause_role":"implementation",
+            "repair_plan":[{"target":"app/main.py","intent":"fix","confidence":0.9}]
+        }"#;
+
+        // Semantic parse returns None — no confidence / preferred_repair_role.
+        assert!(super::parse_semantic_failure_report_from_reply(reply).is_none());
+        // Legacy parse still succeeds — DR3-005: independent paths.
+        let legacy = super::parse_verifier_repair_assessment_reply(reply)
+            .expect("legacy parse must still succeed");
+        assert_eq!(
+            legacy.failure_kind,
+            super::super::VerifierDiagnosticFailureKind::AssertionMismatch
+        );
+    }
+
+    /// Phase D / D.1 (DR3-005): the diagnostic reply guard at
+    /// `run_verifier_diagnostic_pass` short-circuits on `tool_calls`
+    /// before the parsers run, so neither semantic nor legacy parse ever
+    /// sees the payload. We mirror that behavior at the parser level by
+    /// confirming that a non-JSON / unparseable reply yields `None` from
+    /// the semantic parse boundary without panicking.
+    #[test]
+    fn phase_d_semantic_parse_returns_none_for_unparseable_reply() {
+        // Empty / non-JSON / no braces.
+        assert!(super::parse_semantic_failure_report_from_reply("").is_none());
+        assert!(super::parse_semantic_failure_report_from_reply("not json at all").is_none());
+        // Malformed JSON.
+        assert!(super::parse_semantic_failure_report_from_reply(r#"{"failure_kind":"#).is_none());
+    }
+
+    /// Phase D / D.2: a positive-path semantic report produces a
+    /// `SemanticRepairPlan` whose fields are wired from the report
+    /// (cluster id from `failure_clusters[0]`, `semantic_cause = failure_kind`,
+    /// `repair_hypothesis` from the report, `expected_improvement = None`).
+    /// `spec_authority` falls back to `ImplementationContract` per the
+    /// Phase-D candidate set (D.2 design).
+    #[test]
+    fn phase_d_build_semantic_repair_plan_wires_report_into_plan_slot() {
+        let reply = r#"{
+            "failure_kind":"assertion_mismatch",
+            "confidence":0.91,
+            "preferred_repair_role":"implementation",
+            "repair_hypothesis":"impl returns 200, test expects 201",
+            "failure_clusters":[
+                {
+                    "observed":"200 OK",
+                    "expected":"201 Created",
+                    "input_shape":"POST /todos",
+                    "assertion_shape":"AssertEq",
+                    "involved_artifacts":["implementation","test"],
+                    "affected_cases":["test_create_todo"]
+                }
+            ]
+        }"#;
+        let report = super::parse_semantic_failure_report_from_reply(reply).expect("parses");
+        let cluster_id = report.failure_clusters[0].cluster_key.clone();
+        let plan = super::build_semantic_repair_plan_from_report(report)
+            .expect("plan should be built for AssertionMismatch with clusters");
+
+        assert_eq!(
+            plan.semantic_cause,
+            super::super::VerifierDiagnosticFailureKind::AssertionMismatch
+        );
+        assert_eq!(plan.failure_cluster_id, cluster_id);
+        assert_eq!(
+            plan.preferred_repair_role,
+            super::super::task_contract::ArtifactRole::Implementation
+        );
+        assert!(plan.repair_hypothesis.contains("returns 200"));
+        assert!(plan.expected_improvement.is_none());
+    }
+
+    /// Phase D / D.3 (S1-010): `DependencyMissing` dispatches to the
+    /// setup-repair / `MissingVerifierJob` path; no `SemanticRepairPlan`
+    /// is constructed (slot stays `None`).
+    #[test]
+    fn phase_d_dependency_missing_routes_to_setup_with_no_semantic_plan() {
+        let reply = r#"{
+            "failure_kind":"dependency_missing",
+            "confidence":0.97,
+            "preferred_repair_role":"setup",
+            "repair_hypothesis":"pytest cannot import requests",
+            "failure_clusters":[
+                {
+                    "observed":"ModuleNotFoundError: requests",
+                    "expected":"requests importable",
+                    "input_shape":"pytest collection",
+                    "assertion_shape":"ImportError",
+                    "involved_artifacts":["setup"],
+                    "affected_cases":["test_health"]
+                }
+            ]
+        }"#;
+        let report = super::parse_semantic_failure_report_from_reply(reply).expect("parses");
+        assert!(super::build_semantic_repair_plan_from_report(report).is_none());
+    }
+
+    /// Phase D / D.3: `ConfigOrVerifierError` likewise routes to setup
+    /// repair — no `SemanticRepairPlan` is constructed.
+    #[test]
+    fn phase_d_config_or_verifier_error_routes_to_setup_with_no_semantic_plan() {
+        let reply = r#"{
+            "failure_kind":"config_or_verifier_error",
+            "confidence":0.80,
+            "preferred_repair_role":"setup",
+            "repair_hypothesis":"pytest config malformed",
+            "failure_clusters":[
+                {
+                    "observed":"ERROR: pytest.ini malformed",
+                    "expected":"pytest.ini parseable",
+                    "input_shape":"pytest startup",
+                    "assertion_shape":"ConfigError",
+                    "involved_artifacts":["setup"]
+                }
+            ]
+        }"#;
+        let report = super::parse_semantic_failure_report_from_reply(reply).expect("parses");
+        assert!(super::build_semantic_repair_plan_from_report(report).is_none());
+    }
+
+    /// Phase D / D.2: an `AssertionMismatch` report with **no** clusters
+    /// cannot identify a cluster to attack — the plan slot stays `None`
+    /// (1 RepairJob = 1 cluster, slot reuse is a Phase E concern).
+    #[test]
+    fn phase_d_assertion_mismatch_with_no_clusters_yields_no_plan() {
+        let reply = r#"{
+            "failure_kind":"assertion_mismatch",
+            "confidence":0.75,
+            "preferred_repair_role":"implementation",
+            "repair_hypothesis":"hypothesis without clusters",
+            "failure_clusters":[]
+        }"#;
+        let report = super::parse_semantic_failure_report_from_reply(reply).expect("parses");
+        assert!(super::build_semantic_repair_plan_from_report(report).is_none());
+    }
+
+    /// Phase D / D.4 (DR4-002): the repair editor prompt carries the
+    /// `SemanticRepairPlan` as a structured JSON data field. The plan is
+    /// **never** concatenated into the system / developer instruction
+    /// text — the system message still declares verifier output as
+    /// untrusted data, and the plan fields appear only inside the JSON
+    /// payload.
+    #[test]
+    fn phase_d_repair_editor_prompt_carries_semantic_plan_as_json_data() {
+        use super::super::repair_job::{RepairJob, SemanticRepairPlan};
+        use super::super::semantic_failure::{
+            ContractConflict, FailureCluster, SemanticFailureReport,
+            build_failure_cluster_from_observation,
+        };
+        use super::super::spec_authority::SpecAuthority;
+
+        let temp = tempdir().unwrap();
+        let work_root = temp.path().to_path_buf();
+        let app = work_root.join("app").join("main.py");
+        std::fs::create_dir_all(app.parent().unwrap()).unwrap();
+        std::fs::write(&app, "def todos():\n    return []\n").unwrap();
+
+        let cluster: FailureCluster = build_failure_cluster_from_observation(
+            "200 OK",
+            "201 Created",
+            "POST /todos",
+            "AssertEq",
+            &[
+                super::super::task_contract::ArtifactRole::Implementation,
+                super::super::task_contract::ArtifactRole::Test,
+            ],
+        );
+        let cluster_id = cluster.cluster_key.clone();
+        let report = SemanticFailureReport {
+            failure_kind: super::super::VerifierDiagnosticFailureKind::AssertionMismatch,
+            failure_clusters: vec![cluster],
+            contract_conflict: ContractConflict {
+                implementation: "returns 200".to_string(),
+                test: "expects 201".to_string(),
+                usage_docs: String::new(),
+            },
+            preferred_repair_role: super::super::task_contract::ArtifactRole::Implementation,
+            repair_hypothesis: "impl returns 200; test expects 201".to_string(),
+            confidence: 0.91,
+        };
+        let plan = SemanticRepairPlan {
+            semantic_cause: super::super::VerifierDiagnosticFailureKind::AssertionMismatch,
+            spec_authority: SpecAuthority::ImplementationContract,
+            preferred_repair_role: super::super::task_contract::ArtifactRole::Implementation,
+            repair_hypothesis: "impl returns 200; test expects 201".to_string(),
+            failure_cluster_id: cluster_id.clone(),
+            expected_improvement: None,
+            semantic_report: report,
+        };
+
+        let target_hint = super::super::task_contract::RecoveryTargetHint {
+            role: super::super::task_contract::ArtifactRole::Implementation,
+            path: "app/main.py".to_string(),
+            reason: "fix impl".to_string(),
+        };
+
+        let job = RepairJob {
+            command: "python3 -m pytest".to_string(),
+            output_excerpt: "FAILED".to_string(),
+            failure_type: super::super::VerifierFailureType::AssertionFailure,
+            target_hint: Some(target_hint.clone()),
+            repair_target_hint: Some(target_hint.clone()),
+            failure_signature: "sig".to_string(),
+            semantic_plan: Some(plan),
+            ..RepairJob::new_for_test()
+        };
+        let messages = super::verifier_repair_pass_messages(&work_root, &job, &target_hint, "task")
+            .expect("messages built");
+        assert_eq!(messages.len(), 2);
+
+        // The system message must NOT contain semantic-plan fields — those
+        // are untrusted data, not instructions.
+        let system_text = format!("{:?}", messages[0]);
+        assert!(
+            !system_text.contains("impl returns 200"),
+            "semantic_plan must not leak into system instruction: {system_text}",
+        );
+        assert!(
+            !system_text.contains(cluster_id.as_str()),
+            "cluster_id must not leak into system instruction: {system_text}",
+        );
+
+        // The user message JSON payload must carry the plan under
+        // `semantic_plan` as structured data, not as free-form prose.
+        let user_text = format!("{:?}", messages[1]);
+        assert!(
+            user_text.contains("\\\"semantic_plan\\\""),
+            "user payload must include semantic_plan key: {user_text}",
+        );
+        assert!(
+            user_text.contains(cluster_id.as_str()),
+            "user payload must include the cluster id: {user_text}",
+        );
+        assert!(
+            user_text.contains("failure_cluster_id"),
+            "user payload must include failure_cluster_id field",
+        );
+    }
+
+    /// Phase D / D.4 (DR4-002): when `semantic_plan = None` (legacy
+    /// fallback / SetupRepair dispatch), the prompt still builds and
+    /// carries `semantic_plan: null` — the field is present but empty so
+    /// the JSON shape is stable across legacy / semantic runs.
+    #[test]
+    fn phase_d_repair_editor_prompt_carries_null_semantic_plan_for_legacy_path() {
+        use super::super::repair_job::RepairJob;
+        let temp = tempdir().unwrap();
+        let work_root = temp.path().to_path_buf();
+        let app = work_root.join("app").join("main.py");
+        std::fs::create_dir_all(app.parent().unwrap()).unwrap();
+        std::fs::write(&app, "def f():\n    return 1\n").unwrap();
+        let target_hint = super::super::task_contract::RecoveryTargetHint {
+            role: super::super::task_contract::ArtifactRole::Implementation,
+            path: "app/main.py".to_string(),
+            reason: "fix impl".to_string(),
+        };
+        let job = RepairJob {
+            failure_signature: "sig".to_string(),
+            target_hint: Some(target_hint.clone()),
+            semantic_plan: None,
+            ..RepairJob::new_for_test()
+        };
+        let messages = super::verifier_repair_pass_messages(&work_root, &job, &target_hint, "task")
+            .expect("messages built");
+        let user_text = format!("{:?}", messages[1]);
+        assert!(
+            user_text.contains("\\\"semantic_plan\\\":null"),
+            "legacy path must emit semantic_plan: null in payload: {user_text}",
         );
     }
 

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -9294,6 +9294,30 @@ impl Agent {
     }
 
     fn run_verifier_diagnostic_pass(&mut self) -> VerifierDiagnosticPassOutcome {
+        // Issue #647 (CB-013): before the Skipped short-circuit consults
+        // `context.assessment.is_some()`, detect the "advanced semantic_plan
+        // + stale assessment" state that CB-012 catches at the decision
+        // layer. If we are in that state, clear the stale assessment so the
+        // diagnostic actually runs — otherwise the Skipped short-circuit
+        // below would fire and neutralize the CB-012 fix at the production
+        // layer (the decision layer returns NeedDiagnostic, but this runner
+        // refuses to actually run because the stale assessment is still
+        // present).
+        //
+        // We deliberately do NOT touch `assessment_attempts` here — the
+        // existing diagnostic runner logic below increments it via the
+        // `current.assessment_attempts = current.assessment_attempts.saturating_add(1)`
+        // line after `verifier_diagnostic_attempt_spec` resolves. We only
+        // clear the stale assessment + flip `diagnostic_attempted` back to
+        // `false` so a fresh diagnostic pass is permitted under the same
+        // attempt budget.
+        let stale_advance = self.repair_job.as_ref().is_some_and(|job| {
+            super::repair_job::has_stale_assessment_after_cluster_advance(job, &self.work_root)
+        });
+        if stale_advance && let Some(current) = self.repair_job.as_mut() {
+            current.assessment = None;
+            current.diagnostic_attempted = false;
+        }
         let Some(context) = self.repair_job.clone() else {
             return VerifierDiagnosticPassOutcome::Skipped;
         };
@@ -20741,6 +20765,134 @@ mod progress_tests {
             dec,
             VerifierRepairDecision::NeedDiagnostic,
             "CB-012: guard must NOT fire when exhausted_attempts is empty"
+        );
+    }
+
+    /// Issue #647 (CB-013): production-level integration test.
+    ///
+    /// When `run_verifier_diagnostic_pass` is invoked with the same
+    /// "advanced semantic_plan + stale assessment" state that the CB-012
+    /// decision layer routes through `NeedDiagnostic`, the runner MUST
+    /// clear the stale assessment before its own `assessment.is_some()`
+    /// Skipped short-circuit fires — otherwise the CB-012 fix is
+    /// neutralized at the production layer.
+    ///
+    /// We assert two production invariants:
+    ///   1. The outcome is NOT `Skipped` — diagnostic actually ran.
+    ///   2. `repair_job.assessment_attempts` was incremented (>= 1),
+    ///      proving the diagnostic runner's body executed past the
+    ///      Skipped short-circuit.
+    ///
+    /// The ollama call inside the runner will fail (the test agent's
+    /// host points at a fake endpoint), but that is intentional —
+    /// `Failed`/`Unavailable`/`RetryPending` are all acceptable; the
+    /// essential signal is that we left `Skipped` behind.
+    #[test]
+    fn cb013_stale_advanced_semantic_plan_actually_runs_diagnostic() {
+        use super::super::commands::test_agent_with_config;
+        use super::super::repair_job::{RepairJob, SemanticRepairPlan};
+        use crate::config::Config;
+
+        let (mut agent, _temp) = test_agent_with_config(Config::default());
+
+        // Build the stale-state RepairJob: semantic_plan = Some,
+        // exhausted_attempts non-empty, assessment = Some (stale cluster A).
+        let mut job: RepairJob = verifier_context_for("app/main.py");
+        assert!(
+            job.assessment.is_some(),
+            "fixture invariant: assessment must be Some so CB-013 has something to clear"
+        );
+        let plan: SemanticRepairPlan = semantic_plan_for_test_fixture();
+        let cluster_id = plan.failure_cluster_id.clone();
+        job.semantic_plan = Some(plan);
+        job.exhausted_attempts.push((
+            cluster_id,
+            super::super::task_contract::ArtifactRole::Implementation,
+        ));
+        job.assessment_attempts = 0;
+        job.diagnostic_attempted = true;
+        agent.repair_job = Some(job);
+        agent.task_contract_verifier_repair_pending = true;
+
+        // Sanity check: the decision layer (CB-012) would route this state
+        // through NeedDiagnostic. CB-013's job is to make sure the
+        // diagnostic runner honors that intent in production.
+        assert!(
+            super::super::repair_job::has_stale_assessment_after_cluster_advance(
+                agent.repair_job.as_ref().unwrap(),
+                &agent.work_root,
+            ),
+            "CB-013 fixture must satisfy the stale-state predicate"
+        );
+
+        let outcome = agent.run_verifier_diagnostic_pass();
+        assert!(
+            !matches!(outcome, super::VerifierDiagnosticPassOutcome::Skipped),
+            "CB-013: diagnostic must NOT short-circuit to Skipped when the \
+             stale-advance state holds; got {outcome:?}"
+        );
+
+        let attempts = agent
+            .repair_job
+            .as_ref()
+            .map(|job| job.assessment_attempts)
+            .unwrap_or(0);
+        assert!(
+            attempts >= 1,
+            "CB-013: assessment_attempts must be incremented after the \
+             diagnostic runner clears the stale assessment and proceeds \
+             past Skipped (got {attempts})"
+        );
+    }
+
+    /// Issue #647 (CB-013) regression: when `semantic_plan` is `None` (=
+    /// legacy / SetupRepair path), the existing Skipped short-circuit on
+    /// `assessment.is_some()` must remain intact. CB-013 only bypasses
+    /// Skipped for the narrow stale-advance state.
+    #[test]
+    fn cb013_fresh_state_with_assessment_still_skips() {
+        use super::super::commands::test_agent_with_config;
+        use super::super::repair_job::RepairJob;
+        use crate::config::Config;
+
+        let (mut agent, _temp) = test_agent_with_config(Config::default());
+
+        // Legacy state: no semantic_plan, no exhausted_attempts, but
+        // assessment is Some. CB-013 must NOT fire — Skipped wins.
+        let mut job: RepairJob = verifier_context_for("app/main.py");
+        assert!(job.assessment.is_some(), "fixture invariant");
+        assert!(job.semantic_plan.is_none(), "fixture invariant");
+        assert!(job.exhausted_attempts.is_empty(), "fixture invariant");
+        job.assessment_attempts = 0;
+        agent.repair_job = Some(job);
+        agent.task_contract_verifier_repair_pending = true;
+
+        // Confirm CB-013 predicate does not fire for legacy state.
+        assert!(
+            !super::super::repair_job::has_stale_assessment_after_cluster_advance(
+                agent.repair_job.as_ref().unwrap(),
+                &agent.work_root,
+            ),
+            "CB-013 must not fire for legacy / no-semantic-plan state"
+        );
+
+        let outcome = agent.run_verifier_diagnostic_pass();
+        assert!(
+            matches!(outcome, super::VerifierDiagnosticPassOutcome::Skipped),
+            "CB-013 regression: legacy `assessment.is_some()` Skipped \
+             short-circuit must remain intact; got {outcome:?}"
+        );
+
+        // assessment_attempts must NOT have been incremented (diagnostic
+        // body never ran).
+        assert_eq!(
+            agent
+                .repair_job
+                .as_ref()
+                .map(|job| job.assessment_attempts)
+                .unwrap_or(0),
+            0,
+            "CB-013 regression: Skipped must not increment assessment_attempts"
         );
     }
 

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -20768,6 +20768,88 @@ mod progress_tests {
         );
     }
 
+    /// Issue #647 (CB-014): the stale advanced-semantic-plan state must
+    /// fail closed when `assessment_attempts` reaches the diagnostic
+    /// budget limit. Without this branch the same stale state bypasses
+    /// `NeedDiagnostic` (limit-gated) and falls through to
+    /// `latest_successful_read_existing_path` / `NeedTargetDiscovery`,
+    /// reopening the stale-target fallback at the budget boundary.
+    #[test]
+    fn cb014_stale_advanced_semantic_plan_at_budget_limit_returns_diagnostic_unavailable() {
+        use super::super::repair_job::{
+            RepairJob, VerifierRepairDecision, verifier_repair_decision as decision_fn,
+        };
+        let temp = tempdir().unwrap();
+        let work_root = temp.path().to_path_buf();
+        // Pre-populate an unrelated read-existing file so the
+        // `latest_successful_read_existing_path` fallback *could* match
+        // if the CB-014 guard fails to fire.
+        let unrelated = work_root.join("unrelated.txt");
+        std::fs::write(&unrelated, "irrelevant\n").unwrap();
+
+        let mut context: RepairJob = verifier_context_for("app/main.py");
+        assert!(context.assessment.is_some(), "fixture invariant");
+        context.semantic_plan = Some(semantic_plan_for_test_fixture());
+        let any_cluster_id = context
+            .semantic_plan
+            .as_ref()
+            .unwrap()
+            .failure_cluster_id
+            .clone();
+        context.exhausted_attempts.push((
+            any_cluster_id,
+            super::super::task_contract::ArtifactRole::Implementation,
+        ));
+        // **Budget exhausted**: assessment_attempts == LIMIT.
+        context.assessment_attempts = VERIFIER_DIAGNOSTIC_ATTEMPT_LIMIT;
+        context.diagnostic_attempted = true;
+
+        let dec = decision_fn(true, Some(&context), &[], &work_root, Some(1), 1);
+        assert_eq!(
+            dec,
+            VerifierRepairDecision::DiagnosticUnavailable,
+            "CB-014: stale advanced semantic_plan with exhausted diagnostic budget must fail closed"
+        );
+    }
+
+    /// Issue #647 (CB-014): the stale advanced-semantic-plan state must
+    /// still return `NeedDiagnostic` while attempts remain under the
+    /// budget (= CB-012 behavior unchanged for under-budget). Pins the
+    /// split between CB-012 (under-budget) and CB-014 (at-budget).
+    #[test]
+    fn cb014_stale_advanced_semantic_plan_under_budget_still_returns_need_diagnostic() {
+        use super::super::repair_job::{
+            RepairJob, VerifierRepairDecision, verifier_repair_decision as decision_fn,
+        };
+        let temp = tempdir().unwrap();
+        let work_root = temp.path().to_path_buf();
+
+        let mut context: RepairJob = verifier_context_for("app/main.py");
+        assert!(context.assessment.is_some(), "fixture invariant");
+        context.semantic_plan = Some(semantic_plan_for_test_fixture());
+        let any_cluster_id = context
+            .semantic_plan
+            .as_ref()
+            .unwrap()
+            .failure_cluster_id
+            .clone();
+        context.exhausted_attempts.push((
+            any_cluster_id,
+            super::super::task_contract::ArtifactRole::Implementation,
+        ));
+        // **Budget remaining**: attempts strictly below LIMIT.
+        const _: () = assert!(VERIFIER_DIAGNOSTIC_ATTEMPT_LIMIT >= 1);
+        context.assessment_attempts = VERIFIER_DIAGNOSTIC_ATTEMPT_LIMIT - 1;
+        context.diagnostic_attempted = true;
+
+        let dec = decision_fn(true, Some(&context), &[], &work_root, Some(1), 1);
+        assert_eq!(
+            dec,
+            VerifierRepairDecision::NeedDiagnostic,
+            "CB-014 boundary: attempts < LIMIT must still elect NeedDiagnostic"
+        );
+    }
+
     /// Issue #647 (CB-013): production-level integration test.
     ///
     /// When `run_verifier_diagnostic_pass` is invoked with the same

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -9532,6 +9532,22 @@ impl Agent {
                 semantic_plan,
                 new_report.as_ref(),
             );
+            // CB-017 A''': immediately rebind the freshly-landed legacy
+            // assessment to the current semantic-plan cluster so the
+            // controller routes to the new cluster's admitted targets —
+            // not the previous cluster's stale paths surfaced by
+            // `needed_reads` / `repair_plan`. The rebind helper is a no-op
+            // when `semantic_plan = None` (legacy fallback) or when the
+            // current cluster is targetless (caller already skipped it via
+            // `first_repairable_cluster` / `next_repairable_cluster`).
+            //
+            // Path-coverage: this is the `DiagnosticSkip` callsite when
+            // `assign_semantic_plan_preserving_exhausted` walked past an
+            // already-exhausted cluster; for the "new bind" path it
+            // realigns the assessment to the freshly-elected first
+            // cluster. Either way `applied_repair_intents` only clears
+            // on actual cluster-id transition.
+            super::repair_job::rebind_legacy_assessment_to_current_cluster(current);
         }
         log_llm_event(
             "agent.verifier_diagnostic.completed",
@@ -14414,6 +14430,14 @@ fn verifier_repair_context_from_failure(
         assessment_generation: previous_context
             .map(|context| context.assessment_generation)
             .unwrap_or(0),
+        // Issue #647 / CB-017 A''' (CR-4 V2): carry over the cluster-key bind
+        // so `rebind_legacy_assessment_to_current_cluster` can detect cluster
+        // transitions across turn boundaries. A new failure that builds a
+        // fresh `RepairJob` (no previous_context) starts with `None` —
+        // matching the "no semantic plan yet" defaults applied above so the
+        // first rebind after a fresh diagnostic is treated as a new bind.
+        assessment_bound_cluster_id: previous_context
+            .and_then(|context| context.assessment_bound_cluster_id.clone()),
     }
 }
 
@@ -24941,6 +24965,85 @@ export default function App() {
         assert_eq!(
             next.assessment_generation, 5,
             "CB-015: assessment_generation must survive turn boundary via previous_context",
+        );
+    }
+
+    /// Issue #647 / CB-017 A''' (CR-4 V2): `verifier_repair_context_from_failure`
+    /// must carry the `assessment_bound_cluster_id` over the turn boundary so
+    /// `rebind_legacy_assessment_to_current_cluster` can detect cluster-key
+    /// transitions across slot reuse. A fresh failure with no previous
+    /// context starts at `None`; subsequent failures inherit the prior bind.
+    #[test]
+    fn cb017_verifier_repair_context_carries_over_assessment_bound_cluster_id() {
+        use super::repair_job::SemanticRepairPlan;
+        use super::spec_authority::SpecAuthority;
+        use super::task_contract::ArtifactRole;
+        let temp = tempdir().unwrap();
+        let work_root = temp.path();
+        std::fs::create_dir_all(work_root.join("app")).unwrap();
+        std::fs::write(work_root.join("app/main.py"), "def main(): pass\n").unwrap();
+        let changed = vec!["app/main.py".to_string()];
+        let output = "FAILED tests/test_api.py::test_x - AssertionError\n1 failed";
+
+        // First cycle: no previous context → bound id starts at None.
+        let mut previous = verifier_repair_context_from_failure(
+            work_root,
+            "python3 -B -m pytest",
+            output,
+            &changed,
+            1,
+            None,
+        );
+        assert!(
+            previous.assessment_bound_cluster_id.is_none(),
+            "CB-017: fresh RepairJob without previous_context starts with bound id None",
+        );
+
+        // Simulate a successful diagnostic + rebind landing on cluster A.
+        let report = super::semantic_failure::parse_semantic_failure_report(&serde_json::json!({
+            "failure_kind": "assertion_mismatch",
+            "confidence": 0.7,
+            "preferred_repair_role": "implementation",
+            "repair_hypothesis": "h",
+            "failure_clusters": [
+                {
+                    "observed": "alpha",
+                    "expected": "ALPHA",
+                    "input_shape": "alpha-shape",
+                    "assertion_shape": "AssertEq",
+                    "involved_artifacts": ["implementation"],
+                    "affected_cases": ["case_alpha"],
+                }
+            ],
+        }))
+        .expect("report parses");
+        let cluster_a = report.failure_clusters[0].cluster_key.clone();
+        let prev_plan = SemanticRepairPlan {
+            semantic_report: report,
+            failure_cluster_id: cluster_a.clone(),
+            semantic_cause: super::VerifierDiagnosticFailureKind::AssertionMismatch,
+            spec_authority: SpecAuthority::ImplementationContract,
+            preferred_repair_role: ArtifactRole::Implementation,
+            repair_hypothesis: "h".to_string(),
+            expected_improvement: None,
+            assessment_generation_at_creation: 0,
+        };
+        previous.semantic_plan = Some(prev_plan);
+        previous.assessment_bound_cluster_id = Some(cluster_a.clone());
+
+        // Second cycle: previous_context carries the bind forward.
+        let next = verifier_repair_context_from_failure(
+            work_root,
+            "python3 -B -m pytest",
+            output,
+            &changed,
+            2,
+            Some(&previous),
+        );
+        assert_eq!(
+            next.assessment_bound_cluster_id.as_ref(),
+            Some(&cluster_a),
+            "CB-017: assessment_bound_cluster_id must survive turn boundary via previous_context",
         );
     }
 

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -7561,7 +7561,7 @@ impl Agent {
             }
             TaskContractVerifierOutcome::Failed { command, output } => {
                 *args.contract_verification_retries += 1;
-                let repair_context = verifier_repair_context_from_failure(
+                let mut repair_context = verifier_repair_context_from_failure(
                     &self.work_root,
                     &command,
                     &output,
@@ -7581,6 +7581,24 @@ impl Agent {
                         ),
                     };
                 }
+                // Issue #647 (MF2.2 / MF2.3): drive the cluster-aware
+                // sequential repair state machine after the new
+                // `RepairJob` is built (MF2.1 already carried the semantic
+                // plan and exhausted ledger over). `previous_cluster_id`
+                // is the failure_cluster_id from the previous turn — the
+                // dispatch wraps the base rerun outcome via
+                // `rerun_outcome_with_cluster` and advances to the next
+                // cluster (or falls back to re-diagnostic) accordingly.
+                // S7-005: the dispatch never touches the legacy retry
+                // counters (`repair_attempt`).
+                let previous_cluster_id = previous_repair_context
+                    .as_ref()
+                    .and_then(|context| context.semantic_plan.as_ref())
+                    .map(|plan| plan.failure_cluster_id.clone());
+                super::repair_job::apply_semantic_repair_dispatch_after_rerun(
+                    &mut repair_context,
+                    previous_cluster_id.as_ref(),
+                );
                 *args.contract_verifier_repair_edit_count =
                     Some(args.repo_edit_calls_made_this_turn);
                 self.task_contract_verifier_repair_pending = true;
@@ -14228,14 +14246,19 @@ fn verifier_repair_context_from_failure(
         previous_failure_count,
         rerun_outcome,
         repair_attempt,
-        // Issue #647 (Phase B): semantic-repair planning fields are populated
-        // by Phase D (`model_assessment_to_verifier_repair_assessment` end).
-        // At this construction point we have not yet parsed the diagnostic
-        // LLM payload into a `SemanticFailureReport`, so both slots start
-        // empty. `exhausted_attempts` is the per-job ledger that survives
-        // slot reuse — it has no prior entries when the job is first built.
-        semantic_plan: None,
-        exhausted_attempts: Vec::new(),
+        // Issue #647 (Phase B / MF2.1): carry `semantic_plan` and
+        // `exhausted_attempts` over from the previous turn so cluster-aware
+        // sequential repair survives slot reuse. The Phase-D diagnostic
+        // populates these slots — without the carryover, every new verifier
+        // failure would discard the active cluster plan and the per-job
+        // ledger, forcing a fresh diagnostic round-trip and defeating the
+        // sequential-repair design (設計判断 #5, S3-010). The post-rerun
+        // dispatch in `drive_task_contract_verifier` (MF2.2 / MF2.3) walks
+        // these carried-over slots via the Phase-E helpers.
+        semantic_plan: previous_context.and_then(|context| context.semantic_plan.clone()),
+        exhausted_attempts: previous_context
+            .map(|context| context.exhausted_attempts.clone())
+            .unwrap_or_default(),
     }
 }
 
@@ -23164,6 +23187,96 @@ export default function App() {
 
         assert!(
             verifier_repair_target_candidate_from_output(work_root, output, &changed).is_none()
+        );
+    }
+
+    /// Issue #647 (MF2.1): `verifier_repair_context_from_failure` must carry
+    /// over `semantic_plan` and `exhausted_attempts` from the previous turn's
+    /// `RepairJob`. Without this, every new verifier failure would drop the
+    /// Phase-D semantic plan and force a fresh diagnostic round-trip, which
+    /// in turn defeats sequential cluster repair (the slot reuse design).
+    #[test]
+    fn verifier_repair_context_carries_over_semantic_plan_and_exhausted_attempts() {
+        use super::super::repair_job::SemanticRepairPlan;
+        use super::super::semantic_failure::parse_semantic_failure_report;
+        use super::super::spec_authority::SpecAuthority;
+        use super::super::task_contract::ArtifactRole;
+
+        let temp = tempdir().unwrap();
+        let work_root = temp.path();
+        std::fs::create_dir_all(work_root.join("app")).unwrap();
+        std::fs::write(work_root.join("app/main.py"), "def create_todo(): pass\n").unwrap();
+        let changed = vec!["app/main.py".to_string()];
+        let output = "FAILED tests/test_api.py::test_create - AssertionError\n1 failed";
+
+        // Build a multi-cluster SemanticFailureReport via the SSOT parser.
+        let report_json = serde_json::json!({
+            "failure_kind": "assertion_mismatch",
+            "confidence": 0.7,
+            "preferred_repair_role": "implementation",
+            "repair_hypothesis": "carryover hypothesis",
+            "failure_clusters": [
+                {
+                    "observed": "alpha",
+                    "expected": "ALPHA",
+                    "input_shape": "alphashape",
+                    "assertion_shape": "AssertEq",
+                    "involved_artifacts": ["implementation", "test"],
+                    "affected_cases": ["alphacase"],
+                },
+                {
+                    "observed": "beta",
+                    "expected": "BETA",
+                    "input_shape": "betashape",
+                    "assertion_shape": "AssertEq",
+                    "involved_artifacts": ["implementation", "test"],
+                    "affected_cases": ["betacase"],
+                },
+            ],
+        });
+        let report = parse_semantic_failure_report(&report_json).expect("report parses");
+        let cluster_a = report.failure_clusters[0].cluster_key.clone();
+        let cluster_b = report.failure_clusters[1].cluster_key.clone();
+
+        // Build a previous-turn RepairJob with a semantic plan + a non-empty
+        // ledger (simulating "we already burned cluster A").
+        let prev_plan = SemanticRepairPlan {
+            semantic_report: report.clone(),
+            failure_cluster_id: cluster_b.clone(),
+            semantic_cause: report.failure_kind,
+            spec_authority: SpecAuthority::ImplementationContract,
+            preferred_repair_role: report.preferred_repair_role,
+            repair_hypothesis: report.repair_hypothesis.clone(),
+            expected_improvement: None,
+        };
+        let mut previous = verifier_repair_context_from_failure(
+            work_root,
+            "python3 -B -m pytest",
+            output,
+            &changed,
+            1,
+            None,
+        );
+        previous.semantic_plan = Some(prev_plan);
+        previous.exhausted_attempts = vec![(cluster_a.clone(), ArtifactRole::Implementation)];
+
+        // Run a second cycle. The new context must carry both fields over.
+        let next = verifier_repair_context_from_failure(
+            work_root,
+            "python3 -B -m pytest",
+            output,
+            &changed,
+            2,
+            Some(&previous),
+        );
+
+        // semantic_plan was carried over.
+        let next_plan = next.semantic_plan.expect("plan carried over");
+        assert_eq!(next_plan.failure_cluster_id, cluster_b);
+        // exhausted_attempts ledger was carried over.
+        assert_eq!(
+            next.exhausted_attempts,
+            vec![(cluster_a.clone(), ArtifactRole::Implementation)]
         );
     }
 

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -28495,6 +28495,281 @@ export default function App() {
             "unsafe paths (../, absolute, control chars) must NOT survive enrich admission"
         );
     }
+
+    /// CB-017 A''' (Commit 5, §12 #21 — legacy fallback closure):
+    /// when the diagnostic LLM returns ONLY legacy fields (no semantic
+    /// `failure_clusters` schema), the SF1 → CB-017 pipeline must still
+    /// yield an admitted semantic plan:
+    ///
+    /// 1. `parse_semantic_failure_report_from_reply` returns `None` — the
+    ///    reply does not satisfy the semantic schema.
+    /// 2. `build_semantic_failure_report_from_legacy` synthesizes a
+    ///    single-cluster report with **no** proposed target candidates.
+    /// 3. `merge_legacy_targets_into_clusters` populates the first
+    ///    cluster's `proposed_target_candidates` from
+    ///    `parsed.repair_targets` (the "all clusters targetless" branch
+    ///    fires because the synthesized report has exactly one targetless
+    ///    cluster).
+    /// 4. `enrich_failure_clusters_with_admitted_targets` admits each
+    ///    candidate via the SSOT `recovery_target_hint_for_diagnostic_path`
+    ///    — at least one survives because the legacy target points at a
+    ///    real implementation file in the workspace.
+    /// 5. The cluster now carries a non-empty
+    ///    `admitted_cluster_targets` slice → the production callsite
+    ///    keeps the semantic report (non-None) and downstream code can
+    ///    build a `SemanticRepairPlan`.
+    ///
+    /// This is the production-level closure for the legacy-only reply
+    /// case Codex review 4 flagged as the last A''' §12 item.
+    #[test]
+    fn cb017_legacy_only_reply_yields_semantic_plan_via_merge_then_enrich() {
+        use super::super::repair_job::RepairJob;
+
+        let temp = tempdir().unwrap();
+        let work_root = temp.path().to_path_buf();
+        let impl_file = work_root.join("app").join("main.py");
+        std::fs::create_dir_all(impl_file.parent().unwrap()).unwrap();
+        std::fs::write(&impl_file, "def f():\n    return 200\n").unwrap();
+
+        // Legacy schema: no `failure_clusters` array — only
+        // `probable_cause_role` / `repair_targets` / `summary`.
+        let legacy_reply = r#"{
+            "failure_kind":"assertion_mismatch",
+            "probable_cause_role":"implementation",
+            "repair_targets":[
+                {"target":"app/main.py","reason":"return 201 not 200","confidence":0.9}
+            ],
+            "summary":"impl returns 200 but test expects 201"
+        }"#;
+
+        // Step 1: semantic parse fails on the legacy reply.
+        assert!(
+            super::parse_semantic_failure_report_from_reply(legacy_reply).is_none(),
+            "pre-condition: semantic parse must fail on legacy-only reply",
+        );
+
+        // Step 2: legacy fallback synthesizes a SemanticFailureReport with
+        // a single cluster that has NO proposed target candidates.
+        let parsed = super::parse_verifier_repair_assessment_reply(legacy_reply)
+            .expect("legacy parse must succeed");
+        let job = RepairJob {
+            failure_signature: "tests/test_health.py::test_create AssertionError".to_string(),
+            output_excerpt: "FAILED tests/test_health.py::test_create - assert 200 == 201"
+                .to_string(),
+            ..RepairJob::new_for_test()
+        };
+        let mut report = super::build_semantic_failure_report_from_legacy(&parsed, &job)
+            .expect("legacy fallback must yield a semantic report");
+        assert_eq!(report.failure_clusters.len(), 1);
+        assert!(
+            report.failure_clusters[0]
+                .proposed_target_candidates
+                .is_empty(),
+            "legacy fallback must yield a cluster with NO proposed_target_candidates",
+        );
+        assert!(
+            report.failure_clusters[0]
+                .admitted_cluster_targets
+                .is_empty(),
+            "legacy fallback must yield a cluster with NO admitted_cluster_targets pre-merge",
+        );
+
+        // Step 3: merge — "all clusters targetless" branch fires, the
+        // first cluster gets the legacy `repair_targets` appended.
+        super::merge_legacy_targets_into_clusters(&mut report, &parsed);
+        let candidates = &report.failure_clusters[0].proposed_target_candidates;
+        assert_eq!(
+            candidates.len(),
+            1,
+            "merge must populate proposed_target_candidates from legacy repair_targets",
+        );
+        assert_eq!(candidates[0].raw_path, "app/main.py");
+        assert!(
+            candidates[0].role_hint.is_none(),
+            "merge from legacy: role_hint is always None (ParsedVerifierRepairTarget has no role)",
+        );
+
+        // Step 4: enrich — the SSOT admission gate produces at least one
+        // admitted target because `app/main.py` exists in the workspace.
+        let scope = super::super::task_workspace_scope::TaskWorkspaceScope::detect(&work_root, "");
+        let admission = cb017_admission_for_test(&work_root, &scope);
+        super::enrich_failure_clusters_with_admitted_targets(
+            &mut report,
+            &work_root,
+            &admission,
+            super::super::spec_authority::SpecAuthority::ImplementationContract,
+        );
+
+        // Step 5: cluster now carries an admitted target — the
+        // production "all admitted_cluster_targets empty → drop semantic
+        // report" predicate would now be **false**, so the caller keeps
+        // the report and the downstream pipeline can build a
+        // SemanticRepairPlan.
+        let admitted = &report.failure_clusters[0].admitted_cluster_targets;
+        assert!(
+            !admitted.is_empty(),
+            "enrich must admit at least one target from the legacy reply (production-level closure)",
+        );
+        assert_eq!(
+            admitted[0].path, "app/main.py",
+            "admitted path must round-trip the legacy target",
+        );
+        assert!(
+            !report
+                .failure_clusters
+                .iter()
+                .all(|c| c.admitted_cluster_targets.is_empty()),
+            "production gate: report is kept (NOT dropped) because at least one cluster has admitted targets",
+        );
+    }
+
+    /// CB-017 A''' (Commit 5, Codex required change #2 closure): the
+    /// `enrich_failure_clusters_with_admitted_targets` callsite MUST pass
+    /// `SpecAuthority` as an **explicit argument** — not consult some
+    /// implicit helper inside the function body. This is enforced
+    /// structurally at the production callsite in `run_verifier_diagnostic_pass`.
+    ///
+    /// The grep half asserts that the enrich helper's signature names
+    /// `spec_authority` (no implicit helper like `current_spec_authority_for`
+    /// inside the body), and the call-site half observes that two
+    /// different `SpecAuthority` values can be passed and threaded
+    /// through to `sort_admitted_by_authority_role_priority` (the
+    /// authority parameter is currently advisory per the CR-5 V2 decision
+    /// table, but the parameter is structurally wired so future
+    /// authority-conditional branches can be introduced without touching
+    /// the call-sites).
+    #[test]
+    fn cb017_enrich_uses_explicit_spec_authority_argument() {
+        // Grep half: confirm the enrich signature names spec_authority and
+        // the body has no `current_spec_authority_for(` helper invocation.
+        let src = include_str!("turn.rs");
+        let fn_pos = src
+            .find("pub(super) fn enrich_failure_clusters_with_admitted_targets(")
+            .expect("enrich function must exist");
+        let signature_window = &src[fn_pos..fn_pos + 400];
+        assert!(
+            signature_window.contains("spec_authority: super::spec_authority::SpecAuthority"),
+            "enrich must declare SpecAuthority as an explicit named argument (Codex CR #2)",
+        );
+        // Take a generous body slice (up to the next top-level fn).
+        let after = &src[fn_pos..];
+        let next_fn = after[1..]
+            .find("\npub(super) fn ")
+            .or_else(|| after[1..].find("\nfn "))
+            .map(|n| n + 1)
+            .unwrap_or(after.len());
+        let body = &after[..next_fn];
+        assert!(
+            !body.contains("current_spec_authority_for("),
+            "enrich body must NOT consult an implicit `current_spec_authority_for` helper — \
+             SpecAuthority is threaded as an explicit argument (Codex CR #2)",
+        );
+
+        // Behaviour half: confirm the explicit argument is actually
+        // observable by the sort routine — two enrich runs with different
+        // SpecAuthority values successfully complete with the explicit
+        // argument visible to the sort.
+        let temp = tempdir().unwrap();
+        let work_root = temp.path().to_path_buf();
+        let impl_file = work_root.join("app").join("main.py");
+        std::fs::create_dir_all(impl_file.parent().unwrap()).unwrap();
+        std::fs::write(&impl_file, "x = 1\n").unwrap();
+        let scope = super::super::task_workspace_scope::TaskWorkspaceScope::detect(&work_root, "");
+
+        let candidate = |path: &str| super::super::semantic_failure::RawClusterTargetCandidate {
+            raw_path: path.to_string(),
+            role_hint: None,
+            reason: "r".to_string(),
+        };
+        let mut report_user = cb017_single_cluster_report_with_candidates(
+            super::super::VerifierDiagnosticFailureKind::AssertionMismatch,
+            vec![candidate("app/main.py")],
+        );
+        let mut report_contract = cb017_single_cluster_report_with_candidates(
+            super::super::VerifierDiagnosticFailureKind::AssertionMismatch,
+            vec![candidate("app/main.py")],
+        );
+        let admission = cb017_admission_for_test(&work_root, &scope);
+        super::enrich_failure_clusters_with_admitted_targets(
+            &mut report_user,
+            &work_root,
+            &admission,
+            super::super::spec_authority::SpecAuthority::UserRequest,
+        );
+        super::enrich_failure_clusters_with_admitted_targets(
+            &mut report_contract,
+            &work_root,
+            &admission,
+            super::super::spec_authority::SpecAuthority::ImplementationContract,
+        );
+        // Both runs admit the same single target — different SpecAuthority
+        // values do not crash and produce a determinstic admitted list (the
+        // decision table is advisory under CR-5 V2 but the argument is
+        // structurally wired all the way to the sort routine).
+        assert_eq!(
+            report_user.failure_clusters[0]
+                .admitted_cluster_targets
+                .len(),
+            1
+        );
+        assert_eq!(
+            report_contract.failure_clusters[0]
+                .admitted_cluster_targets
+                .len(),
+            1
+        );
+    }
+
+    /// CB-017 A''' (Commit 5, Codex required change #3 closure):
+    /// `RawClusterTargetCandidate.role_hint` is untrusted advisory data
+    /// (LLM-supplied). Production code must NOT log it as raw metadata —
+    /// the value is consumed only inside the structured sort routines and
+    /// is never threaded into `log_llm_event` / `tracing::info!` /
+    /// `tracing::debug!` / `tracing::warn!` payloads.
+    ///
+    /// This is a structural grep test: production-grade source files in
+    /// `src/agent/loop_run/` must contain no occurrence of
+    /// `role_hint` inside a log payload context. Test fixtures (in
+    /// `#[cfg(test)] mod ...`) are permitted to mention `role_hint` for
+    /// assertions.
+    #[test]
+    fn cb017_role_hint_not_logged_as_raw_metadata() {
+        // We grep each file's production region (everything before the
+        // first `#[cfg(test)]` marker) for prohibited combinations of
+        // `role_hint` with logging macros / helpers.
+        const FILES: &[(&str, &str)] = &[
+            ("turn.rs", include_str!("turn.rs")),
+            ("repair_job.rs", include_str!("repair_job.rs")),
+            ("semantic_failure.rs", include_str!("semantic_failure.rs")),
+        ];
+        for (name, src) in FILES {
+            // Take everything before the first `#[cfg(test)]` block — this
+            // is the production region. Files without a cfg(test) marker
+            // are scanned in full.
+            let prod_region: &str = match src.find("#[cfg(test)]") {
+                Some(idx) => &src[..idx],
+                None => src,
+            };
+            // Forbidden patterns: role_hint appearing on the same line as
+            // a logging entry-point. We use a coarse line scan.
+            for (lineno, line) in prod_region.lines().enumerate() {
+                if !line.contains("role_hint") {
+                    continue;
+                }
+                let in_log_payload = line.contains("log_llm_event")
+                    || line.contains("tracing::info!")
+                    || line.contains("tracing::debug!")
+                    || line.contains("tracing::warn!")
+                    || line.contains("tracing::error!")
+                    || line.contains("tracing::trace!");
+                assert!(
+                    !in_log_payload,
+                    "{name}:{}: role_hint must NOT appear inside a log payload line (Codex CR #3 / DR4-001 advisory boundary)",
+                    lineno + 1
+                );
+            }
+        }
+    }
 }
 
 // ───────────────────────────────────────────────────────────────────────────

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -1699,6 +1699,10 @@ fn verifier_diagnostic_messages(
 Allowed failure_kind values: dependency_missing, local_import_contract_mismatch, compile_or_syntax_error, assertion_mismatch, runtime_error, test_bug, config_or_verifier_error, unknown.\n\
 Allowed probable_cause_role values: implementation, test, setup, usage_docs, unknown.\n\
 Schema: {{\"failure_kind\":\"...\",\"probable_cause_role\":\"...\",\"repair_targets\":[{{\"path\":\"workspace-relative existing file\",\"confidence\":0.0,\"reason\":\"short bounded reason\"}}],\"repair_plan\":[{{\"target\":\"workspace-relative existing file\",\"intent\":\"short bounded intent\",\"confidence\":0.0}}],\"secondary_targets\":[\"workspace-relative existing file\"],\"do_not_edit_tests_without_evidence\":true,\"summary\":\"short bounded summary\"}}.\n\
+Issue #647 (MF1) — additionally return a SemanticFailureReport in the SAME JSON object so the agent can plan a semantic repair. Add these top-level fields next to the legacy fields above (do not nest under a wrapper key, do not omit the legacy fields):\n\
+SemanticFailureReport schema (extra fields, same object):\n\
+{{\"failure_clusters\":[{{\"observed\":\"short bounded observed text\",\"expected\":\"short bounded expected text\",\"input_shape\":\"short bounded input shape\",\"assertion_shape\":\"short bounded assertion shape\",\"affected_cases\":[\"short bounded case id\"],\"involved_artifacts\":[\"implementation|test|usage_docs|setup\"]}}],\"contract_conflict\":{{\"implementation\":\"short bounded view\",\"test\":\"short bounded view\",\"usage_docs\":\"short bounded view\"}},\"preferred_repair_role\":\"implementation|test|setup|usage_docs\",\"repair_hypothesis\":\"<= 240 chars, single sentence\",\"confidence\":0.0}}.\n\
+Rules for the SemanticFailureReport fields: confidence MUST be a finite number in [0.0, 1.0]; repair_hypothesis MUST be <= 240 characters; do NOT set cluster_key (the agent computes it locally); preferred_repair_role must agree with probable_cause_role above.\n\
 Only include paths present in changed_candidates or safe_file_excerpts. For local import contract mismatches, prefer the provider/source file named by the import error before importer test frames. For assertion failures, distinguish product behavior defects from generated-test defects; if the output shows state leaking across tests, order-dependent expectations, or missing setup/teardown, classify it as test_bug and target the test artifact. Use setup files only for dependency_missing or config_or_verifier_error. Payload JSON:\n{payload}"
         )),
     ]
@@ -9315,11 +9319,16 @@ impl Agent {
             );
         };
         // Issue #647 (Phase D / D.1 / DR3-005): independently parse the
-        // semantic-failure report from the *same* reply. A `None` here
-        // collapses to `semantic_plan = None` (legacy fallback) without
-        // disturbing the legacy `ParsedVerifierRepairAssessment` /
-        // `VerifierRepairAssessment` flow above.
-        let semantic_report = parse_semantic_failure_report_from_reply(&reply.content);
+        // semantic-failure report from the *same* reply. When the LLM omits
+        // the extended SemanticFailureReport fields (MF1: production LLMs
+        // historically returned only the legacy schema), we deterministically
+        // synthesize a SemanticFailureReport from the legacy parsed result so
+        // semantic repair planning fires on every diagnostic pass — not only
+        // when the LLM volunteered the extended schema. The legacy
+        // `ParsedVerifierRepairAssessment` / `VerifierRepairAssessment` flow
+        // below is **not** disturbed.
+        let semantic_report = parse_semantic_failure_report_from_reply(&reply.content)
+            .or_else(|| build_semantic_failure_report_from_legacy(&parsed, &context));
         let semantic_plan = semantic_report.and_then(build_semantic_repair_plan_from_report);
         // Issue #647 (§5.1 SSOT plumbing): build the path-local admission
         // context from the agent's current scope + edit signals so every
@@ -15498,6 +15507,113 @@ fn parse_semantic_failure_report_from_reply(
     super::semantic_failure::parse_semantic_failure_report(&value)
 }
 
+/// Issue #647 (MF1): deterministic fallback that synthesizes a
+/// [`super::semantic_failure::SemanticFailureReport`] from a legacy
+/// [`ParsedVerifierRepairAssessment`] and the surrounding [`RepairJob`].
+///
+/// MF1 production motivation: most LLMs today emit only the legacy fields
+/// (`probable_cause_role` / `failure_kind` / `repair_plan` / `summary`), so
+/// `parse_semantic_failure_report_from_reply` returns `None` and the
+/// `semantic_plan` slot stays empty in production. This helper recovers a
+/// usable `SemanticFailureReport` from the legacy parse so semantic repair
+/// planning kicks in for every diagnostic pass, not only when the LLM
+/// volunteered the extended schema.
+///
+/// Determinism contract: same `(parsed, repair_job)` input MUST produce the
+/// same `SemanticFailureReport`. No randomness, no clock, no LLM-derived
+/// confidence — `confidence` is fixed at the deterministic legacy default
+/// (`LEGACY_FALLBACK_CONFIDENCE`).
+///
+/// Returns `None` only when the legacy parsed result cannot produce a
+/// meaningful failure cluster (e.g. `failure_signature` is empty AND
+/// `output_excerpt` is empty AND there is no summary text). In practice the
+/// caller passes a `RepairJob` with at least a non-empty `failure_signature`
+/// (built by `verifier_repair_context_from_failure`), so the helper returns
+/// `Some` for every realistic production input.
+fn build_semantic_failure_report_from_legacy(
+    parsed: &ParsedVerifierRepairAssessment,
+    repair_job: &super::repair_job::RepairJob,
+) -> Option<super::semantic_failure::SemanticFailureReport> {
+    use super::semantic_failure::{
+        ContractConflict, MAX_CLUSTER_TEXT_CHARS, MAX_REPAIR_HYPOTHESIS_CHARS,
+        build_failure_cluster_from_observation,
+    };
+
+    // Map legacy probable_cause_role → preferred_repair_role; default to
+    // Implementation (deterministic) when the LLM did not supply one.
+    let preferred_repair_role = parsed
+        .probable_cause_role
+        .unwrap_or(super::task_contract::ArtifactRole::Implementation);
+
+    // Build a single failure cluster from the legacy RepairJob signal. The
+    // cluster_key is generated locally via the SSOT cluster builder, so it
+    // never depends on attacker-controlled text.
+    let observed = if !repair_job.failure_signature.is_empty() {
+        repair_job.failure_signature.as_str()
+    } else {
+        repair_job.output_excerpt.as_str()
+    };
+    let expected = parsed.summary.as_deref().unwrap_or("");
+    // input_shape / assertion_shape are not surfaced by the legacy schema;
+    // we leave them empty so the SSOT shape-normalizer collapses them
+    // identically across legacy inputs (deterministic cluster key).
+    let cluster = build_failure_cluster_from_observation(
+        observed,
+        expected,
+        "",
+        "",
+        &[preferred_repair_role],
+    );
+
+    // contract_conflict is sourced from the legacy summary — it lives in the
+    // `implementation` slot because the legacy summary historically described
+    // implementation-side findings. The other two slots are empty so the
+    // schema's invariant ("each side sanitized to MAX_CLUSTER_TEXT_CHARS")
+    // still holds without us inventing test / docs content.
+    let contract_conflict = ContractConflict {
+        implementation: super::repair_job::sanitize_repair_job_text_with_char_cap(
+            parsed.summary.as_deref().unwrap_or(""),
+            MAX_CLUSTER_TEXT_CHARS,
+        ),
+        test: String::new(),
+        usage_docs: String::new(),
+    };
+
+    // repair_hypothesis: first entry of the legacy repair_plan (intent +
+    // path), truncated by the SSOT sanitize entry. Falls back to the legacy
+    // summary when the plan is empty.
+    let raw_hypothesis = parsed
+        .repair_plan
+        .first()
+        .map(|target| {
+            if target.reason.is_empty() {
+                target.path.clone()
+            } else {
+                format!("{}: {}", target.path, target.reason)
+            }
+        })
+        .or_else(|| parsed.summary.clone())
+        .unwrap_or_default();
+    let repair_hypothesis = super::repair_job::sanitize_repair_job_text_with_char_cap(
+        &raw_hypothesis,
+        MAX_REPAIR_HYPOTHESIS_CHARS,
+    );
+
+    /// Deterministic legacy default — never LLM-supplied. Chosen as 0.5 so
+    /// downstream consumers can distinguish "fallback" reports from
+    /// "LLM-supplied" reports by checking for the midpoint value.
+    const LEGACY_FALLBACK_CONFIDENCE: f32 = 0.5;
+
+    Some(super::semantic_failure::SemanticFailureReport {
+        failure_kind: parsed.failure_kind,
+        failure_clusters: vec![cluster],
+        contract_conflict,
+        preferred_repair_role,
+        repair_hypothesis,
+        confidence: LEGACY_FALLBACK_CONFIDENCE,
+    })
+}
+
 /// Issue #647 (Phase D / D.2 + D.3): build a [`super::repair_job::SemanticRepairPlan`]
 /// from a parsed [`super::semantic_failure::SemanticFailureReport`].
 ///
@@ -20881,6 +20997,233 @@ E   assert [{'id': 1}] == []\n";
         assert!(
             user_text.contains("\\\"semantic_plan\\\":null"),
             "legacy path must emit semantic_plan: null in payload: {user_text}",
+        );
+    }
+
+    // ---- Issue #647 (MF1): diagnostic prompt embeds semantic schema + ---- //
+    // ---- legacy → semantic fallback so production emits SemanticRepairPlan ---- //
+
+    /// MF1-a: the diagnostic prompt MUST advertise the `SemanticFailureReport`
+    /// schema so LLMs return the new fields (`failure_clusters`,
+    /// `contract_conflict`, `preferred_repair_role`, `repair_hypothesis`,
+    /// `confidence`) alongside the legacy fields. Without these field names
+    /// in the prompt, `parse_semantic_failure_report` never gets a payload to
+    /// parse and `semantic_plan` stays `None` in production.
+    #[test]
+    fn mf1_a_diagnostic_prompt_includes_semantic_schema() {
+        let temp = tempdir().unwrap();
+        let work_root = temp.path().to_path_buf();
+        let app = work_root.join("app").join("main.py");
+        std::fs::create_dir_all(app.parent().unwrap()).unwrap();
+        std::fs::write(&app, "def f():\n    return 1\n").unwrap();
+        let context = verifier_context_for("app/main.py");
+
+        let messages = verifier_diagnostic_messages(&work_root, &context, "build api");
+        let prompt = messages
+            .iter()
+            .map(|message| message.content.as_str())
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        for needle in [
+            "SemanticFailureReport",
+            "failure_clusters",
+            "contract_conflict",
+            "preferred_repair_role",
+            "repair_hypothesis",
+            "confidence",
+        ] {
+            assert!(
+                prompt.contains(needle),
+                "diagnostic prompt must mention semantic field {needle:?}: {prompt}",
+            );
+        }
+    }
+
+    /// MF1-b: the deterministic legacy-fallback helper MUST produce a
+    /// `SemanticFailureReport` from a `ParsedVerifierRepairAssessment` even
+    /// when the LLM returned only legacy fields (so
+    /// `parse_semantic_failure_report` returned `None`).
+    #[test]
+    fn mf1_b_legacy_fallback_builds_semantic_report() {
+        use super::super::repair_job::RepairJob;
+
+        let legacy_reply = r#"{
+            "failure_kind":"assertion_mismatch",
+            "probable_cause_role":"implementation",
+            "repair_plan":[{"target":"app/main.py","intent":"return 201 not 200","confidence":0.9}],
+            "summary":"impl returns 200 but test expects 201"
+        }"#;
+        // Confirm pre-condition: the semantic parse fails on this legacy reply.
+        assert!(super::parse_semantic_failure_report_from_reply(legacy_reply).is_none());
+        let parsed = super::parse_verifier_repair_assessment_reply(legacy_reply)
+            .expect("legacy parse should succeed");
+        let job = RepairJob {
+            failure_signature: "tests/test_health.py::test_create_validation AssertionError"
+                .to_string(),
+            output_excerpt:
+                "FAILED tests/test_health.py::test_create_validation - assert 200 == 201"
+                    .to_string(),
+            ..RepairJob::new_for_test()
+        };
+
+        let report = super::build_semantic_failure_report_from_legacy(&parsed, &job)
+            .expect("legacy fallback must yield a semantic report");
+        assert_eq!(
+            report.failure_kind,
+            super::super::VerifierDiagnosticFailureKind::AssertionMismatch
+        );
+        // Deterministic legacy default — never LLM-supplied.
+        assert!((report.confidence - 0.5).abs() < f32::EPSILON);
+        // The fallback re-uses the legacy `repair_plan` first item as the
+        // repair_hypothesis, truncated by the SSOT sanitize entry.
+        assert!(
+            !report.repair_hypothesis.is_empty(),
+            "repair_hypothesis must be populated from legacy result",
+        );
+        // preferred_repair_role is mapped from probable_cause_role.
+        assert_eq!(
+            report.preferred_repair_role,
+            super::super::task_contract::ArtifactRole::Implementation
+        );
+    }
+
+    /// MF1-b: the legacy fallback constructs exactly one failure cluster
+    /// derived from `RepairJob.failure_signature` / `output_excerpt`, and the
+    /// cluster's `involved_artifacts` reflects the legacy `probable_cause_role`.
+    #[test]
+    fn mf1_b_legacy_fallback_constructs_one_failure_cluster() {
+        use super::super::repair_job::RepairJob;
+
+        let legacy_reply = r#"{
+            "failure_kind":"runtime_error",
+            "probable_cause_role":"test",
+            "repair_plan":[{"target":"tests/test_health.py","intent":"fix fixture","confidence":0.8}]
+        }"#;
+        let parsed = super::parse_verifier_repair_assessment_reply(legacy_reply)
+            .expect("legacy parse should succeed");
+        let job = RepairJob {
+            failure_signature: "tests/test_health.py KeyError".to_string(),
+            output_excerpt: "KeyError: 'missing_fixture'".to_string(),
+            ..RepairJob::new_for_test()
+        };
+
+        let report = super::build_semantic_failure_report_from_legacy(&parsed, &job)
+            .expect("legacy fallback must yield a semantic report");
+        assert_eq!(report.failure_clusters.len(), 1);
+        assert_eq!(
+            report.failure_kind,
+            super::super::VerifierDiagnosticFailureKind::RuntimeError
+        );
+        assert_eq!(
+            report.preferred_repair_role,
+            super::super::task_contract::ArtifactRole::Test
+        );
+        let cluster = &report.failure_clusters[0];
+        assert!(
+            cluster
+                .involved_artifacts
+                .contains(&super::super::task_contract::ArtifactRole::Test),
+            "cluster must record the probable_cause_role as an involved artifact",
+        );
+    }
+
+    /// MF1-b: the legacy fallback is deterministic — the same
+    /// `(ParsedVerifierRepairAssessment, RepairJob)` input MUST yield the same
+    /// `SemanticFailureReport` (cluster keys identical, confidence fixed).
+    #[test]
+    fn mf1_b_legacy_fallback_is_deterministic() {
+        use super::super::repair_job::RepairJob;
+
+        let legacy_reply = r#"{
+            "failure_kind":"assertion_mismatch",
+            "probable_cause_role":"implementation",
+            "repair_plan":[{"target":"app/main.py","intent":"return 201","confidence":0.9}]
+        }"#;
+        let parsed_a = super::parse_verifier_repair_assessment_reply(legacy_reply)
+            .expect("legacy parse should succeed");
+        let parsed_b = super::parse_verifier_repair_assessment_reply(legacy_reply)
+            .expect("legacy parse should succeed");
+        let job = RepairJob {
+            failure_signature: "sig".to_string(),
+            output_excerpt: "FAILED assert 200 == 201".to_string(),
+            ..RepairJob::new_for_test()
+        };
+
+        let report_a = super::build_semantic_failure_report_from_legacy(&parsed_a, &job)
+            .expect("fallback report a");
+        let report_b = super::build_semantic_failure_report_from_legacy(&parsed_b, &job)
+            .expect("fallback report b");
+        assert_eq!(
+            report_a.failure_clusters[0].cluster_key,
+            report_b.failure_clusters[0].cluster_key,
+        );
+        assert_eq!(report_a.confidence, report_b.confidence);
+        assert_eq!(report_a.repair_hypothesis, report_b.repair_hypothesis);
+    }
+
+    /// MF1-b: `DependencyMissing` / `ConfigOrVerifierError` legacy replies
+    /// still route to setup repair after the fallback — the helper produces a
+    /// report, but `build_semantic_repair_plan_from_report` returns `None`,
+    /// so the existing setup-repair pipeline keeps owning those failure kinds.
+    #[test]
+    fn mf1_b_legacy_fallback_routes_dependency_missing_to_setup() {
+        use super::super::repair_job::RepairJob;
+
+        let legacy_reply = r#"{
+            "failure_kind":"dependency_missing",
+            "probable_cause_role":"setup",
+            "repair_plan":[{"target":"requirements.txt","intent":"add requests","confidence":0.95}]
+        }"#;
+        let parsed = super::parse_verifier_repair_assessment_reply(legacy_reply)
+            .expect("legacy parse should succeed");
+        let job = RepairJob {
+            failure_signature: "ModuleNotFoundError requests".to_string(),
+            output_excerpt: "ModuleNotFoundError: No module named 'requests'".to_string(),
+            ..RepairJob::new_for_test()
+        };
+        let report = super::build_semantic_failure_report_from_legacy(&parsed, &job)
+            .expect("legacy fallback must yield a semantic report");
+        // Even though we build a report for the dependency_missing kind, the
+        // dispatch_target → setup-repair contract keeps `semantic_plan = None`.
+        assert!(super::build_semantic_repair_plan_from_report(report).is_none());
+    }
+
+    /// MF1 production flow integration: when the LLM reply returns only
+    /// legacy fields, the semantic parse returns `None`, but the fallback
+    /// kicks in and a `SemanticRepairPlan` is built end-to-end via
+    /// `build_semantic_failure_report_from_legacy` →
+    /// `build_semantic_repair_plan_from_report`.
+    #[test]
+    fn mf1_legacy_reply_yields_semantic_plan_via_fallback() {
+        use super::super::repair_job::RepairJob;
+
+        let legacy_reply = r#"{
+            "failure_kind":"assertion_mismatch",
+            "probable_cause_role":"implementation",
+            "repair_plan":[{"target":"app/main.py","intent":"return 201","confidence":0.9}]
+        }"#;
+        // pre-condition: pure semantic parse returns None.
+        assert!(super::parse_semantic_failure_report_from_reply(legacy_reply).is_none());
+
+        let parsed = super::parse_verifier_repair_assessment_reply(legacy_reply)
+            .expect("legacy parse should succeed");
+        let job = RepairJob {
+            failure_signature: "app/main.py AssertionError".to_string(),
+            output_excerpt: "assert 200 == 201".to_string(),
+            ..RepairJob::new_for_test()
+        };
+        let report = super::build_semantic_failure_report_from_legacy(&parsed, &job)
+            .expect("legacy fallback must yield report");
+        let plan = super::build_semantic_repair_plan_from_report(report)
+            .expect("semantic plan must be built from legacy fallback report");
+        assert_eq!(
+            plan.semantic_cause,
+            super::super::VerifierDiagnosticFailureKind::AssertionMismatch
+        );
+        assert_eq!(
+            plan.preferred_repair_role,
+            super::super::task_contract::ArtifactRole::Implementation
         );
     }
 


### PR DESCRIPTION
## Summary

Verifier failure の repair loop は動くようになったが、失敗を **「どの仕様を正とみなして、実装・テスト・README のどれを直すか」** という semantic repair planning として扱えていなかった。本 PR は #647 の修正方針 (1-6) を 7 段階の commit に分け、bounded schema / SpecAuthority / RepairHypothesis / failure clustering / role-first repair / weakening detector を一通り導入する。

### Phase 別 commit

| Commit | Phase | 内容 |
|--------|-------|------|
| `2191bb2` | A | `SemanticFailureReport` / `SpecAuthority` schemas (新規 modules, pub(super)) |
| `37d5f14` | B | `SemanticRepairPlan` sub-struct + `RepairJob` に semantic-repair fields 追加 + Eq drop |
| `484f00f` | C | `admit_repair_target_hint` SSOT で 6 RecoveryTargetHint 経路統合 |
| `0f7633d` | D | diagnostic 経路統合 (parse → `SemanticRepairPlan` slot) |
| `25b245f` | E | cluster-aware sequential repair helpers (`advance` / `should_re_diagnostic` / `rerun_outcome_with_cluster`) |
| `8c21bac` | F | test/impl weakening detectors を `validate_verifier_repair_intents` に適用 |
| `6ea9866` | G | DR3-001 / DR3-002 / DR4-003 と受入条件の structural guard test |

### 受入条件カバレッジ

Issue #647 受入条件 (16+ 件) を以下で満たす:

- `SemanticFailureReport` 生成 (Phase A/D)
- 複数 failure cluster 化 (Phase E)
- `SpecAuthority` 基づく role 決定 (Phase A/B/C)
- 新規生成タスクで impl/test/README 同等 authority (Phase B)
- 同一 hypothesis + role で改善しなければ re-diagnostic (Phase E)
- test edit に `SpecAuthority` + `RepairHypothesis` 必須 (Phase F)
- assertion 削除 / 期待値緩和 / skip 追加を禁止 (Phase F)
- #646 `Owned` artifact のみを repair target / completion evidence に (Phase C)
- failure clustering は observed/expected/input shape/assertion shape/artifact role で実施 (Phase A)
- multiple independent clusters は cluster 単位で verifier rerun (Phase E)
- FastAPI / pytest / 422 / 404 専用 hardcode なし
- verifier output 命令文を instruction として扱わない (untrusted data 化、Phase A)

### 依存関係

- #646 (PR #648, merged) の `Owned` / active scope を前提として動作

## Test plan

- [ ] CI: cargo fmt --check
- [ ] CI: cargo clippy --all-targets
- [ ] CI: cargo test (1953+ lib tests, Phase G で structural guards 追加)
- [ ] CI: cargo build
- [ ] Codex 影響範囲レビュー (Stage 7/8 完了済、Must Fix 2 反映)
- [ ] Codex 最終クロスレビュー (PR 上)

Fixes #647.