### PR TITLE
Phase 3 batch 12: UI polish + local-LLM small-edit fallback (#683)

### DIFF
--- a/src/agent/loop_run/scaffold_pipeline.rs
+++ b/src/agent/loop_run/scaffold_pipeline.rs
@@ -60,6 +60,7 @@ use super::turn::{
 use crate::agent::prompting;
 use crate::agent::recovery;
 use crate::logging::log_llm_event;
+use crate::model_capabilities::model_capabilities;
 use crate::modes::plan_act::{ExecutionMode, ModePolicy, PlanStage};
 use crate::ollama::client::AssistantReply;
 use crate::ollama::xml_fallback::ToolCall;
@@ -1361,6 +1362,114 @@ if __name__ == "__main__":
         }),
     );
     Ok(Some(test_name))
+}
+
+pub(super) fn maybe_apply_deterministic_polish_fallback(
+    agent: &Agent,
+    request: &str,
+    relative_target: &str,
+) -> Result<bool, String> {
+    if !agent
+        .config
+        .deterministic_fallback
+        .allows_template_completion()
+    {
+        return Ok(false);
+    }
+    let target = agent.work_root.join(relative_target);
+    let current = std::fs::read_to_string(&target)
+        .map_err(|err| format!("failed to read {}: {err}", target.display()))?;
+    let Some(replacement) = deterministic::playable_ui_polish(request, &target, &current) else {
+        return Ok(false);
+    };
+    std::fs::write(&target, replacement)
+        .map_err(|err| format!("failed to write {}: {err}", target.display()))?;
+    agent.maybe_apply_requested_port_script(request)?;
+    log_llm_event(
+        "agent.deterministic_ui_polish",
+        serde_json::json!({
+            "session_id": agent.session_store.session_id(),
+            "work_root": agent.work_root.display().to_string(),
+            "fallback_level": agent.config.deterministic_fallback.fallback_level(),
+            "fallback_action": "full_template",
+            "target": relative_target,
+        }),
+    );
+    Ok(true)
+}
+
+pub(super) fn maybe_apply_local_llm_small_edit_fallback(
+    agent: &mut Agent,
+    request: &str,
+) -> Result<Option<String>, String> {
+    if !agent
+        .config
+        .deterministic_fallback
+        .allows_template_completion()
+    {
+        return Ok(None);
+    }
+    if !model_capabilities(&agent.current_assistant_model()).read_after_small_edit_protocol {
+        return Ok(None);
+    }
+    let Some(target) = local_llm_small_edit_fallback_target(agent) else {
+        return Ok(None);
+    };
+    let current = std::fs::read_to_string(&target)
+        .map_err(|err| format!("failed to read {}: {err}", target.display()))?;
+    let polish_request = if super::quality::request_needs_playable_ui_quality_gate(request) {
+        "ゲームUIの品質を上げてください。".to_string()
+    } else {
+        format!("{request}\n品質を上げてください。")
+    };
+    let Some(replacement) = deterministic::playable_ui_polish(&polish_request, &target, &current)
+    else {
+        return Ok(None);
+    };
+    std::fs::write(&target, replacement)
+        .map_err(|err| format!("failed to write {}: {err}", target.display()))?;
+    agent
+        .session
+        .record_feedback_if_unset(build_feedback_for_deterministic_content_fallback(
+            &agent.work_root,
+        ));
+    let relative = target
+        .strip_prefix(&agent.work_root)
+        .unwrap_or(target.as_path())
+        .to_string_lossy()
+        .replace('\\', "/");
+    log_llm_event(
+        "agent.deterministic_local_llm_small_edit",
+        serde_json::json!({
+            "session_id": agent.session_store.session_id(),
+            "work_root": agent.work_root.display().to_string(),
+            "fallback_level": agent.config.deterministic_fallback.fallback_level(),
+            "fallback_action": "full_template",
+            "target": &relative,
+        }),
+    );
+    Ok(Some(relative))
+}
+
+pub(super) fn local_llm_small_edit_fallback_target(agent: &Agent) -> Option<PathBuf> {
+    if agent.session.mode_state.mode != ExecutionMode::Act
+        || !agent.session.mode_state.policy().repo_edit_required
+        || !agent.active_task_expects_repo_change()
+    {
+        return None;
+    }
+    if let Some(candidate) =
+        latest_turn_preferred_read_edit_target(&agent.session.messages, &agent.work_root)
+    {
+        return Some(candidate);
+    }
+    if let Some(path) = last_read_tool_path(&agent.session.messages)
+        && let Ok(candidate) = resolve_user_path(&agent.work_root, &path)
+        && candidate.is_file()
+    {
+        return Some(candidate);
+    }
+    first_existing_impl_target(&agent.work_root)
 }
 
 pub(super) fn maybe_apply_deterministic_quality_fallback(

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -10044,108 +10044,18 @@ impl Agent {
         request: &str,
         relative_target: &str,
     ) -> Result<bool, String> {
-        if !self
-            .config
-            .deterministic_fallback
-            .allows_template_completion()
-        {
-            return Ok(false);
-        }
-        let target = self.work_root.join(relative_target);
-        let current = std::fs::read_to_string(&target)
-            .map_err(|err| format!("failed to read {}: {err}", target.display()))?;
-        let Some(replacement) = deterministic::playable_ui_polish(request, &target, &current)
-        else {
-            return Ok(false);
-        };
-        std::fs::write(&target, replacement)
-            .map_err(|err| format!("failed to write {}: {err}", target.display()))?;
-        self.maybe_apply_requested_port_script(request)?;
-        log_llm_event(
-            "agent.deterministic_ui_polish",
-            serde_json::json!({
-                "session_id": self.session_store.session_id(),
-                "work_root": self.work_root.display().to_string(),
-                "fallback_level": self.config.deterministic_fallback.fallback_level(),
-                "fallback_action": "full_template",
-                "target": relative_target,
-            }),
-        );
-        Ok(true)
+        super::scaffold_pipeline::maybe_apply_deterministic_polish_fallback(
+            self,
+            request,
+            relative_target,
+        )
     }
 
     pub(super) fn maybe_apply_local_llm_small_edit_fallback(
         &mut self,
         request: &str,
     ) -> Result<Option<String>, String> {
-        if !self
-            .config
-            .deterministic_fallback
-            .allows_template_completion()
-        {
-            return Ok(None);
-        }
-        if !model_capabilities(&self.current_assistant_model()).read_after_small_edit_protocol {
-            return Ok(None);
-        }
-        let Some(target) = self.local_llm_small_edit_fallback_target() else {
-            return Ok(None);
-        };
-        let current = std::fs::read_to_string(&target)
-            .map_err(|err| format!("failed to read {}: {err}", target.display()))?;
-        let polish_request = if quality::request_needs_playable_ui_quality_gate(request) {
-            "ゲームUIの品質を上げてください。".to_string()
-        } else {
-            format!("{request}\n品質を上げてください。")
-        };
-        let Some(replacement) =
-            deterministic::playable_ui_polish(&polish_request, &target, &current)
-        else {
-            return Ok(None);
-        };
-        std::fs::write(&target, replacement)
-            .map_err(|err| format!("failed to write {}: {err}", target.display()))?;
-        self.session
-            .record_feedback_if_unset(build_feedback_for_deterministic_content_fallback(
-                &self.work_root,
-            ));
-        let relative = target
-            .strip_prefix(&self.work_root)
-            .unwrap_or(target.as_path())
-            .to_string_lossy()
-            .replace('\\', "/");
-        log_llm_event(
-            "agent.deterministic_local_llm_small_edit",
-            serde_json::json!({
-                "session_id": self.session_store.session_id(),
-                "work_root": self.work_root.display().to_string(),
-                "fallback_level": self.config.deterministic_fallback.fallback_level(),
-                "fallback_action": "full_template",
-                "target": &relative,
-            }),
-        );
-        Ok(Some(relative))
-    }
-
-    fn local_llm_small_edit_fallback_target(&self) -> Option<PathBuf> {
-        if self.session.mode_state.mode != ExecutionMode::Act
-            || !self.session.mode_state.policy().repo_edit_required
-            || !self.active_task_expects_repo_change()
-        {
-            return None;
-        }
-        if let Some(candidate) =
-            latest_turn_preferred_read_edit_target(&self.session.messages, &self.work_root)
-        {
-            return Some(candidate);
-        }
-        if let Some(path) = last_read_tool_path(&self.session.messages)
-            && let Ok(candidate) = resolve_user_path(&self.work_root, &path)
-            && candidate.is_file()
-        {
-            return Some(candidate);
-        }
-        first_existing_impl_target(&self.work_root)
+        super::scaffold_pipeline::maybe_apply_local_llm_small_edit_fallback(self, request)
     }
 
     pub(super) fn maybe_apply_requested_port_script(&self, request: &str) -> Result<(), String> {


### PR DESCRIPTION
## Summary

Issue #683 (parent #680, Phase 3) batch 12: migrate the \`maybe_apply_deterministic_polish_fallback\`, \`maybe_apply_local_llm_small_edit_fallback\`, and the supporting \`local_llm_small_edit_fallback_target\` selector from \`turn.rs\` to \`scaffold_pipeline.rs\` via the veneer pattern.

## Migrated as free fns in \`scaffold_pipeline.rs\` (\`pub(super)\`)

- \`maybe_apply_deterministic_polish_fallback(&Agent, request, relative_target) -> Result<bool, String>\`
- \`maybe_apply_local_llm_small_edit_fallback(&mut Agent, request) -> Result<Option<String>, String>\`
- \`local_llm_small_edit_fallback_target(&Agent) -> Option<PathBuf>\` (was a private \`fn\` on \`impl Agent\`; now a free fn since the only caller migrated alongside it)

\`scaffold_pipeline.rs\` imports gain \`crate::model_capabilities::model_capabilities\`.

## LOC delta

- \`turn.rs\`: 30,633 → 30,543 (-90 LOC)
- \`scaffold_pipeline.rs\`: 1,399 → 1,508 (+109 LOC)
- Cumulative \`turn.rs\`: 39,489 → 30,543 (**-8,946 LOC, -22.7%**)

## Constraints

- \`pub(super)\` limited / no facade re-export (DR3-001)
- \`turn.rs\` remains the only in-crate consumer
- Veneer shells in \`turn.rs\` preserve all caller sites for the 2 dispatch methods

## Test plan

- [x] \`cargo fmt\`
- [x] \`cargo clippy --lib --all-targets -- -D warnings\` clean
- [x] \`cargo test --lib\` 3,114 passed / 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)