### PR TITLE
Veneer-migrate 4 verifier dispatch core methods (Issue #682, batch 16)

### DIFF
--- a/src/agent/loop_run/actor_loop_flow.rs
+++ b/src/agent/loop_run/actor_loop_flow.rs
@@ -1902,7 +1902,7 @@ pub(super) fn handle_actor_loop_pre_reply_control_action(
             .dispatch_missing_verifier_job_step(flow_args, next_action)
             .map(actor_loop_pre_reply_flow_outcome),
         LoopControlAction::RunVerifier => Some(actor_loop_pre_reply_flow_outcome(
-            agent.drive_task_contract_verifier(flow_args),
+            super::verifier_orchestration::drive_task_contract_verifier(agent, flow_args),
         )),
         LoopControlAction::RequestModelTurn => None,
     }
@@ -2309,7 +2309,8 @@ pub(super) fn handle_actor_loop_task_contract_run_verifier(
     agent: &mut Agent,
     args: ActorLoopTaskContractReplyArgs<'_, '_>,
 ) -> ActorLoopTaskContractReplyOutcome {
-    match agent.drive_task_contract_verifier(
+    match super::verifier_orchestration::drive_task_contract_verifier(
+        agent,
         super::verifier_orchestration::TaskContractVerifierFlowArgs {
             before_snapshot: args.before_snapshot,
             accumulated: args.accumulated,

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -19,7 +19,7 @@ use super::actor_loop_flow::{
     format_iteration_status, repair_job_done_outcome, run_actor_loop,
 };
 use super::auto_test::{
-    AutoTestKind, AutoTestPlan, AutoTestResult, AutoTestRunner, auto_test_disabled,
+    AutoTestKind, AutoTestPlan, AutoTestResult, AutoTestRunner,
     build_agent_verifier_external_import_rejected_payload, build_agent_verifier_invoked_payload,
     classify_auto_test, count_compile_errors, count_test_failures,
 };
@@ -148,10 +148,10 @@ use super::verifier_driver::classify_verifier_timeout;
 #[cfg(test)]
 use super::verifier_driver::task_contract_structured_missing_outcome;
 use super::verifier_driver::{
-    TaskContractVerifierOutcome, TaskContractVerifierSelection,
-    detect_verifier_external_import_contamination, run_structured_task_contract_verifier,
-    structured_verifier_invocation_report, task_contract_auto_test_result_to_outcome,
-    task_contract_verifier_outcome_label, task_contract_verifier_transport_error_to_outcome,
+    TaskContractVerifierOutcome, detect_verifier_external_import_contamination,
+    run_structured_task_contract_verifier, structured_verifier_invocation_report,
+    task_contract_auto_test_result_to_outcome, task_contract_verifier_outcome_label,
+    task_contract_verifier_transport_error_to_outcome,
 };
 use super::verifier_failure_signature::compact_verifier_failure_text;
 #[cfg(test)]
@@ -368,7 +368,9 @@ mod v0421_repair_runner_contract_tests {
         assert!(dispatch.contains("RepairStep::RunVerifier"));
         assert!(dispatch.contains("self.drive_repair_job_verifier(args)"));
         assert!(
-            !dispatch.contains("self.drive_task_contract_verifier(args)"),
+            !dispatch.contains(
+                "super::verifier_orchestration::drive_task_contract_verifier(self, args)"
+            ),
             "repair job verifier rerun must not re-enter the job-rebuilding verifier flow"
         );
     }
@@ -4612,73 +4614,7 @@ impl Agent {
         }
     }
 
-    fn run_task_contract_verifier_once(
-        &mut self,
-        changed_files: &[String],
-    ) -> TaskContractVerifierOutcome {
-        if auto_test_disabled(|key| std::env::var(key)) {
-            log_llm_event(
-                "agent.task_contract.verifier.completed",
-                serde_json::json!({
-                    "session_id": self.session_store.session_id(),
-                    "outcome": "disabled",
-                }),
-            );
-            return TaskContractVerifierOutcome::Disabled;
-        }
-
-        let (verifier_selection, workspace_scope_opt) =
-            super::verifier_orchestration::select_task_contract_verifier_once(self, changed_files);
-        match verifier_selection {
-            TaskContractVerifierSelection::StructuredRunnable {
-                plan,
-                command,
-                display_command,
-                bound_test_artifacts_count,
-                bound_test_artifacts_paths,
-            } => self.handle_structured_task_contract_verifier_selection(
-                changed_files,
-                workspace_scope_opt.as_ref(),
-                StructuredTaskContractVerifierRun {
-                    plan,
-                    command,
-                    display_command,
-                    bound_test_artifacts_count,
-                    bound_test_artifacts_paths,
-                },
-            ),
-            TaskContractVerifierSelection::StructuredWeak {
-                detected_source,
-                owned_test_artifacts_count,
-            } => super::verifier_orchestration::handle_weak_task_contract_verifier_selection(
-                self,
-                detected_source,
-                owned_test_artifacts_count,
-            ),
-            TaskContractVerifierSelection::StructuredMissing {
-                outcome,
-                owned_test_artifacts_count,
-            } => super::verifier_orchestration::handle_missing_task_contract_verifier_selection(
-                self,
-                outcome,
-                owned_test_artifacts_count,
-            ),
-            TaskContractVerifierSelection::LegacyRunnable {
-                plan,
-                command_for_log,
-            } => super::verifier_orchestration::handle_legacy_task_contract_verifier_selection(
-                self,
-                changed_files,
-                plan,
-                command_for_log,
-            ),
-            TaskContractVerifierSelection::Missing => {
-                super::verifier_orchestration::handle_absent_task_contract_verifier_selection(self)
-            }
-        }
-    }
-
-    fn handle_structured_task_contract_verifier_selection(
+    pub(super) fn handle_structured_task_contract_verifier_selection(
         &mut self,
         changed_files: &[String],
         workspace_scope: Option<&super::task_workspace_scope::TaskWorkspaceScope>,
@@ -4859,49 +4795,7 @@ impl Agent {
         created
     }
 
-    fn handle_task_contract_verifier_pass(
-        &mut self,
-        args: TaskContractVerifierFlowArgs<'_, '_>,
-        previous_repair_context: Option<super::repair_job::RepairJob>,
-        command: String,
-    ) -> TaskContractVerifierFlowOutcome {
-        if task_contract_needs_verification(
-            self.session.mode_state.mode,
-            args.task_contract,
-            &self.task_contract_evidence_set_this_turn,
-        ) {
-            return TaskContractVerifierFlowOutcome::Exit {
-                reason: ExitReason::MissingVerification,
-                error_text: "verifier passed but verifier evidence could not be recorded"
-                    .to_string(),
-            };
-        }
-        let safe_command = crate::session::feedback::mask_secrets(&command).replace('`', "\\`");
-        if let Some(sanitized) =
-            super::verifier_skill::sanitize_verify_command_for_case_record(&command)
-        {
-            args.task_contract_verify_commands_collected.push(sanitized);
-        }
-        emit_repair_progress_classified_event(
-            self.session_store.session_id(),
-            previous_repair_context.as_ref(),
-            None,
-            true,
-        );
-        self.repair_job = None;
-        self.missing_verifier_job = None;
-        *args.verifier_repair_retries = 0;
-        self.repair_job_artifact_attempts = 0;
-        *args.task_contract_verifier_passed_in_loop = true;
-        self.task_contract_verifier_passed_this_actor_loop = true;
-        TaskContractVerifierFlowOutcome::Done {
-            final_prose: format!(
-                "Completed requested repository changes and verified them with `{safe_command}`."
-            ),
-        }
-    }
-
-    fn handle_task_contract_verifier_failure(
+    pub(super) fn handle_task_contract_verifier_failure(
         &mut self,
         args: TaskContractVerifierFlowArgs<'_, '_>,
         previous_repair_context: Option<super::repair_job::RepairJob>,
@@ -4987,58 +4881,6 @@ impl Agent {
             *args.contract_verification_retries,
             attempt_limit,
             self.repair_job.as_ref(),
-        ));
-        TaskContractVerifierFlowOutcome::Continue
-    }
-
-    fn handle_task_contract_verifier_no_verifier(
-        &mut self,
-        args: TaskContractVerifierFlowArgs<'_, '_>,
-    ) -> TaskContractVerifierFlowOutcome {
-        if self.missing_verifier_job.is_none() {
-            self.missing_verifier_job = Some(super::repair_job::MissingVerifierJob::new(
-                TASK_CONTRACT_VERIFIER_ATTEMPT_LIMIT as u8,
-                args.repo_edit_calls_made_this_turn,
-            ));
-        }
-        let budget_exhausted = self
-            .missing_verifier_job
-            .as_mut()
-            .is_some_and(|job| !job.record_retry());
-        if budget_exhausted {
-            self.emit_safe_stop_report_for_verifier_missing();
-            return TaskContractVerifierFlowOutcome::Exit {
-                reason: ExitReason::MissingVerification,
-                error_text:
-                    "task contract requires verification, but the MissingVerifierJob retry budget is exhausted"
-                        .to_string(),
-            };
-        }
-        *args.contract_verifier_repair_edit_count = Some(args.repo_edit_calls_made_this_turn);
-        self.task_contract_verifier_repair_pending = true;
-        self.repair_job = None;
-        *args.repo_change_retries = 0;
-        *args.verifier_repair_retries = 0;
-        self.repair_job_artifact_attempts = 0;
-        write_stdout_rendered(
-            &format_iteration_status(
-                args.last_iter,
-                self.config.max_iterations,
-                "Verification missing",
-                "Asked the model to add or fix a runnable verifier path.",
-                self.footer.current_cols(),
-            ),
-            true,
-        );
-        let job_attempt = self
-            .missing_verifier_job
-            .as_ref()
-            .map(|job| job.retries_used as usize)
-            .unwrap_or(0);
-        self.push_system_note(task_contract_no_verifier_note(
-            job_attempt,
-            TASK_CONTRACT_VERIFIER_ATTEMPT_LIMIT,
-            self.active_request_text().unwrap_or_default().as_str(),
         ));
         TaskContractVerifierFlowOutcome::Continue
     }
@@ -5214,64 +5056,6 @@ impl Agent {
             });
         }
         outcome
-    }
-
-    pub(super) fn drive_task_contract_verifier(
-        &mut self,
-        args: TaskContractVerifierFlowArgs<'_, '_>,
-    ) -> TaskContractVerifierFlowOutcome {
-        *args.contract_verifier_repair_edit_count = None;
-        self.task_contract_verifier_repair_pending = false;
-        self.clear_artifact_recovery_target("artifact_controller_verify_pending");
-        let previous_repair_context = self.repair_job.clone();
-        self.repair_job = None;
-        let current_verif = verify_repo_progress(args.before_snapshot, &self.work_root);
-        let changed_files = changed_files_for_verifier(args.accumulated, &current_verif);
-        write_stdout_rendered(
-            &format_iteration_status(
-                args.last_iter,
-                self.config.max_iterations,
-                "Task contract",
-                "Running verifier for completed required artifacts.",
-                self.footer.current_cols(),
-            ),
-            true,
-        );
-        match self.run_task_contract_verifier_once(&changed_files) {
-            TaskContractVerifierOutcome::Passed { command } => {
-                self.handle_task_contract_verifier_pass(args, previous_repair_context, command)
-            }
-            TaskContractVerifierOutcome::Failed { command, output } => self
-                .handle_task_contract_verifier_failure(
-                    args,
-                    previous_repair_context,
-                    &changed_files,
-                    command,
-                    output,
-                ),
-            TaskContractVerifierOutcome::NoVerifier => {
-                self.handle_task_contract_verifier_no_verifier(args)
-            }
-            TaskContractVerifierOutcome::Disabled => TaskContractVerifierFlowOutcome::Exit {
-                reason: ExitReason::MissingVerification,
-                error_text: "task contract requires verification, but ANVIL_NO_AUTO_TEST is set"
-                    .to_string(),
-            },
-            TaskContractVerifierOutcome::TransportError { error } => {
-                TaskContractVerifierFlowOutcome::Exit {
-                    reason: ExitReason::TransportError,
-                    error_text: error,
-                }
-            }
-            TaskContractVerifierOutcome::SafeStop { reason } => {
-                super::verifier_orchestration::handle_task_contract_verifier_safe_stop(
-                    self,
-                    args.last_iter,
-                    reason,
-                    "task_contract_verifier",
-                )
-            }
-        }
     }
 
     pub(super) fn dispatch_repair_job_step(
@@ -5454,7 +5238,7 @@ impl Agent {
             true,
         );
 
-        match self.run_task_contract_verifier_once(&changed_files) {
+        match super::verifier_orchestration::run_task_contract_verifier_once(self, &changed_files) {
             TaskContractVerifierOutcome::Passed { command } => {
                 self.handle_repair_job_verifier_pass(args, previous_repair_context, command)
             }
@@ -5493,9 +5277,9 @@ impl Agent {
     ) -> Option<TaskContractVerifierFlowOutcome> {
         match next_action {
             super::repair_job::VerifierBootstrapNextAction::RequestSetupEdit => None,
-            super::repair_job::VerifierBootstrapNextAction::RerunVerifier => {
-                Some(self.drive_task_contract_verifier(args))
-            }
+            super::repair_job::VerifierBootstrapNextAction::RerunVerifier => Some(
+                super::verifier_orchestration::drive_task_contract_verifier(self, args),
+            ),
             super::repair_job::VerifierBootstrapNextAction::SafeStop { reason } => {
                 self.emit_safe_stop_report_for_verifier_missing();
                 Some(TaskContractVerifierFlowOutcome::Exit {

--- a/src/agent/loop_run/verifier_orchestration.rs
+++ b/src/agent/loop_run/verifier_orchestration.rs
@@ -102,7 +102,7 @@ use super::verifier_repair_targeting::{
     verifier_repair_preferred_local_import_source, verifier_repair_stale_assertion_test_target,
 };
 use super::{Agent, VerifierRepairAssessment, VerifierRepairAssessmentSource};
-use crate::agent::orchestration::{RepoSnapshot, RepoVerification};
+use crate::agent::orchestration::{RepoSnapshot, RepoVerification, verify_repo_progress};
 use crate::logging::{log_llm_event, stable_path_hash};
 use crate::modes::plan_act::ExecutionMode;
 use crate::ollama::client::OllamaClient;
@@ -2360,4 +2360,226 @@ pub(super) fn handle_legacy_task_contract_verifier_selection(
         agent.observe_task_contract_verifier_exit_zero(&result.command);
     }
     super::verifier_driver::task_contract_auto_test_result_to_outcome(result)
+}
+
+pub(super) fn handle_task_contract_verifier_pass(
+    agent: &mut Agent,
+    args: TaskContractVerifierFlowArgs<'_, '_>,
+    previous_repair_context: Option<RepairJob>,
+    command: String,
+) -> super::actor_loop_flow::TaskContractVerifierFlowOutcome {
+    if task_contract_needs_verification(
+        agent.session.mode_state.mode,
+        args.task_contract,
+        &agent.task_contract_evidence_set_this_turn,
+    ) {
+        return super::actor_loop_flow::TaskContractVerifierFlowOutcome::Exit {
+            reason: ExitReason::MissingVerification,
+            error_text: "verifier passed but verifier evidence could not be recorded".to_string(),
+        };
+    }
+    let safe_command = crate::session::feedback::mask_secrets(&command).replace('`', "\\`");
+    if let Some(sanitized) =
+        super::verifier_skill::sanitize_verify_command_for_case_record(&command)
+    {
+        args.task_contract_verify_commands_collected.push(sanitized);
+    }
+    emit_repair_progress_classified_event(
+        agent.session_store.session_id(),
+        previous_repair_context.as_ref(),
+        None,
+        true,
+    );
+    agent.repair_job = None;
+    agent.missing_verifier_job = None;
+    *args.verifier_repair_retries = 0;
+    agent.repair_job_artifact_attempts = 0;
+    *args.task_contract_verifier_passed_in_loop = true;
+    agent.task_contract_verifier_passed_this_actor_loop = true;
+    super::actor_loop_flow::TaskContractVerifierFlowOutcome::Done {
+        final_prose: format!(
+            "Completed requested repository changes and verified them with `{safe_command}`."
+        ),
+    }
+}
+
+pub(super) fn handle_task_contract_verifier_no_verifier(
+    agent: &mut Agent,
+    args: TaskContractVerifierFlowArgs<'_, '_>,
+) -> super::actor_loop_flow::TaskContractVerifierFlowOutcome {
+    if agent.missing_verifier_job.is_none() {
+        agent.missing_verifier_job = Some(super::repair_job::MissingVerifierJob::new(
+            TASK_CONTRACT_VERIFIER_ATTEMPT_LIMIT as u8,
+            args.repo_edit_calls_made_this_turn,
+        ));
+    }
+    let budget_exhausted = agent
+        .missing_verifier_job
+        .as_mut()
+        .is_some_and(|job| !job.record_retry());
+    if budget_exhausted {
+        agent.emit_safe_stop_report_for_verifier_missing();
+        return super::actor_loop_flow::TaskContractVerifierFlowOutcome::Exit {
+            reason: ExitReason::MissingVerification,
+            error_text:
+                "task contract requires verification, but the MissingVerifierJob retry budget is exhausted"
+                    .to_string(),
+        };
+    }
+    *args.contract_verifier_repair_edit_count = Some(args.repo_edit_calls_made_this_turn);
+    agent.task_contract_verifier_repair_pending = true;
+    agent.repair_job = None;
+    *args.repo_change_retries = 0;
+    *args.verifier_repair_retries = 0;
+    agent.repair_job_artifact_attempts = 0;
+    super::turn::write_stdout_rendered(
+        &super::actor_loop_flow::format_iteration_status(
+            args.last_iter,
+            agent.config.max_iterations,
+            "Verification missing",
+            "Asked the model to add or fix a runnable verifier path.",
+            agent.footer.current_cols(),
+        ),
+        true,
+    );
+    let job_attempt = agent
+        .missing_verifier_job
+        .as_ref()
+        .map(|job| job.retries_used as usize)
+        .unwrap_or(0);
+    agent.push_system_note(task_contract_no_verifier_note(
+        job_attempt,
+        TASK_CONTRACT_VERIFIER_ATTEMPT_LIMIT,
+        agent.active_request_text().unwrap_or_default().as_str(),
+    ));
+    super::actor_loop_flow::TaskContractVerifierFlowOutcome::Continue
+}
+
+pub(super) fn run_task_contract_verifier_once(
+    agent: &mut Agent,
+    changed_files: &[String],
+) -> TaskContractVerifierOutcome {
+    if super::auto_test::auto_test_disabled(|key| std::env::var(key)) {
+        log_llm_event(
+            "agent.task_contract.verifier.completed",
+            serde_json::json!({
+                "session_id": agent.session_store.session_id(),
+                "outcome": "disabled",
+            }),
+        );
+        return TaskContractVerifierOutcome::Disabled;
+    }
+
+    let (verifier_selection, workspace_scope_opt) =
+        select_task_contract_verifier_once(agent, changed_files);
+    match verifier_selection {
+        super::verifier_driver::TaskContractVerifierSelection::StructuredRunnable {
+            plan,
+            command,
+            display_command,
+            bound_test_artifacts_count,
+            bound_test_artifacts_paths,
+        } => agent.handle_structured_task_contract_verifier_selection(
+            changed_files,
+            workspace_scope_opt.as_ref(),
+            StructuredTaskContractVerifierRun {
+                plan,
+                command,
+                display_command,
+                bound_test_artifacts_count,
+                bound_test_artifacts_paths,
+            },
+        ),
+        super::verifier_driver::TaskContractVerifierSelection::StructuredWeak {
+            detected_source,
+            owned_test_artifacts_count,
+        } => handle_weak_task_contract_verifier_selection(
+            agent,
+            detected_source,
+            owned_test_artifacts_count,
+        ),
+        super::verifier_driver::TaskContractVerifierSelection::StructuredMissing {
+            outcome,
+            owned_test_artifacts_count,
+        } => handle_missing_task_contract_verifier_selection(
+            agent,
+            outcome,
+            owned_test_artifacts_count,
+        ),
+        super::verifier_driver::TaskContractVerifierSelection::LegacyRunnable {
+            plan,
+            command_for_log,
+        } => handle_legacy_task_contract_verifier_selection(
+            agent,
+            changed_files,
+            plan,
+            command_for_log,
+        ),
+        super::verifier_driver::TaskContractVerifierSelection::Missing => {
+            handle_absent_task_contract_verifier_selection(agent)
+        }
+    }
+}
+
+pub(super) fn drive_task_contract_verifier(
+    agent: &mut Agent,
+    args: TaskContractVerifierFlowArgs<'_, '_>,
+) -> super::actor_loop_flow::TaskContractVerifierFlowOutcome {
+    *args.contract_verifier_repair_edit_count = None;
+    agent.task_contract_verifier_repair_pending = false;
+    agent.clear_artifact_recovery_target("artifact_controller_verify_pending");
+    let previous_repair_context = agent.repair_job.clone();
+    agent.repair_job = None;
+    let current_verif = verify_repo_progress(args.before_snapshot, &agent.work_root);
+    let changed_files = super::verifier_repair_targeting::changed_files_for_verifier(
+        args.accumulated,
+        &current_verif,
+    );
+    super::turn::write_stdout_rendered(
+        &super::actor_loop_flow::format_iteration_status(
+            args.last_iter,
+            agent.config.max_iterations,
+            "Task contract",
+            "Running verifier for completed required artifacts.",
+            agent.footer.current_cols(),
+        ),
+        true,
+    );
+    match run_task_contract_verifier_once(agent, &changed_files) {
+        TaskContractVerifierOutcome::Passed { command } => {
+            handle_task_contract_verifier_pass(agent, args, previous_repair_context, command)
+        }
+        TaskContractVerifierOutcome::Failed { command, output } => agent
+            .handle_task_contract_verifier_failure(
+                args,
+                previous_repair_context,
+                &changed_files,
+                command,
+                output,
+            ),
+        TaskContractVerifierOutcome::NoVerifier => {
+            handle_task_contract_verifier_no_verifier(agent, args)
+        }
+        TaskContractVerifierOutcome::Disabled => {
+            super::actor_loop_flow::TaskContractVerifierFlowOutcome::Exit {
+                reason: ExitReason::MissingVerification,
+                error_text: "task contract requires verification, but ANVIL_NO_AUTO_TEST is set"
+                    .to_string(),
+            }
+        }
+        TaskContractVerifierOutcome::TransportError { error } => {
+            super::actor_loop_flow::TaskContractVerifierFlowOutcome::Exit {
+                reason: ExitReason::TransportError,
+                error_text: error,
+            }
+        }
+        TaskContractVerifierOutcome::SafeStop { reason } => {
+            handle_task_contract_verifier_safe_stop(
+                agent,
+                args.last_iter,
+                reason,
+                "task_contract_verifier",
+            )
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Phase 2 batch 16 for Issue #682. Migrates 4 more `impl Agent` dispatch methods including the **top-level entry point `drive_task_contract_verifier`** and related core helpers.

### Moved (turn.rs `impl Agent` → verifier_orchestration.rs free fn)

- `drive_task_contract_verifier` (57 LOC, top-level dispatch entry point) — runs the verifier-once + dispatches to pass / failure / no_verifier / safe_stop / Disabled / TransportError branches.
- `run_task_contract_verifier_once` (65 LOC) — selects + runs the verifier exactly once and routes to one of 6 `TaskContractVerifierSelection` branches.
- `handle_task_contract_verifier_pass` (41 LOC) — sanitizes the verifier command, emits the repair-progress classified event, clears `repair_job`/`missing_verifier_job`, and returns Done.
- `handle_task_contract_verifier_no_verifier` (51 LOC) — installs/advances `MissingVerifierJob`, emits safe-stop on budget exhaust, or returns Continue with the missing-verifier system note.

### Adjustments

- `verifier_orchestration.rs`: added `verify_repo_progress` to the existing `crate::agent::orchestration` import block (all other deps already imported from earlier batches or live in sibling modules reached via `super::*`).
- `turn.rs`:
  - Promoted 2 Agent methods to `pub(super)` so the relocated `drive_`/`run_` veneers can call them via `agent.method(...)`: `handle_task_contract_verifier_failure` (89 LOC, not migrated this batch — only opened for cross-module access), `handle_structured_task_contract_verifier_selection` (62 LOC).
  - Deleted the 4 original `impl Agent` method bodies (214 LOC).
  - Rewrote `self.run_task_contract_verifier_once(...)` and `self.drive_task_contract_verifier(...)` call sites (production + 2 in `actor_loop_flow.rs`) to `super::verifier_orchestration::*(self, ...)`.
  - Dropped now-unused turn.rs imports `auto_test_disabled` + `TaskContractVerifierSelection`.
- `actor_loop_flow.rs`:
  - 2 `agent.drive_task_contract_verifier(...)` call sites rewritten to `super::verifier_orchestration::drive_task_contract_verifier(agent, ...)`.

### Metrics

| File | Before | After | Delta |
|---|---:|---:|---:|
| `src/agent/loop_run/turn.rs` | 32,726 | 32,510 | **-216** |
| `src/agent/loop_run/verifier_orchestration.rs` | 2,363 | 2,585 | +222 |

Cumulative Issue #682 progress: turn.rs 34,958 → 32,510 (**-2,448**, ~82% of Phase 2 target). Acceptance gap: 32,510 → 32,000 = **~510 LOC remaining**.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --lib` (3,114 passed)
- [ ] CI green (fmt / clippy / test / build)

## Layer rule notes

- No facade re-export (DR3-001 maintained).
- No photon → session → agent inversion (DR3-002 unchanged).
- Pure code-motion + visibility relaxation; no production-binary behaviour change.