### PR TITLE
refactor(agent/loop_run): relocate build_stats helper to actor_loop_flow (part of #681)

### DIFF
--- a/src/agent/loop_run/actor_loop_flow.rs
+++ b/src/agent/loop_run/actor_loop_flow.rs
@@ -34,7 +34,7 @@
 //! DR3-001: `pub(super)` limited. `loop_run.rs` MUST NOT re-export via
 //! `pub use`. `turn.rs` is the only in-crate consumer.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use crate::agent::orchestration::{
     RepoSnapshot, RepoVerification, capture_repo_snapshot, verify_repo_progress,
@@ -55,20 +55,22 @@ use super::lifecycle;
 use super::progress_text::truncate;
 use super::progress_text::{no_color_requested, unicode_supported};
 use super::spinner::Spinner;
-use super::summary::{ExitReason, LoopResult};
+use super::summary::{ExitReason, LoopResult, LoopStats};
 use super::tool_history::focused_edit_target_already_read;
 use super::tool_history::is_plan_file_tool_call;
 use super::tool_policy::EffectiveToolPolicy;
 use super::turn::{
     LOG_ARGS_MAX_CHARS, PLAN_REPEATED_EXPLORATION_BLOCK_THRESHOLD, PlanExplorationKey,
-    build_feedback_for_no_repo_progress, build_feedback_for_unsafe_block, build_stats,
+    build_feedback_for_no_repo_progress, build_feedback_for_unsafe_block,
     format_blocked_progress_line, format_progress_line, normalize_plan_exploration_key,
     progress_stage_label, should_record_no_repo_progress, summarize_plan_write,
     write_stdout_rendered,
 };
 use crate::agent::prompting;
 use crate::session::compact::approximate_token_count;
+use crate::util::workspace_paths::is_ignored_workspace_display_path;
 use std::io::{self, IsTerminal};
+use std::path::Path;
 use std::time::Instant;
 
 /// Issue #652: `error_text` shared by the three `ArtifactCompletionJob`
@@ -3885,5 +3887,88 @@ pub(super) fn run_actor_loop(
             error_text = exit_reason.default_error_text().to_string();
         }
         Err((exit_reason, error_text, stats))
+    }
+}
+
+pub(super) fn build_stats(
+    accumulated: Vec<RepoVerification>,
+    final_verif: RepoVerification,
+    iter_used: usize,
+    iter_max: usize,
+    duration_secs: u64,
+) -> LoopStats {
+    let mut all_changed: HashSet<String> = HashSet::new();
+    let mut all_changed_full: HashSet<String> = HashSet::new();
+    let mut impl_changed = 0usize;
+    let mut test_changed = 0usize;
+    let mut setup_changed = 0usize;
+    let mut other_changed = 0usize;
+    let mut deleted_changed = 0usize;
+
+    for verif in accumulated.iter().chain(std::iter::once(&final_verif)) {
+        for f in &verif.changed_files {
+            if is_ignored_workspace_display_path(f) {
+                continue;
+            }
+            all_changed.insert(f.clone());
+        }
+        for f in &verif.all_changed_files {
+            if is_ignored_workspace_display_path(f) {
+                continue;
+            }
+            all_changed_full.insert(f.clone());
+        }
+        if verif
+            .all_changed_files
+            .iter()
+            .all(|f| !is_ignored_workspace_display_path(f))
+        {
+            impl_changed += verif.implementation_files_changed;
+            test_changed += verif.test_files_changed;
+            setup_changed += verif.setup_files_changed;
+            other_changed += verif.other_files_changed;
+            deleted_changed += verif.deleted_files_changed;
+        } else {
+            for f in &verif.all_changed_files {
+                if is_ignored_workspace_display_path(f) {
+                    continue;
+                }
+                let (path, deleted) = f
+                    .strip_suffix(" (deleted)")
+                    .map(|path| (path, true))
+                    .unwrap_or((f.as_str(), false));
+                if deleted {
+                    deleted_changed += 1;
+                } else if crate::util::file_classify::is_test_file(Path::new(path)) {
+                    test_changed += 1;
+                } else if crate::util::file_classify::is_setup_file(Path::new(path)) {
+                    setup_changed += 1;
+                } else if crate::util::file_classify::is_implementation_file(Path::new(path)) {
+                    impl_changed += 1;
+                } else {
+                    other_changed += 1;
+                }
+            }
+        }
+    }
+
+    let total_changed =
+        impl_changed + test_changed + setup_changed + other_changed + deleted_changed;
+    let mut changed_files: Vec<String> = all_changed.into_iter().collect();
+    changed_files.sort();
+    changed_files.truncate(16);
+    let mut all_changed_files: Vec<String> = all_changed_full.into_iter().collect();
+    all_changed_files.sort();
+
+    LoopStats {
+        iter_used,
+        iter_max,
+        duration_secs,
+        changed_files: changed_files.into_boxed_slice(),
+        all_changed_files: all_changed_files.into_boxed_slice(),
+        total_changed,
+        changed_impl_count: impl_changed,
+        changed_test_count: test_changed,
+        changed_setup_count: setup_changed,
     }
 }

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -97,7 +97,7 @@ use super::semantic_repair_planning::{
     sort_admitted_by_authority_role_priority,
 };
 use super::spinner::{Spinner, SpinnerStopSignal};
-use super::summary::{ExitReason, LoopResult, LoopStats};
+use super::summary::{ExitReason, LoopResult};
 use super::tester;
 use super::tool_execution::{
     failed_outcome_for_call, rejected_outcome_for_call, success_outcome_for_call,
@@ -3224,89 +3224,6 @@ fn sort_precautions_for_prompt<'a>(
         relevance_score(b, touched, suspected).cmp(&relevance_score(a, touched, suspected))
     });
     active
-}
-
-pub(super) fn build_stats(
-    accumulated: Vec<RepoVerification>,
-    final_verif: RepoVerification,
-    iter_used: usize,
-    iter_max: usize,
-    duration_secs: u64,
-) -> LoopStats {
-    let mut all_changed: HashSet<String> = HashSet::new();
-    let mut all_changed_full: HashSet<String> = HashSet::new();
-    let mut impl_changed = 0usize;
-    let mut test_changed = 0usize;
-    let mut setup_changed = 0usize;
-    let mut other_changed = 0usize;
-    let mut deleted_changed = 0usize;
-
-    for verif in accumulated.iter().chain(std::iter::once(&final_verif)) {
-        for f in &verif.changed_files {
-            if is_ignored_workspace_display_path(f) {
-                continue;
-            }
-            all_changed.insert(f.clone());
-        }
-        for f in &verif.all_changed_files {
-            if is_ignored_workspace_display_path(f) {
-                continue;
-            }
-            all_changed_full.insert(f.clone());
-        }
-        if verif
-            .all_changed_files
-            .iter()
-            .all(|f| !is_ignored_workspace_display_path(f))
-        {
-            impl_changed += verif.implementation_files_changed;
-            test_changed += verif.test_files_changed;
-            setup_changed += verif.setup_files_changed;
-            other_changed += verif.other_files_changed;
-            deleted_changed += verif.deleted_files_changed;
-        } else {
-            for f in &verif.all_changed_files {
-                if is_ignored_workspace_display_path(f) {
-                    continue;
-                }
-                let (path, deleted) = f
-                    .strip_suffix(" (deleted)")
-                    .map(|path| (path, true))
-                    .unwrap_or((f.as_str(), false));
-                if deleted {
-                    deleted_changed += 1;
-                } else if crate::util::file_classify::is_test_file(Path::new(path)) {
-                    test_changed += 1;
-                } else if crate::util::file_classify::is_setup_file(Path::new(path)) {
-                    setup_changed += 1;
-                } else if crate::util::file_classify::is_implementation_file(Path::new(path)) {
-                    impl_changed += 1;
-                } else {
-                    other_changed += 1;
-                }
-            }
-        }
-    }
-
-    let total_changed =
-        impl_changed + test_changed + setup_changed + other_changed + deleted_changed;
-    let mut changed_files: Vec<String> = all_changed.into_iter().collect();
-    changed_files.sort();
-    changed_files.truncate(16);
-    let mut all_changed_files: Vec<String> = all_changed_full.into_iter().collect();
-    all_changed_files.sort();
-
-    LoopStats {
-        iter_used,
-        iter_max,
-        duration_secs,
-        changed_files: changed_files.into_boxed_slice(),
-        all_changed_files: all_changed_files.into_boxed_slice(),
-        total_changed,
-        changed_impl_count: impl_changed,
-        changed_test_count: test_changed,
-        changed_setup_count: setup_changed,
-    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]


### PR DESCRIPTION
## 概要

Issue #681 (parent #680) の incremental migration **第二十段**。`build_stats` (81 LOC、`run_actor_loop` の唯一消費者) を turn.rs から actor_loop_flow.rs へ relocate。

## 移管 item

| Item | LOC |
|---|---|
| `build_stats` (free fn) | **81** |

## Imports added to actor_loop_flow.rs

- `std::collections::HashSet`
- `std::path::Path`
- `crate::util::workspace_paths::is_ignored_workspace_display_path`
- `super::summary::LoopStats`

## メトリクス

| | 起点 (develop = PR #707 merge後) | 本 PR 後 | 差分 |
|---|---|---|---|
| turn.rs LOC | 35,810 | **35,729** | **-81** |

PR #689 起点 (39,489) からの累計: **-3,760 LOC** (Phase 1 受入条件 -4,000 の **約 94%**)。

🎯 **94% 突破** — Phase 1 まで残り **約 -729 LOC**。

## 受入条件

- [x] `cargo fmt --check` 緑
- [x] `cargo clippy --all-targets --all-features` 警告 0 件
- [x] `cargo test --all-features` 3,731 pass / 0 fail
- [x] DR3-001 遵守
- [x] `super::turn::build_stats` back-import 撤去

## 関連 Issue

- 子: #681
- 親 (epic): #680

🤖 Generated with [Claude Code](https://claude.com/claude-code)