### PR TITLE
Relocate request-language classification cluster (Issue #682, batch 11)

### DIFF
--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -168,17 +168,18 @@ use super::verifier_orchestration::{
     emit_patch_proposal_legacy_validation_comparison_event,
     emit_patch_proposal_shadow_validation_event, emit_repair_progress_classified_event,
     model_assessment_to_verifier_repair_assessment, repair_terminal_exit_reason,
-    task_contract_needs_verification, task_contract_no_verifier_note,
-    task_contract_verifier_failure_attempt_limit, task_contract_verifier_repair_note,
-    task_contract_verifier_targeted_edit_required_note,
-    validate_verifier_repair_intents_with_accepted_plan, verifier_diagnostic_file_excerpts,
-    verifier_diagnostic_messages, verifier_framework_signal_for_context,
-    verifier_repair_context_diagnostics, verifier_repair_diagnostic_pending_note,
-    verifier_repair_intent_limits, verifier_repair_pass_messages,
-    verifier_repair_pass_request_error_message, verifier_repair_policy_for_target_hint,
-    verifier_repair_safe_stop_message, verifier_repair_target_display,
-    verifier_repair_transition_message, verifier_repair_unsafe_target_message,
-    verifier_setup_policy_message,
+    synthesized_missing_implementation_target_path_for_request,
+    synthesized_missing_test_target_path_for_request, task_contract_needs_verification,
+    task_contract_no_verifier_note, task_contract_verifier_failure_attempt_limit,
+    task_contract_verifier_repair_note, task_contract_verifier_targeted_edit_required_note,
+    test_target_path_compatible_with_request, validate_verifier_repair_intents_with_accepted_plan,
+    verifier_diagnostic_file_excerpts, verifier_diagnostic_messages,
+    verifier_framework_signal_for_context, verifier_repair_context_diagnostics,
+    verifier_repair_diagnostic_pending_note, verifier_repair_intent_limits,
+    verifier_repair_pass_messages, verifier_repair_pass_request_error_message,
+    verifier_repair_policy_for_target_hint, verifier_repair_safe_stop_message,
+    verifier_repair_target_display, verifier_repair_transition_message,
+    verifier_repair_unsafe_target_message, verifier_setup_policy_message,
 };
 #[cfg(test)]
 use super::verifier_orchestration::{
@@ -17609,25 +17610,6 @@ fn existing_workspace_candidate_for_role(
         .map(|path| path.to_string_lossy().replace('\\', "/"))
 }
 
-/// Issue #646: project the workspace-target half of a [`VerifierRepairDecision`]
-/// so the MissingVerifierJob safeguard can re-validate the scope when no real
-/// [`RepairJob`] is attached. Returns `None` for decisions that do not carry
-/// a path (NoRepair / NeedDiagnostic / NeedTargetDiscovery / ReadyToVerify /
-/// DiagnosticUnavailable).
-#[cfg(test)]
-pub(super) fn decision_target_path(decision: &VerifierRepairDecision) -> Option<&Path> {
-    match decision {
-        VerifierRepairDecision::NeedFreshRead(path)
-        | VerifierRepairDecision::NeedWrite(path)
-        | VerifierRepairDecision::NeedEdit(path) => Some(path.as_path()),
-        VerifierRepairDecision::NoRepair
-        | VerifierRepairDecision::NeedDiagnostic
-        | VerifierRepairDecision::NeedTargetDiscovery
-        | VerifierRepairDecision::DiagnosticUnavailable
-        | VerifierRepairDecision::ReadyToVerify => None,
-    }
-}
-
 /// v0.4.11: after an invalid controller repair proposal is recorded in the
 /// repair ledger, the next policy decision may have advanced to a fresh
 /// diagnostic or a different concrete target. Only those transitions count as
@@ -17683,133 +17665,6 @@ pub(super) fn existing_workspace_candidate_for_role_in_scope(
     candidates
         .first()
         .map(|path| path.to_string_lossy().replace('\\', "/"))
-}
-
-const PYTHON_REQUEST_PATTERNS: &[&str] = &["fastapi", "python", ".py"];
-const PYTHON_REQUEST_JA_PATTERNS: &[&str] = &["Pythonで", "FastAPIで"];
-const RUST_REQUEST_PATTERNS: &[&str] = &["rust", "cargo test", "cargo"];
-const RUST_REQUEST_JA_PATTERNS: &[&str] = &["Rustで", "Rust"];
-const RUST_LIBRARY_REQUEST_PATTERNS: &[&str] = &["library", "crate"];
-const RUST_LIBRARY_REQUEST_JA_PATTERNS: &[&str] = &["ライブラリ", "クレート"];
-const TYPESCRIPT_REQUEST_PATTERNS: &[&str] = &["typescript", "type script", ".ts"];
-const JAVASCRIPT_REQUEST_PATTERNS: &[&str] = &["javascript", "node", "npm test"];
-const NODE_REQUEST_PATTERNS: &[&str] = &["node", "npm", "typescript", "javascript"];
-const PYTHON_TEST_REQUEST_PATTERNS: &[&str] =
-    &["fastapi", "flask", "django", "python", "pytest", ".py"];
-
-fn lower_contains_any(lower: &str, patterns: &[&str]) -> bool {
-    patterns.iter().any(|pattern| lower.contains(pattern))
-}
-
-fn request_contains_any(request: &str, patterns: &[&str]) -> bool {
-    patterns.iter().any(|pattern| request.contains(pattern))
-}
-
-fn request_matches_family(
-    lower: &str,
-    request: &str,
-    lower_patterns: &[&str],
-    request_patterns: &[&str],
-) -> bool {
-    lower_contains_any(lower, lower_patterns) || request_contains_any(request, request_patterns)
-}
-
-fn synthesized_missing_implementation_target_path_for_request(
-    role: super::task_contract::ArtifactRole,
-    request: &str,
-) -> Option<String> {
-    if role != super::task_contract::ArtifactRole::Implementation {
-        return None;
-    }
-    let lower = request.to_ascii_lowercase();
-    if request_matches_family(
-        &lower,
-        request,
-        PYTHON_REQUEST_PATTERNS,
-        PYTHON_REQUEST_JA_PATTERNS,
-    ) {
-        return Some("main.py".to_string());
-    }
-    if request_matches_family(
-        &lower,
-        request,
-        RUST_REQUEST_PATTERNS,
-        RUST_REQUEST_JA_PATTERNS,
-    ) {
-        if request_matches_family(
-            &lower,
-            request,
-            RUST_LIBRARY_REQUEST_PATTERNS,
-            RUST_LIBRARY_REQUEST_JA_PATTERNS,
-        ) {
-            return Some("src/lib.rs".to_string());
-        }
-        return Some("src/main.rs".to_string());
-    }
-    None
-}
-
-fn synthesized_missing_test_target_path_for_request(
-    request: &str,
-) -> Option<(&'static str, &'static str)> {
-    let lower = request.to_ascii_lowercase();
-    if request_matches_family(&lower, request, RUST_REQUEST_PATTERNS, &["Rustで"]) {
-        return Some(("tests/main.rs", "rust"));
-    }
-    if lower_contains_any(&lower, TYPESCRIPT_REQUEST_PATTERNS) {
-        return Some(("tests/main.test.ts", "typescript"));
-    }
-    if lower_contains_any(&lower, JAVASCRIPT_REQUEST_PATTERNS) {
-        return Some(("tests/main.test.js", "javascript"));
-    }
-    if request_matches_family(
-        &lower,
-        request,
-        PYTHON_TEST_REQUEST_PATTERNS,
-        PYTHON_REQUEST_JA_PATTERNS,
-    ) {
-        return Some(("tests/test_main.py", "python"));
-    }
-    None
-}
-
-fn test_target_path_compatible_with_request(path: &str, request: &str) -> bool {
-    let Some((target_path, _)) = synthesized_missing_test_target_path_for_request(request) else {
-        return true;
-    };
-    let expected_ext = std::path::Path::new(target_path)
-        .extension()
-        .and_then(|ext| ext.to_str());
-    let actual_ext = std::path::Path::new(path)
-        .extension()
-        .and_then(|ext| ext.to_str());
-    expected_ext == actual_ext
-}
-
-pub(super) fn missing_verifier_setup_hint_for_request(request: &str) -> Option<&'static str> {
-    let lower = request.to_ascii_lowercase();
-    if request_matches_family(
-        &lower,
-        request,
-        RUST_REQUEST_PATTERNS,
-        RUST_REQUEST_JA_PATTERNS,
-    ) {
-        return Some("For Rust/Cargo workspaces, create or update Cargo.toml.");
-    }
-    if request_matches_family(
-        &lower,
-        request,
-        PYTHON_TEST_REQUEST_PATTERNS,
-        PYTHON_REQUEST_JA_PATTERNS,
-    ) {
-        return Some(
-            "For Python/pytest workspaces, create or update pyproject.toml, requirements.txt, or pytest configuration.",
-        );
-    }
-    if lower_contains_any(&lower, NODE_REQUEST_PATTERNS) {
-        return Some("For Node/npm workspaces, create or update package.json with a test script.");
-    }
-    None
 }
 
 fn sha256_hex(bytes: &[u8]) -> String {
@@ -19069,7 +18924,7 @@ mod truncate_tests {
     #[test]
     fn missing_verifier_setup_hint_points_rust_requests_to_cargo_manifest() {
         assert_eq!(
-            super::missing_verifier_setup_hint_for_request(
+            super::super::verifier_orchestration::missing_verifier_setup_hint_for_request(
                 "Rustライブラリを作成し、cargo testで動くテストも実装してください。"
             ),
             Some("For Rust/Cargo workspaces, create or update Cargo.toml.")
@@ -19091,7 +18946,7 @@ mod truncate_tests {
     #[test]
     fn missing_verifier_setup_hint_points_python_requests_to_python_metadata() {
         assert_eq!(
-            super::missing_verifier_setup_hint_for_request(
+            super::super::verifier_orchestration::missing_verifier_setup_hint_for_request(
                 "FastAPIでCRUD APIを作り、pytestでテストしてください。"
             ),
             Some(
@@ -19103,7 +18958,7 @@ mod truncate_tests {
     #[test]
     fn missing_verifier_setup_hint_points_node_requests_to_package_json() {
         assert_eq!(
-            super::missing_verifier_setup_hint_for_request(
+            super::super::verifier_orchestration::missing_verifier_setup_hint_for_request(
                 "TypeScript CLI を作成し、npm test で確認してください。"
             ),
             Some("For Node/npm workspaces, create or update package.json with a test script.")

--- a/src/agent/loop_run/verifier_orchestration.rs
+++ b/src/agent/loop_run/verifier_orchestration.rs
@@ -84,7 +84,6 @@ use super::tool_history::focused_edit_target_already_read;
 use super::tool_policy::{EffectiveToolPolicy, EffectiveToolPolicyReason};
 use super::turn::{
     TASK_CONTRACT_VERIFIER_ATTEMPT_LIMIT, TASK_CONTRACT_VERIFIER_REPAIR_ATTEMPT_LIMIT,
-    missing_verifier_setup_hint_for_request,
 };
 use super::verifier_assessment_parser::{
     ParsedVerifierRepairAssessment, verifier_failure_type_for_diagnostic_kind,
@@ -115,8 +114,6 @@ use super::repair_job::VerifierRepairDecision;
 use super::repair_patch_validation::{RepairIntentEdit, repair_intent_edits_fingerprint};
 #[cfg(test)]
 use super::tool_policy::workspace_relative_path_for_tool_arg;
-#[cfg(test)]
-use super::turn::decision_target_path;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum JobInstallOutcome {
@@ -1917,4 +1914,150 @@ pub(super) fn patch_proposal_target_contents_for_shadow(
         return None;
     }
     std::fs::read_to_string(canonical).ok()
+}
+
+/// Issue #646: project the workspace-target half of a [`VerifierRepairDecision`]
+/// so the MissingVerifierJob safeguard can re-validate the scope when no real
+/// [`RepairJob`] is attached. Returns `None` for decisions that do not carry
+/// a path (NoRepair / NeedDiagnostic / NeedTargetDiscovery / ReadyToVerify /
+/// DiagnosticUnavailable).
+#[cfg(test)]
+pub(super) fn decision_target_path(decision: &VerifierRepairDecision) -> Option<&Path> {
+    match decision {
+        VerifierRepairDecision::NeedFreshRead(path)
+        | VerifierRepairDecision::NeedWrite(path)
+        | VerifierRepairDecision::NeedEdit(path) => Some(path.as_path()),
+        VerifierRepairDecision::NoRepair
+        | VerifierRepairDecision::NeedDiagnostic
+        | VerifierRepairDecision::NeedTargetDiscovery
+        | VerifierRepairDecision::DiagnosticUnavailable
+        | VerifierRepairDecision::ReadyToVerify => None,
+    }
+}
+
+pub(super) const PYTHON_REQUEST_PATTERNS: &[&str] = &["fastapi", "python", ".py"];
+pub(super) const PYTHON_REQUEST_JA_PATTERNS: &[&str] = &["Pythonで", "FastAPIで"];
+pub(super) const RUST_REQUEST_PATTERNS: &[&str] = &["rust", "cargo test", "cargo"];
+pub(super) const RUST_REQUEST_JA_PATTERNS: &[&str] = &["Rustで", "Rust"];
+pub(super) const RUST_LIBRARY_REQUEST_PATTERNS: &[&str] = &["library", "crate"];
+pub(super) const RUST_LIBRARY_REQUEST_JA_PATTERNS: &[&str] = &["ライブラリ", "クレート"];
+pub(super) const TYPESCRIPT_REQUEST_PATTERNS: &[&str] = &["typescript", "type script", ".ts"];
+pub(super) const JAVASCRIPT_REQUEST_PATTERNS: &[&str] = &["javascript", "node", "npm test"];
+pub(super) const NODE_REQUEST_PATTERNS: &[&str] = &["node", "npm", "typescript", "javascript"];
+pub(super) const PYTHON_TEST_REQUEST_PATTERNS: &[&str] =
+    &["fastapi", "flask", "django", "python", "pytest", ".py"];
+
+pub(super) fn lower_contains_any(lower: &str, patterns: &[&str]) -> bool {
+    patterns.iter().any(|pattern| lower.contains(pattern))
+}
+
+pub(super) fn request_contains_any(request: &str, patterns: &[&str]) -> bool {
+    patterns.iter().any(|pattern| request.contains(pattern))
+}
+
+pub(super) fn request_matches_family(
+    lower: &str,
+    request: &str,
+    lower_patterns: &[&str],
+    request_patterns: &[&str],
+) -> bool {
+    lower_contains_any(lower, lower_patterns) || request_contains_any(request, request_patterns)
+}
+
+pub(super) fn synthesized_missing_implementation_target_path_for_request(
+    role: ArtifactRole,
+    request: &str,
+) -> Option<String> {
+    if role != ArtifactRole::Implementation {
+        return None;
+    }
+    let lower = request.to_ascii_lowercase();
+    if request_matches_family(
+        &lower,
+        request,
+        PYTHON_REQUEST_PATTERNS,
+        PYTHON_REQUEST_JA_PATTERNS,
+    ) {
+        return Some("main.py".to_string());
+    }
+    if request_matches_family(
+        &lower,
+        request,
+        RUST_REQUEST_PATTERNS,
+        RUST_REQUEST_JA_PATTERNS,
+    ) {
+        if request_matches_family(
+            &lower,
+            request,
+            RUST_LIBRARY_REQUEST_PATTERNS,
+            RUST_LIBRARY_REQUEST_JA_PATTERNS,
+        ) {
+            return Some("src/lib.rs".to_string());
+        }
+        return Some("src/main.rs".to_string());
+    }
+    None
+}
+
+pub(super) fn synthesized_missing_test_target_path_for_request(
+    request: &str,
+) -> Option<(&'static str, &'static str)> {
+    let lower = request.to_ascii_lowercase();
+    if request_matches_family(&lower, request, RUST_REQUEST_PATTERNS, &["Rustで"]) {
+        return Some(("tests/main.rs", "rust"));
+    }
+    if lower_contains_any(&lower, TYPESCRIPT_REQUEST_PATTERNS) {
+        return Some(("tests/main.test.ts", "typescript"));
+    }
+    if lower_contains_any(&lower, JAVASCRIPT_REQUEST_PATTERNS) {
+        return Some(("tests/main.test.js", "javascript"));
+    }
+    if request_matches_family(
+        &lower,
+        request,
+        PYTHON_TEST_REQUEST_PATTERNS,
+        PYTHON_REQUEST_JA_PATTERNS,
+    ) {
+        return Some(("tests/test_main.py", "python"));
+    }
+    None
+}
+
+pub(super) fn test_target_path_compatible_with_request(path: &str, request: &str) -> bool {
+    let Some((target_path, _)) = synthesized_missing_test_target_path_for_request(request) else {
+        return true;
+    };
+    let expected_ext = std::path::Path::new(target_path)
+        .extension()
+        .and_then(|ext| ext.to_str());
+    let actual_ext = std::path::Path::new(path)
+        .extension()
+        .and_then(|ext| ext.to_str());
+    expected_ext == actual_ext
+}
+
+pub(super) fn missing_verifier_setup_hint_for_request(request: &str) -> Option<&'static str> {
+    let lower = request.to_ascii_lowercase();
+    if request_matches_family(
+        &lower,
+        request,
+        RUST_REQUEST_PATTERNS,
+        RUST_REQUEST_JA_PATTERNS,
+    ) {
+        return Some("For Rust/Cargo workspaces, create or update Cargo.toml.");
+    }
+    if request_matches_family(
+        &lower,
+        request,
+        PYTHON_TEST_REQUEST_PATTERNS,
+        PYTHON_REQUEST_JA_PATTERNS,
+    ) {
+        return Some(
+            "For Python/pytest workspaces, create or update pyproject.toml, requirements.txt, or pytest configuration.",
+        );
+    }
+    if lower_contains_any(&lower, NODE_REQUEST_PATTERNS) {
+        return Some("For Node/npm workspaces, create or update package.json with a test script.");
+    }
+    None
 }


### PR DESCRIPTION
## Summary

Phase 2 batch 11 for Issue #682. Moves the verifier-adjacent request-language classification cluster (~140 LOC) out of `turn.rs` into `verifier_orchestration.rs`. **Removes all 4 remaining `super::turn::` back-imports** from `verifier_orchestration.rs`.

### Moved (turn.rs → verifier_orchestration.rs)

**Pure helpers** (5):
- `decision_target_path` (`#[cfg(test)]`, 12 LOC) — projects the workspace-target half of a `VerifierRepairDecision` so the MissingVerifierJob safeguard can re-validate scope when no real `RepairJob` is attached. Previously back-imported from turn.rs.
- `missing_verifier_setup_hint_for_request` (25 LOC) — returns language-specific config hint for the no-verifier note. Previously back-imported from turn.rs by both `task_contract_no_verifier_note` and `verifier_setup_policy_message`.
- `synthesized_missing_implementation_target_path_for_request` (34 LOC) — request-derived default implementation target path
- `synthesized_missing_test_target_path_for_request` (23 LOC) — request-derived default test target path
- `test_target_path_compatible_with_request` (12 LOC) — gate that checks a hint path's extension against the language family implied by the request

**Pattern-match helpers** (3):
- `lower_contains_any`
- `request_contains_any`
- `request_matches_family`

**Language-pattern consts** (10 entries, ~11 LOC):
- `PYTHON_REQUEST_PATTERNS` / `PYTHON_REQUEST_JA_PATTERNS` / `PYTHON_TEST_REQUEST_PATTERNS`
- `RUST_REQUEST_PATTERNS` / `RUST_REQUEST_JA_PATTERNS` / `RUST_LIBRARY_REQUEST_PATTERNS` / `RUST_LIBRARY_REQUEST_JA_PATTERNS`
- `TYPESCRIPT_REQUEST_PATTERNS` / `JAVASCRIPT_REQUEST_PATTERNS` / `NODE_REQUEST_PATTERNS`

All 8 fns + 10 consts promoted to `pub(super)`. `decision_target_path` retains its `#[cfg(test)]` attribute. The cluster is now fully self-contained inside `verifier_orchestration.rs`.

### Adjustments

- `verifier_orchestration.rs`: removed `missing_verifier_setup_hint_for_request` + `decision_target_path` from the `super::turn::` back-imports (no longer needed — both are now defined locally). The `super::turn::` block is now only the 2 `TASK_CONTRACT_VERIFIER_*` consts.
- `turn.rs`: extended `use super::verifier_orchestration::{...}` with 3 production callers (`synthesized_missing_implementation_target_path_for_request` / `synthesized_missing_test_target_path_for_request` / `test_target_path_compatible_with_request`). Rewrote test-mod `super::missing_verifier_setup_hint_for_request(` + `super::decision_target_path(` references to `super::super::verifier_orchestration::*`.

### Metrics

| File | Before | After | Delta |
|---|---:|---:|---:|
| `src/agent/loop_run/turn.rs` | 33,149 | 33,004 | **-145** |
| `src/agent/loop_run/verifier_orchestration.rs` | 1,920 | 2,063 | +143 |

Cumulative Issue #682 progress: turn.rs 34,958 → 33,004 (**-1,954**, ~65% of Phase 2 target). Acceptance gap: 33,004 → 32,000 = **~1,004 LOC remaining**.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --lib` (3,114 passed)
- [ ] CI green (fmt / clippy / test / build)

## Layer rule notes

- No facade re-export (DR3-001 maintained).
- No photon → session → agent inversion (DR3-002 unchanged).
- Pure code-motion + visibility relaxation; no production-binary behaviour change.