### PR TITLE
Relocate 5 scaffold framework-detection helpers (Issue #683, batch 2)

### DIFF
--- a/src/agent/loop_run/scaffold_pipeline.rs
+++ b/src/agent/loop_run/scaffold_pipeline.rs
@@ -36,6 +36,9 @@
 
 use std::path::PathBuf;
 
+use crate::ollama::client::AssistantReply;
+use crate::ollama::xml_fallback::ToolCall;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum ScaffoldFramework {
     Next,
@@ -74,3 +77,69 @@ pub(super) const EVENT_DETERMINISTIC_FORMAT_ERROR_SMALL_EDIT: &str =
 pub(super) const EVENT_DETERMINISTIC_PYTHON_TEST_FALLBACK: &str =
     "agent.empty_workspace.deterministic_python_test_fallback";
 pub(super) const CREATE_NEXT_APP_PACKAGE_VERSION: &str = "16.2.4";
+
+pub(super) fn task_requires_nextjs_scaffold(task: &str) -> bool {
+    requested_scaffold_framework(task) == Some(ScaffoldFramework::Next)
+}
+
+pub(super) fn requested_scaffold_framework(task: &str) -> Option<ScaffoldFramework> {
+    let normalized = task.to_ascii_lowercase();
+    if normalized.contains("next.js") || normalized.contains("nextjs") {
+        Some(ScaffoldFramework::Next)
+    } else if normalized.contains("nuxt.js") || normalized.contains("nuxt") {
+        Some(ScaffoldFramework::Nuxt)
+    } else if normalized.contains("react.js") || normalized.contains("react") {
+        Some(ScaffoldFramework::React)
+    } else {
+        None
+    }
+}
+
+pub(super) fn scaffold_command_matches_framework(
+    framework: ScaffoldFramework,
+    command: &str,
+) -> bool {
+    let normalized = command.to_ascii_lowercase();
+    match framework {
+        ScaffoldFramework::Next => normalized.contains("create-next-app"),
+        ScaffoldFramework::React => {
+            (normalized.contains("create vite")
+                || normalized.contains("create-vite")
+                || normalized.contains("vite@latest")
+                || normalized.contains("vite@"))
+                && normalized.contains("react")
+        }
+        ScaffoldFramework::Nuxt => {
+            normalized.contains("nuxi")
+                || normalized.contains("create-nuxt")
+                || normalized.contains("create nuxt")
+                || normalized.contains("nuxt@")
+        }
+    }
+}
+
+pub(super) fn task_or_plan_requires_nextjs_scaffold(
+    active_task: Option<&str>,
+    plan_contents: Option<&str>,
+) -> bool {
+    active_task.is_some_and(task_requires_nextjs_scaffold)
+        || plan_contents.is_some_and(task_requires_nextjs_scaffold)
+}
+
+pub(super) fn deterministic_nextjs_scaffold_reply() -> AssistantReply {
+    let command = format!(
+        "npx --yes create-next-app@{CREATE_NEXT_APP_PACKAGE_VERSION} . --typescript --tailwind --eslint --app --no-src-dir --import-alias \"@/*\" --use-npm --yes"
+    );
+    AssistantReply {
+        content: String::new(),
+        tool_calls: vec![ToolCall {
+            id: "deterministic-nextjs-scaffold-1".to_string(),
+            name: "Bash".to_string(),
+            arguments: serde_json::json!({
+                "command": command
+            }),
+        }],
+        prompt_tokens: None,
+        completion_tokens: None,
+    }
+}

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -86,11 +86,15 @@ use super::safe_stop_payload::SAFE_STOP_REPORT_EVENT_MAX_BYTES;
 use super::safe_stop_payload::{build_safe_stop_payload, collect_recent_action_labels};
 #[cfg(test)]
 use super::scaffold_pipeline::PlanExplorationKey;
+#[cfg(test)]
+use super::scaffold_pipeline::task_requires_nextjs_scaffold;
 use super::scaffold_pipeline::{
     CREATE_NEXT_APP_PACKAGE_VERSION, DeterministicScaffoldSpec,
     EVENT_DETERMINISTIC_FASTAPI_SCAFFOLD, EVENT_DETERMINISTIC_FORMAT_ERROR_SMALL_EDIT,
     EVENT_DETERMINISTIC_PYTHON_CLI, EVENT_DETERMINISTIC_PYTHON_TEST_FALLBACK,
-    ScaffoldFallbackResult, ScaffoldFramework,
+    ScaffoldFallbackResult, ScaffoldFramework, deterministic_nextjs_scaffold_reply,
+    requested_scaffold_framework, scaffold_command_matches_framework,
+    task_or_plan_requires_nextjs_scaffold,
 };
 #[cfg(test)]
 use super::semantic_repair_planning::{
@@ -1630,10 +1634,6 @@ fn extract_requested_port(task: &str) -> Option<String> {
     None
 }
 
-fn task_requires_nextjs_scaffold(task: &str) -> bool {
-    requested_scaffold_framework(task) == Some(ScaffoldFramework::Next)
-}
-
 impl ScaffoldFramework {
     fn label(self) -> &'static str {
         match self {
@@ -1653,65 +1653,6 @@ impl ScaffoldFramework {
                 "Use a Nuxt scaffold, for example: npx nuxi@latest init . --packageManager npm."
             }
         }
-    }
-}
-
-fn requested_scaffold_framework(task: &str) -> Option<ScaffoldFramework> {
-    let normalized = task.to_ascii_lowercase();
-    if normalized.contains("next.js") || normalized.contains("nextjs") {
-        Some(ScaffoldFramework::Next)
-    } else if normalized.contains("nuxt.js") || normalized.contains("nuxt") {
-        Some(ScaffoldFramework::Nuxt)
-    } else if normalized.contains("react.js") || normalized.contains("react") {
-        Some(ScaffoldFramework::React)
-    } else {
-        None
-    }
-}
-
-fn scaffold_command_matches_framework(framework: ScaffoldFramework, command: &str) -> bool {
-    let normalized = command.to_ascii_lowercase();
-    match framework {
-        ScaffoldFramework::Next => normalized.contains("create-next-app"),
-        ScaffoldFramework::React => {
-            (normalized.contains("create vite")
-                || normalized.contains("create-vite")
-                || normalized.contains("vite@latest")
-                || normalized.contains("vite@"))
-                && normalized.contains("react")
-        }
-        ScaffoldFramework::Nuxt => {
-            normalized.contains("nuxi")
-                || normalized.contains("create-nuxt")
-                || normalized.contains("create nuxt")
-                || normalized.contains("nuxt@")
-        }
-    }
-}
-
-fn task_or_plan_requires_nextjs_scaffold(
-    active_task: Option<&str>,
-    plan_contents: Option<&str>,
-) -> bool {
-    active_task.is_some_and(task_requires_nextjs_scaffold)
-        || plan_contents.is_some_and(task_requires_nextjs_scaffold)
-}
-
-fn deterministic_nextjs_scaffold_reply() -> AssistantReply {
-    let command = format!(
-        "npx --yes create-next-app@{CREATE_NEXT_APP_PACKAGE_VERSION} . --typescript --tailwind --eslint --app --no-src-dir --import-alias \"@/*\" --use-npm --yes"
-    );
-    AssistantReply {
-        content: String::new(),
-        tool_calls: vec![ToolCall {
-            id: "deterministic-nextjs-scaffold-1".to_string(),
-            name: "Bash".to_string(),
-            arguments: serde_json::json!({
-                "command": command
-            }),
-        }],
-        prompt_tokens: None,
-        completion_tokens: None,
     }
 }
 


### PR DESCRIPTION
## Summary

Phase 3 follow-up PR for Issue #683. Moves 5 small pure-fn scaffold framework-detection helpers (~58 LOC of bodies) out of `turn.rs` into `scaffold_pipeline.rs`.

### Moved (turn.rs → scaffold_pipeline.rs)

- `task_requires_nextjs_scaffold` (3 LOC)
- `requested_scaffold_framework` (12 LOC) — keyword detector that classifies a task string into Next / Nuxt / React or None.
- `scaffold_command_matches_framework` (19 LOC) — gate that the LLM-issued command matches the requested framework's scaffolder (create-next-app / create vite + react / nuxi).
- `task_or_plan_requires_nextjs_scaffold` (7 LOC) — combines the active-task and plan-contents checks.
- `deterministic_nextjs_scaffold_reply` (17 LOC) — synthesizes the canned `npx create-next-app@<v>` Bash tool call when the deterministic scaffold path fires.

All 5 promoted to `pub(super)`. `task_requires_nextjs_scaffold` is exposed in scaffold_pipeline.rs (not `#[cfg(test)]` gated there) since the production `task_or_plan_requires_nextjs_scaffold` caller dispatches through it. turn.rs re-imports it under `#[cfg(test)]` only because its production callers all live in actor_loop_flow.rs or in the just-moved sibling.

### Adjustments

- `scaffold_pipeline.rs`: added `use crate::ollama::client::AssistantReply;` and `use crate::ollama::xml_fallback::ToolCall;`.
- `turn.rs`: extended `use super::scaffold_pipeline::{...}` with the 4 production-callable helpers; added the `#[cfg(test)]` gate for `task_requires_nextjs_scaffold`.

### Metrics

| File | Before | After | Delta |
|---|---:|---:|---:|
| `src/agent/loop_run/turn.rs` | 31,823 | 31,764 | **-59** |
| `src/agent/loop_run/scaffold_pipeline.rs` | 76 | 145 | +69 |

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --lib` (3,114 passed)
- [ ] CI green (fmt / clippy / test / build)

## Layer rule notes

- No facade re-export (DR3-001 maintained).
- No photon → session → agent inversion (DR3-002 unchanged).
- Pure code-motion + visibility relaxation; no production-binary behaviour change.