### PR TITLE
refactor(agent/loop_run): migrate maybe_handle_repo_change_partial_progress_recovery (part of #681)

### DIFF
--- a/src/agent/loop_run/actor_loop_flow.rs
+++ b/src/agent/loop_run/actor_loop_flow.rs
@@ -446,6 +446,47 @@ pub(super) fn maybe_handle_answer_only_inadequate_recovery(
     None
 }
 
+pub(super) fn maybe_handle_repo_change_partial_progress_recovery(
+    agent: &mut Agent,
+    args: &mut PostReplyRecoveryArgs<'_, '_>,
+) -> Option<PostReplyRecoveryOutcome> {
+    if !super::turn::should_apply_repo_change_partial_progress_recovery(
+        args.action_expectation,
+        args.repo_edit_calls_made_this_turn,
+        args.final_reply,
+        args.task_contract_action,
+    ) || !args
+        .recovery_dispatch_gate
+        .allows_generic_repo_change_recovery()
+    {
+        return None;
+    }
+    *args.repo_change_retries += 1;
+    if *args.repo_change_retries >= 3 {
+        return Some(PostReplyRecoveryOutcome::Finalize {
+            final_prose: String::new(),
+            exit_reason: ExitReason::MissingRepoEdits,
+            error_text: ExitReason::MissingRepoEdits
+                .default_error_text()
+                .to_string(),
+        });
+    }
+    super::turn::write_stdout_rendered(
+        &super::turn::format_iteration_status(
+            args.last_iter,
+            agent.config.max_iterations,
+            "Retry requested",
+            "A small edit landed, but the model answered with next-step prose instead of a completed result. Asked it to keep implementing with tools.",
+            agent.footer.current_cols(),
+        ),
+        true,
+    );
+    agent.push_system_note(recovery::repo_change_partial_progress_note(
+        *args.repo_change_retries,
+    ));
+    Some(PostReplyRecoveryOutcome::Continue)
+}
+
 pub(super) fn maybe_handle_answer_only_future_work_recovery(
     agent: &mut Agent,
     args: &mut PostReplyRecoveryArgs<'_, '_>,

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -19,6 +19,7 @@ use super::actor_loop_flow::{
     TaskContractVerifierFlowOutcome, finalize_missing_repo_edit_retry_exhausted,
     handle_non_progress_plan_edit_fallback, handle_plan_progress_prose_only_fallback,
     maybe_handle_answer_only_future_work_recovery, maybe_handle_answer_only_inadequate_recovery,
+    maybe_handle_repo_change_partial_progress_recovery,
     missing_repo_change_budget_exhausted_outcome, missing_repo_edit_recovery_allowed,
     missing_repo_edits_finalize_outcome, plan_tool_followup_done_message, repair_job_done_outcome,
 };
@@ -1839,7 +1840,7 @@ fn increment_artifact_completion_role_attempt(
     *entry
 }
 
-fn should_apply_repo_change_partial_progress_recovery(
+pub(super) fn should_apply_repo_change_partial_progress_recovery(
     action_expectation: recovery::ActionExpectation,
     repo_edit_calls_made_this_turn: usize,
     final_reply: &str,
@@ -5814,7 +5815,7 @@ impl Agent {
         if let Some(outcome) = maybe_handle_answer_only_inadequate_recovery(self, &mut args) {
             return Some(outcome);
         }
-        if let Some(outcome) = self.maybe_handle_repo_change_partial_progress_recovery(&mut args) {
+        if let Some(outcome) = maybe_handle_repo_change_partial_progress_recovery(self, &mut args) {
             return Some(outcome);
         }
         if let Some(outcome) = self.maybe_handle_repo_change_quality_gate_recovery(&mut args) {
@@ -5960,47 +5961,6 @@ impl Agent {
             "[Python Test Policy] The user explicitly requested tests. Add a concrete Python test artifact now, such as test_*.py, *_test.py, or a clearly runnable self-test command. Keep the edit small and verify it if possible."
                 .to_string(),
         );
-        Some(PostReplyRecoveryOutcome::Continue)
-    }
-
-    fn maybe_handle_repo_change_partial_progress_recovery(
-        &mut self,
-        args: &mut PostReplyRecoveryArgs<'_, '_>,
-    ) -> Option<PostReplyRecoveryOutcome> {
-        if !should_apply_repo_change_partial_progress_recovery(
-            args.action_expectation,
-            args.repo_edit_calls_made_this_turn,
-            args.final_reply,
-            args.task_contract_action,
-        ) || !args
-            .recovery_dispatch_gate
-            .allows_generic_repo_change_recovery()
-        {
-            return None;
-        }
-        *args.repo_change_retries += 1;
-        if *args.repo_change_retries >= 3 {
-            return Some(PostReplyRecoveryOutcome::Finalize {
-                final_prose: String::new(),
-                exit_reason: ExitReason::MissingRepoEdits,
-                error_text: ExitReason::MissingRepoEdits
-                    .default_error_text()
-                    .to_string(),
-            });
-        }
-        write_stdout_rendered(
-            &format_iteration_status(
-                args.last_iter,
-                self.config.max_iterations,
-                "Retry requested",
-                "A small edit landed, but the model answered with next-step prose instead of a completed result. Asked it to keep implementing with tools.",
-                self.footer.current_cols(),
-            ),
-            true,
-        );
-        self.push_system_note(recovery::repo_change_partial_progress_note(
-            *args.repo_change_retries,
-        ));
         Some(PostReplyRecoveryOutcome::Continue)
     }
 


### PR DESCRIPTION
## 概要

Issue #681 (parent #680) の incremental method migration **第四段**。`maybe_handle_repo_change_partial_progress_recovery` leaf method を turn.rs から actor_loop_flow.rs へ移管。

## 含まれる commit

| Commit | 内容 |
|---|---|
| `4f181bc` | method migrate + `should_apply_repo_change_partial_progress_recovery` pub(super) 昇格 |
| `7b72b90` | merge develop (PR #691 取り込み — 同位置に新 fn 追加された conflict を解消) |

## メトリクス

| | 起点 (develop = PR #691 merge後) | 本 PR 後 | 差分 |
|---|---|---|---|
| turn.rs LOC | 38,934 | **38,895** | **-39** |
| actor_loop_flow.rs LOC | 630 | 671 | +41 |
| 移管済 method (累計) | 10 | **11** | +1 |

PR #689 起点 (39,489) からの累計: **-594 LOC** (Phase 1 受入条件 -4,000 の **約 15%**)。

## 受入条件

- [x] `cargo fmt --check` 緑
- [x] `cargo clippy --all-targets --all-features` 警告 0 件
- [x] `cargo test --all-features` 3,731 pass / 0 fail
- [x] DR3-001 遵守
- [x] develop と conflict 解消済

## 関連 Issue

- 子: #681 (Phase 1 actor_loop_flow extraction)
- 親 (epic): #680

🤖 Generated with [Claude Code](https://claude.com/claude-code)