### PR TITLE
Phase 8 batch 11 (close): request_explicitly_requests_script_execution (#688)

### DIFF
--- a/src/agent/loop_run/photon_feedback_derive.rs
+++ b/src/agent/loop_run/photon_feedback_derive.rs
@@ -163,6 +163,35 @@ pub(crate) fn case_f_condition_met(inputs: &PhotonOutcomeInputs<'_>) -> bool {
 /// `src/agent/loop_run.rs`.
 pub const PHOTON_OUTCOME_DETAIL_NO_PROGRESS_DESPITE_INJECT: &str = "no_progress_despite_inject";
 
+/// Issue #574: answer-only mode helper. Detects whether the user's
+/// request explicitly asks Anvil to execute a script. Pure / no I/O.
+pub(super) fn request_explicitly_requests_script_execution(request: &str) -> bool {
+    let lower = request.to_ascii_lowercase();
+    let mentions_script = [
+        "script",
+        ".sh",
+        ".py",
+        ".js",
+        "スクリプト",
+        "シェル",
+        "コマンド",
+    ]
+    .iter()
+    .any(|needle| lower.contains(needle));
+    let asks_execution = [
+        "run",
+        "execute",
+        "実行",
+        "起動",
+        "結果",
+        "要約",
+        "summarize",
+    ]
+    .iter()
+    .any(|needle| lower.contains(needle));
+    mentions_script && asks_execution
+}
+
 /// Issue #556: max bytes to inject from context_pack into the prompt.
 pub const MAX_PHOTON_CONTEXT_PACK_PROMPT_BYTES: usize = 8192;
 

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -76,7 +76,9 @@ use super::verifier_repair_targeting::{
     verifier_repair_preferred_local_import_source, verifier_repair_stale_assertion_test_target,
 };
 
-use super::photon_feedback_derive::build_rerun_prompt_hint_if_eligible;
+use super::photon_feedback_derive::{
+    build_rerun_prompt_hint_if_eligible, request_explicitly_requests_script_execution,
+};
 #[cfg(test)]
 use super::repair_patch_validation::VerifierRepairIntent;
 #[cfg(test)]
@@ -512,33 +514,6 @@ where
         out.push(format!("{:016x}", hasher.finish()));
     }
     out
-}
-
-fn request_explicitly_requests_script_execution(request: &str) -> bool {
-    let lower = request.to_ascii_lowercase();
-    let mentions_script = [
-        "script",
-        ".sh",
-        ".py",
-        ".js",
-        "スクリプト",
-        "シェル",
-        "コマンド",
-    ]
-    .iter()
-    .any(|needle| lower.contains(needle));
-    let asks_execution = [
-        "run",
-        "execute",
-        "実行",
-        "起動",
-        "結果",
-        "要約",
-        "summarize",
-    ]
-    .iter()
-    .any(|needle| lower.contains(needle));
-    mentions_script && asks_execution
 }
 
 fn latest_tool_result_since_last_user<'a>(
@@ -8555,6 +8530,7 @@ mod tests {
         answer_only_reply_is_inadequate, normalize_plan_exploration_key,
         task_contract_verifier_safe_stop_mapping,
     };
+    use super::super::photon_feedback_derive::request_explicitly_requests_script_execution;
     use super::ExitReason;
     use super::{
         PlanExplorationKey, TaskContractVerifierOutcome, answer_only_script_command_allowed,
@@ -8564,8 +8540,8 @@ mod tests {
         classify_verifier_timeout, deterministic_timeout_fallback_plan,
         effective_non_streaming_timeout_secs, latest_tool_result_since_last_user,
         non_streaming_assistant_reply_timeout_secs, normalize_exploration_path,
-        repair_terminal_exit_reason, request_explicitly_requests_script_execution,
-        should_fallback_plan_model_after_timeout, should_materialize_plan_after_timeout,
+        repair_terminal_exit_reason, should_fallback_plan_model_after_timeout,
+        should_materialize_plan_after_timeout,
         should_materialize_plan_after_tool_call_format_error, should_use_streaming_transport,
         task_contract_structured_missing_outcome, verifier_repair_context_from_failure,
     };


### PR DESCRIPTION
## Summary

Issue #688 (parent #680, Phase 8) batch 11: migrate the last photon-adjacent helper enumerated in the Issue #688 scope — \`request_explicitly_requests_script_execution\` — from \`turn.rs\` to \`photon_feedback_derive.rs\`.

**Phase 8 (#688) close.** \`turn.rs\` no longer hosts any photon-feedback-derive helper from the Issue #688 scope. The remaining photon references in \`turn.rs\` are test-mod call sites only (already routed via \`super::super::photon_feedback_derive::*\`).

## Migrated as a free fn in \`photon_feedback_derive.rs\` (\`pub(super)\`)

- \`request_explicitly_requests_script_execution(request: &str) -> bool\` — answer-only-mode 2-clause AND predicate (mentions script kind AND uses execution verb)

## \`turn.rs\` adjustments

- Removed the fn definition.
- Added \`request_explicitly_requests_script_execution\` to the existing \`use super::photon_feedback_derive::{...}\` block.
- Test mod \`tests\` rewrote its import to \`super::super::photon_feedback_derive::*\`.

## LOC delta

- \`turn.rs\`: 28,833 → 28,809 (-24 LOC)
- \`photon_feedback_derive.rs\`: 1,162 → 1,191 (+29 LOC)
- Cumulative \`turn.rs\`: 39,489 → 28,809 (**-10,680 LOC, -27.0%**)

## Constraints

- \`pub(super)\` matching the pre-extraction module-private visibility
- \`turn.rs\` remains the only in-crate consumer

## Test plan

- [x] \`cargo fmt\`
- [x] \`cargo clippy --lib --all-targets -- -D warnings\` clean
- [x] \`cargo test --lib\` 3,114 passed / 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)