### PR TITLE
Phase 3 batch 11: python test + UI quality fallback (#683)

### DIFF
--- a/src/agent/loop_run/scaffold_pipeline.rs
+++ b/src/agent/loop_run/scaffold_pipeline.rs
@@ -1253,3 +1253,147 @@ pub(super) fn maybe_materialize_framework_game_fallback(
     ));
     true
 }
+
+pub(super) fn maybe_materialize_python_test_fallback(
+    agent: &mut Agent,
+) -> Result<Option<String>, String> {
+    if !super::policy_allows_python_specialized_fallback(
+        &agent.session.mode_state.policy(),
+        &agent.config,
+    ) {
+        return Ok(None);
+    }
+    let request = agent.active_request_text().unwrap_or_default();
+    let mut python_files = std::fs::read_dir(&agent.work_root)
+        .map_err(|err| format!("failed to read {}: {err}", agent.work_root.display()))?
+        .flatten()
+        .map(|entry| entry.path())
+        .filter(|path| {
+            path.is_file()
+                && path.extension().and_then(|ext| ext.to_str()) == Some("py")
+                && path
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| {
+                        !name.starts_with("test_")
+                            && !name.ends_with("_test.py")
+                            && name != "tests.py"
+                    })
+        })
+        .collect::<Vec<_>>();
+    python_files.sort();
+    if python_files.len() != 1 {
+        return Ok(None);
+    }
+    let script = python_files.remove(0);
+    let Some(file_name) = script.file_name().and_then(|name| name.to_str()) else {
+        return Ok(None);
+    };
+    let stem = script
+        .file_stem()
+        .and_then(|name| name.to_str())
+        .unwrap_or("script");
+    let test_name = format!("test_{stem}.py");
+    let target = agent.work_root.join(&test_name);
+    let content = if request.to_ascii_lowercase().contains("fizzbuzz") {
+        format!(
+            r#"#!/usr/bin/env python3
+import subprocess
+import sys
+
+
+def test_fizzbuzz_limit_15():
+    result = subprocess.run(
+        [sys.executable, "{file_name}", "--limit", "15"],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    assert result.stdout.strip().splitlines() == [
+        "1", "2", "Fizz", "4", "Buzz", "Fizz", "7", "8", "Fizz", "Buzz",
+        "11", "Fizz", "13", "14", "FizzBuzz",
+    ]
+
+
+if __name__ == "__main__":
+    test_fizzbuzz_limit_15()
+    print("python smoke ok")
+"#
+        )
+    } else {
+        format!(
+            r#"#!/usr/bin/env python3
+import subprocess
+import sys
+
+
+def test_cli_help_runs():
+    result = subprocess.run(
+        [sys.executable, "{file_name}", "--help"],
+        text=True,
+        capture_output=True,
+    )
+    assert result.returncode == 0
+    assert result.stdout.strip() or result.stderr.strip()
+
+
+if __name__ == "__main__":
+    test_cli_help_runs()
+    print("python smoke ok")
+"#
+        )
+    };
+    std::fs::write(&target, content)
+        .map_err(|err| format!("failed to write {}: {err}", target.display()))?;
+    agent
+        .session
+        .working_memory
+        .note_touched_file(normalize_memory_path(&test_name, &agent.work_root));
+    log_llm_event(
+        EVENT_DETERMINISTIC_PYTHON_TEST_FALLBACK,
+        serde_json::json!({
+            "session_id": agent.session_store.session_id(),
+            "work_root": agent.work_root.display().to_string(),
+            "work_mode": agent.session.mode_state.work_mode.as_str(),
+            "fallback_level": agent.config.deterministic_fallback.fallback_level(),
+            "fallback_action": "python_test_scaffold",
+            "target": &test_name,
+        }),
+    );
+    Ok(Some(test_name))
+}
+
+pub(super) fn maybe_apply_deterministic_quality_fallback(
+    agent: &Agent,
+    request: &str,
+    relative_target: &str,
+) -> Result<bool, String> {
+    if !agent
+        .config
+        .deterministic_fallback
+        .allows_template_completion()
+    {
+        return Ok(false);
+    }
+    let target = agent.work_root.join(relative_target);
+    let current = std::fs::read_to_string(&target)
+        .map_err(|err| format!("failed to read {}: {err}", target.display()))?;
+    let Some(replacement) = deterministic::playable_ui_repair(request, &target, &current) else {
+        return Ok(false);
+    };
+    std::fs::write(&target, replacement)
+        .map_err(|err| format!("failed to write {}: {err}", target.display()))?;
+    agent.maybe_apply_deterministic_framework_support_files(request)?;
+    agent.maybe_apply_requested_port_script(request)?;
+    log_llm_event(
+        "agent.deterministic_ui_quality_repair",
+        serde_json::json!({
+            "session_id": agent.session_store.session_id(),
+            "work_root": agent.work_root.display().to_string(),
+            "fallback_level": agent.config.deterministic_fallback.fallback_level(),
+            "fallback_action": "full_template",
+            "target": relative_target,
+        }),
+    );
+    Ok(true)
+}

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -91,9 +91,9 @@ use super::scaffold_pipeline::recent_deterministic_framework_app_fallback_seen;
 #[cfg(test)]
 use super::scaffold_pipeline::task_requires_nextjs_scaffold;
 use super::scaffold_pipeline::{
-    EVENT_DETERMINISTIC_FORMAT_ERROR_SMALL_EDIT, EVENT_DETERMINISTIC_PYTHON_TEST_FALLBACK,
-    ScaffoldFallbackResult, ScaffoldFramework, deterministic_framework_game_impl_path,
-    deterministic_support_target_relative, scaffold_candidate_priority,
+    EVENT_DETERMINISTIC_FORMAT_ERROR_SMALL_EDIT, ScaffoldFallbackResult, ScaffoldFramework,
+    deterministic_framework_game_impl_path, deterministic_support_target_relative,
+    scaffold_candidate_priority,
 };
 #[cfg(test)]
 use super::semantic_repair_planning::{
@@ -9983,115 +9983,7 @@ impl Agent {
     pub(super) fn maybe_materialize_python_test_fallback(
         &mut self,
     ) -> Result<Option<String>, String> {
-        // Issue #634: 特化 fallback (FizzBuzz test scaffold) は experimental flag
-        // 配下に隔離。flag off の場合は早期 `Ok(None)` で抜け、呼出側の
-        // `python_test_retries >= 2` ブランチは MissingRepoEdits で break する。
-        if !super::policy_allows_python_specialized_fallback(
-            &self.session.mode_state.policy(),
-            &self.config,
-        ) {
-            return Ok(None);
-        }
-        let request = self.active_request_text().unwrap_or_default();
-        let mut python_files = std::fs::read_dir(&self.work_root)
-            .map_err(|err| format!("failed to read {}: {err}", self.work_root.display()))?
-            .flatten()
-            .map(|entry| entry.path())
-            .filter(|path| {
-                path.is_file()
-                    && path.extension().and_then(|ext| ext.to_str()) == Some("py")
-                    && path
-                        .file_name()
-                        .and_then(|name| name.to_str())
-                        .is_some_and(|name| {
-                            !name.starts_with("test_")
-                                && !name.ends_with("_test.py")
-                                && name != "tests.py"
-                        })
-            })
-            .collect::<Vec<_>>();
-        python_files.sort();
-        if python_files.len() != 1 {
-            return Ok(None);
-        }
-        let script = python_files.remove(0);
-        let Some(file_name) = script.file_name().and_then(|name| name.to_str()) else {
-            return Ok(None);
-        };
-        let stem = script
-            .file_stem()
-            .and_then(|name| name.to_str())
-            .unwrap_or("script");
-        let test_name = format!("test_{stem}.py");
-        let target = self.work_root.join(&test_name);
-        let content = if request.to_ascii_lowercase().contains("fizzbuzz") {
-            format!(
-                r#"#!/usr/bin/env python3
-import subprocess
-import sys
-
-
-def test_fizzbuzz_limit_15():
-    result = subprocess.run(
-        [sys.executable, "{file_name}", "--limit", "15"],
-        check=True,
-        text=True,
-        capture_output=True,
-    )
-    assert result.stdout.strip().splitlines() == [
-        "1", "2", "Fizz", "4", "Buzz", "Fizz", "7", "8", "Fizz", "Buzz",
-        "11", "Fizz", "13", "14", "FizzBuzz",
-    ]
-
-
-if __name__ == "__main__":
-    test_fizzbuzz_limit_15()
-    print("python smoke ok")
-"#
-            )
-        } else {
-            format!(
-                r#"#!/usr/bin/env python3
-import subprocess
-import sys
-
-
-def test_cli_help_runs():
-    result = subprocess.run(
-        [sys.executable, "{file_name}", "--help"],
-        text=True,
-        capture_output=True,
-    )
-    assert result.returncode == 0
-    assert result.stdout.strip() or result.stderr.strip()
-
-
-if __name__ == "__main__":
-    test_cli_help_runs()
-    print("python smoke ok")
-"#
-            )
-        };
-        std::fs::write(&target, content)
-            .map_err(|err| format!("failed to write {}: {err}", target.display()))?;
-        self.session
-            .working_memory
-            .note_touched_file(normalize_memory_path(&test_name, &self.work_root));
-        // Issue #634: emit dedicated event so receive-side (UAT / log grep) can
-        // assert that the specialized FizzBuzz test fallback is the path that
-        // produced the test artifact. Mirrors the other specialized events.
-        log_llm_event(
-            EVENT_DETERMINISTIC_PYTHON_TEST_FALLBACK,
-            serde_json::json!({
-                "session_id": self.session_store.session_id(),
-                "work_root": self.work_root.display().to_string(),
-                "work_mode": self.session.mode_state.work_mode.as_str(),
-                "fallback_level": self.config.deterministic_fallback.fallback_level(),
-                "fallback_action": "python_test_scaffold",
-                "target": &test_name,
-            }),
-        );
-        Ok(Some(test_name))
+        super::scaffold_pipeline::maybe_materialize_python_test_fallback(self)
     }
 
     pub(super) fn maybe_apply_deterministic_quality_fallback(
@@ -10099,38 +9991,14 @@ if __name__ == "__main__":
         request: &str,
         relative_target: &str,
     ) -> Result<bool, String> {
-        if !self
-            .config
-            .deterministic_fallback
-            .allows_template_completion()
-        {
-            return Ok(false);
-        }
-        let target = self.work_root.join(relative_target);
-        let current = std::fs::read_to_string(&target)
-            .map_err(|err| format!("failed to read {}: {err}", target.display()))?;
-        let Some(replacement) = deterministic::playable_ui_repair(request, &target, &current)
-        else {
-            return Ok(false);
-        };
-        std::fs::write(&target, replacement)
-            .map_err(|err| format!("failed to write {}: {err}", target.display()))?;
-        self.maybe_apply_deterministic_framework_support_files(request)?;
-        self.maybe_apply_requested_port_script(request)?;
-        log_llm_event(
-            "agent.deterministic_ui_quality_repair",
-            serde_json::json!({
-                "session_id": self.session_store.session_id(),
-                "work_root": self.work_root.display().to_string(),
-                "fallback_level": self.config.deterministic_fallback.fallback_level(),
-                "fallback_action": "full_template",
-                "target": relative_target,
-            }),
-        );
-        Ok(true)
+        super::scaffold_pipeline::maybe_apply_deterministic_quality_fallback(
+            self,
+            request,
+            relative_target,
+        )
     }
 
-    fn maybe_apply_deterministic_framework_support_files(
+    pub(super) fn maybe_apply_deterministic_framework_support_files(
         &self,
         request: &str,
     ) -> Result<(), String> {
@@ -10280,7 +10148,7 @@ if __name__ == "__main__":
         first_existing_impl_target(&self.work_root)
     }
 
-    fn maybe_apply_requested_port_script(&self, request: &str) -> Result<(), String> {
+    pub(super) fn maybe_apply_requested_port_script(&self, request: &str) -> Result<(), String> {
         let package_path = self.work_root.join("package.json");
         let Ok(current) = std::fs::read_to_string(&package_path) else {
             return Ok(());


### PR DESCRIPTION
## Summary

Issue #683 (parent #680, Phase 3) batch 11: migrate the \`maybe_materialize_python_test_fallback\` and \`maybe_apply_deterministic_quality_fallback\` materializers from \`turn.rs\` to \`scaffold_pipeline.rs\` via the veneer pattern.

## Migrated as free fns in \`scaffold_pipeline.rs\` (\`pub(super)\`)

- \`maybe_materialize_python_test_fallback(&mut Agent) -> Result<Option<String>, String>\`
- \`maybe_apply_deterministic_quality_fallback(&Agent, request, relative_target) -> Result<bool, String>\`

## Promotions in \`turn.rs\` (\`pub(super)\`)

- \`Agent::maybe_apply_deterministic_framework_support_files\`
- \`Agent::maybe_apply_requested_port_script\`

Both stay as Agent methods in this PR; promotion is needed so the moved \`maybe_apply_deterministic_quality_fallback\` free fn can call them via \`agent.<method>()\` across the module boundary.

## LOC delta

- \`turn.rs\`: 30,765 → 30,633 (-132 LOC)
- \`scaffold_pipeline.rs\`: 1,255 → 1,399 (+144 LOC)
- Cumulative \`turn.rs\`: 39,489 → 30,633 (**-8,856 LOC, -22.4%**)

## Constraints

- \`pub(super)\` limited / no facade re-export (DR3-001)
- \`turn.rs\` remains the only in-crate consumer
- Veneer shells in \`turn.rs\` preserve all caller sites

## Test plan

- [x] \`cargo fmt\`
- [x] \`cargo clippy --lib --all-targets -- -D warnings\` clean
- [x] \`cargo test --lib\` 3,114 passed / 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)