### PR TITLE
refactor(agent/loop_run): migrate first 2 post_reply_recovery leaves (part of #681)

### DIFF
--- a/src/agent/loop_run/actor_loop_flow.rs
+++ b/src/agent/loop_run/actor_loop_flow.rs
@@ -405,6 +405,47 @@ pub(super) fn plan_tool_followup_done_message() -> String {
     "Plan complete. Reply yes to execute, no to revise, or provide feedback.".to_string()
 }
 
+pub(super) fn maybe_handle_answer_only_inadequate_recovery(
+    agent: &mut Agent,
+    args: &mut PostReplyRecoveryArgs<'_, '_>,
+) -> Option<PostReplyRecoveryOutcome> {
+    if !args.requires_action
+        && agent.answer_only_mode_active()
+        && super::turn::answer_only_reply_is_inadequate(args.final_reply)
+    {
+        *args.no_tool_retries += 1;
+        if *args.no_tool_retries >= 2 {
+            agent
+                .session
+                .record_feedback_if_unset(super::turn::build_feedback_for_no_tool_call(
+                    "answer_only_inadequate_reply",
+                    &agent.work_root,
+                ));
+            return Some(PostReplyRecoveryOutcome::Finalize {
+                final_prose: agent.answer_only_fallback_response(),
+                exit_reason: ExitReason::Done,
+                error_text: String::new(),
+            });
+        }
+        super::turn::write_stdout_rendered(
+            &super::turn::format_iteration_status(
+                args.last_iter,
+                agent.config.max_iterations,
+                "Retry requested",
+                "The model gave an underspecified answer in answer-only mode. Asked it to provide a concrete response.",
+                agent.footer.current_cols(),
+            ),
+            true,
+        );
+        agent.push_system_note(
+            "[Answer-only Recovery] Answer the user's request now with concrete findings from the available context. Do not output a tool call, do not edit files, and do not ask the user to run anything."
+                .to_string(),
+        );
+        return Some(PostReplyRecoveryOutcome::Continue);
+    }
+    None
+}
+
 pub(super) fn maybe_handle_answer_only_future_work_recovery(
     agent: &mut Agent,
     args: &mut PostReplyRecoveryArgs<'_, '_>,

--- a/src/agent/loop_run/actor_loop_flow.rs
+++ b/src/agent/loop_run/actor_loop_flow.rs
@@ -405,6 +405,41 @@ pub(super) fn plan_tool_followup_done_message() -> String {
     "Plan complete. Reply yes to execute, no to revise, or provide feedback.".to_string()
 }
 
+pub(super) fn maybe_handle_answer_only_future_work_recovery(
+    agent: &mut Agent,
+    args: &mut PostReplyRecoveryArgs<'_, '_>,
+) -> Option<PostReplyRecoveryOutcome> {
+    if !args.requires_action
+        && agent.answer_only_mode_active()
+        && super::turn::reply_looks_like_future_work(args.final_reply)
+    {
+        *args.no_tool_retries += 1;
+        if *args.no_tool_retries >= 1 {
+            return Some(PostReplyRecoveryOutcome::Finalize {
+                final_prose: agent.answer_only_fallback_response(),
+                exit_reason: ExitReason::Done,
+                error_text: String::new(),
+            });
+        }
+        super::turn::write_stdout_rendered(
+            &super::turn::format_iteration_status(
+                args.last_iter,
+                agent.config.max_iterations,
+                "Retry requested",
+                "The model answered with next-step prose in answer-only mode. Asked it to answer directly without more tools.",
+                agent.footer.current_cols(),
+            ),
+            true,
+        );
+        agent.push_system_note(
+            "[Answer-only Recovery] Answer the user's request now using only the context already inspected. Do not announce the next action, do not use tools, do not edit files, and do not ask the user to run anything."
+                .to_string(),
+        );
+        return Some(PostReplyRecoveryOutcome::Continue);
+    }
+    None
+}
+
 pub(super) fn handle_plan_progress_prose_only_fallback(
     agent: &mut Agent,
 ) -> ActorLoopNoToolReplyOutcome {

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -18,9 +18,9 @@ use super::actor_loop_flow::{
     ActorLoopToolPreparationOutcome, PostReplyRecoveryArgs, PostReplyRecoveryOutcome,
     TaskContractVerifierFlowOutcome, finalize_missing_repo_edit_retry_exhausted,
     handle_non_progress_plan_edit_fallback, handle_plan_progress_prose_only_fallback,
-    maybe_handle_answer_only_future_work_recovery, missing_repo_change_budget_exhausted_outcome,
-    missing_repo_edit_recovery_allowed, missing_repo_edits_finalize_outcome,
-    plan_tool_followup_done_message, repair_job_done_outcome,
+    maybe_handle_answer_only_future_work_recovery, maybe_handle_answer_only_inadequate_recovery,
+    missing_repo_change_budget_exhausted_outcome, missing_repo_edit_recovery_allowed,
+    missing_repo_edits_finalize_outcome, plan_tool_followup_done_message, repair_job_done_outcome,
 };
 use super::auto_test::{
     AutoTestKind, AutoTestPlan, AutoTestResult, AutoTestRunner, auto_test_disabled,
@@ -1577,7 +1577,10 @@ fn build_feedback_for_no_repo_progress(workspace_root: &Path) -> FeedbackFrame {
 /// `reason` MUST be a `&'static str` classifier — never raw user/assistant
 /// prose (DR4-001). `build_feedback_frame` masks anyway, but caller-side
 /// discipline keeps the prompt-injection surface narrow.
-fn build_feedback_for_no_tool_call(reason: &'static str, workspace_root: &Path) -> FeedbackFrame {
+pub(super) fn build_feedback_for_no_tool_call(
+    reason: &'static str,
+    workspace_root: &Path,
+) -> FeedbackFrame {
     let draft = FeedbackFrameDraft {
         kind: FeedbackKind::NoToolCall,
         primary_error: Some(reason.to_string()),
@@ -2552,7 +2555,7 @@ fn test_artifact_path_family(path: &str) -> Option<&'static str> {
     None
 }
 
-fn answer_only_reply_is_inadequate(reply: &str) -> bool {
+pub(super) fn answer_only_reply_is_inadequate(reply: &str) -> bool {
     let trimmed = reply.trim();
     if trimmed.is_empty() {
         return true;
@@ -5808,7 +5811,7 @@ impl Agent {
         if let Some(outcome) = self.maybe_handle_python_test_artifact_recovery(&mut args) {
             return Some(outcome);
         }
-        if let Some(outcome) = self.maybe_handle_answer_only_inadequate_recovery(&mut args) {
+        if let Some(outcome) = maybe_handle_answer_only_inadequate_recovery(self, &mut args) {
             return Some(outcome);
         }
         if let Some(outcome) = self.maybe_handle_repo_change_partial_progress_recovery(&mut args) {
@@ -5958,46 +5961,6 @@ impl Agent {
                 .to_string(),
         );
         Some(PostReplyRecoveryOutcome::Continue)
-    }
-
-    fn maybe_handle_answer_only_inadequate_recovery(
-        &mut self,
-        args: &mut PostReplyRecoveryArgs<'_, '_>,
-    ) -> Option<PostReplyRecoveryOutcome> {
-        if !args.requires_action
-            && self.answer_only_mode_active()
-            && answer_only_reply_is_inadequate(args.final_reply)
-        {
-            *args.no_tool_retries += 1;
-            if *args.no_tool_retries >= 2 {
-                self.session
-                    .record_feedback_if_unset(build_feedback_for_no_tool_call(
-                        "answer_only_inadequate_reply",
-                        &self.work_root,
-                    ));
-                return Some(PostReplyRecoveryOutcome::Finalize {
-                    final_prose: self.answer_only_fallback_response(),
-                    exit_reason: ExitReason::Done,
-                    error_text: String::new(),
-                });
-            }
-            write_stdout_rendered(
-                &format_iteration_status(
-                    args.last_iter,
-                    self.config.max_iterations,
-                    "Retry requested",
-                    "The model gave an underspecified answer in answer-only mode. Asked it to provide a concrete response.",
-                    self.footer.current_cols(),
-                ),
-                true,
-            );
-            self.push_system_note(
-                "[Answer-only Recovery] Answer the user's request now with concrete findings from the available context. Do not output a tool call, do not edit files, and do not ask the user to run anything."
-                    .to_string(),
-            );
-            return Some(PostReplyRecoveryOutcome::Continue);
-        }
-        None
     }
 
     fn maybe_handle_repo_change_partial_progress_recovery(

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -18,8 +18,9 @@ use super::actor_loop_flow::{
     ActorLoopToolPreparationOutcome, PostReplyRecoveryArgs, PostReplyRecoveryOutcome,
     TaskContractVerifierFlowOutcome, finalize_missing_repo_edit_retry_exhausted,
     handle_non_progress_plan_edit_fallback, handle_plan_progress_prose_only_fallback,
-    missing_repo_change_budget_exhausted_outcome, missing_repo_edit_recovery_allowed,
-    missing_repo_edits_finalize_outcome, plan_tool_followup_done_message, repair_job_done_outcome,
+    maybe_handle_answer_only_future_work_recovery, missing_repo_change_budget_exhausted_outcome,
+    missing_repo_edit_recovery_allowed, missing_repo_edits_finalize_outcome,
+    plan_tool_followup_done_message, repair_job_done_outcome,
 };
 use super::auto_test::{
     AutoTestKind, AutoTestPlan, AutoTestResult, AutoTestRunner, auto_test_disabled,
@@ -1704,7 +1705,7 @@ fn raw_mode_safe_text(text: &str) -> String {
     text.replace('\n', "\r\n")
 }
 
-fn reply_looks_like_future_work(reply: &str) -> bool {
+pub(super) fn reply_looks_like_future_work(reply: &str) -> bool {
     let normalized = reply.trim().to_ascii_lowercase();
     if normalized.is_empty() {
         return false;
@@ -2613,7 +2614,7 @@ fn extract_filename_with_suffix(text: &str, suffix: &str) -> Option<String> {
     .map(ToString::to_string)
 }
 
-fn write_stdout_rendered(text: &str, trailing_newline: bool) {
+pub(super) fn write_stdout_rendered(text: &str, trailing_newline: bool) {
     let mut out = io::stdout().lock();
     let rendered = raw_mode_safe_text(text);
     let _ = out.write_all(rendered.as_bytes());
@@ -2788,7 +2789,7 @@ fn deterministic_timeout_fallback_plan(
     )
 }
 
-fn format_iteration_status(
+pub(super) fn format_iteration_status(
     iter_human: usize,
     max_iterations: usize,
     headline: &str,
@@ -5798,7 +5799,7 @@ impl Agent {
         &mut self,
         mut args: PostReplyRecoveryArgs<'_, '_>,
     ) -> Option<PostReplyRecoveryOutcome> {
-        if let Some(outcome) = self.maybe_handle_answer_only_future_work_recovery(&mut args) {
+        if let Some(outcome) = maybe_handle_answer_only_future_work_recovery(self, &mut args) {
             return Some(outcome);
         }
         if let Some(outcome) = self.maybe_handle_missing_repo_edit_recovery(&mut args) {
@@ -5817,41 +5818,6 @@ impl Agent {
             return Some(outcome);
         }
 
-        None
-    }
-
-    fn maybe_handle_answer_only_future_work_recovery(
-        &mut self,
-        args: &mut PostReplyRecoveryArgs<'_, '_>,
-    ) -> Option<PostReplyRecoveryOutcome> {
-        if !args.requires_action
-            && self.answer_only_mode_active()
-            && reply_looks_like_future_work(args.final_reply)
-        {
-            *args.no_tool_retries += 1;
-            if *args.no_tool_retries >= 1 {
-                return Some(PostReplyRecoveryOutcome::Finalize {
-                    final_prose: self.answer_only_fallback_response(),
-                    exit_reason: ExitReason::Done,
-                    error_text: String::new(),
-                });
-            }
-            write_stdout_rendered(
-                &format_iteration_status(
-                    args.last_iter,
-                    self.config.max_iterations,
-                    "Retry requested",
-                    "The model answered with next-step prose in answer-only mode. Asked it to answer directly without more tools.",
-                    self.footer.current_cols(),
-                ),
-                true,
-            );
-            self.push_system_note(
-                "[Answer-only Recovery] Answer the user's request now using only the context already inspected. Do not announce the next action, do not use tools, do not edit files, and do not ask the user to run anything."
-                    .to_string(),
-            );
-            return Some(PostReplyRecoveryOutcome::Continue);
-        }
         None
     }
 
@@ -15802,7 +15768,7 @@ impl Agent {
         ))
     }
 
-    fn answer_only_mode_active(&self) -> bool {
+    pub(super) fn answer_only_mode_active(&self) -> bool {
         // Issue #576 / DR3-001: tool policy must honour the second-pass-
         // corrected `session.mode_state.work_mode` as the single source of
         // truth. The previous OR with `infer_work_mode_from_text(active_request_text())`
@@ -16929,7 +16895,7 @@ if __name__ == "__main__":
             .map(ConversationMessage::system)
     }
 
-    fn answer_only_fallback_response(&self) -> String {
+    pub(super) fn answer_only_fallback_response(&self) -> String {
         let request = self.active_request_text().unwrap_or_default();
         let lower = request.to_ascii_lowercase();
         if request_explicitly_requests_script_execution(&request)


### PR DESCRIPTION
## 概要

Issue #681 (parent #680) の incremental method migration **第二段** (PR #689 に stacked)。post_reply_recovery family のうち **2 つの leaf method** を `turn.rs::impl Agent` から `actor_loop_flow.rs` の free function に移管。

> **依存**: 本 PR は #689 (`feature/issue-681-actor-loop-flow`) を base とする stacked PR です。#689 が merge されれば自動的に develop が base に切り替わります。

## 含まれる commits

| # | Commit | 内容 |
|---|---|---|
| 1 | `5865efb` | `maybe_handle_answer_only_future_work_recovery` 移管 + 関連 5 visibility upgrade (`answer_only_mode_active`, `answer_only_fallback_response`, `reply_looks_like_future_work`, `write_stdout_rendered`, `format_iteration_status`) |
| 2 | `ec4fe93` | `maybe_handle_answer_only_inadequate_recovery` 移管 + 関連 2 visibility upgrade (`answer_only_reply_is_inadequate`, `build_feedback_for_no_tool_call`) |

## メトリクス (PR #689 tip からの差分)

| | PR #689 tip | 本 PR 後 | 差分 |
|---|---|---|---|
| turn.rs LOC | 39,073 | **39,001** | **-72** |
| actor_loop_flow.rs LOC | 506 | 575 | +69 |
| 移管済 method (累計) | 5 | **7** | +2 |

PR #689 起点 (39,489) からは累計 **-488 LOC** (~12%) → Phase 1 受入条件 (-4,000 LOC) まで残り **約 88%**。

## 確立した pattern

- **`super::turn::*` back-import**: 移管先 free function が必要とする turn.rs 内の free fn / Agent method を `pub(super)` 昇格、`actor_loop_flow.rs` 側で `super::turn::name` で参照。
- **transitional**: これらの helper は後続 PR で actor_loop_flow.rs に co-migrate するか、または共有モジュールへ relocate する予定。

## 受入条件

- [x] `cargo fmt --check` 緑
- [x] `cargo clippy --all-targets --all-features` 警告 0 件
- [x] `cargo test --all-features` 3,731 pass / 0 fail
- [x] PR #689 と互換 (build なし conflict)
- [x] DR3-001 遵守 (pub(super) 限定 / facade 再 export なし)

## 残作業 (後続 PR で順次)

post_reply_recovery family の残り **8 method**:
- `maybe_handle_python_test_artifact_recovery` (L5944 — 中規模)
- `maybe_handle_repo_change_partial_progress_recovery` (L6037 — 中規模)
- `maybe_handle_repo_change_quality_gate_recovery` (L6078 — 大規模)
- `maybe_continue_missing_repo_framework_fallback` (L5889)
- `maybe_continue_missing_repo_scaffold_fallback` (L5905)
- `push_missing_repo_edit_retry_note` (L5928)
- `maybe_handle_missing_repo_edit_recovery` (L5858 — 上記 3 つに依存)
- `handle_post_reply_recovery` (L5797 — dispatcher、最後)

## 関連 Issue

- 子: #681 (Phase 1 actor_loop_flow extraction)
- 親 (epic): #680
- Stacked on: PR #689

🤖 Generated with [Claude Code](https://claude.com/claude-code)