### PR TITLE
Phase 4 batch 3: consolidate maybe_invoke_reminder shim (#684)

### DIFF
--- a/src/agent/loop_run/actor_loop_flow.rs
+++ b/src/agent/loop_run/actor_loop_flow.rs
@@ -1209,7 +1209,7 @@ pub(super) fn handle_actor_loop_post_tool_cleanup(
     args: ActorLoopPostToolCleanupArgs<'_>,
 ) -> ActorLoopPostToolCleanupOutcome {
     sync_post_tool_contract_recovery_target(agent, &args);
-    agent.maybe_invoke_reminder(args.interrupt_flag);
+    super::reminder_pipeline::maybe_invoke_reminder(agent, args.interrupt_flag);
     run_post_tool_cleanup_compaction(
         agent,
         args.tool_calls_made_this_turn,
@@ -3703,7 +3703,7 @@ pub(super) fn run_actor_loop(
     // NoRepoProgress / auto_test / NoVerifierAvailable frames recorded
     // after the actor loop exited. Per-turn cap means this no-ops if the
     // iteration-internal hook already ran.
-    agent.maybe_invoke_reminder(&interrupt_flag);
+    super::reminder_pipeline::maybe_invoke_reminder(agent, &interrupt_flag);
     // Issue #462: CaseRecord extraction (post-loop, after Reminder, before
     // turn_completed event). Pure success-condition + scrub + persist; no
     // sidecar / LLM calls. Failures are logged and never propagate.

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -3539,15 +3539,6 @@ impl Agent {
         }
     }
 
-    /// Issue #452: post-actor-loop hook for the Reminder Sidecar. Called from
-    /// `run_actor_loop` (iteration-internal before compaction, and post-loop
-    /// for NoRepoProgress / auto_test / NoVerifierAvailable). Per-turn cap
-    /// (`reminder_called_this_turn`) is consumed only by Completed / Failed
-    /// — Skipped does not consume the cap (DR3-002).
-    pub(super) fn maybe_invoke_reminder(&mut self, interrupt_flag: &InterruptFlag) {
-        super::reminder_pipeline::maybe_invoke_reminder(self, interrupt_flag)
-    }
-
     /// Issue #557: call photon context_pack and store rendered response.
     /// Canary gate runs BEFORE the HTTP fetch (DR3-002).
     fn invoke_photon_context_pack(&mut self) {


### PR DESCRIPTION
## Summary

Issue #684 (parent #680, Phase 4) batch 3: remove the final reminder veneer shim on \`impl Agent\` and rewrite its two callers in \`actor_loop_flow.rs\` to invoke \`super::reminder_pipeline::*\` directly. After this batch, \`impl Agent\` no longer hosts any reminder-pipeline shim methods. **Phase 4 (#684) close.**

## Veneer shim removed

- \`Agent::maybe_invoke_reminder\` (2 callers in \`actor_loop_flow.rs\`: iteration-internal pre-compaction + post-loop hook for NoRepoProgress / auto_test / NoVerifierAvailable)

## LOC delta

- \`turn.rs\`: 30,004 → 29,995 (-9 LOC)
- \`actor_loop_flow.rs\`: 4,754 → 4,754 (path widening, no net LOC change)
- \`reminder_pipeline.rs\`: unchanged (263)
- Cumulative \`turn.rs\`: 39,489 → 29,995 (**-9,494 LOC, -24.0%**)

## Constraints

- \`pub(super)\` limited / no facade re-export (DR3-001)
- \`turn.rs\` remains the only in-crate consumer
- Behavior unchanged — direct free-fn call replaces a one-line shim

## Test plan

- [x] \`cargo fmt\`
- [x] \`cargo clippy --lib --all-targets -- -D warnings\` clean
- [x] \`cargo test --lib\` 3,114 passed / 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)