### PR TITLE
Relocate verifier repair decision + policy helpers (Issue #682, batch 6)

### DIFF
--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -163,9 +163,9 @@ use super::verifier_orchestration::{
     verifier_framework_signal_for_context, verifier_repair_context_diagnostics,
     verifier_repair_diagnostic_pending_note, verifier_repair_intent_limits,
     verifier_repair_pass_messages, verifier_repair_pass_request_error_message,
-    verifier_repair_safe_stop_message, verifier_repair_target_display,
-    verifier_repair_transition_message, verifier_repair_unsafe_target_message,
-    verifier_setup_policy_message,
+    verifier_repair_policy_for_target_hint, verifier_repair_safe_stop_message,
+    verifier_repair_target_display, verifier_repair_transition_message,
+    verifier_repair_unsafe_target_message, verifier_setup_policy_message,
 };
 #[cfg(test)]
 use super::verifier_orchestration::{
@@ -18532,101 +18532,6 @@ fn model_assessment_to_verifier_repair_assessment(
 /// argument is kept so the `Agent::task_contract_verifier_repair_pending`
 /// flag and the repair-job presence remain decoupled at the call sites
 /// (Issue #637: SSOT for the decision lives in `repair_job`).
-#[cfg(test)]
-fn verifier_repair_decision(
-    pending: bool,
-    context: Option<&super::repair_job::RepairJob>,
-    messages: &[ConversationMessage],
-    work_root: &Path,
-    repair_edit_count: Option<usize>,
-    repo_edit_calls_made_this_turn: usize,
-) -> VerifierRepairDecision {
-    repair_job::verifier_repair_decision(
-        pending,
-        context,
-        messages,
-        work_root,
-        repair_edit_count,
-        repo_edit_calls_made_this_turn,
-    )
-}
-
-#[cfg(test)]
-fn verifier_repair_policy_for_decision(decision: VerifierRepairDecision) -> EffectiveToolPolicy {
-    match decision {
-        VerifierRepairDecision::NeedDiagnostic => {
-            EffectiveToolPolicy::restricted(EffectiveToolPolicyReason::VerifierRepair, Vec::new())
-        }
-        VerifierRepairDecision::DiagnosticUnavailable => {
-            EffectiveToolPolicy::restricted(EffectiveToolPolicyReason::VerifierRepair, Vec::new())
-        }
-        VerifierRepairDecision::NeedFreshRead(target) => EffectiveToolPolicy::focused_edit(
-            EffectiveToolPolicyReason::VerifierRepair,
-            vec!["Read"],
-            target,
-            false,
-        ),
-        VerifierRepairDecision::NeedWrite(target) => EffectiveToolPolicy::focused_edit(
-            EffectiveToolPolicyReason::VerifierRepair,
-            vec!["Write"],
-            target,
-            false,
-        ),
-        VerifierRepairDecision::NeedEdit(target) => EffectiveToolPolicy::focused_edit(
-            EffectiveToolPolicyReason::VerifierRepair,
-            vec!["Edit"],
-            target,
-            true,
-        ),
-        VerifierRepairDecision::NeedTargetDiscovery => EffectiveToolPolicy::restricted(
-            EffectiveToolPolicyReason::VerifierRepair,
-            vec!["Read", "Glob", "Grep"],
-        ),
-        VerifierRepairDecision::NoRepair | VerifierRepairDecision::ReadyToVerify => {
-            EffectiveToolPolicy::restricted(EffectiveToolPolicyReason::VerifierRepair, Vec::new())
-        }
-    }
-}
-
-fn verifier_repair_policy_for_target_hint(
-    target_hint: &super::task_contract::RecoveryTargetHint,
-    messages: &[ConversationMessage],
-    work_root: &Path,
-) -> EffectiveToolPolicy {
-    let Some(relative) = super::repair_job::safe_relative_path_string(&target_hint.path) else {
-        return EffectiveToolPolicy::restricted(
-            EffectiveToolPolicyReason::VerifierRepair,
-            Vec::new(),
-        );
-    };
-    let target = work_root.join(relative);
-    let target = std::fs::canonicalize(&target).unwrap_or(target);
-    if !target.is_file() {
-        return EffectiveToolPolicy::focused_edit(
-            EffectiveToolPolicyReason::VerifierRepair,
-            vec!["Write"],
-            target,
-            false,
-        );
-    }
-    let target_already_read = focused_edit_target_already_read(messages, &target, work_root);
-    if target_already_read {
-        EffectiveToolPolicy::focused_edit(
-            EffectiveToolPolicyReason::VerifierRepair,
-            vec!["Edit"],
-            target,
-            true,
-        )
-    } else {
-        EffectiveToolPolicy::focused_edit(
-            EffectiveToolPolicyReason::VerifierRepair,
-            vec!["Read"],
-            target,
-            false,
-        )
-    }
-}
-
 const PYTHON_REQUEST_PATTERNS: &[&str] = &["fastapi", "python", ".py"];
 const PYTHON_REQUEST_JA_PATTERNS: &[&str] = &["Pythonで", "FastAPIで"];
 const RUST_REQUEST_PATTERNS: &[&str] = &["rust", "cargo test", "cargo"];
@@ -20227,7 +20132,8 @@ mod progress_tests {
     };
     use super::super::verifier_orchestration::{
         task_contract_verifier_target_discovery_note, verifier_diagnostic_messages,
-        verifier_file_excerpt_for_line, verifier_repair_pass_messages,
+        verifier_file_excerpt_for_line, verifier_repair_decision, verifier_repair_pass_messages,
+        verifier_repair_policy_for_decision, verifier_repair_policy_for_target_hint,
     };
     use super::{
         EffectiveToolPolicy, EffectiveToolPolicyReason, FocusedEditBatchAction,
@@ -20268,13 +20174,12 @@ mod progress_tests {
         tool_emoji, unicode_supported, validate_accepted_repair_plan_authorizes_target,
         validate_verifier_repair_intent, validate_verifier_repair_intents,
         validate_verifier_repair_intents_with_accepted_plan, verifier_diagnostic_attempt_spec,
-        verifier_repair_context_from_failure, verifier_repair_decision,
-        verifier_repair_effective_target_hint, verifier_repair_intent_fingerprint,
-        verifier_repair_intents_fingerprint, verifier_repair_invalid_can_continue,
-        verifier_repair_pass_retry_message, verifier_repair_policy_for_decision,
-        verifier_repair_policy_for_target_hint, verifier_repair_preferred_local_import_source,
-        verifier_repair_stale_assertion_test_target, verifier_repair_target_candidate_from_output,
-        verifier_repair_target_hint_from_output, workspace_appears_empty,
+        verifier_repair_context_from_failure, verifier_repair_effective_target_hint,
+        verifier_repair_intent_fingerprint, verifier_repair_intents_fingerprint,
+        verifier_repair_invalid_can_continue, verifier_repair_pass_retry_message,
+        verifier_repair_preferred_local_import_source, verifier_repair_stale_assertion_test_target,
+        verifier_repair_target_candidate_from_output, verifier_repair_target_hint_from_output,
+        workspace_appears_empty,
     };
     use crate::agent::recovery::ActionExpectation;
     use crate::modes::plan_act::{ExecutionMode, PlanStage};
@@ -28518,8 +28423,14 @@ export default function App() {
             ..super::super::repair_job::RepairJob::new_for_test()
         };
 
-        let decision =
-            super::verifier_repair_decision(true, Some(&job), &[], work_root, Some(0), 0);
+        let decision = super::super::verifier_orchestration::verifier_repair_decision(
+            true,
+            Some(&job),
+            &[],
+            work_root,
+            Some(0),
+            0,
+        );
         let super::VerifierRepairDecision::NeedWrite(path) = decision else {
             panic!("expected NeedWrite for missing provider target, got {decision:?}");
         };

--- a/src/agent/loop_run/verifier_orchestration.rs
+++ b/src/agent/loop_run/verifier_orchestration.rs
@@ -55,12 +55,14 @@ use super::repair_framework_findings::{
 };
 use super::repair_job::{
     RepairJob, mask_code_excerpt_preserving_patch_anchors, mask_secrets_headers_and_neutralize,
-    verifier_repair_effective_target_hint,
+    safe_relative_path_string, verifier_repair_effective_target_hint,
 };
 use super::repair_patch_validation::{VerifierRepairIntentLimits, is_repair_path_input_safe};
 use super::repair_plan::AcceptedRepairPlan;
 use super::required_behavior::{BehaviorContractProjection, behavior_contract_payload_value};
 use super::task_contract::{RecoveryTargetHint, TaskContract};
+use super::tool_history::focused_edit_target_already_read;
+use super::tool_policy::{EffectiveToolPolicy, EffectiveToolPolicyReason};
 use super::turn::{
     TASK_CONTRACT_VERIFIER_ATTEMPT_LIMIT, TASK_CONTRACT_VERIFIER_REPAIR_ATTEMPT_LIMIT,
     missing_verifier_setup_hint_for_request,
@@ -970,4 +972,101 @@ pub(super) fn safe_verifier_repair_file_excerpt(
         VERIFIER_REPAIR_PASS_MAX_FILE_EXCERPT_BYTES,
     );
     Some(mask_code_excerpt_preserving_patch_anchors(&excerpt))
+}
+
+#[cfg(test)]
+pub(super) fn verifier_repair_decision(
+    pending: bool,
+    context: Option<&RepairJob>,
+    messages: &[ConversationMessage],
+    work_root: &Path,
+    repair_edit_count: Option<usize>,
+    repo_edit_calls_made_this_turn: usize,
+) -> VerifierRepairDecision {
+    super::repair_job::verifier_repair_decision(
+        pending,
+        context,
+        messages,
+        work_root,
+        repair_edit_count,
+        repo_edit_calls_made_this_turn,
+    )
+}
+
+#[cfg(test)]
+pub(super) fn verifier_repair_policy_for_decision(
+    decision: VerifierRepairDecision,
+) -> EffectiveToolPolicy {
+    match decision {
+        VerifierRepairDecision::NeedDiagnostic => {
+            EffectiveToolPolicy::restricted(EffectiveToolPolicyReason::VerifierRepair, Vec::new())
+        }
+        VerifierRepairDecision::DiagnosticUnavailable => {
+            EffectiveToolPolicy::restricted(EffectiveToolPolicyReason::VerifierRepair, Vec::new())
+        }
+        VerifierRepairDecision::NeedFreshRead(target) => EffectiveToolPolicy::focused_edit(
+            EffectiveToolPolicyReason::VerifierRepair,
+            vec!["Read"],
+            target,
+            false,
+        ),
+        VerifierRepairDecision::NeedWrite(target) => EffectiveToolPolicy::focused_edit(
+            EffectiveToolPolicyReason::VerifierRepair,
+            vec!["Write"],
+            target,
+            false,
+        ),
+        VerifierRepairDecision::NeedEdit(target) => EffectiveToolPolicy::focused_edit(
+            EffectiveToolPolicyReason::VerifierRepair,
+            vec!["Edit"],
+            target,
+            true,
+        ),
+        VerifierRepairDecision::NeedTargetDiscovery => EffectiveToolPolicy::restricted(
+            EffectiveToolPolicyReason::VerifierRepair,
+            vec!["Read", "Glob", "Grep"],
+        ),
+        VerifierRepairDecision::NoRepair | VerifierRepairDecision::ReadyToVerify => {
+            EffectiveToolPolicy::restricted(EffectiveToolPolicyReason::VerifierRepair, Vec::new())
+        }
+    }
+}
+
+pub(super) fn verifier_repair_policy_for_target_hint(
+    target_hint: &RecoveryTargetHint,
+    messages: &[ConversationMessage],
+    work_root: &Path,
+) -> EffectiveToolPolicy {
+    let Some(relative) = safe_relative_path_string(&target_hint.path) else {
+        return EffectiveToolPolicy::restricted(
+            EffectiveToolPolicyReason::VerifierRepair,
+            Vec::new(),
+        );
+    };
+    let target = work_root.join(relative);
+    let target = std::fs::canonicalize(&target).unwrap_or(target);
+    if !target.is_file() {
+        return EffectiveToolPolicy::focused_edit(
+            EffectiveToolPolicyReason::VerifierRepair,
+            vec!["Write"],
+            target,
+            false,
+        );
+    }
+    let target_already_read = focused_edit_target_already_read(messages, &target, work_root);
+    if target_already_read {
+        EffectiveToolPolicy::focused_edit(
+            EffectiveToolPolicyReason::VerifierRepair,
+            vec!["Edit"],
+            target,
+            true,
+        )
+    } else {
+        EffectiveToolPolicy::focused_edit(
+            EffectiveToolPolicyReason::VerifierRepair,
+            vec!["Read"],
+            target,
+            false,
+        )
+    }
 }


### PR DESCRIPTION
## Summary

Phase 2 batch 6 for Issue #682. Moves 3 verifier-repair policy helpers (~90 LOC of bodies) out of `turn.rs` into `verifier_orchestration.rs`.

### Moved (turn.rs → verifier_orchestration.rs)

- `verifier_repair_decision` (17 LOC, `#[cfg(test)]` — thin wrapper around `super::repair_job::verifier_repair_decision` retained for the legacy test surface).
- `verifier_repair_policy_for_decision` (35 LOC, `#[cfg(test)]` — decision → `EffectiveToolPolicy` mapping consumed by test fixtures pinning the focused-edit policy shape).
- `verifier_repair_policy_for_target_hint` (38 LOC, **production** — consumed by the actor loop dispatcher to assemble the verifier-repair tool policy from a recovered target hint).

All 3 promoted to `pub(super)`. The 2 cfg(test) fns retain their `#[cfg(test)]` attribute since they were test-only in turn.rs.

### Adjustments

- `verifier_orchestration.rs`: added imports for `safe_relative_path_string`, `VerifierRepairDecision` (`#[cfg(test)]`), `focused_edit_target_already_read`, `EffectiveToolPolicy`/`EffectiveToolPolicyReason`.
- `turn.rs`:
  - Extended `use super::verifier_orchestration::{...}` with `verifier_repair_policy_for_target_hint` (production).
  - Dropped the 3 fns from `mod progress_tests use super::{...}` and added them to the existing `use super::super::verifier_orchestration::{...}` block.
  - Rewrote 1 `super::verifier_repair_decision(...)` call site to `super::super::verifier_orchestration::verifier_repair_decision(...)`.
  - Cleaned 2 orphaned `#[cfg(test)]` attributes left over the `const PYTHON_REQUEST_PATTERNS` line (would otherwise cfg-gate the next production fn out of release builds).

### Metrics

| File | Before | After | Delta |
|---|---:|---:|---:|
| `src/agent/loop_run/turn.rs` | 34,086 | 33,998 | **-88** |
| `src/agent/loop_run/verifier_orchestration.rs` | 973 | 1,072 | +99 |

Cumulative Issue #682 progress: turn.rs 34,958 → 33,998 (**-960**, ~32% of Phase 2 target). Acceptance gap: 33,998 → 32,000 = **~1,998 LOC remaining**.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --lib` (3,114 passed)
- [ ] CI green (fmt / clippy / test / build)

## Layer rule notes

- No facade re-export (DR3-001 maintained).
- No photon → session → agent inversion (DR3-002 unchanged).
- Pure code-motion + visibility relaxation; no production-binary behaviour change.