### PR TITLE
Relocate plan write helpers to actor_loop_flow — Issue #681 acceptance

### DIFF
--- a/src/agent/loop_run/actor_loop_flow.rs
+++ b/src/agent/loop_run/actor_loop_flow.rs
@@ -45,10 +45,12 @@ use crate::model_capabilities::model_capabilities;
 use crate::modes::plan_act::{ExecutionMode, PlanStage};
 use crate::ollama::client::AssistantReply;
 use crate::ollama::xml_fallback::ToolCall;
+use crate::safety::path_guard::resolve_user_path;
 use crate::session::feedback::{
     FeedbackFrame, FeedbackFrameDraft, FeedbackKind, build_feedback_frame,
 };
 use crate::session::store::ConversationMessage;
+use crate::tools::registry::resolve_plan_mode_write_target;
 
 use super::Agent;
 use super::active_job_arbiter::{LoopControlAction, RecoveryDispatchGate, RecoveryOwner};
@@ -67,9 +69,8 @@ use super::tool_history::is_plan_file_tool_call;
 use super::tool_policy::EffectiveToolPolicy;
 use super::turn::{
     LOG_ARGS_MAX_CHARS, PLAN_REPEATED_EXPLORATION_BLOCK_THRESHOLD, PlanExplorationKey,
-    PlanWriteSummary, build_plan_write_section_delta, join_sections_for_progress,
-    normalize_exploration_path, plan_path_matches, plan_phase_from_sections, plan_section_excerpt,
-    plan_write_previous_contents, plan_write_status, tool_display, write_stdout_rendered,
+    join_sections_for_progress, normalize_exploration_path, plan_section_body_for_progress,
+    plan_sections_with_content, tool_display, write_stdout_rendered,
 };
 use crate::agent::prompting;
 use crate::session::compact::approximate_token_count;
@@ -4536,4 +4537,172 @@ pub(super) fn should_apply_repo_change_quality_gate(
     mode == ExecutionMode::Act
         && (action_expectation == recovery::ActionExpectation::RepoChange
             || active_task_expects_repo_change)
+}
+
+pub(super) struct PlanWriteSummary {
+    pub(super) action: String,
+    pub(super) note: Option<String>,
+    pub(super) status: Option<String>,
+    pub(super) phase: String,
+    pub(super) signature: String,
+}
+
+pub(super) fn plan_path_matches(
+    raw_path: &str,
+    work_root: &Path,
+    plan_path: Option<&Path>,
+) -> bool {
+    resolve_plan_mode_write_target(work_root, raw_path, plan_path)
+        .ok()
+        .flatten()
+        .is_some()
+}
+
+pub(super) fn plan_section_excerpt(contents: &str, sections: &[&str]) -> Option<String> {
+    for section in sections {
+        let Some(body) = plan_section_body_for_progress(contents, section) else {
+            continue;
+        };
+        for line in body.lines().map(str::trim) {
+            if line.is_empty()
+                || line == "-"
+                || matches!(
+                    line,
+                    "1." | "2."
+                        | "3."
+                        | "1. First slice:"
+                        | "2. Next phases:"
+                        | "3. Review checkpoint:"
+                )
+            {
+                continue;
+            }
+            let cleaned = line.trim_start_matches("- ").trim();
+            return Some(format!(
+                "{section}: {}",
+                truncate(&sanitize_for_progress(cleaned), 72)
+            ));
+        }
+    }
+    None
+}
+
+pub(super) fn plan_write_previous_contents(
+    raw_path: &str,
+    work_root: &Path,
+    plan_path: Option<&Path>,
+) -> String {
+    if raw_path.is_empty() {
+        String::new()
+    } else if plan_path_matches(raw_path, work_root, plan_path) {
+        plan_path
+            .and_then(|path| std::fs::read_to_string(path).ok())
+            .unwrap_or_default()
+    } else {
+        resolve_user_path(work_root, raw_path)
+            .ok()
+            .and_then(|path| std::fs::read_to_string(path).ok())
+            .unwrap_or_default()
+    }
+}
+
+pub(super) struct PlanWriteSectionDelta {
+    pub(super) previous_sections: Vec<&'static str>,
+    pub(super) current_sections: Vec<&'static str>,
+    pub(super) added_sections: Vec<&'static str>,
+    pub(super) removed_sections: Vec<&'static str>,
+    pub(super) focus_sections: Vec<&'static str>,
+}
+
+pub(super) fn build_plan_write_section_delta(
+    previous: &str,
+    new_text: &str,
+) -> PlanWriteSectionDelta {
+    let previous_sections = plan_sections_with_content(previous);
+    let current_sections = plan_sections_with_content(new_text);
+    let changed_sections = current_sections
+        .iter()
+        .copied()
+        .filter(|section| {
+            let old_body = plan_section_body_for_progress(previous, section).unwrap_or_default();
+            let new_body = plan_section_body_for_progress(new_text, section).unwrap_or_default();
+            sanitize_for_progress(old_body) != sanitize_for_progress(new_body)
+        })
+        .collect::<Vec<_>>();
+    let added_sections = current_sections
+        .iter()
+        .copied()
+        .filter(|section| !previous_sections.contains(section))
+        .collect::<Vec<_>>();
+    let removed_sections = previous_sections
+        .iter()
+        .copied()
+        .filter(|section| !current_sections.contains(section))
+        .collect::<Vec<_>>();
+    let focus_sections = if !changed_sections.is_empty() {
+        changed_sections
+    } else if !current_sections.is_empty() {
+        current_sections.clone()
+    } else {
+        Vec::new()
+    };
+    PlanWriteSectionDelta {
+        previous_sections,
+        current_sections,
+        added_sections,
+        removed_sections,
+        focus_sections,
+    }
+}
+
+pub(super) fn plan_write_status(new_text: &str, delta: isize) -> Option<String> {
+    let next = lifecycle::plan_next_stage_sections(new_text);
+    if lifecycle::plan_missing_sections(new_text).is_empty() {
+        Some(format!("Approval ready | delta {delta:+}B"))
+    } else if !next.is_empty() {
+        Some(format!(
+            "Next: {} | delta {delta:+}B",
+            join_sections_for_progress(&next)
+        ))
+    } else {
+        Some(format!("delta {delta:+}B"))
+    }
+}
+
+pub(super) fn plan_phase_from_sections(
+    sections: &[&str],
+    current_stage: PlanStage,
+    approval_ready: bool,
+) -> &'static str {
+    if approval_ready {
+        "Approval review"
+    } else if sections.iter().any(|section| {
+        matches!(
+            *section,
+            "First Action"
+                | "Verification"
+                | "Execution Plan"
+                | "Verification Plan"
+                | "Risks / Fallbacks"
+        )
+    }) {
+        "Define next action"
+    } else if sections
+        .iter()
+        .any(|section| matches!(*section, "Acceptance Criteria" | "Quality Bar"))
+    {
+        "Define quality bar"
+    } else if sections
+        .iter()
+        .any(|section| matches!(*section, "Goal" | "Constraints" | "Deliverables"))
+    {
+        "Draft foundation"
+    } else {
+        match current_stage {
+            PlanStage::Stage1 => "Draft foundation",
+            PlanStage::Stage2 => "Define next action",
+            PlanStage::Stage3 => "Approval review",
+            PlanStage::Ready => "Approval review",
+        }
+    }
 }

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -194,7 +194,7 @@ use crate::session::precaution::{Precaution, PrecautionStatus, severity_order};
 use crate::session::store::{
     ScaffoldArtifactFileSnapshot, ScaffoldArtifactRole, ScaffoldArtifactSnapshot, WorkingMemory,
 };
-use crate::tools::registry::{BashErrorClass, ToolSpec, resolve_plan_mode_write_target};
+use crate::tools::registry::{BashErrorClass, ToolSpec};
 use crate::util::file_classify::is_test_file;
 use crate::util::workspace_paths::is_ignored_workspace_display_path;
 use sha2::{Digest, Sha256};
@@ -14631,13 +14631,13 @@ mod tests {
     fn plan_write_status_prefers_approval_then_next() {
         let ready = "## Goal\n- g\n## Constraints\n- c\n## Deliverables\n- d\n## Acceptance Criteria\n- a\n## Quality Bar\n- q\n## First Action\n- f\n## Verification\n- v\n## Execution Plan\n- e\n## Verification Plan\n- vp\n## Risks / Fallbacks\n- r\n";
         assert_eq!(
-            super::plan_write_status(ready, 12),
+            super::super::actor_loop_flow::plan_write_status(ready, 12),
             Some("Approval ready | delta +12B".to_string())
         );
 
         let staged = "## Goal\n- g\n";
         assert_eq!(
-            super::plan_write_status(staged, -3),
+            super::super::actor_loop_flow::plan_write_status(staged, -3),
             Some("Next: Constraints | delta -3B".to_string())
         );
     }
@@ -17965,25 +17965,6 @@ pub(super) struct ProgressDisplay {
     pub(super) status: Option<String>,
 }
 
-pub(super) struct PlanWriteSummary {
-    pub(super) action: String,
-    pub(super) note: Option<String>,
-    pub(super) status: Option<String>,
-    pub(super) phase: String,
-    pub(super) signature: String,
-}
-
-pub(super) fn plan_path_matches(
-    raw_path: &str,
-    work_root: &Path,
-    plan_path: Option<&Path>,
-) -> bool {
-    resolve_plan_mode_write_target(work_root, raw_path, plan_path)
-        .ok()
-        .flatten()
-        .is_some()
-}
-
 fn progress_path_display(
     raw_path: &str,
     work_root: &Path,
@@ -17993,7 +17974,7 @@ fn progress_path_display(
     if raw_path.is_empty() {
         return "<missing path>".to_string();
     }
-    if plan_path_matches(raw_path, work_root, plan_path) {
+    if super::actor_loop_flow::plan_path_matches(raw_path, work_root, plan_path) {
         return compact_progress_path(
             &sanitize_for_progress(&plan_path.unwrap().display().to_string()),
             max_chars,
@@ -20098,7 +20079,7 @@ fn format_numbered_read_block(contents: &str) -> String {
         .join("\n")
 }
 
-fn plan_sections_with_content(contents: &str) -> Vec<&'static str> {
+pub(super) fn plan_sections_with_content(contents: &str) -> Vec<&'static str> {
     [
         "Goal",
         "Constraints",
@@ -20116,7 +20097,10 @@ fn plan_sections_with_content(contents: &str) -> Vec<&'static str> {
     .collect()
 }
 
-fn plan_section_body_for_progress<'a>(contents: &'a str, section: &str) -> Option<&'a str> {
+pub(super) fn plan_section_body_for_progress<'a>(
+    contents: &'a str,
+    section: &str,
+) -> Option<&'a str> {
     let mut start = None;
     let mut end = contents.len();
     let mut offset = 0usize;
@@ -20134,155 +20118,6 @@ fn plan_section_body_for_progress<'a>(contents: &'a str, section: &str) -> Optio
         offset += line.len() + 1;
     }
     start.map(|idx| &contents[idx..end])
-}
-
-pub(super) fn plan_section_excerpt(contents: &str, sections: &[&str]) -> Option<String> {
-    for section in sections {
-        let Some(body) = plan_section_body_for_progress(contents, section) else {
-            continue;
-        };
-        for line in body.lines().map(str::trim) {
-            if line.is_empty()
-                || line == "-"
-                || matches!(
-                    line,
-                    "1." | "2."
-                        | "3."
-                        | "1. First slice:"
-                        | "2. Next phases:"
-                        | "3. Review checkpoint:"
-                )
-            {
-                continue;
-            }
-            let cleaned = line.trim_start_matches("- ").trim();
-            return Some(format!(
-                "{section}: {}",
-                truncate(&sanitize_for_progress(cleaned), 72)
-            ));
-        }
-    }
-    None
-}
-
-pub(super) fn plan_write_previous_contents(
-    raw_path: &str,
-    work_root: &Path,
-    plan_path: Option<&Path>,
-) -> String {
-    if raw_path.is_empty() {
-        String::new()
-    } else if plan_path_matches(raw_path, work_root, plan_path) {
-        plan_path
-            .and_then(|path| std::fs::read_to_string(path).ok())
-            .unwrap_or_default()
-    } else {
-        resolve_user_path(work_root, raw_path)
-            .ok()
-            .and_then(|path| std::fs::read_to_string(path).ok())
-            .unwrap_or_default()
-    }
-}
-
-pub(super) struct PlanWriteSectionDelta {
-    pub(super) previous_sections: Vec<&'static str>,
-    pub(super) current_sections: Vec<&'static str>,
-    pub(super) added_sections: Vec<&'static str>,
-    pub(super) removed_sections: Vec<&'static str>,
-    pub(super) focus_sections: Vec<&'static str>,
-}
-
-pub(super) fn build_plan_write_section_delta(
-    previous: &str,
-    new_text: &str,
-) -> PlanWriteSectionDelta {
-    let previous_sections = plan_sections_with_content(previous);
-    let current_sections = plan_sections_with_content(new_text);
-    let changed_sections = current_sections
-        .iter()
-        .copied()
-        .filter(|section| {
-            let old_body = plan_section_body_for_progress(previous, section).unwrap_or_default();
-            let new_body = plan_section_body_for_progress(new_text, section).unwrap_or_default();
-            sanitize_for_progress(old_body) != sanitize_for_progress(new_body)
-        })
-        .collect::<Vec<_>>();
-    let added_sections = current_sections
-        .iter()
-        .copied()
-        .filter(|section| !previous_sections.contains(section))
-        .collect::<Vec<_>>();
-    let removed_sections = previous_sections
-        .iter()
-        .copied()
-        .filter(|section| !current_sections.contains(section))
-        .collect::<Vec<_>>();
-    let focus_sections = if !changed_sections.is_empty() {
-        changed_sections
-    } else if !current_sections.is_empty() {
-        current_sections.clone()
-    } else {
-        Vec::new()
-    };
-    PlanWriteSectionDelta {
-        previous_sections,
-        current_sections,
-        added_sections,
-        removed_sections,
-        focus_sections,
-    }
-}
-
-pub(super) fn plan_write_status(new_text: &str, delta: isize) -> Option<String> {
-    let next = lifecycle::plan_next_stage_sections(new_text);
-    if lifecycle::plan_missing_sections(new_text).is_empty() {
-        Some(format!("Approval ready | delta {delta:+}B"))
-    } else if !next.is_empty() {
-        Some(format!(
-            "Next: {} | delta {delta:+}B",
-            join_sections_for_progress(&next)
-        ))
-    } else {
-        Some(format!("delta {delta:+}B"))
-    }
-}
-
-pub(super) fn plan_phase_from_sections(
-    sections: &[&str],
-    current_stage: PlanStage,
-    approval_ready: bool,
-) -> &'static str {
-    if approval_ready {
-        "Approval review"
-    } else if sections.iter().any(|section| {
-        matches!(
-            *section,
-            "First Action"
-                | "Verification"
-                | "Execution Plan"
-                | "Verification Plan"
-                | "Risks / Fallbacks"
-        )
-    }) {
-        "Define next action"
-    } else if sections
-        .iter()
-        .any(|section| matches!(*section, "Acceptance Criteria" | "Quality Bar"))
-    {
-        "Define quality bar"
-    } else if sections
-        .iter()
-        .any(|section| matches!(*section, "Goal" | "Constraints" | "Deliverables"))
-    {
-        "Draft foundation"
-    } else {
-        match current_stage {
-            PlanStage::Stage1 => "Draft foundation",
-            PlanStage::Stage2 => "Define next action",
-            PlanStage::Stage3 => "Approval review",
-            PlanStage::Ready => "Approval review",
-        }
-    }
 }
 
 fn summarize_plan_read(contents: &str) -> (String, Option<String>) {
@@ -20361,23 +20196,24 @@ fn tool_display_write(
     current_stage: PlanStage,
 ) -> ProgressDisplay {
     let content = tool_display_str_arg(arguments, "content");
-    let (action, note, status) = if plan_path_matches(raw_path, work_root, plan_path) {
-        let summary = super::actor_loop_flow::summarize_plan_write(
-            "Write",
-            raw_path,
-            content,
-            work_root,
-            plan_path,
-            current_stage,
-        );
-        (summary.action, summary.note, summary.status)
-    } else {
-        (
-            "Write file".to_string(),
-            tool_display_preview_note(content),
-            Some(format!("{}B", content.len())),
-        )
-    };
+    let (action, note, status) =
+        if super::actor_loop_flow::plan_path_matches(raw_path, work_root, plan_path) {
+            let summary = super::actor_loop_flow::summarize_plan_write(
+                "Write",
+                raw_path,
+                content,
+                work_root,
+                plan_path,
+                current_stage,
+            );
+            (summary.action, summary.note, summary.status)
+        } else {
+            (
+                "Write file".to_string(),
+                tool_display_preview_note(content),
+                Some(format!("{}B", content.len())),
+            )
+        };
     ProgressDisplay {
         action,
         path: Some(path_display),
@@ -20395,23 +20231,24 @@ fn tool_display_edit(
     current_stage: PlanStage,
 ) -> ProgressDisplay {
     let new_text = tool_display_str_arg(arguments, "new_string");
-    let (action, note, status) = if plan_path_matches(raw_path, work_root, plan_path) {
-        let summary = super::actor_loop_flow::summarize_plan_write(
-            "Edit",
-            raw_path,
-            new_text,
-            work_root,
-            plan_path,
-            current_stage,
-        );
-        (summary.action, summary.note, summary.status)
-    } else {
-        (
-            "Revise file".to_string(),
-            tool_display_preview_note(new_text),
-            None,
-        )
-    };
+    let (action, note, status) =
+        if super::actor_loop_flow::plan_path_matches(raw_path, work_root, plan_path) {
+            let summary = super::actor_loop_flow::summarize_plan_write(
+                "Edit",
+                raw_path,
+                new_text,
+                work_root,
+                plan_path,
+                current_stage,
+            );
+            (summary.action, summary.note, summary.status)
+        } else {
+            (
+                "Revise file".to_string(),
+                tool_display_preview_note(new_text),
+                None,
+            )
+        };
     ProgressDisplay {
         action,
         path: Some(path_display),
@@ -20436,11 +20273,12 @@ fn tool_display_read(
 ) -> ProgressDisplay {
     let line_suffix = read_line_suffix(arguments);
     let path = format!("{path_display}{line_suffix}");
-    let (action, note, status) = if plan_path_matches(raw_path, work_root, plan_path) {
-        tool_display_plan_read(plan_path, current_stage)
-    } else {
-        tool_display_workspace_read(raw_path, work_root, &line_suffix)
-    };
+    let (action, note, status) =
+        if super::actor_loop_flow::plan_path_matches(raw_path, work_root, plan_path) {
+            tool_display_plan_read(plan_path, current_stage)
+        } else {
+            tool_display_workspace_read(raw_path, work_root, &line_suffix)
+        };
     ProgressDisplay {
         action,
         path: Some(compact_progress_path(&path, arg_budget.max(48))),
@@ -20464,7 +20302,7 @@ fn tool_display_plan_read(
         (!next.is_empty()).then(|| {
             format!(
                 "Current phase: {}",
-                plan_phase_from_sections(&next, current_stage, false)
+                super::actor_loop_flow::plan_phase_from_sections(&next, current_stage, false)
             )
         })
     };


### PR DESCRIPTION
## Summary

**Issue #681 acceptance criterion (`turn.rs <= 35,000` LOC) MET with this PR.**

Moves 6 plan-write fns + 2 supporting structs (~160 LOC of bodies) out of `turn.rs` into `actor_loop_flow.rs`, completing the Phase 1 reduction target tracked under meta-issue #680.

### Moved (turn.rs → actor_loop_flow.rs)

**Structs:**
- `PlanWriteSummary`
- `PlanWriteSectionDelta` (+ all 5 fields, already `pub(super)`)

**Pure helpers:**
- `plan_path_matches`
- `plan_section_excerpt`
- `plan_write_previous_contents`
- `build_plan_write_section_delta`
- `plan_write_status`
- `plan_phase_from_sections`

### Required adjustments

- `actor_loop_flow.rs`: dropped 7 `super::turn::` names from the use block (now local); added `use crate::safety::path_guard::resolve_user_path;` and `use crate::tools::registry::resolve_plan_mode_write_target;` (needed by the moved `plan_phase_from_sections` / `build_plan_write_section_delta`); kept `plan_section_body_for_progress` + `plan_sections_with_content` as `super::turn::` back-imports (still owned by turn.rs).
- `turn.rs`: removed now-unused `use crate::tools::registry::resolve_plan_mode_write_target`; upgraded `plan_section_body_for_progress` and `plan_sections_with_content` to `pub(super)` so actor_loop_flow can import them; rewrote 4 `plan_path_matches` and 1 `plan_phase_from_sections` call sites to use `super::actor_loop_flow::` qualification; updated 2 `mod tests` `plan_write_status` callers to `super::super::actor_loop_flow::`.

### Metrics

| File | Before | After | Delta |
|---|---:|---:|---:|
| `src/agent/loop_run/turn.rs` | 35,120 | **34,958** | **-162** |
| `src/agent/loop_run/actor_loop_flow.rs` | 4,539 | 4,708 | +169 |

### Cumulative Phase 1 progress (Issue #681)

Starting LOC: **39,489**
Final LOC after this PR: **34,958**
Net reduction: **-4,531 LOC** (12% of the original monolith).

Issue #681 acceptance criterion (`turn.rs <= 35,000`): **MET** ✓

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --lib` (3,114 passed)
- [ ] CI green (fmt / clippy / test / build)

## Layer rule notes

- No facade re-export (DR3-001 maintained); `actor_loop_flow` still declared as `mod actor_loop_flow;` without `pub use`.
- No photon → session → agent inversion (DR3-002 unchanged).
- Pure code-motion; no production-binary behaviour change.