### PR TITLE
Relocate post-scaffold detection cluster + marker (Issue #683, batch 3)

### DIFF
--- a/src/agent/loop_run/scaffold_pipeline.rs
+++ b/src/agent/loop_run/scaffold_pipeline.rs
@@ -34,10 +34,13 @@
 //! `pub(super)` limited / no facade re-export (DR3-001).
 //! `turn.rs` is the only in-crate consumer.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
+use super::tool_history::latest_user_turn_slice;
+use crate::agent::recovery;
 use crate::ollama::client::AssistantReply;
 use crate::ollama::xml_fallback::ToolCall;
+use crate::session::store::ConversationMessage;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum ScaffoldFramework {
@@ -142,4 +145,119 @@ pub(super) fn deterministic_nextjs_scaffold_reply() -> AssistantReply {
         prompt_tokens: None,
         completion_tokens: None,
     }
+}
+
+pub(super) const DETERMINISTIC_FRAMEWORK_APP_FALLBACK_MARKER: &str =
+    "Materialized deterministic framework app fallback files";
+
+pub(super) fn recent_post_scaffold_edit_attempt(messages: &[ConversationMessage]) -> usize {
+    latest_user_turn_slice(messages)
+        .iter()
+        .rev()
+        .find_map(|message| {
+            if message.role != "system" {
+                return None;
+            }
+            message
+                .content
+                .rsplit("post_scaffold_edit_attempt=")
+                .next()
+                .and_then(|suffix| suffix.trim().parse::<usize>().ok())
+        })
+        .unwrap_or(0)
+}
+
+pub(super) fn recent_post_scaffold_continue_attempt(messages: &[ConversationMessage]) -> usize {
+    latest_user_turn_slice(messages)
+        .iter()
+        .rev()
+        .find_map(|message| {
+            if message.role != "system" {
+                return None;
+            }
+            message
+                .content
+                .rsplit("post_scaffold_continue_attempt=")
+                .next()
+                .and_then(|suffix| suffix.trim().parse::<usize>().ok())
+        })
+        .unwrap_or(0)
+}
+
+pub(super) fn recent_scaffold_command_seen(messages: &[ConversationMessage]) -> bool {
+    latest_user_turn_slice(messages)
+        .iter()
+        .rev()
+        .any(|message| {
+            if message.role != "assistant" {
+                return false;
+            }
+            message.tool_calls.iter().rev().any(|tool_call| {
+                // Issue #664: legacy recovery-side scaffold detector.
+                #[allow(deprecated)]
+                let is_scaffold = tool_call.name == "Bash"
+                    && tool_call
+                        .arguments
+                        .get("command")
+                        .and_then(serde_json::Value::as_str)
+                        .is_some_and(recovery::is_scaffold_command);
+                is_scaffold
+            })
+        })
+}
+
+pub(super) fn recent_deterministic_framework_app_fallback_seen(
+    messages: &[ConversationMessage],
+) -> bool {
+    latest_user_turn_slice(messages)
+        .iter()
+        .rev()
+        .any(|message| {
+            message.role == "assistant"
+                && message
+                    .content
+                    .contains(DETERMINISTIC_FRAMEWORK_APP_FALLBACK_MARKER)
+        })
+}
+
+pub(super) fn post_scaffold_recovery_active(
+    messages: &[ConversationMessage],
+    active_root: Option<&Path>,
+    cwd: &Path,
+) -> bool {
+    recent_scaffold_command_seen(messages)
+        || recent_deterministic_framework_app_fallback_seen(messages)
+        || recent_post_scaffold_edit_attempt(messages) > 0
+        || (active_root.is_some_and(|root| root != cwd)
+            && latest_user_turn_slice(messages).iter().any(|message| {
+                message.role == "system"
+                    && message
+                        .content
+                        .trim_start()
+                        .starts_with("[Workspace Root Updated]")
+            }))
+}
+
+pub(super) fn post_scaffold_continuation_active(
+    _messages: &[ConversationMessage],
+    _active_root: Option<&Path>,
+    _cwd: &Path,
+    _work_root: &Path,
+    _plan_path: Option<&Path>,
+) -> bool {
+    // A second forced microscopic edit tends to trap scaffolded apps in
+    // placeholder-copy churn. After the first repo edit, let the normal
+    // implementation loop and final quality gate drive the next action.
+    false
+}
+
+pub(super) fn render_deterministic_scaffold_continuation_note(
+    request: &str,
+    written_paths: &[String],
+) -> String {
+    let request_json = serde_json::to_string(request).unwrap_or_else(|_| "\"<invalid>\"".into());
+    format!(
+        "[Deterministic Scaffold] The generated files are bootstrap scaffold only and do not satisfy the task by themselves. request_json={request_json}. Read and edit the scaffold to implement the user's specific requirements, including domain-specific implementation, tests, and usage documentation. Existing scaffold files: {}. Do not give a final answer until the implementation, tests, and docs match request_json and verification has run.",
+        written_paths.join(", ")
+    )
 }

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -87,12 +87,17 @@ use super::safe_stop_payload::{build_safe_stop_payload, collect_recent_action_la
 #[cfg(test)]
 use super::scaffold_pipeline::PlanExplorationKey;
 #[cfg(test)]
+use super::scaffold_pipeline::recent_deterministic_framework_app_fallback_seen;
+#[cfg(test)]
 use super::scaffold_pipeline::task_requires_nextjs_scaffold;
 use super::scaffold_pipeline::{
     CREATE_NEXT_APP_PACKAGE_VERSION, DeterministicScaffoldSpec,
     EVENT_DETERMINISTIC_FASTAPI_SCAFFOLD, EVENT_DETERMINISTIC_FORMAT_ERROR_SMALL_EDIT,
     EVENT_DETERMINISTIC_PYTHON_CLI, EVENT_DETERMINISTIC_PYTHON_TEST_FALLBACK,
     ScaffoldFallbackResult, ScaffoldFramework, deterministic_nextjs_scaffold_reply,
+    post_scaffold_continuation_active, post_scaffold_recovery_active,
+    recent_post_scaffold_continue_attempt, recent_post_scaffold_edit_attempt,
+    recent_scaffold_command_seen, render_deterministic_scaffold_continuation_note,
     requested_scaffold_framework, scaffold_command_matches_framework,
     task_or_plan_requires_nextjs_scaffold,
 };
@@ -15881,40 +15886,6 @@ fn plan_file_alias(path: &Path) -> String {
         .unwrap_or_else(|| "plans/plan.md".to_string())
 }
 
-fn recent_post_scaffold_edit_attempt(messages: &[ConversationMessage]) -> usize {
-    latest_user_turn_slice(messages)
-        .iter()
-        .rev()
-        .find_map(|message| {
-            if message.role != "system" {
-                return None;
-            }
-            message
-                .content
-                .rsplit("post_scaffold_edit_attempt=")
-                .next()
-                .and_then(|suffix| suffix.trim().parse::<usize>().ok())
-        })
-        .unwrap_or(0)
-}
-
-fn recent_post_scaffold_continue_attempt(messages: &[ConversationMessage]) -> usize {
-    latest_user_turn_slice(messages)
-        .iter()
-        .rev()
-        .find_map(|message| {
-            if message.role != "system" {
-                return None;
-            }
-            message
-                .content
-                .rsplit("post_scaffold_continue_attempt=")
-                .next()
-                .and_then(|suffix| suffix.trim().parse::<usize>().ok())
-        })
-        .unwrap_or(0)
-}
-
 pub(super) fn prune_plan_mode_messages(messages: &mut Vec<ConversationMessage>) {
     messages.retain(|message| {
         if message.role != "system" {
@@ -15988,71 +15959,6 @@ fn latest_turn_preferred_read_edit_target(
     latest_existing
 }
 
-fn recent_scaffold_command_seen(messages: &[ConversationMessage]) -> bool {
-    latest_user_turn_slice(messages)
-        .iter()
-        .rev()
-        .any(|message| {
-            if message.role != "assistant" {
-                return false;
-            }
-            message.tool_calls.iter().rev().any(|tool_call| {
-                // Issue #664: legacy recovery-side scaffold detector.
-                #[allow(deprecated)]
-                let is_scaffold = tool_call.name == "Bash"
-                    && tool_call
-                        .arguments
-                        .get("command")
-                        .and_then(serde_json::Value::as_str)
-                        .is_some_and(recovery::is_scaffold_command);
-                is_scaffold
-            })
-        })
-}
-
-fn post_scaffold_recovery_active(
-    messages: &[ConversationMessage],
-    active_root: Option<&Path>,
-    cwd: &Path,
-) -> bool {
-    recent_scaffold_command_seen(messages)
-        || recent_deterministic_framework_app_fallback_seen(messages)
-        || recent_post_scaffold_edit_attempt(messages) > 0
-        || (active_root.is_some_and(|root| root != cwd)
-            && latest_user_turn_slice(messages).iter().any(|message| {
-                message.role == "system"
-                    && message
-                        .content
-                        .trim_start()
-                        .starts_with("[Workspace Root Updated]")
-            }))
-}
-
-fn recent_deterministic_framework_app_fallback_seen(messages: &[ConversationMessage]) -> bool {
-    latest_user_turn_slice(messages)
-        .iter()
-        .rev()
-        .any(|message| {
-            message.role == "assistant"
-                && message
-                    .content
-                    .contains(DETERMINISTIC_FRAMEWORK_APP_FALLBACK_MARKER)
-        })
-}
-
-fn post_scaffold_continuation_active(
-    _messages: &[ConversationMessage],
-    _active_root: Option<&Path>,
-    _cwd: &Path,
-    _work_root: &Path,
-    _plan_path: Option<&Path>,
-) -> bool {
-    // A second forced microscopic edit tends to trap scaffolded apps in
-    // placeholder-copy churn. After the first repo edit, let the normal
-    // implementation loop and final quality gate drive the next action.
-    false
-}
-
 fn workspace_appears_empty(work_root: &Path) -> bool {
     let Ok(entries) = std::fs::read_dir(work_root) else {
         return false;
@@ -16114,17 +16020,6 @@ fn deterministic_framework_app_files_needed(
         return false;
     }
     deterministic::playable_ui_repair(request, &target, &current).is_some()
-}
-
-fn render_deterministic_scaffold_continuation_note(
-    request: &str,
-    written_paths: &[String],
-) -> String {
-    let request_json = serde_json::to_string(request).unwrap_or_else(|_| "\"<invalid>\"".into());
-    format!(
-        "[Deterministic Scaffold] The generated files are bootstrap scaffold only and do not satisfy the task by themselves. request_json={request_json}. Read and edit the scaffold to implement the user's specific requirements, including domain-specific implementation, tests, and usage documentation. Existing scaffold files: {}. Do not give a final answer until the implementation, tests, and docs match request_json and verification has run.",
-        written_paths.join(", ")
-    )
 }
 
 fn scaffold_file_snapshot(path: &str, content: &[u8]) -> ScaffoldArtifactFileSnapshot {
@@ -16425,9 +16320,6 @@ pub(super) fn existing_workspace_candidate_for_role_in_scope(
 fn sha256_hex(bytes: &[u8]) -> String {
     format!("{:x}", Sha256::digest(bytes))
 }
-
-const DETERMINISTIC_FRAMEWORK_APP_FALLBACK_MARKER: &str =
-    "Materialized deterministic framework app fallback files";
 
 fn deterministic_framework_game_impl_path(path: &Path) -> bool {
     matches!(


### PR DESCRIPTION
## Summary

Phase 3 batch 3 for Issue #683. Moves 7 post-scaffold detection / continuation helpers + 1 deterministic marker const (~115 LOC of bodies) out of `turn.rs` into `scaffold_pipeline.rs`.

### Moved (turn.rs → scaffold_pipeline.rs)

**Marker const:**
- `DETERMINISTIC_FRAMEWORK_APP_FALLBACK_MARKER` — the assistant-content substring that `recent_deterministic_framework_app_fallback_seen` scans for.

**Detection helpers** (4):
- `recent_post_scaffold_edit_attempt` (16 LOC) — parses `post_scaffold_edit_attempt=<n>` from the latest user-turn slice's system messages.
- `recent_post_scaffold_continue_attempt` (16 LOC) — same shape for `post_scaffold_continue_attempt=<n>`.
- `recent_scaffold_command_seen` (21 LOC) — scans for an assistant Bash tool call matching `recovery::is_scaffold_command`.
- `recent_deterministic_framework_app_fallback_seen` (11 LOC) — scans for the marker.

**State predicates** (2):
- `post_scaffold_recovery_active` (17 LOC) — OR of the four detectors above + workspace-root-updated system note.
- `post_scaffold_continuation_active` (12 LOC) — always returns false (placeholder-copy churn guard).

**Note formatter:**
- `render_deterministic_scaffold_continuation_note` (10 LOC) — builds the `[Deterministic Scaffold]` system note with a bounded `request_json` + `written_paths` list.

All 7 fns + const promoted to `pub(super)`.

### Adjustments

- `scaffold_pipeline.rs`: added imports for `std::path::Path`, `super::tool_history::latest_user_turn_slice`, `crate::agent::recovery`, `crate::session::store::ConversationMessage`.
- `turn.rs`: extended `use super::scaffold_pipeline::{...}` with the 6 production-callable helpers. Gated `recent_deterministic_framework_app_fallback_seen` under `#[cfg(test)]` (only the in-mod test fixtures + the just-moved `post_scaffold_recovery_active` reference it in production now, and the latter call site lives in `scaffold_pipeline.rs`).

### Metrics

| File | Before | After | Delta |
|---|---:|---:|---:|
| `src/agent/loop_run/turn.rs` | 31,764 | 31,656 | **-108** |
| `src/agent/loop_run/scaffold_pipeline.rs` | 145 | 263 | +118 |

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --lib` (3,114 passed)
- [ ] CI green (fmt / clippy / test / build)

## Layer rule notes

- No facade re-export (DR3-001 maintained).
- No photon → session → agent inversion (DR3-002 unchanged).
- Pure code-motion + visibility relaxation; no production-binary behaviour change.