### PR TITLE
Extract answer_only_mode.rs sibling module (parent #680)

### DIFF
--- a/src/agent/loop_run.rs
+++ b/src/agent/loop_run.rs
@@ -241,6 +241,14 @@ mod streaming_reply;
 // below so `tests/photon_evaluate_signal_smoke.rs` keeps working without
 // path changes.
 mod photon_feedback_derive;
+// Answer-only mode shell-command allowlist + script-execution fallback
+// response builder extracted from `turn.rs` (parent #680). Hosts
+// `answer_only_script_command_allowed` + the prefix / blocked-contains
+// / blocked-prefix const lists + `truncate_for_answer` +
+// `answer_only_script_execution_fallback_response`. `pub(super)`
+// limited / no facade re-export (DR3-001) — `turn.rs` is the only
+// in-crate consumer.
+mod answer_only_mode;
 // v0.4.13 Phase 6: verifier rerun progress classifier.
 mod repair_progress;
 mod safe_stop_payload;

--- a/src/agent/loop_run/answer_only_mode.rs
+++ b/src/agent/loop_run/answer_only_mode.rs
@@ -1,0 +1,107 @@
+//! Answer-only mode shell-command allowlist + script-execution
+//! fallback response builder extracted from `turn.rs`.
+//!
+//! Hosts:
+//!
+//! * `ANSWER_ONLY_SCRIPT_ALLOWED_PREFIXES` — prefix whitelist of
+//!   allowed script launchers (`bash` / `sh` / `./` / `python` /
+//!   `python3` / `node`).
+//! * `ANSWER_ONLY_SCRIPT_BLOCKED_CONTAINS` / `_BLOCKED_PREFIXES` —
+//!   denylists for shell-control operators (`>` / `>>` / `2>` / `|`
+//!   / `&&` / `||` / `;`) and file-mutating commands (`rm` / `mv` /
+//!   `cp` / `touch` / `mkdir` / `tee` / `sed -i` / `perl -pi`).
+//! * `answer_only_script_command_allowed` — top-level predicate that
+//!   walks the optional `cd <dir> && <rest>` chain and applies the
+//!   allowlist / denylist checks. Pure / no I/O.
+//! * `answer_only_script_execution_fallback_response` — Japanese
+//!   templated response shown after a script execution in answer-only
+//!   mode (truncates the raw output to 1,600 chars, surfaces
+//!   `exit_code=...` if present).
+//!
+//! `pub(super)` limited / no facade re-export (DR3-001).
+//! `turn.rs` is the only in-crate consumer.
+
+pub(super) const ANSWER_ONLY_SCRIPT_ALLOWED_PREFIXES: &[&str] =
+    &["bash ", "sh ", "./", "python ", "python3 ", "node "];
+
+pub(super) const ANSWER_ONLY_SCRIPT_BLOCKED_CONTAINS: &[&str] = &[
+    " >", ">>", " 2>", " | ", " && ", " || ", ";", " rm ", " mv ", " cp ", " touch ", " mkdir ",
+    " tee ", "sed -i", "perl -pi",
+];
+
+pub(super) const ANSWER_ONLY_SCRIPT_BLOCKED_PREFIXES: &[&str] =
+    &["rm ", "mv ", "cp ", "touch ", "mkdir ", "tee "];
+
+/// UTF-8-safe char-count truncation used by the answer-only script
+/// execution fallback response. Returns the original string when its
+/// char count is already at or below `max_chars`; otherwise keeps
+/// `max_chars - 32` characters and appends a
+/// `\n...[truncated N chars]` footer.
+pub(super) fn truncate_for_answer(text: &str, max_chars: usize) -> String {
+    let total = text.chars().count();
+    if total <= max_chars {
+        return text.to_string();
+    }
+    let keep = max_chars.saturating_sub(32);
+    let truncated = text.chars().take(keep).collect::<String>();
+    format!(
+        "{truncated}\n...[truncated {} chars]",
+        total.saturating_sub(keep)
+    )
+}
+
+pub(super) fn answer_only_script_execution_fallback_response(output: &str) -> String {
+    let excerpt = truncate_for_answer(output.trim(), 1_600);
+    let status = output
+        .lines()
+        .find_map(|line| line.trim().strip_prefix("exit_code="))
+        .map(|code| {
+            if code == "0" {
+                "コマンドは exit_code=0 で正常終了しています。".to_string()
+            } else {
+                format!("コマンドは exit_code={code} で終了しています。")
+            }
+        })
+        .unwrap_or_else(|| "コマンドの出力を確認しました。".to_string());
+
+    format!(
+        "ファイルは変更せず、指定されたコマンド/スクリプトの実行結果を確認しました。\n\n実行結果:\n```text\n{excerpt}\n```\n\n要約:\n- {status}\n- 上記の stdout/stderr が今回確認できた実行結果です。"
+    )
+}
+
+fn answer_only_script_contains_any(command: &str, patterns: &[&str]) -> bool {
+    patterns.iter().any(|pattern| command.contains(pattern))
+}
+
+fn answer_only_script_starts_with_any(command: &str, prefixes: &[&str]) -> bool {
+    prefixes.iter().any(|prefix| command.starts_with(prefix))
+}
+
+fn answer_only_cd_segment_allowed(segment: &str) -> bool {
+    segment.starts_with("cd ") && !answer_only_script_contains_any(segment, &[";", "|", ">"])
+}
+
+fn answer_only_cd_chained_script_tail(command: &str) -> Option<&str> {
+    let (cd_segment, rest) = command.split_once(" && ")?;
+    answer_only_cd_segment_allowed(cd_segment).then_some(rest)
+}
+
+fn answer_only_script_has_blocked_operation(command: &str) -> bool {
+    answer_only_script_contains_any(command, ANSWER_ONLY_SCRIPT_BLOCKED_CONTAINS)
+        || answer_only_script_starts_with_any(command, ANSWER_ONLY_SCRIPT_BLOCKED_PREFIXES)
+}
+
+pub(super) fn answer_only_script_command_allowed(command: &str) -> bool {
+    let trimmed = command.trim();
+    if trimmed.is_empty() {
+        return false;
+    }
+    let lower = trimmed.to_ascii_lowercase();
+    if let Some(rest) = answer_only_cd_chained_script_tail(&lower) {
+        return answer_only_script_command_allowed(rest);
+    }
+    if answer_only_script_has_blocked_operation(&lower) {
+        return false;
+    }
+    answer_only_script_starts_with_any(&lower, ANSWER_ONLY_SCRIPT_ALLOWED_PREFIXES)
+}

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -76,6 +76,9 @@ use super::verifier_repair_targeting::{
     verifier_repair_preferred_local_import_source, verifier_repair_stale_assertion_test_target,
 };
 
+use super::answer_only_mode::{
+    answer_only_script_command_allowed, answer_only_script_execution_fallback_response,
+};
 use super::photon_feedback_derive::{
     build_rerun_prompt_hint_if_eligible, request_explicitly_requests_script_execution,
 };
@@ -529,84 +532,6 @@ fn latest_tool_result_since_last_user<'a>(
         }
     }
     None
-}
-
-fn truncate_for_answer(text: &str, max_chars: usize) -> String {
-    let total = text.chars().count();
-    if total <= max_chars {
-        return text.to_string();
-    }
-    let keep = max_chars.saturating_sub(32);
-    let truncated = text.chars().take(keep).collect::<String>();
-    format!(
-        "{truncated}\n...[truncated {} chars]",
-        total.saturating_sub(keep)
-    )
-}
-
-fn answer_only_script_execution_fallback_response(output: &str) -> String {
-    let excerpt = truncate_for_answer(output.trim(), 1_600);
-    let status = output
-        .lines()
-        .find_map(|line| line.trim().strip_prefix("exit_code="))
-        .map(|code| {
-            if code == "0" {
-                "コマンドは exit_code=0 で正常終了しています。".to_string()
-            } else {
-                format!("コマンドは exit_code={code} で終了しています。")
-            }
-        })
-        .unwrap_or_else(|| "コマンドの出力を確認しました。".to_string());
-
-    format!(
-        "ファイルは変更せず、指定されたコマンド/スクリプトの実行結果を確認しました。\n\n実行結果:\n```text\n{excerpt}\n```\n\n要約:\n- {status}\n- 上記の stdout/stderr が今回確認できた実行結果です。"
-    )
-}
-
-const ANSWER_ONLY_SCRIPT_ALLOWED_PREFIXES: &[&str] =
-    &["bash ", "sh ", "./", "python ", "python3 ", "node "];
-const ANSWER_ONLY_SCRIPT_BLOCKED_CONTAINS: &[&str] = &[
-    " >", ">>", " 2>", " | ", " && ", " || ", ";", " rm ", " mv ", " cp ", " touch ", " mkdir ",
-    " tee ", "sed -i", "perl -pi",
-];
-const ANSWER_ONLY_SCRIPT_BLOCKED_PREFIXES: &[&str] =
-    &["rm ", "mv ", "cp ", "touch ", "mkdir ", "tee "];
-
-fn answer_only_script_contains_any(command: &str, patterns: &[&str]) -> bool {
-    patterns.iter().any(|pattern| command.contains(pattern))
-}
-
-fn answer_only_script_starts_with_any(command: &str, prefixes: &[&str]) -> bool {
-    prefixes.iter().any(|prefix| command.starts_with(prefix))
-}
-
-fn answer_only_cd_segment_allowed(segment: &str) -> bool {
-    segment.starts_with("cd ") && !answer_only_script_contains_any(segment, &[";", "|", ">"])
-}
-
-fn answer_only_cd_chained_script_tail(command: &str) -> Option<&str> {
-    let (cd_segment, rest) = command.split_once(" && ")?;
-    answer_only_cd_segment_allowed(cd_segment).then_some(rest)
-}
-
-fn answer_only_script_has_blocked_operation(command: &str) -> bool {
-    answer_only_script_contains_any(command, ANSWER_ONLY_SCRIPT_BLOCKED_CONTAINS)
-        || answer_only_script_starts_with_any(command, ANSWER_ONLY_SCRIPT_BLOCKED_PREFIXES)
-}
-
-fn answer_only_script_command_allowed(command: &str) -> bool {
-    let trimmed = command.trim();
-    if trimmed.is_empty() {
-        return false;
-    }
-    let lower = trimmed.to_ascii_lowercase();
-    if let Some(rest) = answer_only_cd_chained_script_tail(&lower) {
-        return answer_only_script_command_allowed(rest);
-    }
-    if answer_only_script_has_blocked_operation(&lower) {
-        return false;
-    }
-    answer_only_script_starts_with_any(&lower, ANSWER_ONLY_SCRIPT_ALLOWED_PREFIXES)
 }
 
 fn case_record_auto_test_active(score: &crate::session::anvil_score::AnvilScore) -> bool {


### PR DESCRIPTION
## Summary

Create new sibling module \`src/agent/loop_run/answer_only_mode.rs\` to host the answer-only-mode shell-command allowlist + script-execution fallback response builder previously living in \`turn.rs\`. Small follow-on extraction in the meta-issue #680 reduction effort — the helpers form a clean responsibility-focused cluster but did not fit one of the named Phase 1-8 modules.

## Migrated to \`answer_only_mode.rs\` (\`pub(super)\`)

- \`const ANSWER_ONLY_SCRIPT_ALLOWED_PREFIXES\` — prefix whitelist
- \`const ANSWER_ONLY_SCRIPT_BLOCKED_CONTAINS\` — shell-operator + file-mutating-command denylist
- \`const ANSWER_ONLY_SCRIPT_BLOCKED_PREFIXES\` — prefix denylist for file-mutating commands
- \`fn truncate_for_answer(text, max_chars) -> String\` (UTF-8 safe)
- \`fn answer_only_script_execution_fallback_response(output) -> String\` (Japanese templated response)
- \`fn answer_only_script_command_allowed(command) -> bool\` (top-level predicate, walks \`cd <dir> && <rest>\` chains)
- Module-private supporting helpers

## \`loop_run.rs\` adjustments

- Registered \`mod answer_only_mode;\` with a parent-#680 doc comment.

## \`turn.rs\` adjustments

- Removed the const + 7 fn definitions.
- Added \`use super::answer_only_mode::{answer_only_script_command_allowed, answer_only_script_execution_fallback_response};\`.

## LOC delta

- \`turn.rs\`: 28,809 → 28,734 (-75 LOC)
- \`answer_only_mode.rs\`: 0 → 107 (new)
- Cumulative \`turn.rs\`: 39,489 → 28,734 (**-10,755 LOC, -27.2%**)

## Test plan

- [x] \`cargo fmt\`
- [x] \`cargo clippy --lib --all-targets -- -D warnings\` clean
- [x] \`cargo test --lib\` 3,114 passed / 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)