### PR TITLE
Phase 3 batch 13: framework support files + port script + timeout fallbacks (#683)

### DIFF
--- a/src/agent/loop_run/scaffold_pipeline.rs
+++ b/src/agent/loop_run/scaffold_pipeline.rs
@@ -45,7 +45,10 @@ use super::completion_evidence::{RepoEditCategory, classify_repo_edit_path};
 use super::deterministic;
 use super::interrupt::InterruptFlag;
 use super::lifecycle;
-use super::quality::{first_existing_impl_target, implementation_quality_issue_for_request};
+use super::quality::{
+    first_existing_impl_target, implementation_quality_issue_for_request,
+    package_json_with_requested_port, react_dev_wrapper_for_requested_port,
+};
 use super::task_contract::{ArtifactRole, CompletionDecision};
 use super::tool_history::{
     focused_edit_target_already_read, has_successful_non_plan_repo_edit, latest_user_turn_slice,
@@ -54,8 +57,8 @@ use super::turn::{
     WrittenScaffoldArtifacts, current_file_hash_for_relative_path,
     deterministic_timeout_fallback_plan, extract_filename_with_suffix, last_read_tool_path,
     latest_turn_preferred_read_edit_target, meaningful_workspace_files, normalize_memory_path,
-    progress_path_display, sha256_hex, tool_result_failed, workspace_appears_empty,
-    write_stdout_rendered,
+    progress_path_display, sha256_hex, sync_package_json_with_existing_lock, tool_result_failed,
+    workspace_appears_empty, write_stdout_rendered,
 };
 use crate::agent::prompting;
 use crate::agent::recovery;
@@ -1492,8 +1495,8 @@ pub(super) fn maybe_apply_deterministic_quality_fallback(
     };
     std::fs::write(&target, replacement)
         .map_err(|err| format!("failed to write {}: {err}", target.display()))?;
-    agent.maybe_apply_deterministic_framework_support_files(request)?;
-    agent.maybe_apply_requested_port_script(request)?;
+    maybe_apply_deterministic_framework_support_files(agent, request)?;
+    maybe_apply_requested_port_script(agent, request)?;
     log_llm_event(
         "agent.deterministic_ui_quality_repair",
         serde_json::json!({
@@ -1505,4 +1508,105 @@ pub(super) fn maybe_apply_deterministic_quality_fallback(
         }),
     );
     Ok(true)
+}
+
+pub(super) fn maybe_apply_deterministic_framework_support_files(
+    agent: &Agent,
+    request: &str,
+) -> Result<(), String> {
+    if !agent
+        .config
+        .deterministic_fallback
+        .allows_support_recovery()
+    {
+        return Ok(());
+    }
+    let Some(files) = deterministic::empty_framework_app_files(request) else {
+        return Ok(());
+    };
+    let mut written_paths = Vec::<String>::new();
+    for (relative, content) in files {
+        if deterministic_framework_game_impl_path(&relative) {
+            continue;
+        }
+        let content = sync_package_json_with_existing_lock(&agent.work_root, &relative, content);
+        let target_relative = deterministic_support_target_relative(&agent.work_root, &relative);
+        let target = agent.work_root.join(&target_relative);
+        if let Some(parent) = target.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|err| format!("failed to create {}: {err}", parent.display()))?;
+        }
+        std::fs::write(&target, content)
+            .map_err(|err| format!("failed to write {}: {err}", target.display()))?;
+        written_paths.push(target_relative.to_string_lossy().replace('\\', "/"));
+    }
+    if !written_paths.is_empty() {
+        log_llm_event(
+            "agent.deterministic_framework_support_files",
+            serde_json::json!({
+                "session_id": agent.session_store.session_id(),
+                "work_root": agent.work_root.display().to_string(),
+                "fallback_level": agent.config.deterministic_fallback.fallback_level(),
+                "fallback_action": "minimal_patch",
+                "files": written_paths,
+            }),
+        );
+    }
+    Ok(())
+}
+
+pub(super) fn maybe_apply_requested_port_script(
+    agent: &Agent,
+    request: &str,
+) -> Result<(), String> {
+    let package_path = agent.work_root.join("package.json");
+    let Ok(current) = std::fs::read_to_string(&package_path) else {
+        return Ok(());
+    };
+    let react_dev_wrapper = react_dev_wrapper_for_requested_port(request, &current);
+    let Some(updated) = package_json_with_requested_port(request, &current) else {
+        if let Some(wrapper) = react_dev_wrapper {
+            write_react_dev_wrapper(agent, wrapper)?;
+        }
+        return Ok(());
+    };
+    std::fs::write(&package_path, updated)
+        .map_err(|err| format!("failed to write {}: {err}", package_path.display()))?;
+    if let Some(wrapper) = react_dev_wrapper {
+        write_react_dev_wrapper(agent, wrapper)?;
+    }
+    Ok(())
+}
+
+fn write_react_dev_wrapper(agent: &Agent, wrapper: String) -> Result<(), String> {
+    let scripts_dir = agent.work_root.join("scripts");
+    std::fs::create_dir_all(&scripts_dir)
+        .map_err(|err| format!("failed to create {}: {err}", scripts_dir.display()))?;
+    let wrapper_path = scripts_dir.join("dev.mjs");
+    std::fs::write(&wrapper_path, wrapper)
+        .map_err(|err| format!("failed to write {}: {err}", wrapper_path.display()))
+}
+
+pub(super) fn maybe_apply_deterministic_quality_fallback_after_timeout(
+    agent: &Agent,
+    err: &str,
+) -> Option<AssistantReply> {
+    if !err.to_ascii_lowercase().contains("timed out")
+        || !agent.current_request_needs_playable_ui_quality_gate()
+    {
+        return None;
+    }
+    None
+}
+
+pub(super) fn maybe_apply_deterministic_polish_fallback_after_timeout(
+    agent: &Agent,
+    err: &str,
+) -> Option<AssistantReply> {
+    if !err.to_ascii_lowercase().contains("timed out")
+        || !agent.current_request_needs_playable_ui_quality_gate()
+    {
+        return None;
+    }
+    None
 }

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -92,7 +92,6 @@ use super::scaffold_pipeline::recent_deterministic_framework_app_fallback_seen;
 use super::scaffold_pipeline::task_requires_nextjs_scaffold;
 use super::scaffold_pipeline::{
     EVENT_DETERMINISTIC_FORMAT_ERROR_SMALL_EDIT, ScaffoldFallbackResult, ScaffoldFramework,
-    deterministic_framework_game_impl_path, deterministic_support_target_relative,
     scaffold_candidate_priority,
 };
 #[cfg(test)]
@@ -226,8 +225,7 @@ use super::deterministic::empty_framework_game_files as deterministic_empty_fram
 use super::progress_text::{is_utf8_locale, tool_color, tool_emoji};
 use super::progress_text::{sanitize_for_progress, truncate};
 use super::quality::{
-    first_existing_impl_target, package_json_with_requested_port, quality_first_pass_observation,
-    react_dev_wrapper_for_requested_port, repo_change_request_text,
+    first_existing_impl_target, quality_first_pass_observation, repo_change_request_text,
     request_allows_fast_polish_fallback, request_explicitly_requires_tests,
     request_mentions_unsupported_ui_framework, request_needs_playable_ui_quality_gate,
     workspace_has_unsupported_ui_framework,
@@ -1707,7 +1705,7 @@ pub(super) fn normalize_exploration_path(raw_path: &str, work_root: &Path) -> St
     raw_path.trim().replace('\\', "/")
 }
 
-fn sync_package_json_with_existing_lock(
+pub(super) fn sync_package_json_with_existing_lock(
     work_root: &Path,
     relative: &Path,
     package_content: String,
@@ -9998,47 +9996,6 @@ impl Agent {
         )
     }
 
-    pub(super) fn maybe_apply_deterministic_framework_support_files(
-        &self,
-        request: &str,
-    ) -> Result<(), String> {
-        if !self.config.deterministic_fallback.allows_support_recovery() {
-            return Ok(());
-        }
-        let Some(files) = deterministic::empty_framework_app_files(request) else {
-            return Ok(());
-        };
-        let mut written_paths = Vec::<String>::new();
-        for (relative, content) in files {
-            if deterministic_framework_game_impl_path(&relative) {
-                continue;
-            }
-            let content = sync_package_json_with_existing_lock(&self.work_root, &relative, content);
-            let target_relative = deterministic_support_target_relative(&self.work_root, &relative);
-            let target = self.work_root.join(&target_relative);
-            if let Some(parent) = target.parent() {
-                std::fs::create_dir_all(parent)
-                    .map_err(|err| format!("failed to create {}: {err}", parent.display()))?;
-            }
-            std::fs::write(&target, content)
-                .map_err(|err| format!("failed to write {}: {err}", target.display()))?;
-            written_paths.push(target_relative.to_string_lossy().replace('\\', "/"));
-        }
-        if !written_paths.is_empty() {
-            log_llm_event(
-                "agent.deterministic_framework_support_files",
-                serde_json::json!({
-                    "session_id": self.session_store.session_id(),
-                    "work_root": self.work_root.display().to_string(),
-                    "fallback_level": self.config.deterministic_fallback.fallback_level(),
-                    "fallback_action": "minimal_patch",
-                    "files": written_paths,
-                }),
-            );
-        }
-        Ok(())
-    }
-
     pub(super) fn maybe_apply_deterministic_polish_fallback(
         &self,
         request: &str,
@@ -10059,62 +10016,23 @@ impl Agent {
     }
 
     pub(super) fn maybe_apply_requested_port_script(&self, request: &str) -> Result<(), String> {
-        let package_path = self.work_root.join("package.json");
-        let Ok(current) = std::fs::read_to_string(&package_path) else {
-            return Ok(());
-        };
-        let react_dev_wrapper = react_dev_wrapper_for_requested_port(request, &current);
-        let Some(updated) = package_json_with_requested_port(request, &current) else {
-            if let Some(wrapper) = react_dev_wrapper {
-                self.write_react_dev_wrapper(wrapper)?;
-            }
-            return Ok(());
-        };
-        std::fs::write(&package_path, updated)
-            .map_err(|err| format!("failed to write {}: {err}", package_path.display()))?;
-        if let Some(wrapper) = react_dev_wrapper {
-            self.write_react_dev_wrapper(wrapper)?;
-        }
-        Ok(())
-    }
-
-    fn write_react_dev_wrapper(&self, wrapper: String) -> Result<(), String> {
-        let scripts_dir = self.work_root.join("scripts");
-        std::fs::create_dir_all(&scripts_dir)
-            .map_err(|err| format!("failed to create {}: {err}", scripts_dir.display()))?;
-        let wrapper_path = scripts_dir.join("dev.mjs");
-        std::fs::write(&wrapper_path, wrapper)
-            .map_err(|err| format!("failed to write {}: {err}", wrapper_path.display()))
+        super::scaffold_pipeline::maybe_apply_requested_port_script(self, request)
     }
 
     fn maybe_apply_deterministic_quality_fallback_after_timeout(
         &self,
         err: &str,
     ) -> Option<AssistantReply> {
-        if !err.to_ascii_lowercase().contains("timed out")
-            || !self.current_request_needs_playable_ui_quality_gate()
-        {
-            return None;
-        }
-        // Creative/playable UI timeout recovery must not synthesize a
-        // completion reply. Let the focused-edit recovery path continue so the
-        // next successful completion is model-produced or verifier-backed.
-        None
+        super::scaffold_pipeline::maybe_apply_deterministic_quality_fallback_after_timeout(
+            self, err,
+        )
     }
 
     fn maybe_apply_deterministic_polish_fallback_after_timeout(
         &self,
         err: &str,
     ) -> Option<AssistantReply> {
-        if !err.to_ascii_lowercase().contains("timed out")
-            || !self.current_request_needs_playable_ui_quality_gate()
-        {
-            return None;
-        }
-        // Same boundary as quality fallback above: deterministic polish can be
-        // a recovery aid during normal loop iterations, but timeout handling
-        // must not turn it into an assistant completion.
-        None
+        super::scaffold_pipeline::maybe_apply_deterministic_polish_fallback_after_timeout(self, err)
     }
 
     fn refresh_working_memory(&mut self) {


### PR DESCRIPTION
## Summary

Issue #683 (parent #680, Phase 3) batch 13: migrate the support / port script materializers plus the two timeout-fallback no-op predicates from \`turn.rs\` to \`scaffold_pipeline.rs\` via the veneer pattern.

## Migrated as free fns in \`scaffold_pipeline.rs\` (\`pub(super)\`)

- \`maybe_apply_deterministic_framework_support_files(&Agent, request) -> Result<(), String>\`
- \`maybe_apply_requested_port_script(&Agent, request) -> Result<(), String>\`
- \`maybe_apply_deterministic_quality_fallback_after_timeout(&Agent, err) -> Option<AssistantReply>\`
- \`maybe_apply_deterministic_polish_fallback_after_timeout(&Agent, err) -> Option<AssistantReply>\`

Helper moved as module-private:

- \`write_react_dev_wrapper(&Agent, wrapper)\` — single caller \`maybe_apply_requested_port_script\` migrated alongside it.

## Promotions in \`turn.rs\` (\`pub(super)\`)

- \`sync_package_json_with_existing_lock\`

## Removed (dead veneer)

- \`Agent::maybe_apply_deterministic_framework_support_files\` — sole caller migrated in this PR.

## LOC delta

- \`turn.rs\`: 30,543 → 30,461 (-82 LOC)
- \`scaffold_pipeline.rs\`: 1,508 → 1,612 (+104 LOC)
- Cumulative \`turn.rs\`: 39,489 → 30,461 (**-9,028 LOC, -22.9%**)

## Constraints

- \`pub(super)\` limited / no facade re-export (DR3-001)
- \`turn.rs\` remains the only in-crate consumer
- Veneer shells in \`turn.rs\` preserve all caller sites for the 3 still-callable dispatch methods

## Test plan

- [x] \`cargo fmt\`
- [x] \`cargo clippy --lib --all-targets -- -D warnings\` clean
- [x] \`cargo test --lib\` 3,114 passed / 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)