### PR TITLE
refactor(agent/loop_run): migrate rejected_tool_batch family 4 methods (part of #681)

### DIFF
--- a/src/agent/loop_run/actor_loop_flow.rs
+++ b/src/agent/loop_run/actor_loop_flow.rs
@@ -697,6 +697,210 @@ pub(super) fn push_missing_repo_edit_retry_note(agent: &mut Agent, attempt: usiz
     }
 }
 
+pub(super) fn handle_actor_loop_rejected_tool_batch(
+    agent: &mut Agent,
+    args: ActorLoopRejectedToolBatchArgs<'_, '_>,
+) -> ActorLoopToolPreparationOutcome {
+    let focused_retry = args.effective_tool_policy.focused_edit_policy().cloned();
+    let artifact_retry = args
+        .effective_tool_policy
+        .artifact_directed_policy()
+        .cloned();
+    agent.session.working_memory.note_error(args.err);
+    if let Some(outcome) = maybe_handle_rejected_tool_batch_missing_verifier(
+        agent,
+        args.missing_verifier_setup_turn,
+        args.last_iter,
+    ) {
+        return outcome;
+    }
+    if let Some(outcome) = maybe_handle_rejected_tool_batch_artifact(
+        agent,
+        args.last_iter,
+        artifact_retry.is_some(),
+        args.task_contract,
+        args.contract_completion_role_retries,
+    ) {
+        return outcome;
+    }
+
+    *args.focused_policy_retries += 1;
+    if let Some(outcome) = maybe_handle_rejected_tool_batch_focused_retry_exhausted(
+        agent,
+        focused_retry.is_some(),
+        *args.focused_policy_retries,
+        args.recovery_dispatch_gate,
+        args.recovery_owner,
+    ) {
+        return outcome;
+    }
+    if super::turn::unrestricted_policy_retry_exhausted(
+        focused_retry.is_some(),
+        *args.focused_policy_retries,
+    ) {
+        return ActorLoopToolPreparationOutcome::Exit {
+            reason: ExitReason::ToolCallFormatError,
+            error_text: "assistant kept calling tools outside the current tool policy".to_string(),
+        };
+    }
+    let retry_status_note =
+        super::turn::rejected_tool_batch_retry_status_note(focused_retry.is_some());
+    super::turn::write_stdout_rendered(
+        &super::turn::format_iteration_status(
+            args.last_iter,
+            agent.config.max_iterations,
+            "Retry requested",
+            retry_status_note,
+            agent.footer.current_cols(),
+        ),
+        true,
+    );
+    if let Some(policy) = focused_retry {
+        let note = agent.focused_edit_no_tool_note_for_policy(
+            &policy,
+            args.effective_tool_policy,
+            *args.focused_policy_retries,
+        );
+        agent.push_system_note(note);
+    } else {
+        agent.push_system_note(format!(
+            "The previous tool call violated the current tool policy and was not executed. Emit exactly one allowed tool call now. tool_policy_retry_attempt={}",
+            *args.focused_policy_retries
+        ));
+    }
+    ActorLoopToolPreparationOutcome::Continue
+}
+
+pub(super) fn maybe_handle_rejected_tool_batch_missing_verifier(
+    agent: &mut Agent,
+    missing_verifier_setup_turn: bool,
+    last_iter: usize,
+) -> Option<ActorLoopToolPreparationOutcome> {
+    if !missing_verifier_setup_turn {
+        return None;
+    }
+    if agent.record_missing_verifier_setup_failure(last_iter, "tool policy violation") {
+        return Some(ActorLoopToolPreparationOutcome::Exit {
+            reason: ExitReason::MissingVerification,
+            error_text:
+                "task contract requires verification, but the MissingVerifierJob setup budget is exhausted"
+                    .to_string(),
+        });
+    }
+    Some(ActorLoopToolPreparationOutcome::Continue)
+}
+
+pub(super) fn maybe_handle_rejected_tool_batch_artifact(
+    agent: &mut Agent,
+    last_iter: usize,
+    artifact_retry_present: bool,
+    task_contract: Option<&super::task_contract::TaskContract>,
+    contract_completion_role_retries: &mut HashMap<super::task_contract::ArtifactRole, usize>,
+) -> Option<ActorLoopToolPreparationOutcome> {
+    if !artifact_retry_present {
+        return None;
+    }
+    let role = agent
+        .current_artifact_recovery_target
+        .as_ref()
+        .map(|target| target.role)
+        .unwrap_or(super::task_contract::ArtifactRole::Implementation);
+    if agent.record_artifact_completion_attempt(
+        super::artifact_completion_job::ArtifactAttemptOutcomeKind::RolePolicyViolation,
+        vec!["focused_edit_batch_reject".to_string()],
+    ) {
+        return Some(ActorLoopToolPreparationOutcome::Exit {
+            reason: ExitReason::MissingRepoEdits,
+            error_text: format!(
+                "artifact completion role-policy violation budget exhausted for role {}",
+                role.label()
+            ),
+        });
+    }
+    let artifact_attempt = super::turn::increment_artifact_completion_role_attempt(
+        contract_completion_role_retries,
+        role,
+    );
+    let attempt_limit = task_contract
+        .as_ref()
+        .map(|contract| contract.artifact_completion_attempt_limit())
+        .unwrap_or(4);
+    if artifact_attempt >= attempt_limit {
+        let expected_target = agent
+            .current_artifact_recovery_target
+            .as_ref()
+            .map(|target| target.path.clone());
+        agent.emit_safe_stop_report_for_artifact_completion_failed(role, expected_target);
+        return Some(ActorLoopToolPreparationOutcome::Exit {
+            reason: ExitReason::MissingRepoEdits,
+            error_text: format!(
+                "artifact edit rejected repeatedly for required role {}",
+                role.label()
+            ),
+        });
+    }
+    super::turn::write_stdout_rendered(
+        &super::turn::format_iteration_status(
+            last_iter,
+            agent.config.max_iterations,
+            "Retry requested",
+            "Artifact completion rejected an invalid tool call before execution; asked for one allowed edit on the target.",
+            agent.footer.current_cols(),
+        ),
+        true,
+    );
+    if !agent.push_artifact_directed_recovery_note(artifact_attempt) {
+        agent.push_system_note(format!(
+            "[Artifact Completion] Previous tool call was rejected and was not executed. Missing role: {}. Emit exactly one allowed tool call on the current target path now. artifact_completion_attempt={artifact_attempt}/{attempt_limit}",
+            role.label()
+        ));
+    }
+    Some(ActorLoopToolPreparationOutcome::Continue)
+}
+
+pub(super) fn maybe_handle_rejected_tool_batch_focused_retry_exhausted(
+    agent: &mut Agent,
+    focused_retry_present: bool,
+    focused_policy_retries: usize,
+    recovery_dispatch_gate: RecoveryDispatchGate,
+    recovery_owner: RecoveryOwner,
+) -> Option<ActorLoopToolPreparationOutcome> {
+    if !super::turn::focused_policy_retry_exhausted(focused_retry_present, focused_policy_retries) {
+        return None;
+    }
+    if !recovery_dispatch_gate.allows_focused_edit_recovery() {
+        return Some(ActorLoopToolPreparationOutcome::Exit {
+            reason: Agent::tool_policy_violation_exit_reason(recovery_owner),
+            error_text:
+                "verifier-owned recovery rejected invalid tool calls repeatedly before an allowed repair edit"
+                    .to_string(),
+        });
+    }
+    let request = agent.active_request_text().unwrap_or_default();
+    let fallback = match agent.maybe_apply_local_llm_small_edit_fallback(&request) {
+        Ok(fallback) => fallback,
+        Err(err) => {
+            return Some(ActorLoopToolPreparationOutcome::Exit {
+                reason: ExitReason::TransportError,
+                error_text: err,
+            });
+        }
+    };
+    if let Some(relative) = fallback {
+        return Some(ActorLoopToolPreparationOutcome::Done {
+            final_prose: format!(
+                "Applied a verified small edit fallback after the local model could not produce a compact edit for {relative}."
+            ),
+        });
+    }
+    Some(ActorLoopToolPreparationOutcome::Exit {
+        reason: ExitReason::MissingRepoEdits,
+        error_text: ExitReason::MissingRepoEdits
+            .default_error_text()
+            .to_string(),
+    })
+}
+
 pub(super) fn handle_post_reply_recovery(
     agent: &mut Agent,
     mut args: PostReplyRecoveryArgs<'_, '_>,

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -20,10 +20,10 @@ use super::actor_loop_flow::{
     ActorLoopTaskContractReplyArgs, ActorLoopTaskContractReplyOutcome,
     ActorLoopTaskContractToolRecoveryArgs, ActorLoopToolPreparationArgs,
     ActorLoopToolPreparationOutcome, PostReplyRecoveryArgs, PostReplyRecoveryOutcome,
-    TaskContractVerifierFlowOutcome, handle_non_progress_plan_edit_fallback,
-    handle_plan_progress_prose_only_fallback, handle_post_reply_recovery,
-    missing_repo_change_budget_exhausted_outcome, plan_tool_followup_done_message,
-    repair_job_done_outcome,
+    TaskContractVerifierFlowOutcome, handle_actor_loop_rejected_tool_batch,
+    handle_non_progress_plan_edit_fallback, handle_plan_progress_prose_only_fallback,
+    handle_post_reply_recovery, missing_repo_change_budget_exhausted_outcome,
+    plan_tool_followup_done_message, repair_job_done_outcome,
 };
 use super::auto_test::{
     AutoTestKind, AutoTestPlan, AutoTestResult, AutoTestRunner, auto_test_disabled,
@@ -1835,7 +1835,7 @@ fn task_contract_continue_requires_tool_recovery(
     ) && current_reply_tool_calls == 0
 }
 
-fn increment_artifact_completion_role_attempt(
+pub(super) fn increment_artifact_completion_role_attempt(
     attempts: &mut HashMap<super::task_contract::ArtifactRole, usize>,
     role: super::task_contract::ArtifactRole,
 ) -> usize {
@@ -3789,15 +3789,18 @@ fn streaming_reply_needs_trailing_newline(first_chunk: bool, stream_output: bool
     stream_output && !first_chunk
 }
 
-fn focused_policy_retry_exhausted(focused_retry_present: bool, retries: usize) -> bool {
+pub(super) fn focused_policy_retry_exhausted(focused_retry_present: bool, retries: usize) -> bool {
     focused_retry_present && retries >= 3
 }
 
-fn unrestricted_policy_retry_exhausted(focused_retry_present: bool, retries: usize) -> bool {
+pub(super) fn unrestricted_policy_retry_exhausted(
+    focused_retry_present: bool,
+    retries: usize,
+) -> bool {
     !focused_retry_present && retries >= 3
 }
 
-fn rejected_tool_batch_retry_status_note(focused_retry_present: bool) -> &'static str {
+pub(super) fn rejected_tool_batch_retry_status_note(focused_retry_present: bool) -> &'static str {
     if focused_retry_present {
         "Focused edit recovery requires exactly one compact tool call on the target file. Asked the model to retry with a single action."
     } else {
@@ -6245,7 +6248,8 @@ impl Agent {
                     );
                 }
                 FocusedEditBatchAction::Reject(err) => {
-                    return self.handle_actor_loop_rejected_tool_batch(
+                    return handle_actor_loop_rejected_tool_batch(
+                        self,
                         ActorLoopRejectedToolBatchArgs {
                             err,
                             effective_tool_policy: &effective_tool_policy,
@@ -6298,205 +6302,7 @@ impl Agent {
         }
     }
 
-    fn handle_actor_loop_rejected_tool_batch(
-        &mut self,
-        args: ActorLoopRejectedToolBatchArgs<'_, '_>,
-    ) -> ActorLoopToolPreparationOutcome {
-        let focused_retry = args.effective_tool_policy.focused_edit_policy().cloned();
-        let artifact_retry = args
-            .effective_tool_policy
-            .artifact_directed_policy()
-            .cloned();
-        self.session.working_memory.note_error(args.err);
-        if let Some(outcome) = self.maybe_handle_rejected_tool_batch_missing_verifier(
-            args.missing_verifier_setup_turn,
-            args.last_iter,
-        ) {
-            return outcome;
-        }
-        if let Some(outcome) = self.maybe_handle_rejected_tool_batch_artifact(
-            args.last_iter,
-            artifact_retry.is_some(),
-            args.task_contract,
-            args.contract_completion_role_retries,
-        ) {
-            return outcome;
-        }
-
-        *args.focused_policy_retries += 1;
-        if let Some(outcome) = self.maybe_handle_rejected_tool_batch_focused_retry_exhausted(
-            focused_retry.is_some(),
-            *args.focused_policy_retries,
-            args.recovery_dispatch_gate,
-            args.recovery_owner,
-        ) {
-            return outcome;
-        }
-        if unrestricted_policy_retry_exhausted(
-            focused_retry.is_some(),
-            *args.focused_policy_retries,
-        ) {
-            return ActorLoopToolPreparationOutcome::Exit {
-                reason: ExitReason::ToolCallFormatError,
-                error_text: "assistant kept calling tools outside the current tool policy"
-                    .to_string(),
-            };
-        }
-        let retry_status_note = rejected_tool_batch_retry_status_note(focused_retry.is_some());
-        write_stdout_rendered(
-            &format_iteration_status(
-                args.last_iter,
-                self.config.max_iterations,
-                "Retry requested",
-                retry_status_note,
-                self.footer.current_cols(),
-            ),
-            true,
-        );
-        if let Some(policy) = focused_retry {
-            self.push_system_note(self.focused_edit_no_tool_note_for_policy(
-                &policy,
-                args.effective_tool_policy,
-                *args.focused_policy_retries,
-            ));
-        } else {
-            self.push_system_note(format!(
-                "The previous tool call violated the current tool policy and was not executed. Emit exactly one allowed tool call now. tool_policy_retry_attempt={}",
-                *args.focused_policy_retries
-            ));
-        }
-        ActorLoopToolPreparationOutcome::Continue
-    }
-
-    fn maybe_handle_rejected_tool_batch_missing_verifier(
-        &mut self,
-        missing_verifier_setup_turn: bool,
-        last_iter: usize,
-    ) -> Option<ActorLoopToolPreparationOutcome> {
-        if !missing_verifier_setup_turn {
-            return None;
-        }
-        if self.record_missing_verifier_setup_failure(last_iter, "tool policy violation") {
-            return Some(ActorLoopToolPreparationOutcome::Exit {
-                reason: ExitReason::MissingVerification,
-                error_text:
-                    "task contract requires verification, but the MissingVerifierJob setup budget is exhausted"
-                        .to_string(),
-            });
-        }
-        Some(ActorLoopToolPreparationOutcome::Continue)
-    }
-
-    fn maybe_handle_rejected_tool_batch_artifact(
-        &mut self,
-        last_iter: usize,
-        artifact_retry_present: bool,
-        task_contract: Option<&super::task_contract::TaskContract>,
-        contract_completion_role_retries: &mut HashMap<super::task_contract::ArtifactRole, usize>,
-    ) -> Option<ActorLoopToolPreparationOutcome> {
-        if !artifact_retry_present {
-            return None;
-        }
-        let role = self
-            .current_artifact_recovery_target
-            .as_ref()
-            .map(|target| target.role)
-            .unwrap_or(super::task_contract::ArtifactRole::Implementation);
-        if self.record_artifact_completion_attempt(
-            super::artifact_completion_job::ArtifactAttemptOutcomeKind::RolePolicyViolation,
-            vec!["focused_edit_batch_reject".to_string()],
-        ) {
-            return Some(ActorLoopToolPreparationOutcome::Exit {
-                reason: ExitReason::MissingRepoEdits,
-                error_text: format!(
-                    "artifact completion role-policy violation budget exhausted for role {}",
-                    role.label()
-                ),
-            });
-        }
-        let artifact_attempt =
-            increment_artifact_completion_role_attempt(contract_completion_role_retries, role);
-        let attempt_limit = task_contract
-            .as_ref()
-            .map(|contract| contract.artifact_completion_attempt_limit())
-            .unwrap_or(4);
-        if artifact_attempt >= attempt_limit {
-            let expected_target = self
-                .current_artifact_recovery_target
-                .as_ref()
-                .map(|target| target.path.clone());
-            self.emit_safe_stop_report_for_artifact_completion_failed(role, expected_target);
-            return Some(ActorLoopToolPreparationOutcome::Exit {
-                reason: ExitReason::MissingRepoEdits,
-                error_text: format!(
-                    "artifact edit rejected repeatedly for required role {}",
-                    role.label()
-                ),
-            });
-        }
-        write_stdout_rendered(
-            &format_iteration_status(
-                last_iter,
-                self.config.max_iterations,
-                "Retry requested",
-                "Artifact completion rejected an invalid tool call before execution; asked for one allowed edit on the target.",
-                self.footer.current_cols(),
-            ),
-            true,
-        );
-        if !self.push_artifact_directed_recovery_note(artifact_attempt) {
-            self.push_system_note(format!(
-                "[Artifact Completion] Previous tool call was rejected and was not executed. Missing role: {}. Emit exactly one allowed tool call on the current target path now. artifact_completion_attempt={artifact_attempt}/{attempt_limit}",
-                role.label()
-            ));
-        }
-        Some(ActorLoopToolPreparationOutcome::Continue)
-    }
-
-    fn maybe_handle_rejected_tool_batch_focused_retry_exhausted(
-        &mut self,
-        focused_retry_present: bool,
-        focused_policy_retries: usize,
-        recovery_dispatch_gate: RecoveryDispatchGate,
-        recovery_owner: RecoveryOwner,
-    ) -> Option<ActorLoopToolPreparationOutcome> {
-        if !focused_policy_retry_exhausted(focused_retry_present, focused_policy_retries) {
-            return None;
-        }
-        if !recovery_dispatch_gate.allows_focused_edit_recovery() {
-            return Some(ActorLoopToolPreparationOutcome::Exit {
-                reason: Self::tool_policy_violation_exit_reason(recovery_owner),
-                error_text:
-                    "verifier-owned recovery rejected invalid tool calls repeatedly before an allowed repair edit"
-                        .to_string(),
-            });
-        }
-        let request = self.active_request_text().unwrap_or_default();
-        let fallback = match self.maybe_apply_local_llm_small_edit_fallback(&request) {
-            Ok(fallback) => fallback,
-            Err(err) => {
-                return Some(ActorLoopToolPreparationOutcome::Exit {
-                    reason: ExitReason::TransportError,
-                    error_text: err,
-                });
-            }
-        };
-        if let Some(relative) = fallback {
-            return Some(ActorLoopToolPreparationOutcome::Done {
-                final_prose: format!(
-                    "Applied a verified small edit fallback after the local model could not produce a compact edit for {relative}."
-                ),
-            });
-        }
-        Some(ActorLoopToolPreparationOutcome::Exit {
-            reason: ExitReason::MissingRepoEdits,
-            error_text: ExitReason::MissingRepoEdits
-                .default_error_text()
-                .to_string(),
-        })
-    }
-
-    fn tool_policy_violation_exit_reason(recovery_owner: RecoveryOwner) -> ExitReason {
+    pub(super) fn tool_policy_violation_exit_reason(recovery_owner: RecoveryOwner) -> ExitReason {
         if recovery_owner == RecoveryOwner::MissingVerifierJob {
             ExitReason::MissingVerification
         } else if recovery_owner.is_verifier_owned() {
@@ -10095,7 +9901,11 @@ impl Agent {
         "inspect the verifier diagnostics and retry with a narrower repair target"
     }
 
-    fn record_missing_verifier_setup_failure(&mut self, last_iter: usize, reason: &str) -> bool {
+    pub(super) fn record_missing_verifier_setup_failure(
+        &mut self,
+        last_iter: usize,
+        reason: &str,
+    ) -> bool {
         let Some(job) = self.missing_verifier_job.as_mut() else {
             return false;
         };
@@ -13602,7 +13412,7 @@ impl Agent {
     /// `ArtifactCompletionJob` (no-op when no job exists). Triggers the
     /// turn-local `artifact_completion_failed` diagnostic when the
     /// recording causes the job to transition to `Exhausted`.
-    fn record_artifact_completion_attempt(
+    pub(super) fn record_artifact_completion_attempt(
         &mut self,
         kind: super::artifact_completion_job::ArtifactAttemptOutcomeKind,
         actual_actions: Vec<String>,
@@ -13701,7 +13511,7 @@ impl Agent {
         }
     }
 
-    fn focused_edit_no_tool_note_for_policy(
+    pub(super) fn focused_edit_no_tool_note_for_policy(
         &self,
         policy: &FocusedEditPolicy,
         effective_tool_policy: &EffectiveToolPolicy,


### PR DESCRIPTION
## 概要

Issue #681 (parent #680) の incremental method migration **第九段**。rejected_tool_batch family の **全 4 method** (dispatcher + 3 sub-handlers) を turn.rs から actor_loop_flow.rs へ一括移管。

## 移管 method

| Method | 種別 |
|---|---|
| `handle_actor_loop_rejected_tool_batch` | dispatcher |
| `maybe_handle_rejected_tool_batch_missing_verifier` | sub-handler |
| `maybe_handle_rejected_tool_batch_artifact` | sub-handler |
| `maybe_handle_rejected_tool_batch_focused_retry_exhausted` | sub-handler |

## Visibility 昇格 (8 項目)

| 対象 | 種別 |
|---|---|
| `focused_policy_retry_exhausted` | free fn |
| `unrestricted_policy_retry_exhausted` | free fn |
| `rejected_tool_batch_retry_status_note` | free fn |
| `increment_artifact_completion_role_attempt` | free fn |
| `record_missing_verifier_setup_failure` | Agent method |
| `record_artifact_completion_attempt` | Agent method |
| `focused_edit_no_tool_note_for_policy` | Agent method |
| `tool_policy_violation_exit_reason` | Agent associated fn |

## メトリクス

| | 起点 (develop = PR #696 merge後) | 本 PR 後 | 差分 |
|---|---|---|---|
| turn.rs LOC | 38,739 | **38,549** | **-190** |
| actor_loop_flow.rs LOC | 859 | 1,056 | +197 |
| 移管済 method (累計) | 15 | **19** | +4 |

PR #689 起点 (39,489) からの累計: **-940 LOC** (Phase 1 受入条件 -4,000 の **約 24%**)。

## 受入条件

- [x] `cargo fmt --check` 緑
- [x] `cargo clippy --all-targets --all-features` 警告 0 件
- [x] `cargo test --all-features` 3,731 pass / 0 fail
- [x] DR3-001 遵守

## 次の family

- actor_loop_pre_reply 補助群 (約 15 method、~400 LOC)
- task_contract_reply family (大規模)
- tool_preparation family
- `run_actor_loop` orchestrator (最後)

## 関連 Issue

- 子: #681 (Phase 1 actor_loop_flow extraction)
- 親 (epic): #680

🤖 Generated with [Claude Code](https://claude.com/claude-code)