### PR TITLE
Phase 3 batch 8: deterministic Next.js scaffold dispatch (#683)

### DIFF
--- a/src/agent/loop_run/scaffold_pipeline.rs
+++ b/src/agent/loop_run/scaffold_pipeline.rs
@@ -41,6 +41,7 @@ use super::Agent;
 use super::actor_loop_flow::format_iteration_status;
 use super::completion_evidence::{RepoEditCategory, classify_repo_edit_path};
 use super::deterministic;
+use super::interrupt::InterruptFlag;
 use super::quality::{first_existing_impl_target, implementation_quality_issue_for_request};
 use super::task_contract::ArtifactRole;
 use super::tool_history::{
@@ -49,8 +50,8 @@ use super::tool_history::{
 use super::turn::{
     WrittenScaffoldArtifacts, current_file_hash_for_relative_path, extract_filename_with_suffix,
     last_read_tool_path, latest_turn_preferred_read_edit_target, meaningful_workspace_files,
-    normalize_memory_path, progress_path_display, sha256_hex, workspace_appears_empty,
-    write_stdout_rendered,
+    normalize_memory_path, progress_path_display, sha256_hex, tool_result_failed,
+    workspace_appears_empty, write_stdout_rendered,
 };
 use crate::agent::prompting;
 use crate::agent::recovery;
@@ -865,4 +866,110 @@ pub(super) fn finalize_deterministic_scaffold_materialization(
         request,
         &written_paths,
     ));
+}
+
+pub(super) fn maybe_apply_deterministic_nextjs_scaffold(
+    agent: &mut Agent,
+    last_iter: usize,
+    interrupt_flag: &InterruptFlag,
+) -> ScaffoldFallbackResult {
+    if !agent
+        .config
+        .deterministic_fallback
+        .allows_support_recovery()
+    {
+        return ScaffoldFallbackResult::NotApplicable;
+    }
+    if !active_task_requires_nextjs_scaffold(agent)
+        || !workspace_appears_empty(&agent.work_root)
+        || recent_scaffold_command_seen(&agent.session.messages)
+    {
+        return ScaffoldFallbackResult::NotApplicable;
+    }
+
+    if let Some(reason) = deterministic_nextjs_scaffold_skip_reason(agent) {
+        write_stdout_rendered(
+            &format_iteration_status(
+                last_iter,
+                agent.config.max_iterations,
+                "Scaffold fallback skipped",
+                reason,
+                agent.footer.current_cols(),
+            ),
+            true,
+        );
+        log_llm_event(
+            "agent.empty_workspace.deterministic_nextjs_scaffold_skipped",
+            serde_json::json!({
+                "session_id": agent.session_store.session_id(),
+                "work_root": agent.work_root.display().to_string(),
+                "fallback_level": agent.config.deterministic_fallback.fallback_level(),
+                "fallback_action": "minimal_patch",
+                "reason": reason,
+            }),
+        );
+        return ScaffoldFallbackResult::Skipped;
+    }
+
+    let fallback_reply = deterministic_nextjs_scaffold_reply();
+    let fallback_tool_calls = fallback_reply
+        .tool_calls
+        .iter()
+        .cloned()
+        .map(|tool_call| agent.prepare_tool_call(tool_call))
+        .collect::<Vec<_>>();
+    agent.session.messages.push(ConversationMessage::assistant(
+        fallback_reply.content,
+        fallback_tool_calls.clone(),
+    ));
+    write_stdout_rendered(
+        &format_iteration_status(
+            last_iter,
+            agent.config.max_iterations,
+            "Scaffold fallback",
+            "Empty Next.js workspace stalled on exploration; running pinned deterministic scaffold command.",
+            agent.footer.current_cols(),
+        ),
+        true,
+    );
+
+    let mut fallback_failed = false;
+    for tool_call in fallback_tool_calls {
+        let raw_result = agent.execute_tool_call(
+            &tool_call.name,
+            &tool_call.arguments,
+            None,
+            Some(interrupt_flag.flag.clone()),
+        );
+        if tool_result_failed(&raw_result) {
+            fallback_failed = true;
+        }
+        let compact_result = prompting::compact_tool_result(&tool_call.name, raw_result);
+        agent.session.messages.push(ConversationMessage::tool(
+            tool_call.name.clone(),
+            compact_result,
+        ));
+    }
+
+    let event = if fallback_failed {
+        "agent.empty_workspace.deterministic_nextjs_scaffold_failed"
+    } else {
+        "agent.empty_workspace.deterministic_nextjs_scaffold"
+    };
+    log_llm_event(
+        event,
+        serde_json::json!({
+            "session_id": agent.session_store.session_id(),
+            "work_root": agent.work_root.display().to_string(),
+            "fallback_level": agent.config.deterministic_fallback.fallback_level(),
+            "fallback_action": "minimal_patch",
+            "create_next_app_version": CREATE_NEXT_APP_PACKAGE_VERSION,
+        }),
+    );
+
+    if fallback_failed {
+        ScaffoldFallbackResult::Failed
+    } else {
+        ScaffoldFallbackResult::Applied
+    }
 }

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -91,12 +91,10 @@ use super::scaffold_pipeline::recent_deterministic_framework_app_fallback_seen;
 #[cfg(test)]
 use super::scaffold_pipeline::task_requires_nextjs_scaffold;
 use super::scaffold_pipeline::{
-    CREATE_NEXT_APP_PACKAGE_VERSION, DeterministicScaffoldSpec,
-    EVENT_DETERMINISTIC_FORMAT_ERROR_SMALL_EDIT, EVENT_DETERMINISTIC_PYTHON_TEST_FALLBACK,
-    ScaffoldFallbackResult, ScaffoldFramework, deterministic_framework_app_files_needed,
-    deterministic_framework_game_impl_path, deterministic_nextjs_scaffold_reply,
-    deterministic_support_target_relative, recent_scaffold_command_seen,
-    scaffold_candidate_priority,
+    DeterministicScaffoldSpec, EVENT_DETERMINISTIC_FORMAT_ERROR_SMALL_EDIT,
+    EVENT_DETERMINISTIC_PYTHON_TEST_FALLBACK, ScaffoldFallbackResult, ScaffoldFramework,
+    deterministic_framework_app_files_needed, deterministic_framework_game_impl_path,
+    deterministic_support_target_relative, scaffold_candidate_priority,
 };
 #[cfg(test)]
 use super::semantic_repair_planning::{
@@ -1609,7 +1607,7 @@ fn user_interrupt_result() -> String {
     "exit_code=-1\ninterrupted=true\ninterrupt requested by user".to_string()
 }
 
-fn tool_result_failed(result: &str) -> bool {
+pub(super) fn tool_result_failed(result: &str) -> bool {
     result.starts_with("Error:") || result.contains("\ninterrupted=true\n")
 }
 
@@ -9866,10 +9864,6 @@ impl Agent {
         super::scaffold_pipeline::empty_workspace_scaffold_policy_error(self, name, arguments)
     }
 
-    fn deterministic_nextjs_scaffold_skip_reason(&self) -> Option<&'static str> {
-        super::scaffold_pipeline::deterministic_nextjs_scaffold_skip_reason(self)
-    }
-
     fn mode_deterministic_scaffold_spec(
         &self,
         request: &str,
@@ -10136,101 +10130,11 @@ impl Agent {
         last_iter: usize,
         interrupt_flag: &InterruptFlag,
     ) -> ScaffoldFallbackResult {
-        if !self.config.deterministic_fallback.allows_support_recovery() {
-            return ScaffoldFallbackResult::NotApplicable;
-        }
-        if !self.active_task_requires_nextjs_scaffold()
-            || !self.workspace_appears_empty()
-            || recent_scaffold_command_seen(&self.session.messages)
-        {
-            return ScaffoldFallbackResult::NotApplicable;
-        }
-
-        if let Some(reason) = self.deterministic_nextjs_scaffold_skip_reason() {
-            write_stdout_rendered(
-                &format_iteration_status(
-                    last_iter,
-                    self.config.max_iterations,
-                    "Scaffold fallback skipped",
-                    reason,
-                    self.footer.current_cols(),
-                ),
-                true,
-            );
-            log_llm_event(
-                "agent.empty_workspace.deterministic_nextjs_scaffold_skipped",
-                serde_json::json!({
-                    "session_id": self.session_store.session_id(),
-                    "work_root": self.work_root.display().to_string(),
-                    "fallback_level": self.config.deterministic_fallback.fallback_level(),
-                    "fallback_action": "minimal_patch",
-                    "reason": reason,
-                }),
-            );
-            return ScaffoldFallbackResult::Skipped;
-        }
-
-        let fallback_reply = deterministic_nextjs_scaffold_reply();
-        let fallback_tool_calls = fallback_reply
-            .tool_calls
-            .iter()
-            .cloned()
-            .map(|tool_call| self.prepare_tool_call(tool_call))
-            .collect::<Vec<_>>();
-        self.session.messages.push(ConversationMessage::assistant(
-            fallback_reply.content,
-            fallback_tool_calls.clone(),
-        ));
-        write_stdout_rendered(
-            &format_iteration_status(
-                last_iter,
-                self.config.max_iterations,
-                "Scaffold fallback",
-                "Empty Next.js workspace stalled on exploration; running pinned deterministic scaffold command.",
-                self.footer.current_cols(),
-            ),
-            true,
-        );
-
-        let mut fallback_failed = false;
-        for tool_call in fallback_tool_calls {
-            let raw_result = self.execute_tool_call(
-                &tool_call.name,
-                &tool_call.arguments,
-                None,
-                Some(interrupt_flag.flag.clone()),
-            );
-            if tool_result_failed(&raw_result) {
-                fallback_failed = true;
-            }
-            let compact_result = prompting::compact_tool_result(&tool_call.name, raw_result);
-            self.session.messages.push(ConversationMessage::tool(
-                tool_call.name.clone(),
-                compact_result,
-            ));
-        }
-
-        let event = if fallback_failed {
-            "agent.empty_workspace.deterministic_nextjs_scaffold_failed"
-        } else {
-            "agent.empty_workspace.deterministic_nextjs_scaffold"
-        };
-        log_llm_event(
-            event,
-            serde_json::json!({
-                "session_id": self.session_store.session_id(),
-                "work_root": self.work_root.display().to_string(),
-                "fallback_level": self.config.deterministic_fallback.fallback_level(),
-                "fallback_action": "minimal_patch",
-                "create_next_app_version": CREATE_NEXT_APP_PACKAGE_VERSION,
-            }),
-        );
-
-        if fallback_failed {
-            ScaffoldFallbackResult::Failed
-        } else {
-            ScaffoldFallbackResult::Applied
-        }
+        super::scaffold_pipeline::maybe_apply_deterministic_nextjs_scaffold(
+            self,
+            last_iter,
+            interrupt_flag,
+        )
     }
 
     fn workspace_appears_empty(&self) -> bool {
@@ -10244,10 +10148,6 @@ impl Agent {
                 recovery::classify_action_expectation(task, self.session.mode_state.mode)
                     == recovery::ActionExpectation::RepoChange
             })
-    }
-
-    fn active_task_requires_nextjs_scaffold(&self) -> bool {
-        super::scaffold_pipeline::active_task_requires_nextjs_scaffold(self)
     }
 
     fn active_task_requested_scaffold_framework(&self) -> Option<ScaffoldFramework> {
@@ -16666,16 +16566,16 @@ mod truncate_tests {
     };
     use super::super::completion_evidence::{CompletionEvidence, EvidenceSet, RepoEditCategory};
     use super::super::scaffold_pipeline::{
-        requested_scaffold_framework, scaffold_candidate_for_missing_role_from_snapshots,
-        scaffold_command_matches_framework, scaffold_file_snapshot,
-        task_or_plan_requires_nextjs_scaffold,
+        deterministic_nextjs_scaffold_reply, requested_scaffold_framework,
+        scaffold_candidate_for_missing_role_from_snapshots, scaffold_command_matches_framework,
+        scaffold_file_snapshot, task_or_plan_requires_nextjs_scaffold,
     };
     use super::super::task_contract::{ArtifactRecoveryAction, ArtifactRole, TaskContract};
     use super::{
-        ScaffoldFramework, changed_files_for_verifier, deterministic_nextjs_scaffold_reply,
-        extract_filename_with_suffix, focused_edit_tool_policy_error,
-        repo_edit_satisfies_artifact_recovery_target, task_contract_needs_verification,
-        task_contract_verifier_repair_note, task_requires_nextjs_scaffold, truncate,
+        ScaffoldFramework, changed_files_for_verifier, extract_filename_with_suffix,
+        focused_edit_tool_policy_error, repo_edit_satisfies_artifact_recovery_target,
+        task_contract_needs_verification, task_contract_verifier_repair_note,
+        task_requires_nextjs_scaffold, truncate,
     };
     use crate::agent::orchestration::RepoVerification;
     use crate::agent::recovery::ActionExpectation;
@@ -17284,7 +17184,7 @@ mod progress_tests {
         ScaffoldDiffStatus, deterministic_framework_app_files_needed,
         deterministic_framework_game_files_needed, deterministic_support_target_relative,
         post_scaffold_continuation_active, post_scaffold_recovery_active,
-        render_deterministic_scaffold_continuation_note,
+        recent_scaffold_command_seen, render_deterministic_scaffold_continuation_note,
         scaffold_candidate_for_missing_role_from_snapshots, scaffold_diff_status,
         scaffold_file_snapshot,
     };
@@ -17321,7 +17221,7 @@ mod progress_tests {
         latest_page_copy_block_from_read, latest_truncated_tool_call_note_index,
         latest_turn_preferred_read_edit_target, parse_verifier_repair_assessment_reply,
         prune_plan_mode_messages, recent_deterministic_framework_app_fallback_seen,
-        recent_scaffold_command_seen, recent_truncated_tool_call_attempt, repo_change_request_text,
+        recent_truncated_tool_call_attempt, repo_change_request_text,
         request_needs_playable_ui_quality_gate, sanitize_for_progress, sha256_hex,
         should_use_streaming_transport, strip_read_line_number_prefix,
         successful_non_plan_repo_edit_count, successful_repo_edit_count,


### PR DESCRIPTION
## Summary

Issue #683 (parent #680, Phase 3) batch 8: migrate the \`maybe_apply_deterministic_nextjs_scaffold\` fallback dispatch from \`turn.rs\` to \`scaffold_pipeline.rs\` via the veneer pattern, and retire two veneer shells that became dead after the migration.

## Migrated as a free fn in \`scaffold_pipeline.rs\` (\`pub(super)\`)

- \`maybe_apply_deterministic_nextjs_scaffold(&mut Agent, last_iter, &InterruptFlag) -> ScaffoldFallbackResult\`

## Promotions in \`turn.rs\` (\`pub(super)\`)

- \`tool_result_failed\`

## Removed (dead veneers)

- \`Agent::deterministic_nextjs_scaffold_skip_reason\`
- \`Agent::active_task_requires_nextjs_scaffold\`

Both became dead after the sole caller (\`maybe_apply_deterministic_nextjs_scaffold\`) moved to a free fn that calls the underlying free fn directly.

## LOC delta

- \`turn.rs\`: 31,154 → 31,054 (-100 LOC)
- \`scaffold_pipeline.rs\`: 868 → 975 (+107 LOC)
- Cumulative \`turn.rs\`: 39,489 → 31,054 (**-8,435 LOC, -21.4%**)

## Constraints

- \`pub(super)\` limited / no facade re-export (DR3-001)
- \`turn.rs\` remains the only in-crate consumer
- Veneer shell in \`turn.rs\` preserves all caller sites

## Test plan

- [x] \`cargo fmt\`
- [x] \`cargo clippy --lib --all-targets -- -D warnings\` clean
- [x] \`cargo test --lib\` 3,114 passed / 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)