### PR TITLE
Relocate task-contract / feedback helpers (batch 3) to actor_loop_flow (Issue #681)

### DIFF
--- a/src/agent/loop_run/actor_loop_flow.rs
+++ b/src/agent/loop_run/actor_loop_flow.rs
@@ -60,6 +60,7 @@ use super::progress_text::{
 };
 use super::progress_text::{no_color_requested, unicode_supported};
 use super::spinner::Spinner;
+use super::success::DETERMINISTIC_CONTENT_FALLBACK_TAG;
 use super::summary::{ExitReason, LoopResult, LoopStats};
 use super::tool_history::focused_edit_target_already_read;
 use super::tool_history::is_plan_file_tool_call;
@@ -441,7 +442,7 @@ pub(super) fn maybe_handle_answer_only_inadequate_recovery(
 ) -> Option<PostReplyRecoveryOutcome> {
     if !args.requires_action
         && agent.answer_only_mode_active()
-        && super::turn::answer_only_reply_is_inadequate(args.final_reply)
+        && answer_only_reply_is_inadequate(args.final_reply)
     {
         *args.no_tool_retries += 1;
         if *args.no_tool_retries >= 2 {
@@ -458,7 +459,7 @@ pub(super) fn maybe_handle_answer_only_inadequate_recovery(
             });
         }
         super::turn::write_stdout_rendered(
-            &super::turn::format_iteration_status(
+            &format_iteration_status(
                 args.last_iter,
                 agent.config.max_iterations,
                 "Retry requested",
@@ -480,7 +481,7 @@ pub(super) fn maybe_handle_repo_change_quality_gate_recovery(
     agent: &mut Agent,
     args: &mut PostReplyRecoveryArgs<'_, '_>,
 ) -> Option<PostReplyRecoveryOutcome> {
-    if !(super::turn::should_apply_repo_change_quality_gate(
+    if !(should_apply_repo_change_quality_gate(
         args.action_expectation,
         agent.active_task_expects_repo_change(),
         agent.session.mode_state.mode,
@@ -493,7 +494,7 @@ pub(super) fn maybe_handle_repo_change_quality_gate_recovery(
     match agent.maybe_apply_deterministic_quality_fallback(&request, &target_path) {
         Ok(true) => {
             super::turn::write_stdout_rendered(
-                &super::turn::format_iteration_status(
+                &format_iteration_status(
                     args.last_iter,
                     agent.config.max_iterations,
                     "Quality fallback",
@@ -503,7 +504,7 @@ pub(super) fn maybe_handle_repo_change_quality_gate_recovery(
                 true,
             );
             agent.session.record_feedback_if_unset(
-                super::turn::build_feedback_for_deterministic_content_fallback(&agent.work_root),
+                build_feedback_for_deterministic_content_fallback(&agent.work_root),
             );
             agent.push_deterministic_ui_recovery_continuation_note(
                 &target_path,
@@ -529,7 +530,7 @@ pub(super) fn maybe_handle_repo_change_quality_gate_recovery(
         });
     }
     super::turn::write_stdout_rendered(
-        &super::turn::format_iteration_status(
+        &format_iteration_status(
             args.last_iter,
             agent.config.max_iterations,
             "Quality gate",
@@ -551,7 +552,7 @@ pub(super) fn maybe_handle_repo_change_partial_progress_recovery(
     agent: &mut Agent,
     args: &mut PostReplyRecoveryArgs<'_, '_>,
 ) -> Option<PostReplyRecoveryOutcome> {
-    if !super::turn::should_apply_repo_change_partial_progress_recovery(
+    if !should_apply_repo_change_partial_progress_recovery(
         args.action_expectation,
         args.repo_edit_calls_made_this_turn,
         args.final_reply,
@@ -573,7 +574,7 @@ pub(super) fn maybe_handle_repo_change_partial_progress_recovery(
         });
     }
     super::turn::write_stdout_rendered(
-        &super::turn::format_iteration_status(
+        &format_iteration_status(
             args.last_iter,
             agent.config.max_iterations,
             "Retry requested",
@@ -625,7 +626,7 @@ pub(super) fn maybe_handle_python_test_artifact_recovery(
         });
     }
     super::turn::write_stdout_rendered(
-        &super::turn::format_iteration_status(
+        &format_iteration_status(
             args.last_iter,
             agent.config.max_iterations,
             "Quality gate",
@@ -659,7 +660,7 @@ pub(super) fn maybe_handle_missing_repo_edit_recovery(
         return Some(finalize_missing_repo_edit_retry_exhausted(agent));
     }
     super::turn::write_stdout_rendered(
-        &super::turn::format_iteration_status(
+        &format_iteration_status(
             args.last_iter,
             agent.config.max_iterations,
             "Retry requested",
@@ -759,7 +760,7 @@ pub(super) fn actor_loop_pre_reply_request_error(
             || super::lifecycle::is_tool_call_format_error(&err)
             || super::lifecycle::is_native_tool_transport_failure(&err))
     {
-        let frame = super::turn::build_feedback_for_tool_protocol_failure(&err, &agent.work_root);
+        let frame = build_feedback_for_tool_protocol_failure(&err, &agent.work_root);
         agent.session.record_feedback(frame);
     }
     ActorLoopPreReplyOutcome::Exit {
@@ -870,7 +871,7 @@ pub(super) fn handle_actor_loop_empty_reply(
             };
         }
         super::turn::write_stdout_rendered(
-            &super::turn::format_iteration_status(
+            &format_iteration_status(
                 args.last_iter,
                 agent.config.max_iterations,
                 "Retry requested",
@@ -909,7 +910,7 @@ pub(super) fn handle_actor_loop_empty_reply(
         };
     }
     super::turn::write_stdout_rendered(
-        &super::turn::format_iteration_status(
+        &format_iteration_status(
             args.last_iter,
             agent.config.max_iterations,
             "Retry requested",
@@ -974,7 +975,7 @@ fn handle_plan_progress_prose_only_reply(
         return handle_plan_progress_prose_only_fallback(agent);
     }
     super::turn::write_stdout_rendered(
-        &super::turn::format_iteration_status(
+        &format_iteration_status(
             args.last_iter,
             agent.config.max_iterations,
             "Retry requested",
@@ -1023,7 +1024,7 @@ fn handle_generic_prose_only_retry(
         };
     }
     super::turn::write_stdout_rendered(
-        &super::turn::format_iteration_status(
+        &format_iteration_status(
             last_iter,
             agent.config.max_iterations,
             "Retry requested",
@@ -1066,7 +1067,7 @@ fn handle_actor_loop_missing_repo_change_retry_prompt(
     args: ActorLoopMissingRepoChangeRetryPromptArgs,
 ) -> ActorLoopNoToolReplyOutcome {
     super::turn::write_stdout_rendered(
-        &super::turn::format_iteration_status(
+        &format_iteration_status(
             args.last_iter,
             agent.config.max_iterations,
             "Retry requested",
@@ -1142,7 +1143,7 @@ fn handle_actor_loop_missing_repo_change_retry_exhausted(
             || agent.push_repo_change_no_edit_recovery_note(args.repo_change_retries))
     {
         super::turn::write_stdout_rendered(
-            &super::turn::format_iteration_status(
+            &format_iteration_status(
                 args.last_iter,
                 agent.config.max_iterations,
                 "Retry requested",
@@ -1302,7 +1303,7 @@ pub(super) fn handle_actor_loop_completion(
                 };
             }
             super::turn::write_stdout_rendered(
-                &super::turn::format_iteration_status(
+                &format_iteration_status(
                     args.last_iter,
                     agent.config.max_iterations,
                     "Plan still incomplete",
@@ -1440,7 +1441,7 @@ pub(super) fn handle_actor_loop_post_tool_polish_fallback(
     match agent.maybe_apply_deterministic_polish_fallback(request, target_path) {
         Ok(true) => {
             super::turn::write_stdout_rendered(
-                &super::turn::format_iteration_status(
+                &format_iteration_status(
                     last_iter,
                     agent.config.max_iterations,
                     "Polish fallback",
@@ -1450,7 +1451,7 @@ pub(super) fn handle_actor_loop_post_tool_polish_fallback(
                 true,
             );
             agent.session.record_feedback_if_unset(
-                super::turn::build_feedback_for_deterministic_content_fallback(&agent.work_root),
+                build_feedback_for_deterministic_content_fallback(&agent.work_root),
             );
             agent.push_deterministic_ui_recovery_continuation_note(
                 target_path,
@@ -1476,7 +1477,7 @@ fn handle_actor_loop_post_tool_quality_fallback(
     match agent.maybe_apply_deterministic_quality_fallback(request, target_path) {
         Ok(true) => {
             super::turn::write_stdout_rendered(
-                &super::turn::format_iteration_status(
+                &format_iteration_status(
                     last_iter,
                     agent.config.max_iterations,
                     "Quality fallback",
@@ -1486,7 +1487,7 @@ fn handle_actor_loop_post_tool_quality_fallback(
                 true,
             );
             agent.session.record_feedback_if_unset(
-                super::turn::build_feedback_for_deterministic_content_fallback(&agent.work_root),
+                build_feedback_for_deterministic_content_fallback(&agent.work_root),
             );
             agent.push_deterministic_ui_recovery_continuation_note(
                 target_path,
@@ -1512,7 +1513,7 @@ fn handle_actor_loop_post_tool_repo_edit_quality_gate(
 ) -> ActorLoopPostToolFallbackOutcome {
     if repo_edit_calls_made_this_turn == 0
         || !recovery_dispatch_gate.allows_deterministic_fallback()
-        || !(super::turn::should_apply_repo_change_quality_gate(
+        || !(should_apply_repo_change_quality_gate(
             action_expectation,
             agent.active_task_expects_repo_change(),
             agent.session.mode_state.mode,
@@ -1526,7 +1527,7 @@ fn handle_actor_loop_post_tool_repo_edit_quality_gate(
     match agent.maybe_apply_deterministic_quality_fallback(&request, &target_path) {
         Ok(true) => {
             super::turn::write_stdout_rendered(
-                &super::turn::format_iteration_status(
+                &format_iteration_status(
                     last_iter,
                     agent.config.max_iterations,
                     "Quality fallback",
@@ -1536,7 +1537,7 @@ fn handle_actor_loop_post_tool_repo_edit_quality_gate(
                 true,
             );
             agent.session.record_feedback_if_unset(
-                super::turn::build_feedback_for_deterministic_content_fallback(&agent.work_root),
+                build_feedback_for_deterministic_content_fallback(&agent.work_root),
             );
             agent.push_deterministic_ui_recovery_continuation_note(
                 &target_path,
@@ -1553,7 +1554,7 @@ fn handle_actor_loop_post_tool_repo_edit_quality_gate(
                 }
             } else {
                 super::turn::write_stdout_rendered(
-                    &super::turn::format_iteration_status(
+                    &format_iteration_status(
                         last_iter,
                         agent.config.max_iterations,
                         "Quality gate",
@@ -1737,7 +1738,7 @@ pub(super) fn drive_actor_loop_tool_preparation_phase(
             super::tool_policy::FocusedEditBatchAction::TruncateToFirst => {
                 prepared_tool_calls.truncate(1);
                 super::turn::write_stdout_rendered(
-                    &super::turn::format_iteration_status(
+                    &format_iteration_status(
                         args.last_iter,
                         agent.config.max_iterations,
                         "Tool policy narrowed",
@@ -2070,7 +2071,7 @@ pub(super) fn handle_actor_loop_task_contract_continue_action(
                 (*args.contract_completion_retries).saturating_add(1),
             )
         });
-    if super::turn::task_contract_continue_requires_tool_recovery(
+    if task_contract_continue_requires_tool_recovery(
         Some(args.action),
         args.current_reply_tool_call_count,
     ) {
@@ -2135,10 +2136,8 @@ pub(super) fn handle_actor_loop_task_contract_tool_recovery(
             error_text: ARTIFACT_COMPLETION_BUDGET_EXHAUSTED_TEXT.to_string(),
         };
     }
-    let artifact_attempt = super::turn::increment_artifact_completion_role_attempt(
-        args.contract_completion_role_retries,
-        role,
-    );
+    let artifact_attempt =
+        increment_artifact_completion_role_attempt(args.contract_completion_role_retries, role);
     let attempt_limit = args.contract.artifact_completion_attempt_limit();
     if artifact_attempt >= attempt_limit {
         let expected_target = args
@@ -2161,7 +2160,7 @@ pub(super) fn handle_actor_loop_task_contract_tool_recovery(
         };
     }
     super::turn::write_stdout_rendered(
-        &super::turn::format_iteration_status(
+        &format_iteration_status(
             args.last_iter,
             agent.config.max_iterations,
             "Retry requested",
@@ -2198,10 +2197,8 @@ pub(super) fn handle_actor_loop_task_contract_incomplete_artifacts(
         .first()
         .copied()
         .unwrap_or(super::task_contract::ArtifactRole::Implementation);
-    let artifact_attempt = super::turn::increment_artifact_completion_role_attempt(
-        args.contract_completion_role_retries,
-        role,
-    );
+    let artifact_attempt =
+        increment_artifact_completion_role_attempt(args.contract_completion_role_retries, role);
     let attempt_limit = args.contract.artifact_completion_attempt_limit();
     if artifact_attempt >= attempt_limit {
         let expected_target = args
@@ -2224,7 +2221,7 @@ pub(super) fn handle_actor_loop_task_contract_incomplete_artifacts(
         };
     }
     super::turn::write_stdout_rendered(
-        &super::turn::format_iteration_status(
+        &format_iteration_status(
             args.last_iter,
             agent.config.max_iterations,
             "Task contract",
@@ -2287,7 +2284,7 @@ pub(super) fn handle_actor_loop_task_contract_repair_artifact(
         };
     }
     super::turn::write_stdout_rendered(
-        &super::turn::format_iteration_status(
+        &format_iteration_status(
             last_iter,
             agent.config.max_iterations,
             "Retry requested",
@@ -2342,8 +2339,7 @@ pub(super) fn handle_actor_loop_task_contract_safe_stop(
     reason: super::task_contract::SafeStopReason,
     last_iter: usize,
 ) -> ActorLoopTaskContractReplyOutcome {
-    let (mapped_reason, log_outcome) =
-        super::turn::task_contract_verifier_safe_stop_mapping(reason);
+    let (mapped_reason, log_outcome) = task_contract_verifier_safe_stop_mapping(reason);
     crate::logging::log_llm_event(
         "agent.task_contract.safe_stop",
         serde_json::json!({
@@ -2404,7 +2400,7 @@ pub(super) fn handle_actor_loop_rejected_tool_batch(
     }
     let retry_status_note = rejected_tool_batch_retry_status_note(focused_retry.is_some());
     super::turn::write_stdout_rendered(
-        &super::turn::format_iteration_status(
+        &format_iteration_status(
             args.last_iter,
             agent.config.max_iterations,
             "Retry requested",
@@ -2475,10 +2471,8 @@ pub(super) fn maybe_handle_rejected_tool_batch_artifact(
             ),
         });
     }
-    let artifact_attempt = super::turn::increment_artifact_completion_role_attempt(
-        contract_completion_role_retries,
-        role,
-    );
+    let artifact_attempt =
+        increment_artifact_completion_role_attempt(contract_completion_role_retries, role);
     let attempt_limit = task_contract
         .as_ref()
         .map(|contract| contract.artifact_completion_attempt_limit())
@@ -2498,7 +2492,7 @@ pub(super) fn maybe_handle_rejected_tool_batch_artifact(
         });
     }
     super::turn::write_stdout_rendered(
-        &super::turn::format_iteration_status(
+        &format_iteration_status(
             last_iter,
             agent.config.max_iterations,
             "Retry requested",
@@ -2591,7 +2585,7 @@ pub(super) fn maybe_handle_answer_only_future_work_recovery(
 ) -> Option<PostReplyRecoveryOutcome> {
     if !args.requires_action
         && agent.answer_only_mode_active()
-        && super::turn::reply_looks_like_future_work(args.final_reply)
+        && reply_looks_like_future_work(args.final_reply)
     {
         *args.no_tool_retries += 1;
         if *args.no_tool_retries >= 1 {
@@ -2602,7 +2596,7 @@ pub(super) fn maybe_handle_answer_only_future_work_recovery(
             });
         }
         super::turn::write_stdout_rendered(
-            &super::turn::format_iteration_status(
+            &format_iteration_status(
                 args.last_iter,
                 agent.config.max_iterations,
                 "Retry requested",
@@ -4356,4 +4350,190 @@ pub(super) fn should_try_framework_app_fallback(
 
 pub(super) fn framework_app_fallback_continuation_note() -> &'static str {
     "[Deterministic App Fallback] Treat the materialized framework files as a recovery scaffold only, not as task completion. Continue by reading and editing the real UI entry file with task-specific implementation details, then verify the app before final response."
+}
+
+pub(super) fn build_feedback_for_tool_protocol_failure(
+    err: &str,
+    workspace_root: &Path,
+) -> FeedbackFrame {
+    let draft = FeedbackFrameDraft {
+        kind: FeedbackKind::ToolProtocolFailure,
+        primary_error: Some(err.to_string()),
+        ..Default::default()
+    };
+    build_feedback_frame(draft, workspace_root)
+}
+
+pub(super) fn build_feedback_for_deterministic_content_fallback(
+    workspace_root: &Path,
+) -> FeedbackFrame {
+    let draft = FeedbackFrameDraft {
+        kind: FeedbackKind::ToolProtocolFailure,
+        primary_error: Some(DETERMINISTIC_CONTENT_FALLBACK_TAG.to_string()),
+        ..Default::default()
+    };
+    build_feedback_frame(draft, workspace_root)
+}
+
+pub(super) fn reply_looks_like_future_work(reply: &str) -> bool {
+    let normalized = reply.trim().to_ascii_lowercase();
+    if normalized.is_empty() {
+        return false;
+    }
+    let completion_markers = [
+        "done",
+        "completed",
+        "implemented",
+        "finished",
+        "ready",
+        "作成しました",
+        "実装しました",
+        "完了",
+        "できました",
+    ];
+    if completion_markers
+        .iter()
+        .any(|marker| normalized.contains(marker))
+    {
+        return false;
+    }
+    let future_markers = [
+        "now i'll",
+        "now i will",
+        "i'll ",
+        "i will ",
+        "let me ",
+        "you can run",
+        "please run",
+        "run this yourself",
+        "run it yourself",
+        "next,",
+        "next i",
+        "次に",
+        "これから",
+        "今から",
+        "次は",
+        "探してみます",
+        "確認します",
+        "調べます",
+        "見てみます",
+        "してみます",
+        "実行してください",
+        "確認してください",
+    ];
+    future_markers
+        .iter()
+        .any(|marker| normalized.contains(marker))
+}
+
+pub(super) fn task_contract_verifier_safe_stop_mapping(
+    reason: super::task_contract::SafeStopReason,
+) -> (ExitReason, &'static str) {
+    match reason {
+        super::task_contract::SafeStopReason::VerifierWeak => {
+            (ExitReason::SafeStopVerifierWeak, "safe_stop_verifier_weak")
+        }
+        super::task_contract::SafeStopReason::VerifierMissing => (
+            ExitReason::SafeStopVerifierMissing,
+            "safe_stop_verifier_missing",
+        ),
+    }
+}
+
+pub(super) fn task_contract_continue_requires_tool_recovery(
+    action: Option<&super::task_contract::ArtifactRecoveryAction>,
+    current_reply_tool_calls: usize,
+) -> bool {
+    matches!(
+        action,
+        Some(super::task_contract::ArtifactRecoveryAction::Continue { .. })
+    ) && current_reply_tool_calls == 0
+}
+
+pub(super) fn increment_artifact_completion_role_attempt(
+    attempts: &mut HashMap<super::task_contract::ArtifactRole, usize>,
+    role: super::task_contract::ArtifactRole,
+) -> usize {
+    let entry = attempts.entry(role).or_insert(0);
+    *entry = entry.saturating_add(1);
+    *entry
+}
+
+pub(super) fn should_apply_repo_change_partial_progress_recovery(
+    action_expectation: recovery::ActionExpectation,
+    repo_edit_calls_made_this_turn: usize,
+    final_reply: &str,
+    task_contract_action: Option<&super::task_contract::ArtifactRecoveryAction>,
+) -> bool {
+    let contract_allows_generic_recovery = match task_contract_action {
+        None | Some(super::task_contract::ArtifactRecoveryAction::Done) => true,
+        Some(
+            super::task_contract::ArtifactRecoveryAction::Continue { .. }
+            | super::task_contract::ArtifactRecoveryAction::RunVerifier
+            | super::task_contract::ArtifactRecoveryAction::RepairArtifact { .. },
+        ) => false,
+        // Issue #651 Phase 4.2: SafeStop says the agent must stop without
+        // claiming completion. Generic repo-change partial-progress
+        // recovery (which would prompt the model to keep editing) is
+        // never appropriate in that mode — we are about to surface the
+        // safe stop to the user. `_ =>` fallback stays forbidden per
+        // design judgement #2 so a future SafeStopReason variant lights
+        // up this match site.
+        Some(super::task_contract::ArtifactRecoveryAction::SafeStop { .. }) => false,
+    };
+
+    action_expectation == recovery::ActionExpectation::RepoChange
+        && repo_edit_calls_made_this_turn > 0
+        && contract_allows_generic_recovery
+        && reply_looks_like_future_work(final_reply)
+}
+
+pub(super) fn answer_only_reply_is_inadequate(reply: &str) -> bool {
+    let trimmed = reply.trim();
+    if trimmed.is_empty() {
+        return true;
+    }
+    let lower = trimmed.to_ascii_lowercase();
+    if matches!(
+        lower.as_str(),
+        "read('readme.md')" | "read(\"readme.md\")" | "glob('**/*.md')" | "grep"
+    ) {
+        return true;
+    }
+    if (lower.starts_with("read(")
+        || lower.starts_with("glob(")
+        || lower.starts_with("grep(")
+        || lower.starts_with("bash("))
+        && trimmed.chars().count() < 120
+    {
+        return true;
+    }
+    // Issue #574: do not use length as a proxy for adequacy. Short factual
+    // answers (codename, single value, Yes/No, especially in Japanese) were
+    // being discarded and replaced with a canned fallback. Only empty and
+    // tool-call-like replies are inadequate.
+    false
+}
+
+pub(super) fn format_iteration_status(
+    iter_human: usize,
+    max_iterations: usize,
+    headline: &str,
+    note: &str,
+    cols: Option<u16>,
+) -> String {
+    let mut lines = vec![format!("[iter {iter_human}/{max_iterations}] {headline}")];
+    lines.push(format_progress_field("  note:   ", note, cols));
+    lines.push(String::new());
+    lines.join("\n")
+}
+
+pub(super) fn should_apply_repo_change_quality_gate(
+    action_expectation: recovery::ActionExpectation,
+    active_task_expects_repo_change: bool,
+    mode: ExecutionMode,
+) -> bool {
+    mode == ExecutionMode::Act
+        && (action_expectation == recovery::ActionExpectation::RepoChange
+            || active_task_expects_repo_change)
 }

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -15,7 +15,9 @@ use super::actor_loop_flow::{
     actor_loop_pre_reply_repo_change_fallback_allowed,
 };
 use super::actor_loop_flow::{
-    TaskContractVerifierFlowOutcome, repair_job_done_outcome, run_actor_loop,
+    TaskContractVerifierFlowOutcome, build_feedback_for_deterministic_content_fallback,
+    format_iteration_status, repair_job_done_outcome, run_actor_loop,
+    task_contract_verifier_safe_stop_mapping,
 };
 use super::auto_test::{
     AutoTestKind, AutoTestPlan, AutoTestResult, AutoTestRunner, auto_test_disabled,
@@ -196,7 +198,7 @@ use crate::tools::registry::{BashErrorClass, ToolSpec, resolve_plan_mode_write_t
 use crate::util::file_classify::is_test_file;
 use crate::util::workspace_paths::is_ignored_workspace_display_path;
 use sha2::{Digest, Sha256};
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
@@ -205,9 +207,9 @@ use super::deterministic;
 use super::deterministic::empty_framework_app_files as deterministic_empty_framework_app_files;
 #[cfg(test)]
 use super::deterministic::empty_framework_game_files as deterministic_empty_framework_game_files;
-use super::progress_text::{format_progress_field, sanitize_for_progress, truncate};
 #[cfg(test)]
 use super::progress_text::{is_utf8_locale, tool_color, tool_emoji};
+use super::progress_text::{sanitize_for_progress, truncate};
 use super::quality::{
     first_existing_impl_target, implementation_quality_issue_for_request,
     package_json_with_requested_port, quality_first_pass_observation,
@@ -221,7 +223,6 @@ use super::quality_confirm::{
     QualityConfirmation, QualityConfirmationSource, build_quality_confirm_log_payload,
     run_quality_confirm_with_strategy,
 };
-use super::success::DETERMINISTIC_CONTENT_FALLBACK_TAG;
 
 /// Maximum number of characters of tool-call arguments retained in trace logs.
 pub(super) const LOG_ARGS_MAX_CHARS: usize = 200;
@@ -1503,21 +1504,6 @@ fn build_feedback_for_unsafe_block_reason(
     build_feedback_frame(draft, workspace_root)
 }
 
-/// CB-001: build a FeedbackFrame for a tool-protocol failure detected
-/// by `lifecycle::is_native_tool_parser_failure` /
-/// `is_tool_call_format_error` / `is_native_tool_transport_failure`.
-pub(super) fn build_feedback_for_tool_protocol_failure(
-    err: &str,
-    workspace_root: &Path,
-) -> FeedbackFrame {
-    let draft = FeedbackFrameDraft {
-        kind: FeedbackKind::ToolProtocolFailure,
-        primary_error: Some(err.to_string()),
-        ..Default::default()
-    };
-    build_feedback_frame(draft, workspace_root)
-}
-
 /// CB-001: build a FeedbackFrame for an Edit tool Err return. The
 /// command isn't a shell command so we use the raw error message as
 /// `primary_error` and stash the path token as `suspected_files`.
@@ -1531,27 +1517,6 @@ fn build_feedback_for_edit_failure(
         kind: FeedbackKind::EditFailure,
         primary_error: Some(err.to_string()),
         suspected_files: suspected,
-        ..Default::default()
-    };
-    build_feedback_frame(draft, workspace_root)
-}
-
-/// Issue #455 / D2 / DR1-002: subkind ("polish" / "quality" / ...) is
-/// intentionally NOT exposed via this helper because the AC regex
-/// (`(?i)deterministic|fallback|placeholder|scaffold|quality gate|repair|polish`)
-/// does not require it. Callers that need to distinguish in logs should
-/// use the surrounding `agent.*.fallback_applied` events.
-///
-/// Issue #455 / CB-001 / D2: FeedbackFrame for a successful deterministic
-/// content fallback (polish / quality / nextjs scaffold / playable UI repair
-/// / timeout-after wrappers). Uses fixed `primary_error` tag (DR1-002) — no
-/// subkind argument to avoid fan-out.
-pub(super) fn build_feedback_for_deterministic_content_fallback(
-    workspace_root: &Path,
-) -> FeedbackFrame {
-    let draft = FeedbackFrameDraft {
-        kind: FeedbackKind::ToolProtocolFailure,
-        primary_error: Some(DETERMINISTIC_CONTENT_FALLBACK_TAG.to_string()),
         ..Default::default()
     };
     build_feedback_frame(draft, workspace_root)
@@ -1639,57 +1604,6 @@ fn raw_mode_safe_text(text: &str) -> String {
     text.replace('\n', "\r\n")
 }
 
-pub(super) fn reply_looks_like_future_work(reply: &str) -> bool {
-    let normalized = reply.trim().to_ascii_lowercase();
-    if normalized.is_empty() {
-        return false;
-    }
-    let completion_markers = [
-        "done",
-        "completed",
-        "implemented",
-        "finished",
-        "ready",
-        "作成しました",
-        "実装しました",
-        "完了",
-        "できました",
-    ];
-    if completion_markers
-        .iter()
-        .any(|marker| normalized.contains(marker))
-    {
-        return false;
-    }
-    let future_markers = [
-        "now i'll",
-        "now i will",
-        "i'll ",
-        "i will ",
-        "let me ",
-        "you can run",
-        "please run",
-        "run this yourself",
-        "run it yourself",
-        "next,",
-        "next i",
-        "次に",
-        "これから",
-        "今から",
-        "次は",
-        "探してみます",
-        "確認します",
-        "調べます",
-        "見てみます",
-        "してみます",
-        "実行してください",
-        "確認してください",
-    ];
-    future_markers
-        .iter()
-        .any(|marker| normalized.contains(marker))
-}
-
 pub(super) struct TaskContractVerifierFlowArgs<'a, 'b> {
     pub(super) before_snapshot: &'a RepoSnapshot,
     pub(super) accumulated: &'a [RepoVerification],
@@ -1702,29 +1616,6 @@ pub(super) struct TaskContractVerifierFlowArgs<'a, 'b> {
     pub(super) task_contract_verify_commands_collected: &'b mut Vec<String>,
     pub(super) task_contract_verifier_passed_in_loop: &'b mut bool,
     pub(super) last_iter: usize,
-}
-
-/// Issue #651 PR-002: pure mapping from
-/// `task_contract::SafeStopReason` to the surfacing pair
-/// `(ExitReason, "log_outcome" tag)` used by the task-contract verifier
-/// dispatch. Extracted from the inline match in
-/// `drive_task_contract_verifier` so unit tests can pin the mapping
-/// without spinning up an `Agent`.
-///
-/// `_ =>` fallback is forbidden so a future `SafeStopReason` variant
-/// lights up compile errors here (design judgement #2).
-pub(super) fn task_contract_verifier_safe_stop_mapping(
-    reason: super::task_contract::SafeStopReason,
-) -> (ExitReason, &'static str) {
-    match reason {
-        super::task_contract::SafeStopReason::VerifierWeak => {
-            (ExitReason::SafeStopVerifierWeak, "safe_stop_verifier_weak")
-        }
-        super::task_contract::SafeStopReason::VerifierMissing => (
-            ExitReason::SafeStopVerifierMissing,
-            "safe_stop_verifier_missing",
-        ),
-    }
 }
 
 fn repair_terminal_exit_reason(reason: super::repair_job::RepairTerminalReason) -> ExitReason {
@@ -1749,54 +1640,6 @@ fn task_contract_needs_verification(
             super::task_contract::CompletionDecision::Verify
         )
     })
-}
-
-pub(super) fn task_contract_continue_requires_tool_recovery(
-    action: Option<&super::task_contract::ArtifactRecoveryAction>,
-    current_reply_tool_calls: usize,
-) -> bool {
-    matches!(
-        action,
-        Some(super::task_contract::ArtifactRecoveryAction::Continue { .. })
-    ) && current_reply_tool_calls == 0
-}
-
-pub(super) fn increment_artifact_completion_role_attempt(
-    attempts: &mut HashMap<super::task_contract::ArtifactRole, usize>,
-    role: super::task_contract::ArtifactRole,
-) -> usize {
-    let entry = attempts.entry(role).or_insert(0);
-    *entry = entry.saturating_add(1);
-    *entry
-}
-
-pub(super) fn should_apply_repo_change_partial_progress_recovery(
-    action_expectation: recovery::ActionExpectation,
-    repo_edit_calls_made_this_turn: usize,
-    final_reply: &str,
-    task_contract_action: Option<&super::task_contract::ArtifactRecoveryAction>,
-) -> bool {
-    let contract_allows_generic_recovery = match task_contract_action {
-        None | Some(super::task_contract::ArtifactRecoveryAction::Done) => true,
-        Some(
-            super::task_contract::ArtifactRecoveryAction::Continue { .. }
-            | super::task_contract::ArtifactRecoveryAction::RunVerifier
-            | super::task_contract::ArtifactRecoveryAction::RepairArtifact { .. },
-        ) => false,
-        // Issue #651 Phase 4.2: SafeStop says the agent must stop without
-        // claiming completion. Generic repo-change partial-progress
-        // recovery (which would prompt the model to keep editing) is
-        // never appropriate in that mode — we are about to surface the
-        // safe stop to the user. `_ =>` fallback stays forbidden per
-        // design judgement #2 so a future SafeStopReason variant lights
-        // up this match site.
-        Some(super::task_contract::ArtifactRecoveryAction::SafeStop { .. }) => false,
-    };
-
-    action_expectation == recovery::ActionExpectation::RepoChange
-        && repo_edit_calls_made_this_turn > 0
-        && contract_allows_generic_recovery
-        && reply_looks_like_future_work(final_reply)
 }
 
 fn task_contract_verifier_repair_note(
@@ -2480,33 +2323,6 @@ fn test_artifact_path_family(path: &str) -> Option<&'static str> {
     None
 }
 
-pub(super) fn answer_only_reply_is_inadequate(reply: &str) -> bool {
-    let trimmed = reply.trim();
-    if trimmed.is_empty() {
-        return true;
-    }
-    let lower = trimmed.to_ascii_lowercase();
-    if matches!(
-        lower.as_str(),
-        "read('readme.md')" | "read(\"readme.md\")" | "glob('**/*.md')" | "grep"
-    ) {
-        return true;
-    }
-    if (lower.starts_with("read(")
-        || lower.starts_with("glob(")
-        || lower.starts_with("grep(")
-        || lower.starts_with("bash("))
-        && trimmed.chars().count() < 120
-    {
-        return true;
-    }
-    // Issue #574: do not use length as a proxy for adequacy. Short factual
-    // answers (codename, single value, Yes/No, especially in Japanese) were
-    // being discarded and replaced with a canned fallback. Only empty and
-    // tool-call-like replies are inadequate.
-    false
-}
-
 fn extract_filename_with_suffix(text: &str, suffix: &str) -> Option<String> {
     text.split(|ch: char| {
         ch.is_whitespace()
@@ -2715,19 +2531,6 @@ fn deterministic_timeout_fallback_plan(
     format!(
         "# Plan\n\n## Goal\n- Build {request_label} as a {platform_label} inside `{worktree_name}`.\n- Ensure the result runs locally on {port} and feels intentionally polished rather than placeholder-quality.\n\n## Constraints\n- Keep all work inside the current repository root and use repository-relative paths.\n- If the repository is empty, scaffold only the minimum project structure needed before implementing the requested feature.\n- Keep the implementation incremental and avoid placeholder-only output.\n\n## First Action\n- Confirm or scaffold the base app, then make the first concrete implementation edit in a primary artifact such as `src/app/page.tsx`, `app/page.tsx`, or the equivalent entry file.\n- Anchor `package.json` scripts and local startup behavior to {port} before final verification.\n\n## Verification\n- Install dependencies when needed and confirm the app boots locally on {port}.\n- Exercise the main interaction or user-facing flow end-to-end, including success and failure states where applicable.\n- If verification cannot run because of sandbox, network, or host constraints, report that exact constraint instead of treating the work as verified.\n\n<!-- runtime fallback plan: generated after repeated planning model timeouts; focus on {execution_focus}. -->\n"
     )
-}
-
-pub(super) fn format_iteration_status(
-    iter_human: usize,
-    max_iterations: usize,
-    headline: &str,
-    note: &str,
-    cols: Option<u16>,
-) -> String {
-    let mut lines = vec![format!("[iter {iter_human}/{max_iterations}] {headline}")];
-    lines.push(format_progress_field("  note:   ", note, cols));
-    lines.push(String::new());
-    lines.join("\n")
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -13574,12 +13377,14 @@ fn build_task_contract_verifier_exit_zero_evidence_bound(
 
 #[cfg(test)]
 mod tests {
-    use super::super::actor_loop_flow::normalize_plan_exploration_key;
+    use super::super::actor_loop_flow::{
+        answer_only_reply_is_inadequate, normalize_plan_exploration_key,
+    };
     use super::ExitReason;
     use super::{
-        PlanExplorationKey, TaskContractVerifierOutcome, answer_only_reply_is_inadequate,
-        answer_only_script_command_allowed, answer_only_script_execution_fallback_response,
-        assistant_model_for_mode, build_task_contract_verifier_exit_zero_evidence,
+        PlanExplorationKey, TaskContractVerifierOutcome, answer_only_script_command_allowed,
+        answer_only_script_execution_fallback_response, assistant_model_for_mode,
+        build_task_contract_verifier_exit_zero_evidence,
         build_task_contract_verifier_exit_zero_evidence_bound, build_verifier_exit_zero_evidence,
         classify_verifier_timeout, deterministic_timeout_fallback_plan,
         effective_non_streaming_timeout_secs, latest_tool_result_since_last_user,
@@ -14148,7 +13953,7 @@ mod tests {
     #[test]
     fn tool_protocol_failure_yields_tool_protocol_failure_frame() {
         let dir = tempdir().unwrap();
-        let frame = super::build_feedback_for_tool_protocol_failure(
+        let frame = super::super::actor_loop_flow::build_feedback_for_tool_protocol_failure(
             "native tool parser failed: unexpected end element",
             dir.path(),
         );
@@ -19906,16 +19711,6 @@ fn collect_meaningful_workspace_files(
     Ok(())
 }
 
-pub(super) fn should_apply_repo_change_quality_gate(
-    action_expectation: recovery::ActionExpectation,
-    active_task_expects_repo_change: bool,
-    mode: ExecutionMode,
-) -> bool {
-    mode == ExecutionMode::Act
-        && (action_expectation == recovery::ActionExpectation::RepoChange
-            || active_task_expects_repo_change)
-}
-
 fn is_page_component_target(relative: &str) -> bool {
     matches!(relative, "app/page.tsx" | "src/app/page.tsx")
         || relative.ends_with("/app/page.tsx")
@@ -20847,15 +20642,18 @@ fn compact_progress_path(path: &str, max_chars: usize) -> String {
 #[allow(clippy::too_many_arguments)]
 #[cfg(test)]
 mod truncate_tests {
+    use super::super::actor_loop_flow::{
+        reply_looks_like_future_work, should_apply_repo_change_partial_progress_recovery,
+        task_contract_continue_requires_tool_recovery,
+    };
     use super::super::completion_evidence::{CompletionEvidence, EvidenceSet, RepoEditCategory};
     use super::super::task_contract::{ArtifactRecoveryAction, ArtifactRole, TaskContract};
     use super::{
         ScaffoldFramework, changed_files_for_verifier, deterministic_nextjs_scaffold_reply,
-        extract_filename_with_suffix, focused_edit_tool_policy_error, reply_looks_like_future_work,
+        extract_filename_with_suffix, focused_edit_tool_policy_error,
         repo_edit_satisfies_artifact_recovery_target, requested_scaffold_framework,
         scaffold_candidate_for_missing_role_from_snapshots, scaffold_command_matches_framework,
-        scaffold_file_snapshot, should_apply_repo_change_partial_progress_recovery,
-        task_contract_continue_requires_tool_recovery, task_contract_needs_verification,
+        scaffold_file_snapshot, task_contract_needs_verification,
         task_contract_verifier_repair_note, task_or_plan_requires_nextjs_scaffold,
         task_requires_nextjs_scaffold, truncate,
     };
@@ -21455,8 +21253,8 @@ mod truncate_tests {
 mod progress_tests {
     use super::super::actor_loop_flow::{
         format_blocked_progress_line, format_progress_line,
-        framework_app_fallback_continuation_note, should_try_framework_app_fallback,
-        task_contract_verifier_edit_required_note,
+        framework_app_fallback_continuation_note, should_apply_repo_change_quality_gate,
+        should_try_framework_app_fallback, task_contract_verifier_edit_required_note,
     };
     use super::super::repair_job::{
         SNAPSHOT_FIELD_BYTE_CAP, sanitize_repair_job_text, truncate_for_snapshot,
@@ -21494,22 +21292,22 @@ mod progress_tests {
         recent_truncated_tool_call_attempt, render_deterministic_scaffold_continuation_note,
         repo_change_request_text, request_needs_playable_ui_quality_gate, sanitize_for_progress,
         scaffold_candidate_for_missing_role_from_snapshots, scaffold_diff_status,
-        scaffold_file_snapshot, sha256_hex, should_apply_repo_change_quality_gate,
-        should_use_streaming_transport, strip_read_line_number_prefix,
-        successful_non_plan_repo_edit_count, successful_repo_edit_count,
-        sync_package_json_with_existing_lock, task_contract_verifier_target_discovery_note,
-        tool_color, tool_display, tool_emoji, unicode_supported,
-        validate_accepted_repair_plan_authorizes_target, validate_verifier_repair_intent,
-        validate_verifier_repair_intents, validate_verifier_repair_intents_with_accepted_plan,
-        verifier_diagnostic_attempt_spec, verifier_diagnostic_messages,
-        verifier_file_excerpt_for_line, verifier_repair_context_from_failure,
-        verifier_repair_decision, verifier_repair_effective_target_hint,
-        verifier_repair_intent_fingerprint, verifier_repair_intents_fingerprint,
-        verifier_repair_invalid_can_continue, verifier_repair_pass_messages,
-        verifier_repair_pass_retry_message, verifier_repair_policy_for_decision,
-        verifier_repair_policy_for_target_hint, verifier_repair_preferred_local_import_source,
-        verifier_repair_stale_assertion_test_target, verifier_repair_target_candidate_from_output,
-        verifier_repair_target_hint_from_output, workspace_appears_empty,
+        scaffold_file_snapshot, sha256_hex, should_use_streaming_transport,
+        strip_read_line_number_prefix, successful_non_plan_repo_edit_count,
+        successful_repo_edit_count, sync_package_json_with_existing_lock,
+        task_contract_verifier_target_discovery_note, tool_color, tool_display, tool_emoji,
+        unicode_supported, validate_accepted_repair_plan_authorizes_target,
+        validate_verifier_repair_intent, validate_verifier_repair_intents,
+        validate_verifier_repair_intents_with_accepted_plan, verifier_diagnostic_attempt_spec,
+        verifier_diagnostic_messages, verifier_file_excerpt_for_line,
+        verifier_repair_context_from_failure, verifier_repair_decision,
+        verifier_repair_effective_target_hint, verifier_repair_intent_fingerprint,
+        verifier_repair_intents_fingerprint, verifier_repair_invalid_can_continue,
+        verifier_repair_pass_messages, verifier_repair_pass_retry_message,
+        verifier_repair_policy_for_decision, verifier_repair_policy_for_target_hint,
+        verifier_repair_preferred_local_import_source, verifier_repair_stale_assertion_test_target,
+        verifier_repair_target_candidate_from_output, verifier_repair_target_hint_from_output,
+        workspace_appears_empty,
     };
     use crate::agent::recovery::ActionExpectation;
     use crate::modes::plan_act::{ExecutionMode, PlanStage};


### PR DESCRIPTION
## Summary

Issue #681 / meta #680 Phase 1 incremental migration (batch 3). Moves 10 small/medium pure-fn helpers (~176 LOC of bodies) out of `turn.rs` into `actor_loop_flow.rs` where their production callers already live.

### Moved (turn.rs → actor_loop_flow.rs)

**Feedback factories** (2):
- `build_feedback_for_tool_protocol_failure`
- `build_feedback_for_deterministic_content_fallback`

**Pure predicates / mappings** (6):
- `reply_looks_like_future_work`
- `answer_only_reply_is_inadequate`
- `task_contract_verifier_safe_stop_mapping`
- `task_contract_continue_requires_tool_recovery`
- `should_apply_repo_change_partial_progress_recovery`
- `should_apply_repo_change_quality_gate`

**State helpers** (2):
- `increment_artifact_completion_role_attempt`
- `format_iteration_status`

### Required adjustments

- `actor_loop_flow.rs`: added `use super::success::DETERMINISTIC_CONTENT_FALLBACK_TAG;` (other deps — ExitReason, ExecutionMode, HashMap, recovery::, format_progress_field — were already imported). Stripped 10 `super::turn::` prefixes from callers that are now local.
- `turn.rs`: added 4 names to the top-of-file actor_loop_flow re-import (`build_feedback_for_deterministic_content_fallback`, `format_iteration_status`, `task_contract_verifier_safe_stop_mapping` — used in production code paths). Removed now-unused `use std::collections::HashMap`, `use super::progress_text::format_progress_field`, and `use super::success::DETERMINISTIC_CONTENT_FALLBACK_TAG` (the consumers all moved). Updated 3 test mods (`mod tests`, `mod truncate_tests`, `mod progress_tests`) to import the relocated fns from `super::super::actor_loop_flow::` explicitly.
- Orphaned doc-comment blocks above the relocated functions removed (clippy::empty_line_after_doc_comments fail-closed under `-D warnings`).

### Metrics

| File | Before | After | Delta |
|---|---:|---:|---:|
| `src/agent/loop_run/turn.rs` | 35,322 | 35,120 | **-202** |
| `src/agent/loop_run/actor_loop_flow.rs` | 4,359 | 4,539 | +180 |

Remaining gap to Issue #681 acceptance (`turn.rs <= 35,000`): **~120 LOC**.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --lib` (3,114 passed)
- [ ] CI green (fmt / clippy / test / build)

## Layer rule notes

- No facade re-export (DR3-001 maintained); `actor_loop_flow` still declared as `mod actor_loop_flow;` without `pub use`.
- No photon → session → agent inversion (DR3-002 unchanged).
- Pure code-motion; no production-binary behaviour change.