### PR TITLE
Phase 8 batch 10: invoke_photon_context_pack + invoke_photon_evaluate (#688)

### DIFF
--- a/src/agent/loop_run/actor_loop_flow.rs
+++ b/src/agent/loop_run/actor_loop_flow.rs
@@ -3722,7 +3722,7 @@ pub(super) fn run_actor_loop(
     // Clear per-turn context_pack_response here (no longer needed).
     agent.photon_context_pack_response = None;
     if agent.session.mode_state.mode != ExecutionMode::Plan {
-        agent.invoke_photon_evaluate();
+        super::photon_feedback_derive::invoke_photon_evaluate(agent);
     } else if agent.photon.is_some() {
         log_llm_event(
             "agent.photon_evaluate.skipped",

--- a/src/agent/loop_run/photon_feedback_derive.rs
+++ b/src/agent/loop_run/photon_feedback_derive.rs
@@ -30,12 +30,17 @@ use super::tool_history::build_recent_tool_summary;
 use crate::logging::log_llm_event;
 use crate::photon;
 use crate::photon::eval::parse_evaluate_response;
-use crate::photon::mapper::{ContextPackInputs, build_context_pack_request};
+use crate::photon::mapper::{
+    ContextPackInputs, PHOTON_AGENT_NAME, PHOTON_EVALUATE_SCHEMA_VERSION, PhotonGateInputs,
+    build_context_pack_request, should_send_context_pack,
+};
 use crate::photon::prompt::{
     AdmittedItemView, BlockedIdsStats, RenderCandidate, RenderStats, build_section_with_stats,
     enumerate_admitted_items_with_provenance, extract_blocked_summary_ids, sanitize_summary_id,
 };
-use crate::photon::schema::{ContextPackRequest, ContextPackResponse, EvaluateResponse};
+use crate::photon::schema::{
+    ContextPackRequest, ContextPackResponse, EvaluateRequest, EvaluateResponse,
+};
 use crate::session::eval_log::MAX_PHOTON_EVAL_FIELD_BYTES;
 use crate::session::feedback::{FeedbackKind, MAX_VERIFIER_COMMAND_BYTES, mask_secrets};
 use crate::session::precaution::PrecautionStatus;
@@ -996,4 +1001,162 @@ pub(super) fn update_photon_context_pack_render(
         clear_photon_context_pack_injection_tracking(agent);
         false
     }
+}
+
+/// Issue #557: pre-turn photon context_pack dispatch entry point.
+/// Canary gate runs BEFORE the HTTP fetch (DR3-002). Shadow mode
+/// disables injection entirely. On success, updates the per-turn
+/// completion status + emits the `agent.photon_context_pack.completed`
+/// log event.
+pub(super) fn invoke_photon_context_pack(agent: &mut Agent) {
+    clear_photon_context_pack_injection_tracking(agent);
+
+    // DR2-001: photon インライン呼び出しで借用チェッカー衝突を回避
+    if agent.photon.is_none() {
+        return;
+    }
+
+    // Issue #557: shadow mode disables prompt injection entirely.
+    if agent.config.photon_shadow_mode {
+        skip_photon_context_pack(
+            agent,
+            super::PhotonContextPackStatus::ShadowMode,
+            "shadow_mode",
+        );
+        return;
+    }
+
+    // Issue #557: canary gate BEFORE the HTTP fetch (SSOT: should_send_context_pack).
+    let gate = PhotonGateInputs {
+        photon_present: true,
+        shadow_mode: false,
+        canary: agent.config.photon_canary,
+        session_id: agent.session_store.session_id(),
+        turn_idx: agent.current_turn_index,
+    };
+    if !should_send_context_pack(&gate) {
+        skip_photon_context_pack(
+            agent,
+            super::PhotonContextPackStatus::CanarySkipped,
+            "canary_gate",
+        );
+        return;
+    }
+
+    let t0 = std::time::Instant::now();
+    let req = build_pre_turn_photon_context_pack_request(agent);
+    let req_id = req.0["request_id"].as_str().map(|s| s.to_string());
+    let result = agent.photon.as_ref().unwrap().context_pack(&req);
+    let duration_ms = t0.elapsed().as_millis();
+    let failed = result.is_none();
+    agent.session.context_pack_sent_this_turn = true;
+    let warning_filter_enabled = agent.config.photon_respect_warnings;
+    update_last_context_pack_id(agent, result.as_ref(), req_id);
+    let (items_blocked, truncated) = match result {
+        Some(resp) => process_photon_context_pack_response(agent, resp, warning_filter_enabled),
+        None => {
+            clear_photon_context_pack_injection_tracking(agent);
+            (0, false)
+        }
+    };
+    agent.last_photon_context_pack_status =
+        photon_context_pack_completion_status(failed, agent.last_photon_adopted_items);
+    log_photon_context_pack_completed(
+        agent,
+        failed,
+        truncated,
+        duration_ms,
+        warning_filter_enabled,
+        items_blocked,
+    );
+}
+
+/// Issue #556: post-turn photon evaluate dispatch entry point.
+///
+/// Issue #591 (AS-03 / AS-06 / DR4-NEW-001 / DR4-NEW-002):
+/// re-sanitizes `Agent.last_adopted_summary_ids` via
+/// `sanitize_summary_id` (defense-in-depth, evaluate-side pass),
+/// drops `None`s, applies `MAX_PHOTON_EVAL_ADOPTED_IDS=32` cap. In
+/// `config.photon_shadow_mode=true` it forces the
+/// `summary_ids_adopted=[]` / `summary_ids_adopted_count=0` /
+/// `summary_ids_adopted_truncated=false` / `outcome=null` /
+/// `items_adopted_count=0` invariants.
+pub(super) fn invoke_photon_evaluate(agent: &mut Agent) {
+    if agent.photon.is_none() {
+        return;
+    }
+    let t0 = std::time::Instant::now();
+    let shadow_mode = agent.config.photon_shadow_mode;
+    let adoption_status =
+        photon_evaluate_adoption_status(shadow_mode, agent.last_photon_adopted_items);
+
+    let sanitized = prepare_adopted_ids_for_evaluate(&agent.last_adopted_summary_ids, shadow_mode);
+    let summary_ids_adopted = sanitized.list;
+    let truncated = sanitized.truncated;
+    let summary_ids_adopted_count = summary_ids_adopted.len();
+    let items_adopted_count =
+        photon_items_adopted_count(shadow_mode, agent.last_photon_adopted_items);
+
+    let inputs = PhotonOutcomeInputs {
+        last_feedback_kind: agent.session.last_feedback.as_ref().map(|ff| &ff.kind),
+        eligible_feedback_recorded_this_turn: agent.session.eligible_feedback_recorded_this_turn,
+        anvil_score: agent.session.last_anvil_score.as_ref(),
+        adopted_id_count: summary_ids_adopted_count,
+        shadow_mode,
+        iter_count_this_turn: agent.session.iter_count_this_turn,
+        tool_calls_this_turn: agent.session.tool_calls_this_turn,
+        repo_edit_succeeded_this_turn: agent.session.repo_edit_succeeded_this_turn,
+        // DR3-001 SSOT: AnswerOnly check goes through the helper, never
+        // a direct `mode_state.work_mode == WorkMode::AnswerOnly` compare.
+        work_mode_is_answer_only: agent.answer_only_mode_active(),
+        verifier_exit_zero_this_turn: photon_verifier_exit_zero_this_turn(agent),
+    };
+    let PhotonFeedbackOutcome {
+        outcome: outcome_static,
+        outcome_detail: outcome_detail_static,
+    } = derive_photon_feedback_outcome(&inputs);
+    let outcome_json = photon_outcome_json_value(outcome_static);
+    let outcome_detail_json = photon_outcome_json_value(outcome_detail_static);
+
+    let context_pack_event = build_photon_context_pack_event(
+        agent,
+        adoption_status,
+        items_adopted_count,
+        summary_ids_adopted,
+        truncated,
+        &outcome_json,
+        &outcome_detail_json,
+    );
+    let req = EvaluateRequest(serde_json::json!({
+        "schema_version": PHOTON_EVALUATE_SCHEMA_VERSION,
+        "request_id": uuid::Uuid::now_v7().to_string(),
+        "session_id": agent.session_store.session_id(),
+        "agent": {
+            "name": PHOTON_AGENT_NAME,
+            "version": env!("CARGO_PKG_VERSION"),
+        },
+        "context_pack_event": context_pack_event,
+    }));
+    let result = agent.photon.as_ref().unwrap().evaluate(&req);
+    let duration_ms = t0.elapsed().as_millis();
+    store_photon_eval_summary(
+        agent,
+        result.as_ref(),
+        shadow_mode,
+        summary_ids_adopted_count,
+        outcome_static,
+        outcome_detail_static,
+    );
+    log_photon_evaluate_completed(
+        agent,
+        PhotonEvaluateCompletedLog {
+            failed: result.is_none(),
+            duration_ms,
+            summary_ids_adopted_count,
+            adoption_status,
+            truncated,
+            outcome_json,
+            outcome_detail_json,
+        },
+    );
 }

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -76,12 +76,7 @@ use super::verifier_repair_targeting::{
     verifier_repair_preferred_local_import_source, verifier_repair_stale_assertion_test_target,
 };
 
-use super::photon_feedback_derive::{
-    PhotonEvaluateCompletedLog, PhotonFeedbackOutcome, PhotonOutcomeInputs,
-    build_rerun_prompt_hint_if_eligible, derive_photon_feedback_outcome,
-    photon_context_pack_completion_status, photon_evaluate_adoption_status,
-    photon_items_adopted_count, photon_outcome_json_value, prepare_adopted_ids_for_evaluate,
-};
+use super::photon_feedback_derive::build_rerun_prompt_hint_if_eligible;
 #[cfg(test)]
 use super::repair_patch_validation::VerifierRepairIntent;
 #[cfg(test)]
@@ -2922,208 +2917,6 @@ impl Agent {
         }
     }
 
-    /// Issue #557: call photon context_pack and store rendered response.
-    /// Canary gate runs BEFORE the HTTP fetch (DR3-002).
-    fn invoke_photon_context_pack(&mut self) {
-        super::photon_feedback_derive::clear_photon_context_pack_injection_tracking(self);
-
-        // DR2-001: photon インライン呼び出しで借用チェッカー衝突を回避
-        if self.photon.is_none() {
-            return;
-        }
-
-        // Issue #557: shadow mode disables prompt injection entirely.
-        if self.config.photon_shadow_mode {
-            super::photon_feedback_derive::skip_photon_context_pack(
-                self,
-                crate::agent::loop_run::PhotonContextPackStatus::ShadowMode,
-                "shadow_mode",
-            );
-            return;
-        }
-
-        // Issue #557: canary gate BEFORE the HTTP fetch (SSOT: should_send_context_pack).
-        let gate = crate::photon::mapper::PhotonGateInputs {
-            photon_present: true,
-            shadow_mode: false,
-            canary: self.config.photon_canary,
-            session_id: self.session_store.session_id(),
-            turn_idx: self.current_turn_index,
-        };
-        if !crate::photon::mapper::should_send_context_pack(&gate) {
-            super::photon_feedback_derive::skip_photon_context_pack(
-                self,
-                crate::agent::loop_run::PhotonContextPackStatus::CanarySkipped,
-                "canary_gate",
-            );
-            return;
-        }
-
-        let t0 = std::time::Instant::now();
-        let req = super::photon_feedback_derive::build_pre_turn_photon_context_pack_request(self);
-        let req_id = req.0["request_id"].as_str().map(|s| s.to_string());
-        let result = self.photon.as_ref().unwrap().context_pack(&req);
-        let duration_ms = t0.elapsed().as_millis();
-        let failed = result.is_none();
-        self.session.context_pack_sent_this_turn = true;
-        let warning_filter_enabled = self.config.photon_respect_warnings;
-        super::photon_feedback_derive::update_last_context_pack_id(self, result.as_ref(), req_id);
-        let (items_blocked, truncated) = match result {
-            Some(resp) => super::photon_feedback_derive::process_photon_context_pack_response(
-                self,
-                resp,
-                warning_filter_enabled,
-            ),
-            None => {
-                super::photon_feedback_derive::clear_photon_context_pack_injection_tracking(self);
-                (0, false)
-            }
-        };
-        self.last_photon_context_pack_status =
-            photon_context_pack_completion_status(failed, self.last_photon_adopted_items);
-        super::photon_feedback_derive::log_photon_context_pack_completed(
-            self,
-            failed,
-            truncated,
-            duration_ms,
-            warning_filter_enabled,
-            items_blocked,
-        );
-    }
-
-    /// Issue #556: call photon evaluate (post-turn).
-    ///
-    /// Issue #591 (AS-03 / AS-06 / DR4-NEW-001 / DR4-NEW-002):
-    /// - Re-sanitizes `Agent.last_adopted_summary_ids` via
-    ///   `crate::photon::prompt::sanitize_summary_id` (DR4-NEW-001 evaluate-side
-    ///   pass; the injection side runs the same SSOT inside `render_context_pack`).
-    /// - Drops `None` results, then applies the `MAX_PHOTON_EVAL_ADOPTED_IDS=32`
-    ///   cap. `summary_ids_adopted_truncated=true` is emitted when the
-    ///   sanitized list length exceeded the cap *before* truncation (audit
-    ///   signal even though `MAX_PROMPT_ITEMS=5` makes this rare).
-    /// - In `config.photon_shadow_mode=true`, the function forces the
-    ///   `summary_ids_adopted=[]` / `summary_ids_adopted_count=0` /
-    ///   `summary_ids_adopted_truncated=false` / `outcome=null` /
-    ///   `items_adopted_count=0` invariants regardless of Agent state
-    ///   (DR4-NEW-002 final guard, complements the upstream "shadow path skips
-    ///   render" rule).
-    /// - `agent.photon_evaluate.completed` event is expanded 4 → 8 keys:
-    ///   the new keys are `summary_ids_adopted_count` / `outcome` /
-    ///   `adoption_status` / `summary_ids_adopted_truncated`. The raw
-    ///   `summary_ids_adopted` array is NOT emitted in the event payload
-    ///   (DR4-NEW-004 — only counts and static-allowlist strings cross the
-    ///   audit boundary).
-    pub(super) fn invoke_photon_evaluate(&mut self) {
-        if self.photon.is_none() {
-            return;
-        }
-        let t0 = std::time::Instant::now();
-        let shadow_mode = self.config.photon_shadow_mode;
-        let adoption_status =
-            photon_evaluate_adoption_status(shadow_mode, self.last_photon_adopted_items);
-
-        // Issue #591 (DR4-NEW-001 / DR4-NEW-002): re-sanitize → drop → cap.
-        //
-        // Even though the injection side already runs `sanitize_summary_id`,
-        // we re-run it on the evaluate side as defense-in-depth: any future
-        // refactor that introduces a write path into `last_adopted_summary_ids`
-        // bypassing the injection sanitizer must still pass this barrier
-        // before talking to photon. `prepare_adopted_ids_for_evaluate` is a
-        // pure helper so the sanitize/cap/shadow logic can be unit-tested
-        // without going through the agent loop.
-        let sanitized =
-            prepare_adopted_ids_for_evaluate(&self.last_adopted_summary_ids, shadow_mode);
-        let summary_ids_adopted = sanitized.list;
-        let truncated = sanitized.truncated;
-        let summary_ids_adopted_count = summary_ids_adopted.len();
-        let items_adopted_count =
-            photon_items_adopted_count(shadow_mode, self.last_photon_adopted_items);
-
-        // AS-04 / Issue #601: derive outcome + outcome_detail from the
-        // same-turn FeedbackKind / AnvilScore / shadow flag / adopted count
-        // / per-turn counters / WorkMode. Returns a PhotonFeedbackOutcome
-        // whose fields are `Option<&'static str>` allowlist values.
-        // Issue #608 Phase α-2 (AP-10 / 設計判断 #3): derive the same-turn
-        // verifier_exit_zero signal from `evidence_set_this_turn` so we don't
-        // need a separate SessionSnapshot flag. Matches the
-        // `CompletionEvidence::VerifierExitZero` push site in
-        // `observe_evidence_from_bash_outcome` (same turn, same iteration
-        // boundary as `evidence_set_this_turn.clear()` at run_actor_loop head).
-        let inputs = PhotonOutcomeInputs {
-            last_feedback_kind: self.session.last_feedback.as_ref().map(|ff| &ff.kind),
-            eligible_feedback_recorded_this_turn: self.session.eligible_feedback_recorded_this_turn,
-            anvil_score: self.session.last_anvil_score.as_ref(),
-            adopted_id_count: summary_ids_adopted_count,
-            shadow_mode,
-            // Issue #601 NEW (4 fields):
-            iter_count_this_turn: self.session.iter_count_this_turn,
-            tool_calls_this_turn: self.session.tool_calls_this_turn,
-            repo_edit_succeeded_this_turn: self.session.repo_edit_succeeded_this_turn,
-            // DR3-001 SSOT: AnswerOnly check goes through the helper, never
-            // a direct `mode_state.work_mode == WorkMode::AnswerOnly` compare.
-            work_mode_is_answer_only: self.answer_only_mode_active(),
-            // Issue #608 Phase α-2 (AP-10 / 設計判断 #2 + #3): Case E expansion.
-            verifier_exit_zero_this_turn:
-                super::photon_feedback_derive::photon_verifier_exit_zero_this_turn(self),
-        };
-        let PhotonFeedbackOutcome {
-            outcome: outcome_static,
-            outcome_detail: outcome_detail_static,
-        } = derive_photon_feedback_outcome(&inputs);
-        let outcome_json = photon_outcome_json_value(outcome_static);
-        let outcome_detail_json = photon_outcome_json_value(outcome_detail_static);
-
-        // Only include context_pack_event when we have a request_id; the sidecar
-        // requires context_pack_request_id: str (non-null).
-        let context_pack_event = super::photon_feedback_derive::build_photon_context_pack_event(
-            self,
-            adoption_status,
-            items_adopted_count,
-            summary_ids_adopted,
-            truncated,
-            &outcome_json,
-            &outcome_detail_json,
-        );
-        let req = crate::photon::schema::EvaluateRequest(serde_json::json!({
-            "schema_version": crate::photon::mapper::PHOTON_EVALUATE_SCHEMA_VERSION,
-            "request_id": uuid::Uuid::now_v7().to_string(),
-            "session_id": self.session_store.session_id(),
-            "agent": {
-                "name": crate::photon::mapper::PHOTON_AGENT_NAME,
-                "version": env!("CARGO_PKG_VERSION"),
-            },
-            "context_pack_event": context_pack_event,
-        }));
-        let result = self.photon.as_ref().unwrap().evaluate(&req);
-        let duration_ms = t0.elapsed().as_millis();
-        super::photon_feedback_derive::store_photon_eval_summary(
-            self,
-            result.as_ref(),
-            shadow_mode,
-            summary_ids_adopted_count,
-            outcome_static,
-            outcome_detail_static,
-        );
-        // Issue #591 (AS-06 / DR4-NEW-004) + Issue #601: event payload
-        // 4 → 8 keys (#591) → 9 keys (#601 adds `outcome_detail`). The raw
-        // `summary_ids_adopted` array is NOT included — only counts and
-        // static-allowlist strings cross the audit boundary.
-        // `mask_payload_inplace` in `log_llm_event` provides the final
-        // defensive scrub.
-        super::photon_feedback_derive::log_photon_evaluate_completed(
-            self,
-            PhotonEvaluateCompletedLog {
-                failed: result.is_none(),
-                duration_ms,
-                summary_ids_adopted_count,
-                adoption_status,
-                truncated,
-                outcome_json,
-                outcome_detail_json,
-            },
-        );
-    }
-
     fn run_turn(
         &mut self,
         input: &str,
@@ -3152,7 +2945,7 @@ impl Agent {
 
         // [Issue #556] pre-turn photon context_pack hook
         if self.session.mode_state.mode != ExecutionMode::Plan {
-            self.invoke_photon_context_pack();
+            super::photon_feedback_derive::invoke_photon_context_pack(self);
         } else if self.photon.is_some() {
             // Issue #594: surface plan-mode skip via /photon-why.
             self.last_photon_context_pack_status =
@@ -9959,16 +9752,25 @@ mod tests {
     #[test]
     fn photon_evaluate_adoption_status_prefers_shadow_then_injected_then_not_injected() {
         assert_eq!(
-            super::photon_evaluate_adoption_status(true, 3),
+            super::super::photon_feedback_derive::photon_evaluate_adoption_status(true, 3),
             "shadow_not_injected"
         );
-        assert_eq!(super::photon_evaluate_adoption_status(false, 1), "injected");
         assert_eq!(
-            super::photon_evaluate_adoption_status(false, 0),
+            super::super::photon_feedback_derive::photon_evaluate_adoption_status(false, 1),
+            "injected"
+        );
+        assert_eq!(
+            super::super::photon_feedback_derive::photon_evaluate_adoption_status(false, 0),
             "not_injected"
         );
-        assert_eq!(super::photon_items_adopted_count(true, 7), 0);
-        assert_eq!(super::photon_items_adopted_count(false, 7), 7);
+        assert_eq!(
+            super::super::photon_feedback_derive::photon_items_adopted_count(true, 7),
+            0
+        );
+        assert_eq!(
+            super::super::photon_feedback_derive::photon_items_adopted_count(false, 7),
+            7
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Issue #688 (parent #680, Phase 8) batch 10: migrate the two photon dispatch entry points (\`invoke_photon_context_pack\` / \`invoke_photon_evaluate\`) from \`turn.rs\` to \`photon_feedback_derive.rs\`. Each had exactly one caller, so both methods are removed outright and callers rewritten to direct free-fn calls.

## Migrated as free fns in \`photon_feedback_derive.rs\` (\`pub(super)\`)

- \`invoke_photon_context_pack(&mut Agent)\` — pre-turn photon \`/v1/context_pack\` dispatch entry point. Canary gate BEFORE the HTTP fetch (DR3-002). Shadow mode disables injection entirely.
- \`invoke_photon_evaluate(&mut Agent)\` — post-turn photon \`/v1/evaluate\` dispatch entry point. Re-sanitizes adopted ids, applies cap, derives outcome + outcome_detail, sends to photon, persists summary, emits log event.

## \`photon_feedback_derive.rs\` imports gain

- \`crate::photon::mapper::{PHOTON_AGENT_NAME, PHOTON_EVALUATE_SCHEMA_VERSION, PhotonGateInputs, should_send_context_pack}\`
- \`crate::photon::schema::EvaluateRequest\`

## \`turn.rs\` adjustments

- Removed the 2 method definitions.
- Rewrote 1 caller (\`self.invoke_photon_context_pack()\` in \`handle_user_message\`) to direct free-fn call.
- Test mod references re-routed to \`super::super::photon_feedback_derive::*\`.
- Dropped the large top-of-file \`use super::photon_feedback_derive::{...}\` block. Only \`build_rerun_prompt_hint_if_eligible\` is still needed in production turn.rs code.

## \`actor_loop_flow.rs\` adjustments

- Rewrote \`agent.invoke_photon_evaluate()\` → \`super::photon_feedback_derive::invoke_photon_evaluate(agent)\`.

## LOC delta

- \`turn.rs\`: 29,031 → 28,833 (-198 LOC)
- \`photon_feedback_derive.rs\`: 999 → 1,162 (+163 LOC)
- Cumulative \`turn.rs\`: 39,489 → 28,833 (**-10,656 LOC, -27.0%**)

🎉 This batch crosses the **−27%** milestone for the meta-issue #680 reduction target.

## Constraints

- \`pub(super)\` matching pre-extraction visibility
- \`turn.rs\` no longer hosts any photon dispatch methods

## Test plan

- [x] \`cargo fmt\`
- [x] \`cargo clippy --lib --all-targets -- -D warnings\` clean
- [x] \`cargo test --lib\` 3,114 passed / 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)