### PR TITLE
Veneer-migrate apply_verifier_repair_pass_edit (Issue #682, batch 12)

### DIFF
--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -68,7 +68,7 @@ use super::repair_job::{
 #[cfg(test)]
 use super::repair_patch_validation::ValidationWeakening;
 use super::repair_patch_validation::{
-    CheapCheckOutcome, RepairRejectionSignal, ValidatedVerifierRepairEdit, ValidationFailure,
+    CheapCheckOutcome, RepairRejectionSignal, ValidationFailure,
     build_verifier_repair_pass_ledger_outcome, validate_accepted_repair_plan_authorizes_target,
 };
 use super::repair_target_admission::RepairTargetAdmissionContext;
@@ -383,7 +383,7 @@ mod v0421_repair_runner_contract_tests {
         let body = function_body(
             src,
             "\n    fn run_verifier_repair_pass_and_apply(",
-            "\n    fn record_controller_verifier_repair_edit(",
+            "\n    pub(super) fn record_controller_verifier_repair_edit(",
         );
 
         assert!(body.contains("target_hint:"));
@@ -400,7 +400,7 @@ mod v0421_repair_runner_contract_tests {
         let body = function_body(
             src,
             "\n    fn run_verifier_repair_pass_and_apply(",
-            "\n    fn record_controller_verifier_repair_edit(",
+            "\n    pub(super) fn record_controller_verifier_repair_edit(",
         );
 
         assert!(
@@ -427,7 +427,7 @@ mod v0421_repair_runner_contract_tests {
         let body = function_body(
             src,
             "\n    fn run_verifier_repair_pass_and_apply(",
-            "\n    fn record_controller_verifier_repair_edit(",
+            "\n    pub(super) fn record_controller_verifier_repair_edit(",
         );
         let orchestration = include_str!("verifier_orchestration.rs");
         let prompt = function_body(
@@ -9132,55 +9132,18 @@ impl Agent {
                 validation
             });
         match validation {
-            Ok(edit) => self.apply_verifier_repair_pass_edit(prepared, target_hint, attempt, edit),
+            Ok(edit) => super::verifier_orchestration::apply_verifier_repair_pass_edit(
+                self,
+                prepared,
+                target_hint,
+                attempt,
+                edit,
+            ),
             Err(error) => Err(error),
         }
     }
 
-    fn apply_verifier_repair_pass_edit(
-        &mut self,
-        prepared: &PreparedVerifierRepairPass,
-        target_hint: &super::task_contract::RecoveryTargetHint,
-        attempt: usize,
-        edit: ValidatedVerifierRepairEdit,
-    ) -> Result<VerifierRepairPassOutcome, ValidationFailure> {
-        if prepared
-            .context
-            .applied_repair_intents
-            .contains(&edit.fingerprint)
-        {
-            return Err(ValidationFailure::failed(
-                "duplicate repair edit intent for the same failure".to_string(),
-            ));
-        }
-        if let Err(err) = super::repair_patch_executor::apply_validated_repair_edit(&edit) {
-            return Err(ValidationFailure::failed(format!(
-                "failed to apply {}: {err}",
-                edit.relative_path
-            )));
-        }
-        self.record_controller_verifier_repair_edit(
-            &edit.relative_path,
-            &edit.fingerprint,
-            target_hint,
-        );
-        log_llm_event(
-            "agent.verifier_repair_pass.applied",
-            serde_json::json!({
-                "session_id": self.session_store.session_id(),
-                "model": &prepared.model,
-                "path": edit.relative_path,
-                "preimage_hash": edit.preimage_hash,
-                "postimage_hash": edit.postimage_hash,
-                "attempt": attempt,
-            }),
-        );
-        Ok(VerifierRepairPassOutcome::Applied {
-            relative_path: edit.relative_path,
-        })
-    }
-
-    fn record_controller_verifier_repair_edit(
+    pub(super) fn record_controller_verifier_repair_edit(
         &mut self,
         relative_path: &str,
         fingerprint: &str,

--- a/src/agent/loop_run/verifier_orchestration.rs
+++ b/src/agent/loop_run/verifier_orchestration.rs
@@ -96,7 +96,7 @@ use super::verifier_repair_targeting::{
     verifier_diagnostic_path_input_is_safe, verifier_repair_missing_local_module_provider,
     verifier_repair_preferred_local_import_source, verifier_repair_stale_assertion_test_target,
 };
-use super::{VerifierRepairAssessment, VerifierRepairAssessmentSource};
+use super::{Agent, VerifierRepairAssessment, VerifierRepairAssessmentSource};
 use crate::agent::orchestration::{RepoSnapshot, RepoVerification};
 use crate::logging::{log_llm_event, stable_path_hash};
 use crate::modes::plan_act::ExecutionMode;
@@ -2060,4 +2060,47 @@ pub(super) fn missing_verifier_setup_hint_for_request(request: &str) -> Option<&
         return Some("For Node/npm workspaces, create or update package.json with a test script.");
     }
     None
+}
+
+pub(super) fn apply_verifier_repair_pass_edit(
+    agent: &mut Agent,
+    prepared: &PreparedVerifierRepairPass,
+    target_hint: &RecoveryTargetHint,
+    attempt: usize,
+    edit: ValidatedVerifierRepairEdit,
+) -> Result<VerifierRepairPassOutcome, ValidationFailure> {
+    if prepared
+        .context
+        .applied_repair_intents
+        .contains(&edit.fingerprint)
+    {
+        return Err(ValidationFailure::failed(
+            "duplicate repair edit intent for the same failure".to_string(),
+        ));
+    }
+    if let Err(err) = super::repair_patch_executor::apply_validated_repair_edit(&edit) {
+        return Err(ValidationFailure::failed(format!(
+            "failed to apply {}: {err}",
+            edit.relative_path
+        )));
+    }
+    agent.record_controller_verifier_repair_edit(
+        &edit.relative_path,
+        &edit.fingerprint,
+        target_hint,
+    );
+    log_llm_event(
+        "agent.verifier_repair_pass.applied",
+        serde_json::json!({
+            "session_id": agent.session_store.session_id(),
+            "model": &prepared.model,
+            "path": edit.relative_path,
+            "preimage_hash": edit.preimage_hash,
+            "postimage_hash": edit.postimage_hash,
+            "attempt": attempt,
+        }),
+    );
+    Ok(VerifierRepairPassOutcome::Applied {
+        relative_path: edit.relative_path,
+    })
 }


### PR DESCRIPTION
## Summary

Phase 2 batch 12 for Issue #682. **First `&mut Agent` veneer migration** of a dispatch method from `impl Agent` in `turn.rs` to `verifier_orchestration.rs`, following the Phase 1 actor_loop_flow pattern.

### Moved (turn.rs `impl Agent` → verifier_orchestration.rs free fn)

- `apply_verifier_repair_pass_edit` (43 LOC) — applies a validated verifier-repair edit + records the controller action + emits `agent.verifier_repair_pass.applied` event. Returns `Result<VerifierRepairPassOutcome, ValidationFailure>`.

The Agent method becomes a free function:

```rust
pub(super) fn apply_verifier_repair_pass_edit(
    agent: &mut Agent,
    prepared: &PreparedVerifierRepairPass,
    target_hint: &RecoveryTargetHint,
    attempt: usize,
    edit: ValidatedVerifierRepairEdit,
) -> Result<VerifierRepairPassOutcome, ValidationFailure>
```

`&mut self` → `agent: &mut Agent` first parameter; all `self.field` / `self.method(...)` rewritten as `agent.field` / `agent.method(...)`.

### Adjustments

- `verifier_orchestration.rs`: added `use super::Agent;` so the veneer can name the type. Existing imports for `PreparedVerifierRepairPass` / `RecoveryTargetHint` / `ValidatedVerifierRepairEdit` / `VerifierRepairPassOutcome` / `ValidationFailure` / `log_llm_event` are all already present from earlier batches, so the veneer adds zero new imports beyond `Agent` itself.
- `turn.rs`:
  - Promoted `record_controller_verifier_repair_edit` from file-private to `pub(super)` so the veneer can call `agent.record_controller_verifier_repair_edit(...)` from the new module.
  - Deleted the original `impl Agent` method body (42 LOC).
  - Rewrote the 1 call site to `super::verifier_orchestration::apply_verifier_repair_pass_edit(self, ...)`.
  - Removed `ValidatedVerifierRepairEdit` from `super::repair_patch_validation` import (only the moved fn referenced it in turn.rs).

### Metrics

| File | Before | After | Delta |
|---|---:|---:|---:|
| `src/agent/loop_run/turn.rs` | 33,004 | 32,967 | **-37** |
| `src/agent/loop_run/verifier_orchestration.rs` | 2,063 | 2,106 | +43 |

Cumulative Issue #682 progress: turn.rs 34,958 → 32,967 (**-1,991**, ~66% of Phase 2 target). Acceptance gap: 32,967 → 32,000 = **~967 LOC remaining**.

This establishes the `&mut Agent` veneer pattern for subsequent dispatch-method migrations (`run_verifier_diagnostic_pass` / `verifier_repair_pass_and_apply` / `record_controller_verifier_repair_invalid` / `emit_safe_stop_report_for_repair_exhausted` / `drive_task_contract_verifier`).

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --lib` (3,114 passed)
- [ ] CI green (fmt / clippy / test / build)

## Layer rule notes

- No facade re-export (DR3-001 maintained).
- No photon → session → agent inversion (DR3-002 unchanged).
- Pure code-motion + visibility relaxation; no production-binary behaviour change.