### PR TITLE
Phase 3 batch 9: deterministic mode/plan fallback materializers (#683)

### DIFF
--- a/src/agent/loop_run/scaffold_pipeline.rs
+++ b/src/agent/loop_run/scaffold_pipeline.rs
@@ -42,21 +42,23 @@ use super::actor_loop_flow::format_iteration_status;
 use super::completion_evidence::{RepoEditCategory, classify_repo_edit_path};
 use super::deterministic;
 use super::interrupt::InterruptFlag;
+use super::lifecycle;
 use super::quality::{first_existing_impl_target, implementation_quality_issue_for_request};
 use super::task_contract::ArtifactRole;
 use super::tool_history::{
     focused_edit_target_already_read, has_successful_non_plan_repo_edit, latest_user_turn_slice,
 };
 use super::turn::{
-    WrittenScaffoldArtifacts, current_file_hash_for_relative_path, extract_filename_with_suffix,
-    last_read_tool_path, latest_turn_preferred_read_edit_target, meaningful_workspace_files,
-    normalize_memory_path, progress_path_display, sha256_hex, tool_result_failed,
-    workspace_appears_empty, write_stdout_rendered,
+    WrittenScaffoldArtifacts, current_file_hash_for_relative_path,
+    deterministic_timeout_fallback_plan, extract_filename_with_suffix, last_read_tool_path,
+    latest_turn_preferred_read_edit_target, meaningful_workspace_files, normalize_memory_path,
+    progress_path_display, sha256_hex, tool_result_failed, workspace_appears_empty,
+    write_stdout_rendered,
 };
 use crate::agent::prompting;
 use crate::agent::recovery;
 use crate::logging::log_llm_event;
-use crate::modes::plan_act::{ExecutionMode, ModePolicy};
+use crate::modes::plan_act::{ExecutionMode, ModePolicy, PlanStage};
 use crate::ollama::client::AssistantReply;
 use crate::ollama::xml_fallback::ToolCall;
 use crate::safety::path_guard::resolve_user_path;
@@ -972,4 +974,101 @@ pub(super) fn maybe_apply_deterministic_nextjs_scaffold(
     } else {
         ScaffoldFallbackResult::Applied
     }
+}
+
+pub(super) fn maybe_materialize_mode_deterministic_fallback(
+    agent: &mut Agent,
+    last_iter: usize,
+) -> bool {
+    if !agent
+        .config
+        .deterministic_fallback
+        .allows_template_completion()
+    {
+        return false;
+    }
+    let policy = agent.session.mode_state.policy();
+    let Some(request) = agent.active_request_text() else {
+        return false;
+    };
+    let Some(mut spec) = mode_deterministic_scaffold_spec(agent, &request, &policy) else {
+        return false;
+    };
+    if !workspace_appears_empty(&agent.work_root) {
+        return false;
+    }
+    let Some((written, snapshot_files)) = write_deterministic_scaffold_files(
+        agent,
+        std::mem::take(&mut spec.files),
+        "deterministic fallback",
+        false,
+    ) else {
+        return false;
+    };
+    finalize_deterministic_scaffold_materialization(
+        agent,
+        &request,
+        last_iter,
+        &spec,
+        "bootstrap only",
+        written,
+        snapshot_files,
+    );
+    true
+}
+
+pub(super) fn materialize_deterministic_fallback_plan(
+    agent: &mut Agent,
+    event_name: &str,
+) -> Result<bool, String> {
+    let Some(plan_path) = agent.session.mode_state.active_plan_path.clone() else {
+        return Ok(false);
+    };
+
+    let current_contents = agent.current_plan_contents()?.unwrap_or_default();
+    if lifecycle::plan_is_substantive(&current_contents) {
+        return Ok(false);
+    }
+
+    let task = agent
+        .session
+        .working_memory
+        .active_task
+        .clone()
+        .or_else(|| {
+            agent
+                .session
+                .messages
+                .iter()
+                .rev()
+                .find(|message| message.role == "user")
+                .map(|message| message.content.clone())
+        })
+        .unwrap_or_else(|| "Complete the requested task.".to_string());
+
+    let fallback_plan = deterministic_timeout_fallback_plan(
+        &task,
+        agent.session.mode_state.task_profile,
+        &agent.work_root,
+    );
+    agent.ensure_plan_file(&plan_path)?;
+    std::fs::write(&plan_path, fallback_plan).map_err(|err| {
+        format!(
+            "failed to write deterministic fallback plan {}: {err}",
+            plan_path.display()
+        )
+    })?;
+    agent.session.mode_state.plan_stage = PlanStage::Ready;
+    log_llm_event(
+        event_name,
+        serde_json::json!({
+            "session_id": agent.session_store.session_id(),
+            "plan_path": plan_path.display().to_string(),
+            "task_profile": agent.session.mode_state.task_profile.as_str(),
+            "model_override": agent.plan_model_override,
+            "fallback_level": agent.config.deterministic_fallback.fallback_level(),
+            "fallback_action": "minimal_patch",
+        }),
+    );
+    Ok(true)
 }

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -1648,7 +1648,7 @@ fn fallback_plan_platform_label(task: &str) -> &'static str {
     }
 }
 
-fn deterministic_timeout_fallback_plan(
+pub(super) fn deterministic_timeout_fallback_plan(
     task: &str,
     task_profile: TaskProfile,
     work_root: &Path,
@@ -5982,55 +5982,7 @@ impl Agent {
         &mut self,
         event_name: &str,
     ) -> Result<bool, String> {
-        let Some(plan_path) = self.session.mode_state.active_plan_path.clone() else {
-            return Ok(false);
-        };
-
-        let current_contents = self.current_plan_contents()?.unwrap_or_default();
-        if lifecycle::plan_is_substantive(&current_contents) {
-            return Ok(false);
-        }
-
-        let task = self
-            .session
-            .working_memory
-            .active_task
-            .clone()
-            .or_else(|| {
-                self.session
-                    .messages
-                    .iter()
-                    .rev()
-                    .find(|message| message.role == "user")
-                    .map(|message| message.content.clone())
-            })
-            .unwrap_or_else(|| "Complete the requested task.".to_string());
-
-        let fallback_plan = deterministic_timeout_fallback_plan(
-            &task,
-            self.session.mode_state.task_profile,
-            &self.work_root,
-        );
-        self.ensure_plan_file(&plan_path)?;
-        std::fs::write(&plan_path, fallback_plan).map_err(|err| {
-            format!(
-                "failed to write deterministic fallback plan {}: {err}",
-                plan_path.display()
-            )
-        })?;
-        self.session.mode_state.plan_stage = PlanStage::Ready;
-        log_llm_event(
-            event_name,
-            serde_json::json!({
-                "session_id": self.session_store.session_id(),
-                "plan_path": plan_path.display().to_string(),
-                "task_profile": self.session.mode_state.task_profile.as_str(),
-                "model_override": self.plan_model_override,
-                "fallback_level": self.config.deterministic_fallback.fallback_level(),
-                "fallback_action": "minimal_patch",
-            }),
-        );
-        Ok(true)
+        super::scaffold_pipeline::materialize_deterministic_fallback_plan(self, event_name)
     }
 
     fn build_request_messages(
@@ -9864,85 +9816,11 @@ impl Agent {
         super::scaffold_pipeline::empty_workspace_scaffold_policy_error(self, name, arguments)
     }
 
-    fn mode_deterministic_scaffold_spec(
-        &self,
-        request: &str,
-        policy: &crate::modes::plan_act::ModePolicy,
-    ) -> Option<DeterministicScaffoldSpec> {
-        super::scaffold_pipeline::mode_deterministic_scaffold_spec(self, request, policy)
-    }
-
-    fn write_deterministic_scaffold_files(
-        &mut self,
-        files: Vec<(PathBuf, String)>,
-        error_prefix: &str,
-        skip_existing: bool,
-    ) -> Option<WrittenScaffoldArtifacts> {
-        super::scaffold_pipeline::write_deterministic_scaffold_files(
-            self,
-            files,
-            error_prefix,
-            skip_existing,
-        )
-    }
-
-    fn finalize_deterministic_scaffold_materialization(
-        &mut self,
-        request: &str,
-        last_iter: usize,
-        spec: &DeterministicScaffoldSpec,
-        assistant_context: &str,
-        written: Vec<PathBuf>,
-        snapshot_files: Vec<ScaffoldArtifactFileSnapshot>,
-    ) {
-        super::scaffold_pipeline::finalize_deterministic_scaffold_materialization(
-            self,
-            request,
-            last_iter,
-            spec,
-            assistant_context,
-            written,
-            snapshot_files,
-        )
-    }
-
     pub(super) fn maybe_materialize_mode_deterministic_fallback(
         &mut self,
         last_iter: usize,
     ) -> bool {
-        if !self
-            .config
-            .deterministic_fallback
-            .allows_template_completion()
-        {
-            return false;
-        }
-        let policy = self.session.mode_state.policy();
-        let Some(request) = self.active_request_text() else {
-            return false;
-        };
-        let Some(mut spec) = self.mode_deterministic_scaffold_spec(&request, &policy) else {
-            return false;
-        };
-        if !self.workspace_appears_empty() {
-            return false;
-        }
-        let Some((written, snapshot_files)) = self.write_deterministic_scaffold_files(
-            std::mem::take(&mut spec.files),
-            "deterministic fallback",
-            false,
-        ) else {
-            return false;
-        };
-        self.finalize_deterministic_scaffold_materialization(
-            &request,
-            last_iter,
-            &spec,
-            "bootstrap only",
-            written,
-            snapshot_files,
-        );
-        true
+        super::scaffold_pipeline::maybe_materialize_mode_deterministic_fallback(self, last_iter)
     }
 
     pub(super) fn maybe_materialize_task_contract_fallback(
@@ -9982,17 +9860,21 @@ impl Agent {
             scaffold_kind: "FastAPI",
             files,
         };
-        let Some((written, snapshot_files)) = self.write_deterministic_scaffold_files(
-            std::mem::take(&mut spec.files),
-            "task contract deterministic fallback",
-            true,
-        ) else {
+        let Some((written, snapshot_files)) =
+            super::scaffold_pipeline::write_deterministic_scaffold_files(
+                self,
+                std::mem::take(&mut spec.files),
+                "task contract deterministic fallback",
+                true,
+            )
+        else {
             return false;
         };
         if written.is_empty() {
             return false;
         }
-        self.finalize_deterministic_scaffold_materialization(
+        super::scaffold_pipeline::finalize_deterministic_scaffold_materialization(
+            self,
             &request,
             last_iter,
             &spec,


### PR DESCRIPTION
## Summary

Issue #683 (parent #680, Phase 3) batch 9: migrate the \`maybe_materialize_mode_deterministic_fallback\` and \`materialize_deterministic_fallback_plan\` orchestration methods from \`turn.rs\` to \`scaffold_pipeline.rs\` via the veneer pattern, and retire three veneer shells that became dead.

## Migrated as free fns in \`scaffold_pipeline.rs\` (\`pub(super)\`)

- \`maybe_materialize_mode_deterministic_fallback(&mut Agent, last_iter)\`
- \`materialize_deterministic_fallback_plan(&mut Agent, event_name) -> Result<bool, String>\`

## Promotions in \`turn.rs\` (\`pub(super)\`)

- \`deterministic_timeout_fallback_plan\`

## Removed (dead veneers)

- \`Agent::mode_deterministic_scaffold_spec\`
- \`Agent::write_deterministic_scaffold_files\`
- \`Agent::finalize_deterministic_scaffold_materialization\`

The remaining cross-veneer caller \`maybe_materialize_task_contract_fallback\` now invokes the free fns from \`super::scaffold_pipeline\` directly.

## LOC delta

- \`turn.rs\`: 31,054 → 30,936 (-118 LOC)
- \`scaffold_pipeline.rs\`: 975 → 1,074 (+99 LOC)
- Cumulative \`turn.rs\`: 39,489 → 30,936 (**-8,553 LOC, -21.7%**)

## Constraints

- \`pub(super)\` limited / no facade re-export (DR3-001)
- \`turn.rs\` remains the only in-crate consumer
- Veneer shells preserve all caller sites for the 2 migrated dispatch methods

## Test plan

- [x] \`cargo fmt\`
- [x] \`cargo clippy --lib --all-targets -- -D warnings\` clean
- [x] \`cargo test --lib\` 3,114 passed / 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)