### PR TITLE
Veneer-migrate 4 verifier dispatch helpers (Issue #682, batch 14)

### DIFF
--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -44,10 +44,9 @@ use super::reminder::{
 #[cfg(test)]
 use super::repair_driver::VERIFIER_REPAIR_PASS_TIMEOUT_SECS;
 use super::repair_driver::{
-    VERIFIER_REPAIR_PASS_ATTEMPT_LIMIT, VERIFIER_REPAIR_PASS_MAX_PREDICT,
-    VERIFIER_REPAIR_PASS_WALL_CLOCK_LIMIT_SECS, VerifierRepairPassOutcome,
-    verifier_repair_pass_attempt_timeout_secs, verifier_repair_pass_retry_message,
-    verifier_repair_pass_timeout_error,
+    VERIFIER_REPAIR_PASS_ATTEMPT_LIMIT, VERIFIER_REPAIR_PASS_WALL_CLOCK_LIMIT_SECS,
+    VerifierRepairPassOutcome, verifier_repair_pass_attempt_timeout_secs,
+    verifier_repair_pass_retry_message, verifier_repair_pass_timeout_error,
 };
 use super::repair_framework_findings::findings_for_diagnostic as verifier_framework_findings_for_diagnostic;
 #[cfg(test)]
@@ -383,7 +382,7 @@ mod v0421_repair_runner_contract_tests {
         let body = function_body(
             src,
             "\n    fn run_verifier_repair_pass_and_apply(",
-            "\n    fn verifier_repair_pass_client(",
+            "\n    fn verifier_repair_pass_wall_clock_timeout_error(",
         );
 
         assert!(body.contains("target_hint:"));
@@ -400,7 +399,7 @@ mod v0421_repair_runner_contract_tests {
         let body = function_body(
             src,
             "\n    fn run_verifier_repair_pass_and_apply(",
-            "\n    fn verifier_repair_pass_client(",
+            "\n    fn verifier_repair_pass_wall_clock_timeout_error(",
         );
 
         assert!(
@@ -427,7 +426,7 @@ mod v0421_repair_runner_contract_tests {
         let body = function_body(
             src,
             "\n    fn run_verifier_repair_pass_and_apply(",
-            "\n    fn verifier_repair_pass_client(",
+            "\n    fn verifier_repair_pass_wall_clock_timeout_error(",
         );
         let orchestration = include_str!("verifier_orchestration.rs");
         let prompt = function_body(
@@ -4661,7 +4660,8 @@ impl Agent {
             TaskContractVerifierSelection::StructuredMissing {
                 outcome,
                 owned_test_artifacts_count,
-            } => self.handle_missing_task_contract_verifier_selection(
+            } => super::verifier_orchestration::handle_missing_task_contract_verifier_selection(
+                self,
                 outcome,
                 owned_test_artifacts_count,
             ),
@@ -4674,7 +4674,7 @@ impl Agent {
                 command_for_log,
             ),
             TaskContractVerifierSelection::Missing => {
-                self.handle_absent_task_contract_verifier_selection()
+                super::verifier_orchestration::handle_absent_task_contract_verifier_selection(self)
             }
         }
     }
@@ -4689,7 +4689,7 @@ impl Agent {
         let recent_successful_bash_commands =
             super::success::recent_successful_bash_commands_since_last_user(&self.session.messages);
         let (owned_test_artifacts, test_execution_required, workspace_scope_opt) =
-            self.task_contract_verifier_test_binding();
+            super::verifier_orchestration::task_contract_verifier_test_binding(self);
         let active_request = self.active_request_text();
         let task_contract_project_unit = select_task_contract_project_unit(
             &self.work_root,
@@ -4867,47 +4867,6 @@ impl Agent {
         }
     }
 
-    fn handle_missing_task_contract_verifier_selection(
-        &mut self,
-        outcome: TaskContractVerifierOutcome,
-        owned_test_artifacts_count: usize,
-    ) -> TaskContractVerifierOutcome {
-        self.owned_test_verifier_missing_observed_this_turn = true;
-        self.owned_test_verifier_missing_observed_carryover = self
-            .active_request_text()
-            .as_deref()
-            .map(super::task_contract::RequestCarryoverKey::from_request);
-        let frame = super::success::build_feedback_for_no_verifier(&self.work_root);
-        self.session.record_feedback_if_unset(frame);
-        if matches!(outcome, TaskContractVerifierOutcome::NoVerifier) {
-            log_llm_event(
-                "agent.task_contract.verifier.completed",
-                serde_json::json!({
-                    "session_id": self.session_store.session_id(),
-                    "outcome": "no_structured_verifier",
-                    "owned_test_artifacts_count": owned_test_artifacts_count,
-                    "test_execution_required": true,
-                }),
-            );
-            return TaskContractVerifierOutcome::NoVerifier;
-        }
-        if !self.session.verifier_safe_stop_emitted_this_turn {
-            self.session.verifier_safe_stop_emitted_this_turn = true;
-            log_llm_event(
-                "agent.verifier.missing",
-                serde_json::json!({
-                    "session_id": self.session_store.session_id(),
-                    "turn_index": self.current_turn_index,
-                    "iter_index": self.session.iter_count_this_turn,
-                    "owned_test_artifacts_count": owned_test_artifacts_count,
-                    "auto_test_detected": false,
-                    "test_execution_required": true,
-                }),
-            );
-        }
-        outcome
-    }
-
     fn handle_legacy_task_contract_verifier_selection(
         &mut self,
         changed_files: &[String],
@@ -4950,19 +4909,6 @@ impl Agent {
             self.observe_task_contract_verifier_exit_zero(&result.command);
         }
         task_contract_auto_test_result_to_outcome(result)
-    }
-
-    fn handle_absent_task_contract_verifier_selection(&mut self) -> TaskContractVerifierOutcome {
-        let frame = super::success::build_feedback_for_no_verifier(&self.work_root);
-        self.session.record_feedback_if_unset(frame);
-        log_llm_event(
-            "agent.task_contract.verifier.completed",
-            serde_json::json!({
-                "session_id": self.session_store.session_id(),
-                "outcome": "no_verifier",
-            }),
-        );
-        TaskContractVerifierOutcome::NoVerifier
     }
 
     fn materialize_python_package_markers_for_external_import(
@@ -5024,29 +4970,6 @@ impl Agent {
             created.push(relative_path);
         }
         created
-    }
-
-    /// Issue #651 Phase 5.2: SSOT producer for the structured verifier
-    /// path's `(owned_test_artifacts, test_execution_required, scope)`
-    /// tuple. Builds a one-shot `TaskContract` from
-    /// `active_request_text()` so the request-derived signals stay
-    /// aligned with `success.rs::success_verifier_test_binding`.
-    /// Returns `(vec![], false, None)` when there is no active request.
-    fn task_contract_verifier_test_binding(
-        &mut self,
-    ) -> (
-        Vec<String>,
-        bool,
-        Option<super::task_workspace_scope::TaskWorkspaceScope>,
-    ) {
-        let Some(request) = self.active_request_text() else {
-            return (Vec::new(), false, None);
-        };
-        let contract = super::task_contract::TaskContract::from_request(&request);
-        let test_execution_required = contract.required_behavior.test_execution_required;
-        let owned_test_artifacts = self.owned_test_artifacts_for_verifier(&contract);
-        let scope = self.current_workspace_scope();
-        (owned_test_artifacts, test_execution_required, Some(scope))
     }
 
     fn handle_task_contract_verifier_pass(
@@ -8818,7 +8741,10 @@ impl Agent {
                 );
                 break;
             };
-            let repair_client = match self.verifier_repair_pass_client(attempt_timeout_secs) {
+            let repair_client = match super::verifier_orchestration::verifier_repair_pass_client(
+                self,
+                attempt_timeout_secs,
+            ) {
                 Ok(client) => client,
                 Err(err) => {
                     last_error = err;
@@ -8871,15 +8797,6 @@ impl Agent {
             error,
             repair_attempt_outcome: last_invalid_outcome,
         }
-    }
-
-    fn verifier_repair_pass_client(
-        &self,
-        attempt_timeout_secs: u64,
-    ) -> Result<OllamaClient, String> {
-        self.client
-            .clone_with_overrides(attempt_timeout_secs, VERIFIER_REPAIR_PASS_MAX_PREDICT)
-            .map_err(|err| format!("verifier_repair_pass_invalid: client clone failed: {err}"))
     }
 
     fn verifier_repair_pass_wall_clock_timeout_error(

--- a/src/agent/loop_run/verifier_orchestration.rs
+++ b/src/agent/loop_run/verifier_orchestration.rs
@@ -54,8 +54,8 @@ use super::repair_authority::AuthorityEvidence;
 use super::repair_driver::{
     VERIFIER_REPAIR_PASS_MAX_EDIT_BYTES, VERIFIER_REPAIR_PASS_MAX_EDITS,
     VERIFIER_REPAIR_PASS_MAX_FILE_BYTES, VERIFIER_REPAIR_PASS_MAX_FILE_EXCERPT_BYTES,
-    VERIFIER_REPAIR_PASS_MAX_OUTPUT_BYTES, VERIFIER_REPAIR_PASS_MAX_REASON_CHARS,
-    VerifierRepairPassOutcome,
+    VERIFIER_REPAIR_PASS_MAX_OUTPUT_BYTES, VERIFIER_REPAIR_PASS_MAX_PREDICT,
+    VERIFIER_REPAIR_PASS_MAX_REASON_CHARS, VerifierRepairPassOutcome,
 };
 use super::repair_framework_findings::{
     VerifierDiagnosticFileExcerpt,
@@ -79,7 +79,10 @@ use super::semantic_repair_planning::{
     diagnostic_target_allowed_by_confidence, first_role_kind_compatible_diagnostic_target,
 };
 use super::summary::ExitReason;
-use super::task_contract::{ArtifactRole, CompletionDecision, RecoveryTargetHint, TaskContract};
+use super::task_contract::{
+    ArtifactRole, CompletionDecision, RecoveryTargetHint, RequestCarryoverKey, TaskContract,
+};
+use super::task_workspace_scope::TaskWorkspaceScope;
 use super::tool_history::focused_edit_target_already_read;
 use super::tool_policy::{EffectiveToolPolicy, EffectiveToolPolicyReason};
 use super::turn::{
@@ -90,6 +93,7 @@ use super::verifier_assessment_parser::{
     ParsedVerifierRepairAssessment, verifier_failure_type_for_diagnostic_kind,
 };
 use super::verifier_diagnostic_attempt::VerifierDiagnosticAttemptSpec;
+use super::verifier_driver::TaskContractVerifierOutcome;
 use super::verifier_failure_signature::compact_verifier_failure_text;
 use super::verifier_repair_shadow::verifier_repair_action_payload_for_context;
 use super::verifier_repair_targeting::{
@@ -101,6 +105,7 @@ use super::{Agent, VerifierRepairAssessment, VerifierRepairAssessmentSource};
 use crate::agent::orchestration::{RepoSnapshot, RepoVerification};
 use crate::logging::{log_llm_event, stable_path_hash};
 use crate::modes::plan_act::ExecutionMode;
+use crate::ollama::client::OllamaClient;
 use crate::safety::path_guard::resolve_user_path;
 use crate::session::feedback::mask_secrets;
 use crate::session::store::ConversationMessage;
@@ -2139,4 +2144,83 @@ pub(super) fn record_controller_verifier_repair_edit(
             "role": target_hint.role.label(),
         }),
     );
+}
+
+pub(super) fn verifier_repair_pass_client(
+    agent: &Agent,
+    attempt_timeout_secs: u64,
+) -> Result<OllamaClient, String> {
+    agent
+        .client
+        .clone_with_overrides(attempt_timeout_secs, VERIFIER_REPAIR_PASS_MAX_PREDICT)
+        .map_err(|err| format!("verifier_repair_pass_invalid: client clone failed: {err}"))
+}
+
+pub(super) fn task_contract_verifier_test_binding(
+    agent: &mut Agent,
+) -> (Vec<String>, bool, Option<TaskWorkspaceScope>) {
+    let Some(request) = agent.active_request_text() else {
+        return (Vec::new(), false, None);
+    };
+    let contract = TaskContract::from_request(&request);
+    let test_execution_required = contract.required_behavior.test_execution_required;
+    let owned_test_artifacts = agent.owned_test_artifacts_for_verifier(&contract);
+    let scope = agent.current_workspace_scope();
+    (owned_test_artifacts, test_execution_required, Some(scope))
+}
+
+pub(super) fn handle_absent_task_contract_verifier_selection(
+    agent: &mut Agent,
+) -> TaskContractVerifierOutcome {
+    let frame = super::success::build_feedback_for_no_verifier(&agent.work_root);
+    agent.session.record_feedback_if_unset(frame);
+    log_llm_event(
+        "agent.task_contract.verifier.completed",
+        serde_json::json!({
+            "session_id": agent.session_store.session_id(),
+            "outcome": "no_verifier",
+        }),
+    );
+    TaskContractVerifierOutcome::NoVerifier
+}
+
+pub(super) fn handle_missing_task_contract_verifier_selection(
+    agent: &mut Agent,
+    outcome: TaskContractVerifierOutcome,
+    owned_test_artifacts_count: usize,
+) -> TaskContractVerifierOutcome {
+    agent.owned_test_verifier_missing_observed_this_turn = true;
+    agent.owned_test_verifier_missing_observed_carryover = agent
+        .active_request_text()
+        .as_deref()
+        .map(RequestCarryoverKey::from_request);
+    let frame = super::success::build_feedback_for_no_verifier(&agent.work_root);
+    agent.session.record_feedback_if_unset(frame);
+    if matches!(outcome, TaskContractVerifierOutcome::NoVerifier) {
+        log_llm_event(
+            "agent.task_contract.verifier.completed",
+            serde_json::json!({
+                "session_id": agent.session_store.session_id(),
+                "outcome": "no_structured_verifier",
+                "owned_test_artifacts_count": owned_test_artifacts_count,
+                "test_execution_required": true,
+            }),
+        );
+        return TaskContractVerifierOutcome::NoVerifier;
+    }
+    if !agent.session.verifier_safe_stop_emitted_this_turn {
+        agent.session.verifier_safe_stop_emitted_this_turn = true;
+        log_llm_event(
+            "agent.verifier.missing",
+            serde_json::json!({
+                "session_id": agent.session_store.session_id(),
+                "turn_index": agent.current_turn_index,
+                "iter_index": agent.session.iter_count_this_turn,
+                "owned_test_artifacts_count": owned_test_artifacts_count,
+                "auto_test_detected": false,
+                "test_execution_required": true,
+            }),
+        );
+    }
+    outcome
 }


### PR DESCRIPTION
## Summary

Phase 2 batch 14 for Issue #682. Migrates 4 more `impl Agent` dispatch methods to `verifier_orchestration.rs` free fns using the `&mut Agent` veneer pattern from batches 12-13.

### Moved (turn.rs `impl Agent` → verifier_orchestration.rs free fn)

- `verifier_repair_pass_client` (8 LOC) — clones the `OllamaClient` with the verifier-repair attempt timeout / max-predict overrides. First `&Agent` (immutable) veneer in the new module.
- `task_contract_verifier_test_binding` (16 LOC) — SSOT producer for the structured verifier path's `(owned_test_artifacts, test_execution_required, scope)` tuple.
- `handle_absent_task_contract_verifier_selection` (12 LOC) — records the no-verifier feedback frame + emits `agent.task_contract.verifier.completed` event when no verifier is detected.
- `handle_missing_task_contract_verifier_selection` (40 LOC) — same flow as above but for the structured-verifier-missing path, plus carryover-key recording + `verifier.missing` safe-stop event.

### Adjustments

- `verifier_orchestration.rs`: added imports for `VERIFIER_REPAIR_PASS_MAX_PREDICT`, `RequestCarryoverKey`, `TaskWorkspaceScope`, `TaskContractVerifierOutcome`, `OllamaClient`.
- `turn.rs`:
  - Deleted the original 4 `impl Agent` method bodies (76 LOC).
  - Rewrote 4 call sites to call the free fns via `super::verifier_orchestration::*`, passing `self` as the first argument.
  - Removed `VERIFIER_REPAIR_PASS_MAX_PREDICT` from `super::repair_driver` re-import (only the moved `verifier_repair_pass_client` referenced it).
  - Cleaned an orphaned doc-comment block left above the moved `task_contract_verifier_test_binding` method (clippy `empty_line_after_doc_comments` under `-D warnings`).
  - Updated 3 `include_str!` end markers in `v0421_repair_runner_contract_tests` from `\n    fn verifier_repair_pass_client(` (which had already moved) to `\n    fn verifier_repair_pass_wall_clock_timeout_error(` (the next surviving sibling Agent method after `run_verifier_repair_pass_and_apply`).

### Metrics

| File | Before | After | Delta |
|---|---:|---:|---:|
| `src/agent/loop_run/turn.rs` | 32,934 | 32,851 | **-83** |
| `src/agent/loop_run/verifier_orchestration.rs` | 2,142 | 2,226 | +84 |

Cumulative Issue #682 progress: turn.rs 34,958 → 32,851 (**-2,107**, ~70% of Phase 2 target). Acceptance gap: 32,851 → 32,000 = **~851 LOC remaining**.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --lib` (3,114 passed)
- [ ] CI green (fmt / clippy / test / build)

## Layer rule notes

- No facade re-export (DR3-001 maintained).
- No photon → session → agent inversion (DR3-002 unchanged).
- Pure code-motion + visibility relaxation; no production-binary behaviour change.