### PR TITLE
Veneer-migrate record_controller_verifier_repair_edit (Issue #682, batch 13)

### DIFF
--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -383,7 +383,7 @@ mod v0421_repair_runner_contract_tests {
         let body = function_body(
             src,
             "\n    fn run_verifier_repair_pass_and_apply(",
-            "\n    pub(super) fn record_controller_verifier_repair_edit(",
+            "\n    fn verifier_repair_pass_client(",
         );
 
         assert!(body.contains("target_hint:"));
@@ -400,7 +400,7 @@ mod v0421_repair_runner_contract_tests {
         let body = function_body(
             src,
             "\n    fn run_verifier_repair_pass_and_apply(",
-            "\n    pub(super) fn record_controller_verifier_repair_edit(",
+            "\n    fn verifier_repair_pass_client(",
         );
 
         assert!(
@@ -427,7 +427,7 @@ mod v0421_repair_runner_contract_tests {
         let body = function_body(
             src,
             "\n    fn run_verifier_repair_pass_and_apply(",
-            "\n    pub(super) fn record_controller_verifier_repair_edit(",
+            "\n    fn verifier_repair_pass_client(",
         );
         let orchestration = include_str!("verifier_orchestration.rs");
         let prompt = function_body(
@@ -1891,7 +1891,7 @@ fn extract_plan_constraints(contents: &str) -> Vec<String> {
     lines
 }
 
-fn normalize_memory_path(raw_path: &str, work_root: &Path) -> String {
+pub(super) fn normalize_memory_path(raw_path: &str, work_root: &Path) -> String {
     let path = Path::new(raw_path);
     if let Ok(resolved) = resolve_user_path(work_root, raw_path)
         && let Ok(relative) = resolved.strip_prefix(work_root)
@@ -9143,39 +9143,6 @@ impl Agent {
         }
     }
 
-    pub(super) fn record_controller_verifier_repair_edit(
-        &mut self,
-        relative_path: &str,
-        fingerprint: &str,
-        target_hint: &super::task_contract::RecoveryTargetHint,
-    ) {
-        self.session.repo_edit_succeeded_this_turn = true;
-        self.session
-            .working_memory
-            .note_touched_file(normalize_memory_path(relative_path, &self.work_root));
-        self.observe_evidence_from_repo_edit(relative_path);
-        if let Some(context) = self.repair_job.as_mut() {
-            if !context
-                .applied_repair_intents
-                .iter()
-                .any(|existing| existing == fingerprint)
-            {
-                context.applied_repair_intents.push(fingerprint.to_string());
-                context.repair_error = None;
-            }
-            let key = super::repair_job::RepairAttemptKey::from_target(target_hint, None);
-            context.apply_event(super::repair_job::RepairJobEvent::PatchApplied { key });
-        }
-        log_llm_event(
-            "agent.verifier_repair_pass.repo_edit_recorded",
-            serde_json::json!({
-                "session_id": self.session_store.session_id(),
-                "path": relative_path,
-                "role": target_hint.role.label(),
-            }),
-        );
-    }
-
     fn record_controller_verifier_repair_invalid(
         &mut self,
         error: &str,
@@ -9841,7 +9808,7 @@ impl Agent {
     /// `classify_repo_edit_path` which uses the SSOT in `util::file_classify`
     /// and applies the DR1-001 ordering rule (`.mdx → Docs` even though
     /// `is_implementation_file` would otherwise claim it).
-    fn observe_evidence_from_repo_edit(&mut self, path: &str) {
+    pub(super) fn observe_evidence_from_repo_edit(&mut self, path: &str) {
         let Some(relative_path) = workspace_relative_path_for_tool_arg(&self.work_root, path)
         else {
             return;

--- a/src/agent/loop_run/verifier_orchestration.rs
+++ b/src/agent/loop_run/verifier_orchestration.rs
@@ -84,6 +84,7 @@ use super::tool_history::focused_edit_target_already_read;
 use super::tool_policy::{EffectiveToolPolicy, EffectiveToolPolicyReason};
 use super::turn::{
     TASK_CONTRACT_VERIFIER_ATTEMPT_LIMIT, TASK_CONTRACT_VERIFIER_REPAIR_ATTEMPT_LIMIT,
+    normalize_memory_path,
 };
 use super::verifier_assessment_parser::{
     ParsedVerifierRepairAssessment, verifier_failure_type_for_diagnostic_kind,
@@ -2084,7 +2085,8 @@ pub(super) fn apply_verifier_repair_pass_edit(
             edit.relative_path
         )));
     }
-    agent.record_controller_verifier_repair_edit(
+    record_controller_verifier_repair_edit(
+        agent,
         &edit.relative_path,
         &edit.fingerprint,
         target_hint,
@@ -2103,4 +2105,38 @@ pub(super) fn apply_verifier_repair_pass_edit(
     Ok(VerifierRepairPassOutcome::Applied {
         relative_path: edit.relative_path,
     })
+}
+
+pub(super) fn record_controller_verifier_repair_edit(
+    agent: &mut Agent,
+    relative_path: &str,
+    fingerprint: &str,
+    target_hint: &RecoveryTargetHint,
+) {
+    agent.session.repo_edit_succeeded_this_turn = true;
+    agent
+        .session
+        .working_memory
+        .note_touched_file(normalize_memory_path(relative_path, &agent.work_root));
+    agent.observe_evidence_from_repo_edit(relative_path);
+    if let Some(context) = agent.repair_job.as_mut() {
+        if !context
+            .applied_repair_intents
+            .iter()
+            .any(|existing| existing == fingerprint)
+        {
+            context.applied_repair_intents.push(fingerprint.to_string());
+            context.repair_error = None;
+        }
+        let key = super::repair_job::RepairAttemptKey::from_target(target_hint, None);
+        context.apply_event(super::repair_job::RepairJobEvent::PatchApplied { key });
+    }
+    log_llm_event(
+        "agent.verifier_repair_pass.repo_edit_recorded",
+        serde_json::json!({
+            "session_id": agent.session_store.session_id(),
+            "path": relative_path,
+            "role": target_hint.role.label(),
+        }),
+    );
 }


### PR DESCRIPTION
## Summary

Phase 2 batch 13 for Issue #682. Second `&mut Agent` veneer migration (continues batch 12 pattern).

### Moved (turn.rs `impl Agent` → verifier_orchestration.rs free fn)

- `record_controller_verifier_repair_edit` (32 LOC) — records a successful repair edit: flips `repo_edit_succeeded_this_turn`, notes the touched file in working memory, applies a `PatchApplied` repair-job event, and emits `agent.verifier_repair_pass.repo_edit_recorded`.

Signature:

```rust
pub(super) fn record_controller_verifier_repair_edit(
    agent: &mut Agent,
    relative_path: &str,
    fingerprint: &str,
    target_hint: &RecoveryTargetHint,
)
```

### Adjustments

- `verifier_orchestration.rs`:
  - Added `normalize_memory_path` to the `super::turn::` import block.
  - Rewrote `agent.record_controller_verifier_repair_edit(...)` in the `apply_verifier_repair_pass_edit` veneer (from batch 12) to `record_controller_verifier_repair_edit(agent, ...)` since the method is now a free fn in the same module.
- `turn.rs`:
  - Promoted `normalize_memory_path` (private helper) and `observe_evidence_from_repo_edit` (Agent method) to `pub(super)` so the veneer can call them.
  - Deleted the original `impl Agent` method body (32 LOC).
  - Updated 3 `include_str!` test markers in `v0421_repair_runner_contract_tests` that used the now-missing `\n    pub(super) fn record_controller_verifier_repair_edit(` as an end-marker for `run_verifier_repair_pass_and_apply` body scanning. The new end-marker is the next sibling Agent method: `\n    fn verifier_repair_pass_client(`.

### Metrics

| File | Before | After | Delta |
|---|---:|---:|---:|
| `src/agent/loop_run/turn.rs` | 32,967 | 32,934 | **-33** |
| `src/agent/loop_run/verifier_orchestration.rs` | 2,106 | 2,142 | +36 |

Cumulative Issue #682 progress: turn.rs 34,958 → 32,934 (**-2,024**, ~67% of Phase 2 target). Acceptance gap: 32,934 → 32,000 = **~934 LOC remaining**.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --lib` (3,114 passed)
- [ ] CI green (fmt / clippy / test / build)

## Layer rule notes

- No facade re-export (DR3-001 maintained).
- No photon → session → agent inversion (DR3-002 unchanged).
- Pure code-motion + visibility relaxation; no production-binary behaviour change.