### PR TITLE
Phase 8 batch 6: photon context-pack status + evaluate log struct (#688)

### DIFF
--- a/src/agent/loop_run/photon_feedback_derive.rs
+++ b/src/agent/loop_run/photon_feedback_derive.rs
@@ -587,3 +587,35 @@ pub(super) fn photon_outcome_json_value(outcome: Option<&'static str>) -> serde_
         None => serde_json::Value::Null,
     }
 }
+
+/// Issue #591: 3-branch projection of (`failed`, `adopted_items`) to the
+/// status enum used by the `MemoryReport.photon_context_pack` linkage and
+/// the per-turn diagnostic event payload. Failed > injected > no-injection
+/// priority. Lives in the agent layer so the loop_run facade can keep
+/// the enum private to the crate.
+pub(super) fn photon_context_pack_completion_status(
+    failed: bool,
+    adopted_items: usize,
+) -> super::PhotonContextPackStatus {
+    if failed {
+        super::PhotonContextPackStatus::Failed
+    } else if adopted_items > 0 {
+        super::PhotonContextPackStatus::Injected
+    } else {
+        super::PhotonContextPackStatus::NoInjection
+    }
+}
+
+/// Issue #591: bounded payload struct passed from `invoke_photon_evaluate`
+/// to `log_photon_evaluate_completed`. All fields are pre-projected via the
+/// `photon_*` static-allowlist helpers so the consumer cannot leak runtime
+/// data into the `agent.photon_evaluate.completed` log event.
+pub(super) struct PhotonEvaluateCompletedLog {
+    pub(super) failed: bool,
+    pub(super) duration_ms: u128,
+    pub(super) summary_ids_adopted_count: usize,
+    pub(super) adoption_status: &'static str,
+    pub(super) truncated: bool,
+    pub(super) outcome_json: serde_json::Value,
+    pub(super) outcome_detail_json: serde_json::Value,
+}

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -77,9 +77,10 @@ use super::verifier_repair_targeting::{
 };
 
 use super::photon_feedback_derive::{
-    PhotonFeedbackOutcome, PhotonOutcomeInputs, build_rerun_prompt_hint_if_eligible,
-    derive_photon_feedback_outcome, photon_evaluate_adoption_status, photon_items_adopted_count,
-    photon_outcome_json_value, prepare_adopted_ids_for_evaluate,
+    PhotonEvaluateCompletedLog, PhotonFeedbackOutcome, PhotonOutcomeInputs,
+    build_rerun_prompt_hint_if_eligible, derive_photon_feedback_outcome,
+    photon_context_pack_completion_status, photon_evaluate_adoption_status,
+    photon_items_adopted_count, photon_outcome_json_value, prepare_adopted_ids_for_evaluate,
 };
 #[cfg(test)]
 use super::repair_patch_validation::VerifierRepairIntent;
@@ -1612,29 +1613,6 @@ fn log_quality_confirm_outcome(
         latency_ms,
     );
     log_llm_event(event, payload);
-}
-
-fn photon_context_pack_completion_status(
-    failed: bool,
-    adopted_items: usize,
-) -> crate::agent::loop_run::PhotonContextPackStatus {
-    if failed {
-        crate::agent::loop_run::PhotonContextPackStatus::Failed
-    } else if adopted_items > 0 {
-        crate::agent::loop_run::PhotonContextPackStatus::Injected
-    } else {
-        crate::agent::loop_run::PhotonContextPackStatus::NoInjection
-    }
-}
-
-struct PhotonEvaluateCompletedLog {
-    failed: bool,
-    duration_ms: u128,
-    summary_ids_adopted_count: usize,
-    adoption_status: &'static str,
-    truncated: bool,
-    outcome_json: serde_json::Value,
-    outcome_detail_json: serde_json::Value,
 }
 
 pub(super) type WrittenScaffoldArtifacts = (Vec<PathBuf>, Vec<ScaffoldArtifactFileSnapshot>);
@@ -10180,16 +10158,17 @@ mod tests {
 
     #[test]
     fn photon_context_pack_completion_status_prefers_failure_then_adoption() {
+        use super::super::photon_feedback_derive::photon_context_pack_completion_status;
         assert_eq!(
-            super::photon_context_pack_completion_status(true, 3),
+            photon_context_pack_completion_status(true, 3),
             super::PhotonContextPackStatus::Failed
         );
         assert_eq!(
-            super::photon_context_pack_completion_status(false, 2),
+            photon_context_pack_completion_status(false, 2),
             super::PhotonContextPackStatus::Injected
         );
         assert_eq!(
-            super::photon_context_pack_completion_status(false, 0),
+            photon_context_pack_completion_status(false, 0),
             super::PhotonContextPackStatus::NoInjection
         );
     }


### PR DESCRIPTION
## Summary

Issue #688 (parent #680, Phase 8) batch 6: migrate the photon context-pack completion-status projection helper and the \`PhotonEvaluateCompletedLog\` payload struct from \`turn.rs\` to \`photon_feedback_derive.rs\`.

## Migrated as free items in \`photon_feedback_derive.rs\` (\`pub(super)\`)

- \`fn photon_context_pack_completion_status(failed, adopted_items) -> PhotonContextPackStatus\` (3-branch projection: Failed > Injected > NoInjection)
- \`struct PhotonEvaluateCompletedLog { failed, duration_ms, summary_ids_adopted_count, adoption_status, truncated, outcome_json, outcome_detail_json }\` (bounded payload — all fields pre-projected via the \`photon_*\` static-allowlist helpers, so the consumer cannot leak runtime data into the \`agent.photon_evaluate.completed\` log)

## \`turn.rs\` adjustments

- Removed the fn + struct definitions.
- Added the 2 names to the existing \`use super::photon_feedback_derive::{...}\` block.
- Test mod rewrote its \`super::photon_context_pack_completion_status\` import to \`super::super::photon_feedback_derive::*\`.

## LOC delta

- \`turn.rs\`: 29,358 → 29,337 (-21 LOC)
- \`photon_feedback_derive.rs\`: 589 → 621 (+32 LOC)
- Cumulative \`turn.rs\`: 39,489 → 29,337 (**-10,152 LOC, -25.7%**)

## Test plan

- [x] \`cargo fmt\`
- [x] \`cargo clippy --lib --all-targets -- -D warnings\` clean
- [x] \`cargo test --lib\` 3,114 passed / 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)