### PR TITLE
Relocate verifier exit-zero evidence + task-contract verification helpers (Issue #682, batch 8)

### DIFF
--- a/src/agent/loop_run.rs
+++ b/src/agent/loop_run.rs
@@ -601,7 +601,7 @@ pub fn acquire_footer_with_terminal_flag_for_test(
 pub fn build_verifier_exit_zero_evidence_for_test(
     outcome: &crate::tools::bash::BashExecutionOutcome,
 ) -> Option<(String, &'static str)> {
-    let evidence = turn::build_verifier_exit_zero_evidence(outcome)?;
+    let evidence = verifier_orchestration::build_verifier_exit_zero_evidence(outcome)?;
     match evidence {
         completion_evidence::CompletionEvidence::VerifierExitZero { class, command, .. } => {
             Some((command, class.as_str()))

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -163,16 +163,18 @@ use super::verifier_failure_signature::verifier_failure_count;
 use super::verifier_orchestration::{
     JobInstallOutcome, PreparedVerifierDiagnosticPass, PreparedVerifierRepairPass,
     StructuredTaskContractVerifierRun, TaskContractVerifierFlowArgs, VerifierDiagnosticPassOutcome,
-    VerifierRepairAttemptProgress, model_assessment_to_verifier_repair_assessment,
-    task_contract_verifier_failure_attempt_limit, task_contract_verifier_repair_note,
-    task_contract_verifier_targeted_edit_required_note, verifier_diagnostic_file_excerpts,
-    verifier_diagnostic_messages, verifier_framework_signal_for_context,
-    verifier_repair_context_diagnostics, verifier_repair_diagnostic_pending_note,
-    verifier_repair_intent_limits, verifier_repair_pass_messages,
-    verifier_repair_pass_request_error_message, verifier_repair_policy_for_target_hint,
-    verifier_repair_safe_stop_message, verifier_repair_target_display,
-    verifier_repair_transition_message, verifier_repair_unsafe_target_message,
-    verifier_setup_policy_message,
+    VerifierRepairAttemptProgress, build_task_contract_verifier_exit_zero_evidence,
+    build_task_contract_verifier_exit_zero_evidence_bound, build_verifier_exit_zero_evidence,
+    model_assessment_to_verifier_repair_assessment, task_contract_needs_verification,
+    task_contract_no_verifier_note, task_contract_verifier_failure_attempt_limit,
+    task_contract_verifier_repair_note, task_contract_verifier_targeted_edit_required_note,
+    verifier_diagnostic_file_excerpts, verifier_diagnostic_messages,
+    verifier_framework_signal_for_context, verifier_repair_context_diagnostics,
+    verifier_repair_diagnostic_pending_note, verifier_repair_intent_limits,
+    verifier_repair_pass_messages, verifier_repair_pass_request_error_message,
+    verifier_repair_policy_for_target_hint, verifier_repair_safe_stop_message,
+    verifier_repair_target_display, verifier_repair_transition_message,
+    verifier_repair_unsafe_target_message, verifier_setup_policy_message,
 };
 #[cfg(test)]
 use super::verifier_orchestration::{
@@ -1544,35 +1546,6 @@ fn repair_terminal_exit_reason(reason: super::repair_job::RepairTerminalReason) 
         Some(_) => ExitReason::RepairSafeStop,
         None => ExitReason::VerifierFailed,
     }
-}
-
-fn task_contract_needs_verification(
-    mode: ExecutionMode,
-    contract: Option<&super::task_contract::TaskContract>,
-    evidence: &super::completion_evidence::EvidenceSet,
-) -> bool {
-    if mode == ExecutionMode::Plan {
-        return false;
-    }
-    contract.is_some_and(|contract| {
-        matches!(
-            contract.evaluate(evidence),
-            super::task_contract::CompletionDecision::Verify
-        )
-    })
-}
-
-fn task_contract_no_verifier_note(
-    attempt: usize,
-    attempt_limit: usize,
-    active_request: &str,
-) -> String {
-    let hint = missing_verifier_setup_hint_for_request(active_request)
-        .map(|hint| format!(" {hint}"))
-        .unwrap_or_default();
-    format!(
-        "[Task Contract Verification] Required artifacts are present, but no runnable verifier was detected for this workspace. Emit exactly one Write or Edit now for project-local verifier metadata, then Anvil will rerun verification.{hint} Do not call Bash, do not switch tasks, and do not answer in prose. task_contract_verify_attempt={attempt}/{attempt_limit}"
-    )
 }
 
 fn repo_edit_satisfies_artifact_recovery_target(
@@ -12501,105 +12474,6 @@ if __name__ == "__main__":
             .messages
             .push(ConversationMessage::user(content));
     }
-}
-
-/// Issue #606 T-1.6 / Issue #607: pure projection from a Bash outcome to an
-/// optional `VerifierExitZero` completion-evidence record. Gates:
-///
-/// 1. `exit_code == Some(0)` — non-zero / timeout / interrupted is failure.
-/// 2. `class ∈ { BuildTest, EnvSetup }` — read-only / network / mutating /
-///    dangerous classes never produce verifier evidence.
-/// 3. `is_completion_verifier_command` — rejects shell-control-laundered
-///    exit codes (DR4-002, e.g. `cargo test || true`).
-///
-/// The returned command field is run through
-/// `redact_verifier_command_for_storage` so secret tokens never reach the
-/// in-process EvidenceSet (Issue #607 SEC4-003).
-pub(super) fn build_verifier_exit_zero_evidence(
-    outcome: &crate::tools::bash::BashExecutionOutcome,
-) -> Option<super::completion_evidence::CompletionEvidence> {
-    use crate::tools::bash::BashCommandClass;
-    if outcome.exit_code != Some(0) {
-        return None;
-    }
-    if !matches!(
-        outcome.class,
-        BashCommandClass::BuildTest | BashCommandClass::EnvSetup
-    ) {
-        return None;
-    }
-    if !super::completion_evidence::is_completion_verifier_command(&outcome.command) {
-        return None;
-    }
-    let masked = super::completion_evidence::redact_verifier_command_for_storage(&outcome.command);
-    // PR-001: bash-hook / legacy path — `bound_test_artifacts_count: None`
-    // because we cannot prove the runner's argv contained any owned test
-    // path. `TaskContract::evaluate_with_owned_test_artifacts` treats this
-    // as unbound and refuses to promote to Done under
-    // `test_execution_required = true` (Issue #651 PR-001).
-    Some(
-        super::completion_evidence::CompletionEvidence::VerifierExitZero {
-            class: outcome.class,
-            command: masked,
-            bound_test_artifacts_count: None,
-        },
-    )
-}
-
-fn build_task_contract_verifier_exit_zero_evidence(
-    command: &str,
-) -> Option<super::completion_evidence::CompletionEvidence> {
-    // This path is reached only after AutoTestRunner itself executed the
-    // controller-selected verifier and observed exit code 0. Unlike arbitrary
-    // Bash tool output, the command may include an internal setup segment
-    // (`pip install ... && pytest`), so the shell-control evidence gate is not
-    // the right trust boundary here.
-    //
-    // PR-001: this overload covers the **legacy** `AutoTestRunner::run`
-    // (shell-based) path which has no structural binding to owned test
-    // paths. It records `bound_test_artifacts_count: None`. The structured
-    // `AutoTestRunner::run_structured` path goes through
-    // `build_task_contract_verifier_exit_zero_evidence_bound(command, n)`.
-    let masked = super::completion_evidence::redact_verifier_command_for_storage(command);
-    if masked.trim().is_empty() {
-        return None;
-    }
-    Some(
-        super::completion_evidence::CompletionEvidence::VerifierExitZero {
-            class: crate::tools::bash::BashCommandClass::BuildTest,
-            command: masked,
-            bound_test_artifacts_count: None,
-        },
-    )
-}
-
-/// Issue #651 PR-001: build a **bound** `VerifierExitZero` evidence
-/// entry for the structured-runner path. The `bound_count` parameter is
-/// the size of `VerifierCommand::bound_test_artifacts()` at the time
-/// `AutoTestRunner::run_structured` succeeded — i.e. the number of
-/// scope-validated owned test paths that appeared in the child process's
-/// argv.
-///
-/// This entry is the only proof
-/// `TaskContract::evaluate_with_owned_test_artifacts` accepts as
-/// satisfying `test_execution_required = true`. Storing the count (not
-/// the path list) keeps the evidence payload bounded and avoids leaking
-/// path strings into the in-process EvidenceSet.
-fn build_task_contract_verifier_exit_zero_evidence_bound(
-    command: &str,
-    bound_count: usize,
-) -> Option<super::completion_evidence::CompletionEvidence> {
-    let masked = super::completion_evidence::redact_verifier_command_for_storage(command);
-    if masked.trim().is_empty() {
-        return None;
-    }
-    Some(
-        super::completion_evidence::CompletionEvidence::VerifierExitZero {
-            class: crate::tools::bash::BashCommandClass::BuildTest,
-            command: masked,
-            bound_test_artifacts_count: Some(bound_count),
-        },
-    )
 }
 
 #[cfg(test)]

--- a/src/agent/loop_run/verifier_orchestration.rs
+++ b/src/agent/loop_run/verifier_orchestration.rs
@@ -39,6 +39,10 @@
 use std::path::Path;
 
 use super::auto_test::{AutoTestPlan, VerifierCommand};
+use super::completion_evidence::{
+    CompletionEvidence, EvidenceSet, is_completion_verifier_command,
+    redact_verifier_command_for_storage,
+};
 use super::failure_packet::FailurePacket;
 use super::progress_text::truncate;
 use super::repair_attempt_outcome::RepairAttemptOutcome;
@@ -63,7 +67,7 @@ use super::required_behavior::{BehaviorContractProjection, behavior_contract_pay
 use super::semantic_repair_planning::{
     diagnostic_target_allowed_by_confidence, first_role_kind_compatible_diagnostic_target,
 };
-use super::task_contract::{ArtifactRole, RecoveryTargetHint, TaskContract};
+use super::task_contract::{ArtifactRole, CompletionDecision, RecoveryTargetHint, TaskContract};
 use super::tool_history::focused_edit_target_already_read;
 use super::tool_policy::{EffectiveToolPolicy, EffectiveToolPolicyReason};
 use super::turn::{
@@ -83,9 +87,11 @@ use super::verifier_repair_targeting::{
 };
 use super::{VerifierRepairAssessment, VerifierRepairAssessmentSource};
 use crate::agent::orchestration::{RepoSnapshot, RepoVerification};
+use crate::modes::plan_act::ExecutionMode;
 use crate::safety::path_guard::resolve_user_path;
 use crate::session::feedback::mask_secrets;
 use crate::session::store::ConversationMessage;
+use crate::tools::bash::{BashCommandClass, BashExecutionOutcome};
 use std::collections::HashSet;
 
 #[cfg(test)]
@@ -1277,4 +1283,98 @@ pub(super) fn model_assessment_to_verifier_repair_assessment(
         summary: parsed.summary,
         source: VerifierRepairAssessmentSource::DiagnosticPass,
     }
+}
+
+pub(super) fn task_contract_needs_verification(
+    mode: ExecutionMode,
+    contract: Option<&TaskContract>,
+    evidence: &EvidenceSet,
+) -> bool {
+    if mode == ExecutionMode::Plan {
+        return false;
+    }
+    contract
+        .is_some_and(|contract| matches!(contract.evaluate(evidence), CompletionDecision::Verify))
+}
+
+pub(super) fn task_contract_no_verifier_note(
+    attempt: usize,
+    attempt_limit: usize,
+    active_request: &str,
+) -> String {
+    let hint = missing_verifier_setup_hint_for_request(active_request)
+        .map(|hint| format!(" {hint}"))
+        .unwrap_or_default();
+    format!(
+        "[Task Contract Verification] Required artifacts are present, but no runnable verifier was detected for this workspace. Emit exactly one Write or Edit now for project-local verifier metadata, then Anvil will rerun verification.{hint} Do not call Bash, do not switch tasks, and do not answer in prose. task_contract_verify_attempt={attempt}/{attempt_limit}"
+    )
+}
+
+pub(super) fn build_verifier_exit_zero_evidence(
+    outcome: &BashExecutionOutcome,
+) -> Option<CompletionEvidence> {
+    use BashCommandClass;
+    if outcome.exit_code != Some(0) {
+        return None;
+    }
+    if !matches!(
+        outcome.class,
+        BashCommandClass::BuildTest | BashCommandClass::EnvSetup
+    ) {
+        return None;
+    }
+    if !is_completion_verifier_command(&outcome.command) {
+        return None;
+    }
+    let masked = redact_verifier_command_for_storage(&outcome.command);
+    // PR-001: bash-hook / legacy path — `bound_test_artifacts_count: None`
+    // because we cannot prove the runner's argv contained any owned test
+    // path. `TaskContract::evaluate_with_owned_test_artifacts` treats this
+    // as unbound and refuses to promote to Done under
+    // `test_execution_required = true` (Issue #651 PR-001).
+    Some(CompletionEvidence::VerifierExitZero {
+        class: outcome.class,
+        command: masked,
+        bound_test_artifacts_count: None,
+    })
+}
+
+pub(super) fn build_task_contract_verifier_exit_zero_evidence(
+    command: &str,
+) -> Option<CompletionEvidence> {
+    // This path is reached only after AutoTestRunner itself executed the
+    // controller-selected verifier and observed exit code 0. Unlike arbitrary
+    // Bash tool output, the command may include an internal setup segment
+    // (`pip install ... && pytest`), so the shell-control evidence gate is not
+    // the right trust boundary here.
+    //
+    // PR-001: this overload covers the **legacy** `AutoTestRunner::run`
+    // (shell-based) path which has no structural binding to owned test
+    // paths. It records `bound_test_artifacts_count: None`. The structured
+    // `AutoTestRunner::run_structured` path goes through
+    // `build_task_contract_verifier_exit_zero_evidence_bound(command, n)`.
+    let masked = redact_verifier_command_for_storage(command);
+    if masked.trim().is_empty() {
+        return None;
+    }
+    Some(CompletionEvidence::VerifierExitZero {
+        class: BashCommandClass::BuildTest,
+        command: masked,
+        bound_test_artifacts_count: None,
+    })
+}
+
+pub(super) fn build_task_contract_verifier_exit_zero_evidence_bound(
+    command: &str,
+    bound_count: usize,
+) -> Option<CompletionEvidence> {
+    let masked = redact_verifier_command_for_storage(command);
+    if masked.trim().is_empty() {
+        return None;
+    }
+    Some(CompletionEvidence::VerifierExitZero {
+        class: BashCommandClass::BuildTest,
+        command: masked,
+        bound_test_artifacts_count: Some(bound_count),
+    })
 }


### PR DESCRIPTION
## Summary

Phase 2 batch 8 for Issue #682. Moves 5 verifier evidence / task-contract verification helpers (~99 LOC of bodies) out of `turn.rs` into `verifier_orchestration.rs`.

### Moved (turn.rs → verifier_orchestration.rs)

- `task_contract_needs_verification` (15 LOC) — `ExecutionMode + TaskContract + EvidenceSet → bool` gate for the task-contract verifier dispatch.
- `task_contract_no_verifier_note` (12 LOC) — system note when no runnable verifier is detected for a task-contract turn.
- `build_verifier_exit_zero_evidence` (30 LOC, was `pub(super)`) — pure projection from a Bash outcome to an optional `VerifierExitZero` completion-evidence record (Issue #606 T-1.6 / Issue #607 SEC4-003 gate chain: `exit_code==0`, `class ∈ {BuildTest, EnvSetup}`, completion verifier command, `mask_secrets` command for storage).
- `build_task_contract_verifier_exit_zero_evidence` (26 LOC) — legacy `AutoTestRunner::run` shell-path overload with `bound_test_artifacts_count: None`.
- `build_task_contract_verifier_exit_zero_evidence_bound` (16 LOC) — structured `AutoTestRunner::run_structured` overload with `bound_test_artifacts_count: Some(n)`, the only path that can pass `test_execution_required = true` (Issue #651 PR-001 SSOT).

All 5 promoted to `pub(super)` (4 were file-private, `build_verifier_exit_zero_evidence` was already `pub(super)`).

### Adjustments

- `verifier_orchestration.rs`: added imports for `CompletionEvidence` / `EvidenceSet` / `is_completion_verifier_command` / `redact_verifier_command_for_storage` (`super::completion_evidence`), `CompletionDecision` (`super::task_contract`), `ExecutionMode` (`crate::modes::plan_act`), `BashCommandClass` / `BashExecutionOutcome` (`crate::tools::bash`). Replaced inline `use crate::tools::bash::BashCommandClass;` in the moved body with the top-level import.
- `turn.rs`:
  - Extended `use super::verifier_orchestration::{...}` with the 5 production-callable relocated fns.
  - Cleaned 2 orphaned doc comment blocks above the deleted fn sites (clippy `empty_line_after_doc_comments` under `-D warnings`).
- `loop_run.rs`:
  - Rewrote `turn::build_verifier_exit_zero_evidence(...)` call in `pub fn build_verifier_exit_zero_evidence_for_test` to `verifier_orchestration::build_verifier_exit_zero_evidence(...)` since the fn moved.

### Metrics

| File | Before | After | Delta |
|---|---:|---:|---:|
| `src/agent/loop_run/turn.rs` | 33,796 | 33,668 | **-128** |
| `src/agent/loop_run/verifier_orchestration.rs` | 1,280 | 1,380 | +100 |

Cumulative Issue #682 progress: turn.rs 34,958 → 33,668 (**-1,290**, ~43% of Phase 2 target). Acceptance gap: 33,668 → 32,000 = **~1,668 LOC remaining**.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --lib` (3,114 passed)
- [ ] CI green (fmt / clippy / test / build)

## Layer rule notes

- No facade re-export (DR3-001 maintained).
- No photon → session → agent inversion (DR3-002 unchanged).
- Pure code-motion + visibility relaxation; no production-binary behaviour change.