### PR TITLE
Phase 8 batch 5: photon evaluate adoption-status helpers (#688)

### DIFF
--- a/src/agent/loop_run/photon_feedback_derive.rs
+++ b/src/agent/loop_run/photon_feedback_derive.rs
@@ -550,3 +550,40 @@ pub fn build_photon_injection_message(
          [End Photon External Memory]"
     )))
 }
+
+/// Issue #591 (DR4-NEW-004 audit boundary): static-allowlist projection
+/// of (`shadow_mode`, `adopted_items`) to one of three `&'static str`
+/// values used by the `agent.photon_evaluate.completed` log event and
+/// the `context_pack_event` request body. Lives in the agent layer so
+/// the photon layer doesn't gain a dependency on the literal strings.
+pub(super) fn photon_evaluate_adoption_status(
+    shadow_mode: bool,
+    adopted_items: usize,
+) -> &'static str {
+    if shadow_mode {
+        "shadow_not_injected"
+    } else if adopted_items > 0 {
+        "injected"
+    } else {
+        "not_injected"
+    }
+}
+
+/// Issue #591: shadow_mode short-circuit for the `items_adopted` count
+/// shipped to photon. On shadow turns Anvil must not stamp a positive
+/// adoption count even when the local renderer accepted items.
+pub(super) fn photon_items_adopted_count(shadow_mode: bool, adopted_items: usize) -> usize {
+    if shadow_mode { 0 } else { adopted_items }
+}
+
+/// Issue #591 (DR4-NEW-004 audit boundary): static-allowlist projection
+/// for the `outcome` JSON field. `Some(value)` → `JSON::String(value)`,
+/// `None` → `JSON::Null`. Pure function — the helper cannot leak
+/// runtime data into the outbound payload because the input is already
+/// `Option<&'static str>`.
+pub(super) fn photon_outcome_json_value(outcome: Option<&'static str>) -> serde_json::Value {
+    match outcome {
+        Some(value) => serde_json::Value::String(value.to_string()),
+        None => serde_json::Value::Null,
+    }
+}

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -78,7 +78,8 @@ use super::verifier_repair_targeting::{
 
 use super::photon_feedback_derive::{
     PhotonFeedbackOutcome, PhotonOutcomeInputs, build_rerun_prompt_hint_if_eligible,
-    derive_photon_feedback_outcome, prepare_adopted_ids_for_evaluate,
+    derive_photon_feedback_outcome, photon_evaluate_adoption_status, photon_items_adopted_count,
+    photon_outcome_json_value, prepare_adopted_ids_for_evaluate,
 };
 #[cfg(test)]
 use super::repair_patch_validation::VerifierRepairIntent;
@@ -1644,27 +1645,6 @@ fn anti_pattern_failed_action_summary(frame: &FeedbackFrame) -> String {
         .clone()
         .or_else(|| frame.command().map(|s| s.to_string()))
         .unwrap_or_else(|| format!("{:?}", frame.kind))
-}
-
-fn photon_evaluate_adoption_status(shadow_mode: bool, adopted_items: usize) -> &'static str {
-    if shadow_mode {
-        "shadow_not_injected"
-    } else if adopted_items > 0 {
-        "injected"
-    } else {
-        "not_injected"
-    }
-}
-
-fn photon_items_adopted_count(shadow_mode: bool, adopted_items: usize) -> usize {
-    if shadow_mode { 0 } else { adopted_items }
-}
-
-fn photon_outcome_json_value(outcome: Option<&'static str>) -> serde_json::Value {
-    match outcome {
-        Some(value) => serde_json::Value::String(value.to_string()),
-        None => serde_json::Value::Null,
-    }
 }
 
 fn tester_approval_mode(yes_mode: bool, stdin_is_terminal: bool) -> tester::ApprovalMode {


### PR DESCRIPTION
## Summary

Issue #688 (parent #680, Phase 8) batch 5: migrate the three small photon adoption-status / outcome JSON projection helpers from \`turn.rs\` to \`photon_feedback_derive.rs\`.

## Migrated as free fns in \`photon_feedback_derive.rs\` (\`pub(super)\`)

- \`photon_evaluate_adoption_status(shadow_mode, adopted_items) -> &'static str\` (3-branch static-allowlist projection: \`"shadow_not_injected"\` / \`"injected"\` / \`"not_injected"\`)
- \`photon_items_adopted_count(shadow_mode, adopted_items) -> usize\` (shadow-mode short-circuit for \`items_adopted\`)
- \`photon_outcome_json_value(outcome) -> serde_json::Value\` (static-allowlist projection of \`Option<&'static str>\` to \`JSON::String\` / \`JSON::Null\` — cannot leak runtime data)

## \`turn.rs\` adjustments

- Removed the 3 fn definitions; added the 3 names to the existing \`use super::photon_feedback_derive::{...}\` block.

## LOC delta

- \`turn.rs\`: 29,378 → 29,358 (-20 LOC)
- \`photon_feedback_derive.rs\`: 552 → 589 (+37 LOC)
- Cumulative \`turn.rs\`: 39,489 → 29,358 (**-10,131 LOC, -25.7%**)

## Constraints

- \`pub(super)\` (matching the pre-extraction module-private visibility)
- No external test or non-turn consumer

## Test plan

- [x] \`cargo fmt\`
- [x] \`cargo clippy --lib --all-targets -- -D warnings\` clean
- [x] \`cargo test --lib\` 3,114 passed / 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)