### PR TITLE
Phase 8 batch 7: 5 small photon Agent helpers (#688)

### DIFF
--- a/src/agent/loop_run/photon_feedback_derive.rs
+++ b/src/agent/loop_run/photon_feedback_derive.rs
@@ -22,7 +22,9 @@
 //! pre-existing `pub use` of the const). `turn.rs` is the only in-crate
 //! consumer for the `PhotonOutcomeInputs` / `PhotonFeedbackOutcome` types.
 
-use super::completion_evidence;
+use super::Agent;
+use super::completion_evidence::{self, CompletionEvidence};
+use crate::logging::log_llm_event;
 use crate::photon;
 use crate::photon::prompt::sanitize_summary_id;
 use crate::session::feedback::{FeedbackKind, MAX_VERIFIER_COMMAND_BYTES};
@@ -618,4 +620,77 @@ pub(super) struct PhotonEvaluateCompletedLog {
     pub(super) truncated: bool,
     pub(super) outcome_json: serde_json::Value,
     pub(super) outcome_detail_json: serde_json::Value,
+}
+
+/// Issue #557: clear the per-turn tracker fields that record which photon
+/// context_pack summary ids were injected this turn. Called when the photon
+/// pipeline skips / fails / completes-with-zero-adoptions.
+pub(super) fn clear_photon_context_pack_injection_tracking(agent: &mut Agent) {
+    agent.last_injected_summary_ids.clear();
+    agent.last_injected_summary_turn_index = None;
+}
+
+/// Issue #557: short-circuit the photon context_pack pipeline with a status
+/// + reason. Emits the `agent.photon_context_pack.skipped` log event and
+///   resets the per-turn injection-tracking fields.
+pub(super) fn skip_photon_context_pack(
+    agent: &mut Agent,
+    status: super::PhotonContextPackStatus,
+    reason: &str,
+) {
+    agent.last_photon_context_pack_status = status;
+    log_llm_event(
+        "agent.photon_context_pack.skipped",
+        serde_json::json!({
+            "session_id": agent.session_store.session_id(),
+            "turn_index": agent.current_turn_index,
+            "reason": reason,
+        }),
+    );
+    clear_photon_context_pack_injection_tracking(agent);
+}
+
+/// Issue #608 Phase α-2 (AP-10 / 設計判断 #2 + #3): derive the same-turn
+/// `verifier_exit_zero_this_turn` flag fed into
+/// `derive_photon_feedback_outcome`'s Case E OR-merge. Returns `true` iff
+/// the current-turn evidence set contains at least one
+/// `CompletionEvidence::VerifierExitZero` entry.
+pub(super) fn photon_verifier_exit_zero_this_turn(agent: &Agent) -> bool {
+    agent
+        .evidence_set_this_turn
+        .iter()
+        .any(|e| matches!(e, CompletionEvidence::VerifierExitZero { .. }))
+}
+
+/// Issue #591: emit the `agent.photon_evaluate.completed` log event from
+/// the pre-projected `PhotonEvaluateCompletedLog` payload. All payload
+/// fields are already audit-bounded (`outcome_json` /
+/// `outcome_detail_json` come from `photon_outcome_json_value` /
+/// `adoption_status` from `photon_evaluate_adoption_status`) so this
+/// function cannot leak runtime data into the outbound event.
+pub(super) fn log_photon_evaluate_completed(agent: &Agent, payload: PhotonEvaluateCompletedLog) {
+    log_llm_event(
+        "agent.photon_evaluate.completed",
+        serde_json::json!({
+            "session_id": agent.session_store.session_id(),
+            "turn_index": agent.current_turn_index,
+            "failed": payload.failed,
+            "duration_ms": payload.duration_ms,
+            "summary_ids_adopted_count": payload.summary_ids_adopted_count,
+            "outcome": payload.outcome_json,
+            "adoption_status": payload.adoption_status,
+            "summary_ids_adopted_truncated": payload.truncated,
+            "outcome_detail": payload.outcome_detail_json,
+        }),
+    );
+}
+
+/// Issue #556: build the per-turn photon injection system message from
+/// the cached `photon_context_pack_response`. Returns `None` when the
+/// response is absent or the photon shadow_mode flag is set.
+pub(super) fn photon_context_pack_injection_message(agent: &Agent) -> Option<ConversationMessage> {
+    build_photon_injection_message(
+        agent.photon_context_pack_response.as_deref(),
+        agent.config.photon_shadow_mode,
+    )
 }

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -2925,7 +2925,7 @@ impl Agent {
     /// Issue #557: call photon context_pack and store rendered response.
     /// Canary gate runs BEFORE the HTTP fetch (DR3-002).
     fn invoke_photon_context_pack(&mut self) {
-        self.clear_photon_context_pack_injection_tracking();
+        super::photon_feedback_derive::clear_photon_context_pack_injection_tracking(self);
 
         // DR2-001: photon インライン呼び出しで借用チェッカー衝突を回避
         if self.photon.is_none() {
@@ -2934,7 +2934,8 @@ impl Agent {
 
         // Issue #557: shadow mode disables prompt injection entirely.
         if self.config.photon_shadow_mode {
-            self.skip_photon_context_pack(
+            super::photon_feedback_derive::skip_photon_context_pack(
+                self,
                 crate::agent::loop_run::PhotonContextPackStatus::ShadowMode,
                 "shadow_mode",
             );
@@ -2950,7 +2951,8 @@ impl Agent {
             turn_idx: self.current_turn_index,
         };
         if !crate::photon::mapper::should_send_context_pack(&gate) {
-            self.skip_photon_context_pack(
+            super::photon_feedback_derive::skip_photon_context_pack(
+                self,
                 crate::agent::loop_run::PhotonContextPackStatus::CanarySkipped,
                 "canary_gate",
             );
@@ -2969,7 +2971,7 @@ impl Agent {
         let (items_blocked, truncated) = match result {
             Some(resp) => self.process_photon_context_pack_response(resp, warning_filter_enabled),
             None => {
-                self.clear_photon_context_pack_injection_tracking();
+                super::photon_feedback_derive::clear_photon_context_pack_injection_tracking(self);
                 (0, false)
             }
         };
@@ -2982,28 +2984,6 @@ impl Agent {
             warning_filter_enabled,
             items_blocked,
         );
-    }
-
-    fn clear_photon_context_pack_injection_tracking(&mut self) {
-        self.last_injected_summary_ids.clear();
-        self.last_injected_summary_turn_index = None;
-    }
-
-    fn skip_photon_context_pack(
-        &mut self,
-        status: crate::agent::loop_run::PhotonContextPackStatus,
-        reason: &str,
-    ) {
-        self.last_photon_context_pack_status = status;
-        log_llm_event(
-            "agent.photon_context_pack.skipped",
-            serde_json::json!({
-                "session_id": self.session_store.session_id(),
-                "turn_index": self.current_turn_index,
-                "reason": reason,
-            }),
-        );
-        self.clear_photon_context_pack_injection_tracking();
     }
 
     fn build_pre_turn_photon_context_pack_request(
@@ -3176,7 +3156,7 @@ impl Agent {
             self.last_injected_summary_turn_index = Some(self.current_turn_index);
             trunc
         } else {
-            self.clear_photon_context_pack_injection_tracking();
+            super::photon_feedback_derive::clear_photon_context_pack_injection_tracking(self);
             false
         }
     }
@@ -3293,7 +3273,8 @@ impl Agent {
             // a direct `mode_state.work_mode == WorkMode::AnswerOnly` compare.
             work_mode_is_answer_only: self.answer_only_mode_active(),
             // Issue #608 Phase α-2 (AP-10 / 設計判断 #2 + #3): Case E expansion.
-            verifier_exit_zero_this_turn: self.photon_verifier_exit_zero_this_turn(),
+            verifier_exit_zero_this_turn:
+                super::photon_feedback_derive::photon_verifier_exit_zero_this_turn(self),
         };
         let PhotonFeedbackOutcome {
             outcome: outcome_static,
@@ -3337,24 +3318,18 @@ impl Agent {
         // static-allowlist strings cross the audit boundary.
         // `mask_payload_inplace` in `log_llm_event` provides the final
         // defensive scrub.
-        self.log_photon_evaluate_completed(PhotonEvaluateCompletedLog {
-            failed: result.is_none(),
-            duration_ms,
-            summary_ids_adopted_count,
-            adoption_status,
-            truncated,
-            outcome_json,
-            outcome_detail_json,
-        });
-    }
-
-    fn photon_verifier_exit_zero_this_turn(&self) -> bool {
-        self.evidence_set_this_turn.iter().any(|e| {
-            matches!(
-                e,
-                super::completion_evidence::CompletionEvidence::VerifierExitZero { .. }
-            )
-        })
+        super::photon_feedback_derive::log_photon_evaluate_completed(
+            self,
+            PhotonEvaluateCompletedLog {
+                failed: result.is_none(),
+                duration_ms,
+                summary_ids_adopted_count,
+                adoption_status,
+                truncated,
+                outcome_json,
+                outcome_detail_json,
+            },
+        );
     }
 
     fn build_photon_context_pack_event(
@@ -3405,31 +3380,6 @@ impl Agent {
         summary.outcome_emitted = outcome_static.map(String::from);
         summary.outcome_detail_emitted = outcome_detail_static.map(String::from);
         self.last_photon_eval_summary = Some(summary);
-    }
-
-    fn log_photon_evaluate_completed(&self, payload: PhotonEvaluateCompletedLog) {
-        log_llm_event(
-            "agent.photon_evaluate.completed",
-            serde_json::json!({
-                "session_id": self.session_store.session_id(),
-                "turn_index": self.current_turn_index,
-                "failed": payload.failed,
-                "duration_ms": payload.duration_ms,
-                "summary_ids_adopted_count": payload.summary_ids_adopted_count,
-                "outcome": payload.outcome_json,
-                "adoption_status": payload.adoption_status,
-                "summary_ids_adopted_truncated": payload.truncated,
-                "outcome_detail": payload.outcome_detail_json,
-            }),
-        );
-    }
-
-    /// Issue #556: build the system message to inject context_pack into the prompt.
-    fn photon_context_pack_injection_message(&self) -> Option<ConversationMessage> {
-        build_photon_injection_message(
-            self.photon_context_pack_response.as_deref(),
-            self.config.photon_shadow_mode,
-        )
     }
 
     fn run_turn(
@@ -5124,7 +5074,9 @@ impl Agent {
         protocol: prompting::ToolProtocol,
         effective_tool_policy: &EffectiveToolPolicy,
     ) {
-        if let Some(ctx) = self.photon_context_pack_injection_message() {
+        if let Some(ctx) =
+            super::photon_feedback_derive::photon_context_pack_injection_message(self)
+        {
             messages.push(ctx);
         }
         if self.config.offline {


### PR DESCRIPTION
## Summary

Issue #688 (parent #680, Phase 8) batch 7: migrate 5 small photon context-pack / evaluate Agent helpers from \`turn.rs\` to \`photon_feedback_derive.rs\` as \`&Agent\` / \`&mut Agent\` free fns. Callers in \`turn.rs\` are rewritten to invoke \`super::photon_feedback_derive::*\` directly.

## Migrated as free fns in \`photon_feedback_derive.rs\` (\`pub(super)\`)

- \`clear_photon_context_pack_injection_tracking(&mut Agent)\` — clears \`last_injected_summary_ids\` + \`last_injected_summary_turn_index\`
- \`skip_photon_context_pack(&mut Agent, status, reason)\` — sets the per-turn status, emits \`agent.photon_context_pack.skipped\`, calls \`clear_photon_context_pack_injection_tracking\`
- \`photon_verifier_exit_zero_this_turn(&Agent) -> bool\` — derives the same-turn \`verifier_exit_zero_this_turn\` flag for the Case E OR-merge
- \`log_photon_evaluate_completed(&Agent, PhotonEvaluateCompletedLog)\` — emits the \`agent.photon_evaluate.completed\` log event (audit-bounded payload)
- \`photon_context_pack_injection_message(&Agent) -> Option<ConversationMessage>\` — builds the per-turn injection system message

## \`turn.rs\` adjustments

- Removed the 5 method definitions.
- Rewrote all 9 caller sites to \`super::photon_feedback_derive::*\` direct calls.

## LOC delta

- \`turn.rs\`: 29,337 → 29,289 (-48 LOC)
- \`photon_feedback_derive.rs\`: 621 → 696 (+75 LOC)
- Cumulative \`turn.rs\`: 39,489 → 29,289 (**-10,200 LOC, -25.8%**)

## Constraints

- \`pub(super)\` matching pre-extraction visibility
- \`turn.rs\` remains the only in-crate consumer

## Test plan

- [x] \`cargo fmt\`
- [x] \`cargo clippy --lib --all-targets -- -D warnings\` clean
- [x] \`cargo test --lib\` 3,114 passed / 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)