### PR TITLE
Phase 8 batch 4: context-pack truncate + adopted-id prep (#688)

### DIFF
--- a/src/agent/loop_run.rs
+++ b/src/agent/loop_run.rs
@@ -574,8 +574,10 @@ pub use turn::select_precautions_for_prompt;
 // Issue #556: expose pure helper functions so `tests/photon_turn_hook_smoke.rs`
 // can verify truncation and injection-message building without constructing
 // a full Agent (Ollama-free).
-pub use photon_feedback_derive::build_photon_injection_message;
-pub use turn::{MAX_PHOTON_CONTEXT_PACK_PROMPT_BYTES, truncate_photon_context_pack};
+pub use photon_feedback_derive::{
+    MAX_PHOTON_CONTEXT_PACK_PROMPT_BYTES, build_photon_injection_message,
+    truncate_photon_context_pack,
+};
 
 // Issue #601: expose the Case F `outcome_detail` static-allowlist literal so
 // `tests/photon_evaluate_signal_smoke.rs` can grep / assert against the same

--- a/src/agent/loop_run/photon_feedback_derive.rs
+++ b/src/agent/loop_run/photon_feedback_derive.rs
@@ -23,6 +23,8 @@
 //! consumer for the `PhotonOutcomeInputs` / `PhotonFeedbackOutcome` types.
 
 use super::completion_evidence;
+use crate::photon;
+use crate::photon::prompt::sanitize_summary_id;
 use crate::session::feedback::{FeedbackKind, MAX_VERIFIER_COMMAND_BYTES};
 use crate::session::store::{ConversationMessage, SessionSnapshot};
 use crate::tools::bash::{BashCommandClass, classify_command};
@@ -142,6 +144,71 @@ pub(crate) fn case_f_condition_met(inputs: &PhotonOutcomeInputs<'_>) -> bool {
 /// import the symbol via the `pub use` re-export added in
 /// `src/agent/loop_run.rs`.
 pub const PHOTON_OUTCOME_DETAIL_NO_PROGRESS_DESPITE_INJECT: &str = "no_progress_despite_inject";
+
+/// Issue #556: max bytes to inject from context_pack into the prompt.
+pub const MAX_PHOTON_CONTEXT_PACK_PROMPT_BYTES: usize = 8192;
+
+/// Issue #556: apply UTF-8-safe byte truncation to a photon context_pack
+/// masked response. Returns `(truncated_string, was_truncated)`.
+/// Pure function — exposed for unit testing.
+pub fn truncate_photon_context_pack(s: String) -> (String, bool) {
+    if s.len() <= MAX_PHOTON_CONTEXT_PACK_PROMPT_BYTES {
+        return (s, false);
+    }
+    let truncate_at = s
+        .char_indices()
+        .map(|(i, _)| i)
+        .take_while(|&i| i < MAX_PHOTON_CONTEXT_PACK_PROMPT_BYTES)
+        .last()
+        .unwrap_or(0);
+    let mut out = s;
+    out.truncate(truncate_at);
+    out.push_str("\n[truncated]");
+    (out, true)
+}
+
+/// Issue #591 (DR4-NEW-001): result of re-sanitizing + capping an adopted-id
+/// list before sending it to photon `/v1/evaluate`. The struct is a pure
+/// transport for two return values (capped list + audit flag) and lives in
+/// the agent layer so the photon layer doesn't gain a dependency on
+/// `MAX_PHOTON_EVAL_ADOPTED_IDS` outside the SSOT.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SanitizedAdoptedIds {
+    /// Sanitized + capped list to send to photon.
+    pub list: Vec<String>,
+    /// `true` when the post-sanitize list length exceeded
+    /// `MAX_PHOTON_EVAL_ADOPTED_IDS` and was truncated.
+    pub truncated: bool,
+}
+
+/// Issue #591 (DR4-NEW-001 / DR4-NEW-002): pure helper that re-runs
+/// `sanitize_summary_id` on each raw id (drops `None`) and then truncates the
+/// result to `MAX_PHOTON_EVAL_ADOPTED_IDS`. Returns
+/// `SanitizedAdoptedIds { list, truncated }`. In `shadow_mode=true` the helper
+/// short-circuits to `(vec![], false)` regardless of input (the shadow guard).
+///
+/// Pure function — no I/O. Exposed at `pub(crate)` for module unit testing.
+pub(crate) fn prepare_adopted_ids_for_evaluate(
+    raw: &[String],
+    shadow_mode: bool,
+) -> SanitizedAdoptedIds {
+    if shadow_mode {
+        return SanitizedAdoptedIds {
+            list: Vec::new(),
+            truncated: false,
+        };
+    }
+    let sanitized: Vec<String> = raw
+        .iter()
+        .filter_map(|id| sanitize_summary_id(id))
+        .collect();
+    let truncated = sanitized.len() > photon::MAX_PHOTON_EVAL_ADOPTED_IDS;
+    let list: Vec<String> = sanitized
+        .into_iter()
+        .take(photon::MAX_PHOTON_EVAL_ADOPTED_IDS)
+        .collect();
+    SanitizedAdoptedIds { list, truncated }
+}
 
 // ---------------------------------------------------------------------------
 // Issue #608 Phase α-2 (AP-09): rerun-trigger keyword detection (pure helper).

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -78,7 +78,7 @@ use super::verifier_repair_targeting::{
 
 use super::photon_feedback_derive::{
     PhotonFeedbackOutcome, PhotonOutcomeInputs, build_rerun_prompt_hint_if_eligible,
-    derive_photon_feedback_outcome,
+    derive_photon_feedback_outcome, prepare_adopted_ids_for_evaluate,
 };
 #[cfg(test)]
 use super::repair_patch_validation::VerifierRepairIntent;
@@ -478,71 +478,6 @@ mod v0421_repair_runner_contract_tests {
             );
         }
     }
-}
-
-/// Issue #556: max bytes to inject from context_pack into the prompt.
-pub const MAX_PHOTON_CONTEXT_PACK_PROMPT_BYTES: usize = 8192;
-
-/// Issue #556: apply UTF-8-safe byte truncation to a photon context_pack
-/// masked response. Returns `(truncated_string, was_truncated)`.
-/// Pure function — exposed for unit testing.
-pub fn truncate_photon_context_pack(s: String) -> (String, bool) {
-    if s.len() <= MAX_PHOTON_CONTEXT_PACK_PROMPT_BYTES {
-        return (s, false);
-    }
-    let truncate_at = s
-        .char_indices()
-        .map(|(i, _)| i)
-        .take_while(|&i| i < MAX_PHOTON_CONTEXT_PACK_PROMPT_BYTES)
-        .last()
-        .unwrap_or(0);
-    let mut out = s;
-    out.truncate(truncate_at);
-    out.push_str("\n[truncated]");
-    (out, true)
-}
-
-/// Issue #591 (DR4-NEW-001): result of re-sanitizing + capping an adopted-id
-/// list before sending it to photon `/v1/evaluate`. The struct is a pure
-/// transport for two return values (capped list + audit flag) and lives in
-/// the agent layer so the photon layer doesn't gain a dependency on
-/// `MAX_PHOTON_EVAL_ADOPTED_IDS` outside the SSOT.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct SanitizedAdoptedIds {
-    /// Sanitized + capped list to send to photon.
-    pub list: Vec<String>,
-    /// `true` when the post-sanitize list length exceeded
-    /// `MAX_PHOTON_EVAL_ADOPTED_IDS` and was truncated.
-    pub truncated: bool,
-}
-
-/// Issue #591 (DR4-NEW-001 / DR4-NEW-002): pure helper that re-runs
-/// `sanitize_summary_id` on each raw id (drops `None`) and then truncates the
-/// result to `MAX_PHOTON_EVAL_ADOPTED_IDS`. Returns
-/// `SanitizedAdoptedIds { list, truncated }`. In `shadow_mode=true` the helper
-/// short-circuits to `(vec![], false)` regardless of input (the shadow guard).
-///
-/// Pure function — no I/O. Exposed at `pub(crate)` for module unit testing.
-pub(crate) fn prepare_adopted_ids_for_evaluate(
-    raw: &[String],
-    shadow_mode: bool,
-) -> SanitizedAdoptedIds {
-    if shadow_mode {
-        return SanitizedAdoptedIds {
-            list: Vec::new(),
-            truncated: false,
-        };
-    }
-    let sanitized: Vec<String> = raw
-        .iter()
-        .filter_map(|id| crate::photon::prompt::sanitize_summary_id(id))
-        .collect();
-    let truncated = sanitized.len() > crate::photon::MAX_PHOTON_EVAL_ADOPTED_IDS;
-    let list: Vec<String> = sanitized
-        .into_iter()
-        .take(crate::photon::MAX_PHOTON_EVAL_ADOPTED_IDS)
-        .collect();
-    SanitizedAdoptedIds { list, truncated }
 }
 
 /// Issue #608 Phase α-2 (AP-09): RFC3339 UTC timestamp for the current
@@ -29367,7 +29302,7 @@ mod rerun_hint_eligibility_tests {
 // ───────────────────────────────────────────────────────────────────────────
 #[cfg(test)]
 mod prepare_adopted_ids_for_evaluate_tests {
-    use super::prepare_adopted_ids_for_evaluate;
+    use super::super::photon_feedback_derive::prepare_adopted_ids_for_evaluate;
     use crate::photon::MAX_PHOTON_EVAL_ADOPTED_IDS;
 
     #[test]


### PR DESCRIPTION
## Summary

Issue #688 (parent #680, Phase 8) batch 4: migrate the photon context-pack byte-truncation helper, the adopted-id sanitize+cap helper, the supporting \`SanitizedAdoptedIds\` struct, and the \`MAX_PHOTON_CONTEXT_PACK_PROMPT_BYTES\` const from \`turn.rs\` to \`photon_feedback_derive.rs\`.

## Migrated to \`photon_feedback_derive.rs\`

- \`pub const MAX_PHOTON_CONTEXT_PACK_PROMPT_BYTES: usize = 8192\`
- \`pub fn truncate_photon_context_pack(s) -> (String, bool)\` (UTF-8 safe byte truncation, re-exported via \`loop_run.rs\`)
- \`pub(crate) struct SanitizedAdoptedIds { list, truncated }\`
- \`pub(crate) fn prepare_adopted_ids_for_evaluate(raw, shadow_mode) -> SanitizedAdoptedIds\` (re-runs \`sanitize_summary_id\` per id, caps at \`MAX_PHOTON_EVAL_ADOPTED_IDS\`, shadow guard short-circuits to empty)

## \`loop_run.rs\` adjustments

- Consolidated 2 separate \`pub use\` lines into a single block re-exporting the 3 \`pub\` photon symbols (\`MAX_PHOTON_CONTEXT_PACK_PROMPT_BYTES\` / \`build_photon_injection_message\` / \`truncate_photon_context_pack\`) from \`photon_feedback_derive\`. \`tests/photon_turn_hook_smoke.rs\` import paths are unchanged.

## LOC delta

- \`turn.rs\`: 29,443 → 29,378 (-65 LOC)
- \`photon_feedback_derive.rs\`: 485 → 552 (+67 LOC)
- Cumulative \`turn.rs\`: 39,489 → 29,378 (**-10,111 LOC, -25.6%**)

## Constraints

- \`pub(crate)\` for \`SanitizedAdoptedIds\` / \`prepare_adopted_ids_for_evaluate\`, \`pub\` for the 2 public symbols (matching pre-extraction visibility)
- \`turn.rs\` remains the only in-crate consumer of the \`pub(crate)\` symbols

## Test plan

- [x] \`cargo fmt\`
- [x] \`cargo clippy --lib --all-targets -- -D warnings\` clean
- [x] \`cargo test --lib\` 3,114 passed / 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)