### PR TITLE
Phase 8 batch 9: photon context-pack request/response pipeline (#688)

### DIFF
--- a/src/agent/loop_run/photon_feedback_derive.rs
+++ b/src/agent/loop_run/photon_feedback_derive.rs
@@ -26,12 +26,19 @@ use std::collections::HashSet;
 
 use super::Agent;
 use super::completion_evidence::{self, CompletionEvidence};
+use super::tool_history::build_recent_tool_summary;
 use crate::logging::log_llm_event;
 use crate::photon;
 use crate::photon::eval::parse_evaluate_response;
-use crate::photon::prompt::{BlockedIdsStats, extract_blocked_summary_ids, sanitize_summary_id};
-use crate::photon::schema::{ContextPackResponse, EvaluateResponse};
-use crate::session::feedback::{FeedbackKind, MAX_VERIFIER_COMMAND_BYTES};
+use crate::photon::mapper::{ContextPackInputs, build_context_pack_request};
+use crate::photon::prompt::{
+    AdmittedItemView, BlockedIdsStats, RenderCandidate, RenderStats, build_section_with_stats,
+    enumerate_admitted_items_with_provenance, extract_blocked_summary_ids, sanitize_summary_id,
+};
+use crate::photon::schema::{ContextPackRequest, ContextPackResponse, EvaluateResponse};
+use crate::session::eval_log::MAX_PHOTON_EVAL_FIELD_BYTES;
+use crate::session::feedback::{FeedbackKind, MAX_VERIFIER_COMMAND_BYTES, mask_secrets};
+use crate::session::precaution::PrecautionStatus;
 use crate::session::store::{ConversationMessage, SessionSnapshot};
 use crate::tools::bash::{BashCommandClass, classify_command};
 
@@ -850,4 +857,143 @@ pub(super) fn store_photon_eval_summary(
     summary.outcome_emitted = outcome_static.map(String::from);
     summary.outcome_detail_emitted = outcome_detail_static.map(String::from);
     agent.last_photon_eval_summary = Some(summary);
+}
+
+/// Issue #557: build the pre-turn `ContextPackRequest` sent to photon
+/// `/v1/context_pack`. Uses per-turn Agent state (working memory text,
+/// active precaution ids, touched files) plus the recent tool summary
+/// projection.
+pub(super) fn build_pre_turn_photon_context_pack_request(agent: &Agent) -> ContextPackRequest {
+    let working_memory_text = agent.session.working_memory.format_for_prompt();
+    let selected_precaution_ids: Vec<String> = agent
+        .session
+        .working_memory
+        .active_precautions
+        .iter()
+        .filter(|p| p.status == PrecautionStatus::Active)
+        .map(|p| p.id.clone())
+        .collect();
+    let recent_tool_summary = build_recent_tool_summary(&agent.session.messages);
+    build_context_pack_request(&ContextPackInputs {
+        task: agent.session.working_memory.active_task.as_deref(),
+        repo_path: &agent.work_root,
+        branch: None,
+        commit: None,
+        working_memory_text: working_memory_text.as_deref(),
+        touched_files: &agent.session.working_memory.touched_files,
+        recent_tool_summary: &recent_tool_summary,
+        selected_case_ids: &[],
+        selected_anti_pattern_ids: &[],
+        selected_precaution_ids: &selected_precaution_ids,
+    })
+}
+
+/// Issue #591: persist the context_pack `request_id` (or fallback) into
+/// `Agent.last_context_pack_id`, applying the
+/// `MAX_PHOTON_EVAL_FIELD_BYTES` cap with a char-boundary-safe ellipsis.
+pub(super) fn update_last_context_pack_id(
+    agent: &mut Agent,
+    response: Option<&ContextPackResponse>,
+    fallback_req_id: Option<String>,
+) {
+    let from_resp = response
+        .and_then(|resp| resp.0.get("request_id"))
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .map(|s| {
+            let masked = mask_secrets(s);
+            if masked.len() <= MAX_PHOTON_EVAL_FIELD_BYTES {
+                masked
+            } else {
+                let mut end = MAX_PHOTON_EVAL_FIELD_BYTES;
+                while !masked.is_char_boundary(end) {
+                    end -= 1;
+                }
+                format!("{}…", &masked[..end])
+            }
+        });
+    agent.last_context_pack_id = from_resp.or(fallback_req_id);
+}
+
+/// Issue #557: process the photon `/v1/context_pack` response. Returns
+/// `(items_blocked, truncated)` so the caller can wire the completion
+/// log + injection-tracking reset.
+pub(super) fn process_photon_context_pack_response(
+    agent: &mut Agent,
+    resp: ContextPackResponse,
+    warning_filter_enabled: bool,
+) -> (usize, bool) {
+    let (blocked_ids, blocked_stats) =
+        photon_context_pack_blocked_ids(&resp, warning_filter_enabled);
+    log_photon_context_pack_warning_blocked(agent, &blocked_ids, &blocked_stats);
+    let (admitted_views, render_stats) =
+        collect_photon_context_pack_views(agent, &resp, &blocked_ids);
+    let items_blocked = render_stats.items_blocked;
+    let truncated = update_photon_context_pack_render(agent, admitted_views, render_stats);
+    (items_blocked, truncated)
+}
+
+/// Issue #557: enumerate admitted photon items (post-block, post-PAM
+/// advisory). Returns `(admitted_views, render_stats)`. Drives the
+/// `record_pam_advisory_decision` Agent shell which may filter views in
+/// `Live` mode.
+pub(super) fn collect_photon_context_pack_views(
+    agent: &mut Agent,
+    resp: &ContextPackResponse,
+    blocked_ids: &HashSet<String>,
+) -> (Vec<AdmittedItemView>, RenderStats) {
+    let (admitted_views, mut render_stats) =
+        enumerate_admitted_items_with_provenance(resp, blocked_ids);
+    let advisory_outcome = agent.record_pam_advisory_decision(resp, blocked_ids, false);
+    let admitted_views = match advisory_outcome.as_ref() {
+        Some(outcome) => {
+            let filtered = outcome.live_admitted_views.clone();
+            render_stats.items_adopted = filtered.len();
+            filtered
+        }
+        None => admitted_views,
+    };
+    (admitted_views, render_stats)
+}
+
+/// Issue #557: render the admitted photon views into the per-turn
+/// injection state. Updates the per-turn tracker fields (adopted ids,
+/// items, provenance summary) and applies the
+/// `MAX_PHOTON_CONTEXT_PACK_PROMPT_BYTES` cap. Returns whether the
+/// rendered output was truncated.
+pub(super) fn update_photon_context_pack_render(
+    agent: &mut Agent,
+    admitted_views: Vec<AdmittedItemView>,
+    mut render_stats: RenderStats,
+) -> bool {
+    let render_candidates: Vec<RenderCandidate> = admitted_views
+        .iter()
+        .map(|v| RenderCandidate {
+            text: v.render_text.clone(),
+            summary_id: v.provenance.summary_id.clone(),
+        })
+        .collect();
+    let (rendered_opt, _, _, dedup_adopted_ids) = build_section_with_stats(&render_candidates);
+    render_stats.adopted_summary_ids = dedup_adopted_ids;
+    agent.last_injected_seed_provenance = admitted_views
+        .into_iter()
+        .map(|view| view.provenance)
+        .collect();
+    debug_assert_eq!(
+        agent.last_injected_seed_provenance.len(),
+        render_stats.items_adopted,
+        "Invariant: injected_seed_provenance_summary.len() == items_adopted"
+    );
+    if let Some(rendered) = rendered_opt {
+        agent.last_photon_adopted_items = render_stats.items_adopted;
+        agent.last_adopted_summary_ids = render_stats.adopted_summary_ids.clone();
+        let (truncated_rendered, trunc) = truncate_photon_context_pack(rendered);
+        agent.photon_context_pack_response = Some(truncated_rendered);
+        agent.last_injected_summary_ids = render_stats.adopted_summary_ids;
+        agent.last_injected_summary_turn_index = Some(agent.current_turn_index);
+        trunc
+    } else {
+        clear_photon_context_pack_injection_tracking(agent);
+        false
+    }
 }

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -2960,16 +2960,20 @@ impl Agent {
         }
 
         let t0 = std::time::Instant::now();
-        let req = self.build_pre_turn_photon_context_pack_request();
+        let req = super::photon_feedback_derive::build_pre_turn_photon_context_pack_request(self);
         let req_id = req.0["request_id"].as_str().map(|s| s.to_string());
         let result = self.photon.as_ref().unwrap().context_pack(&req);
         let duration_ms = t0.elapsed().as_millis();
         let failed = result.is_none();
         self.session.context_pack_sent_this_turn = true;
         let warning_filter_enabled = self.config.photon_respect_warnings;
-        self.update_last_context_pack_id(result.as_ref(), req_id);
+        super::photon_feedback_derive::update_last_context_pack_id(self, result.as_ref(), req_id);
         let (items_blocked, truncated) = match result {
-            Some(resp) => self.process_photon_context_pack_response(resp, warning_filter_enabled),
+            Some(resp) => super::photon_feedback_derive::process_photon_context_pack_response(
+                self,
+                resp,
+                warning_filter_enabled,
+            ),
             None => {
                 super::photon_feedback_derive::clear_photon_context_pack_injection_tracking(self);
                 (0, false)
@@ -2985,144 +2989,6 @@ impl Agent {
             warning_filter_enabled,
             items_blocked,
         );
-    }
-
-    fn build_pre_turn_photon_context_pack_request(
-        &self,
-    ) -> crate::photon::schema::ContextPackRequest {
-        let working_memory_text = self.session.working_memory.format_for_prompt();
-        let selected_precaution_ids: Vec<String> = self
-            .session
-            .working_memory
-            .active_precautions
-            .iter()
-            .filter(|p| p.status == crate::session::precaution::PrecautionStatus::Active)
-            .map(|p| p.id.clone())
-            .collect();
-        let recent_tool_summary = build_recent_tool_summary(&self.session.messages);
-        crate::photon::mapper::build_context_pack_request(
-            &crate::photon::mapper::ContextPackInputs {
-                task: self.session.working_memory.active_task.as_deref(),
-                repo_path: &self.work_root,
-                branch: None,
-                commit: None,
-                working_memory_text: working_memory_text.as_deref(),
-                touched_files: &self.session.working_memory.touched_files,
-                recent_tool_summary: &recent_tool_summary,
-                selected_case_ids: &[],
-                selected_anti_pattern_ids: &[],
-                selected_precaution_ids: &selected_precaution_ids,
-            },
-        )
-    }
-
-    fn update_last_context_pack_id(
-        &mut self,
-        response: Option<&crate::photon::schema::ContextPackResponse>,
-        fallback_req_id: Option<String>,
-    ) {
-        use crate::session::eval_log::MAX_PHOTON_EVAL_FIELD_BYTES;
-        use crate::session::feedback::mask_secrets;
-
-        let from_resp = response
-            .and_then(|resp| resp.0.get("request_id"))
-            .and_then(|v| v.as_str())
-            .filter(|s| !s.is_empty())
-            .map(|s| {
-                let masked = mask_secrets(s);
-                if masked.len() <= MAX_PHOTON_EVAL_FIELD_BYTES {
-                    masked
-                } else {
-                    let mut end = MAX_PHOTON_EVAL_FIELD_BYTES;
-                    while !masked.is_char_boundary(end) {
-                        end -= 1;
-                    }
-                    format!("{}…", &masked[..end])
-                }
-            });
-        self.last_context_pack_id = from_resp.or(fallback_req_id);
-    }
-
-    fn process_photon_context_pack_response(
-        &mut self,
-        resp: crate::photon::schema::ContextPackResponse,
-        warning_filter_enabled: bool,
-    ) -> (usize, bool) {
-        let (blocked_ids, blocked_stats) =
-            super::photon_feedback_derive::photon_context_pack_blocked_ids(
-                &resp,
-                warning_filter_enabled,
-            );
-        super::photon_feedback_derive::log_photon_context_pack_warning_blocked(
-            self,
-            &blocked_ids,
-            &blocked_stats,
-        );
-        let (admitted_views, render_stats) =
-            self.collect_photon_context_pack_views(&resp, &blocked_ids);
-        let items_blocked = render_stats.items_blocked;
-        let truncated = self.update_photon_context_pack_render(admitted_views, render_stats);
-        (items_blocked, truncated)
-    }
-
-    fn collect_photon_context_pack_views(
-        &mut self,
-        resp: &crate::photon::schema::ContextPackResponse,
-        blocked_ids: &std::collections::HashSet<String>,
-    ) -> (
-        Vec<crate::photon::prompt::AdmittedItemView>,
-        crate::photon::prompt::RenderStats,
-    ) {
-        let (admitted_views, mut render_stats) =
-            crate::photon::prompt::enumerate_admitted_items_with_provenance(resp, blocked_ids);
-        let advisory_outcome = self.record_pam_advisory_decision(resp, blocked_ids, false);
-        let admitted_views = match advisory_outcome.as_ref() {
-            Some(outcome) => {
-                let filtered = outcome.live_admitted_views.clone();
-                render_stats.items_adopted = filtered.len();
-                filtered
-            }
-            None => admitted_views,
-        };
-        (admitted_views, render_stats)
-    }
-
-    fn update_photon_context_pack_render(
-        &mut self,
-        admitted_views: Vec<crate::photon::prompt::AdmittedItemView>,
-        mut render_stats: crate::photon::prompt::RenderStats,
-    ) -> bool {
-        let render_candidates: Vec<crate::photon::prompt::RenderCandidate> = admitted_views
-            .iter()
-            .map(|v| crate::photon::prompt::RenderCandidate {
-                text: v.render_text.clone(),
-                summary_id: v.provenance.summary_id.clone(),
-            })
-            .collect();
-        let (rendered_opt, _, _, dedup_adopted_ids) =
-            crate::photon::prompt::build_section_with_stats(&render_candidates);
-        render_stats.adopted_summary_ids = dedup_adopted_ids;
-        self.last_injected_seed_provenance = admitted_views
-            .into_iter()
-            .map(|view| view.provenance)
-            .collect();
-        debug_assert_eq!(
-            self.last_injected_seed_provenance.len(),
-            render_stats.items_adopted,
-            "Invariant: injected_seed_provenance_summary.len() == items_adopted"
-        );
-        if let Some(rendered) = rendered_opt {
-            self.last_photon_adopted_items = render_stats.items_adopted;
-            self.last_adopted_summary_ids = render_stats.adopted_summary_ids.clone();
-            let (truncated_rendered, trunc) = truncate_photon_context_pack(rendered);
-            self.photon_context_pack_response = Some(truncated_rendered);
-            self.last_injected_summary_ids = render_stats.adopted_summary_ids;
-            self.last_injected_summary_turn_index = Some(self.current_turn_index);
-            trunc
-        } else {
-            super::photon_feedback_derive::clear_photon_context_pack_injection_tracking(self);
-            false
-        }
     }
 
     /// Issue #556: call photon evaluate (post-turn).


### PR DESCRIPTION
## Summary

Issue #688 (parent #680, Phase 8) batch 9: migrate 5 photon context-pack request/response pipeline methods from \`turn.rs\` to \`photon_feedback_derive.rs\` as \`&Agent\` / \`&mut Agent\` free fns.

## Migrated as free fns in \`photon_feedback_derive.rs\` (\`pub(super)\`)

- \`build_pre_turn_photon_context_pack_request(&Agent) -> ContextPackRequest\`
- \`update_last_context_pack_id(&mut Agent, response, fallback_req_id)\` — masks + applies \`MAX_PHOTON_EVAL_FIELD_BYTES\` cap with char-boundary-safe ellipsis
- \`process_photon_context_pack_response(&mut Agent, resp, warning_filter_enabled) -> (items_blocked, truncated)\`
- \`collect_photon_context_pack_views(&mut Agent, &resp, &blocked_ids) -> (Vec<AdmittedItemView>, RenderStats)\` — drives \`record_pam_advisory_decision\` Live mode filter
- \`update_photon_context_pack_render(&mut Agent, admitted_views, render_stats) -> bool\`

## \`photon_feedback_derive.rs\` imports gain

- \`super::tool_history::build_recent_tool_summary\`
- \`crate::photon::mapper::{ContextPackInputs, build_context_pack_request}\`
- \`crate::photon::prompt::{AdmittedItemView, RenderCandidate, RenderStats, build_section_with_stats, enumerate_admitted_items_with_provenance}\`
- \`crate::photon::schema::ContextPackRequest\`
- \`crate::session::eval_log::MAX_PHOTON_EVAL_FIELD_BYTES\`
- \`crate::session::feedback::mask_secrets\`
- \`crate::session::precaution::PrecautionStatus\`

## \`turn.rs\` adjustments

- Removed the 5 method definitions.
- Rewrote 3 caller sites to \`super::photon_feedback_derive::*\` direct calls.
- \`collect_photon_context_pack_views\` / \`update_photon_context_pack_render\` had no external callers; they were called only by \`process_photon_context_pack_response\`, which now calls the sibling free fns inside \`photon_feedback_derive.rs\` directly.

## LOC delta

- \`turn.rs\`: 29,165 → 29,031 (-134 LOC)
- \`photon_feedback_derive.rs\`: 853 → 999 (+146 LOC)
- Cumulative \`turn.rs\`: 39,489 → 29,031 (**-10,458 LOC, -26.5%**)

## Test plan

- [x] \`cargo fmt\`
- [x] \`cargo clippy --lib --all-targets -- -D warnings\` clean
- [x] \`cargo test --lib\` 3,114 passed / 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)