### PR TITLE
Move build_feedback_for_auto_test + artifact-recovery match (parent #680)

### DIFF
--- a/src/agent/loop_run/feedback_builders.rs
+++ b/src/agent/loop_run/feedback_builders.rs
@@ -26,6 +26,7 @@
 use std::path::{Path, PathBuf};
 
 use super::Agent;
+use super::auto_test::{AutoTestPlan, AutoTestResult, classify_auto_test};
 use super::verifier_repair_targeting::extract_path_like_tokens;
 use crate::agent::prompting;
 use crate::safety::path_guard::resolve_user_path;
@@ -33,6 +34,51 @@ use crate::session::feedback::{
     FeedbackFrame, FeedbackFrameDraft, FeedbackKind, build_feedback_frame,
 };
 use crate::tools::bash::{BashExecutionOutcome, classify_bash_outcome};
+
+/// Issue #450: build a FeedbackFrame from an `AutoTestPlan` /
+/// `AutoTestResult` pair. Calls `classify_auto_test` to pick the
+/// `FeedbackKind`, picks the first non-empty stderr/stdout line for
+/// `primary_error` on failure, and runs the resulting draft through
+/// `build_feedback_frame` for truncation / secret masking / path
+/// normalization (per design 5.4: no helper performs those steps
+/// itself). Used by `verifier_skill.rs` / `verifier_orchestration.rs`
+/// callers in addition to turn-internal sites.
+pub(super) fn build_feedback_for_auto_test(
+    plan: &AutoTestPlan,
+    result: &AutoTestResult,
+    workspace_root: &Path,
+    changed_files: &[String],
+) -> FeedbackFrame {
+    let kind = classify_auto_test(plan, result);
+    let primary_error = if !result.passed {
+        result
+            .stderr
+            .lines()
+            .chain(result.stdout.lines())
+            .map(str::trim)
+            .find(|line| !line.is_empty())
+            .map(|s| s.to_string())
+    } else {
+        None
+    };
+    let suspected_files: Vec<PathBuf> = if !result.passed {
+        extract_suspected_files_from_text(&result.stdout, &result.stderr)
+    } else {
+        Vec::new()
+    };
+    let changed_files: Vec<PathBuf> = changed_files.iter().map(PathBuf::from).collect();
+    let draft = FeedbackFrameDraft {
+        command: Some(plan.command.clone()),
+        exit_code: result.exit_code,
+        kind,
+        stdout: result.stdout.clone(),
+        stderr: result.stderr.clone(),
+        primary_error,
+        suspected_files,
+        changed_files,
+    };
+    build_feedback_frame(draft, workspace_root)
+}
 
 /// CB-001: build a FeedbackFrame from a `BashExecutionOutcome`. Uses the
 /// pure `classify_bash_outcome` helper (Timeout / UnsafeCommandBlocked /

--- a/src/agent/loop_run/task_contract.rs
+++ b/src/agent/loop_run/task_contract.rs
@@ -1519,6 +1519,62 @@ pub(super) fn role_from_repo_edit(category: RepoEditCategory) -> Option<Artifact
     }
 }
 
+/// Does a repo edit of `category` at `relative_path` satisfy the
+/// active `RecoveryTarget` (if any)? `None` target means
+/// unconstrained → accept. Otherwise the role must match and the path
+/// must either be identical or live in the same test-artifact family
+/// (rust-integration / pytest / typescript-test / javascript-test).
+pub(super) fn repo_edit_satisfies_artifact_recovery_target(
+    category: RepoEditCategory,
+    relative_path: &str,
+    target: Option<&RecoveryTarget>,
+) -> bool {
+    let Some(target) = target else {
+        return true;
+    };
+    let Some(role) = role_from_repo_edit(category) else {
+        return false;
+    };
+    let target_path = target.path.replace('\\', "/");
+    if role != target.role {
+        return false;
+    }
+    if relative_path == target_path {
+        return true;
+    }
+    target.role == ArtifactRole::Test
+        && test_artifact_path_family(relative_path)
+            .zip(test_artifact_path_family(&target_path))
+            .is_some_and(|(actual, expected)| actual == expected)
+}
+
+/// Classify a path into a known test-artifact family
+/// (rust-integration / pytest / typescript-test / javascript-test).
+/// Returns `None` when the path doesn't match any recognised family.
+fn test_artifact_path_family(path: &str) -> Option<&'static str> {
+    let normalized = path.replace('\\', "/");
+    let name = std::path::Path::new(&normalized)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or_default();
+    if normalized.starts_with("tests/") && normalized.ends_with(".rs") {
+        return Some("rust-integration");
+    }
+    if normalized.starts_with("tests/")
+        && normalized.ends_with(".py")
+        && (name.starts_with("test_") || name.ends_with("_test.py"))
+    {
+        return Some("pytest");
+    }
+    if normalized.ends_with(".test.ts") || normalized.ends_with(".spec.ts") {
+        return Some("typescript-test");
+    }
+    if normalized.ends_with(".test.js") || normalized.ends_with(".spec.js") {
+        return Some("javascript-test");
+    }
+    None
+}
+
 fn has_build_test_verifier(evidence: &EvidenceSet) -> bool {
     evidence.iter().any(|item| {
         matches!(

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -19,9 +19,8 @@ use super::actor_loop_flow::{
     format_iteration_status, repair_job_done_outcome, run_actor_loop,
 };
 use super::auto_test::{
-    AutoTestKind, AutoTestPlan, AutoTestResult, AutoTestRunner,
-    build_agent_verifier_external_import_rejected_payload, build_agent_verifier_invoked_payload,
-    classify_auto_test,
+    AutoTestKind, AutoTestRunner, build_agent_verifier_external_import_rejected_payload,
+    build_agent_verifier_invoked_payload,
 };
 use super::completion_evidence::is_repo_edit_no_op;
 use super::feedback_kind_confirm::{
@@ -86,7 +85,6 @@ use super::case_record_extract::{
 use super::feedback_builders::{
     build_feedback_for_bash, build_feedback_for_edit_failure,
     build_feedback_for_unsafe_block_reason, extract_current_request_paths,
-    extract_suspected_files_from_text,
 };
 use super::photon_feedback_derive::{
     build_rerun_prompt_hint_if_eligible, request_explicitly_requests_script_execution,
@@ -212,9 +210,9 @@ use crate::modes::plan_act::{
     ModeClassification, PlanStage, TaskProfile, WorkMode, classify_work_mode_json,
 };
 use crate::ollama::xml_fallback::normalize_tool_call_arguments;
-use crate::session::feedback::{
-    FeedbackFrame, FeedbackFrameDraft, FeedbackKind, build_feedback_frame,
-};
+use crate::session::feedback::{FeedbackFrame, FeedbackKind};
+#[cfg(test)]
+use crate::session::feedback::{FeedbackFrameDraft, build_feedback_frame};
 use crate::session::precaution::{Precaution, PrecautionStatus, severity_order};
 use crate::session::store::{ScaffoldArtifactFileSnapshot, WorkingMemory};
 use crate::tools::registry::{BashErrorClass, ToolSpec};
@@ -543,115 +541,8 @@ fn latest_tool_result_since_last_user<'a>(
     None
 }
 
-// --- Issue #450 FeedbackFrame builders --------------------------------
-//
-// Each helper builds a `FeedbackFrameDraft`, then funnels it through
-// `crate::session::feedback::build_feedback_frame` for truncation,
-// secret masking, and path normalization. Per design 5.4, no helper
-// performs those steps itself.
-
-pub(super) fn build_feedback_for_auto_test(
-    plan: &AutoTestPlan,
-    result: &AutoTestResult,
-    workspace_root: &Path,
-    changed_files: &[String],
-) -> FeedbackFrame {
-    let kind = classify_auto_test(plan, result);
-    let primary_error = if !result.passed {
-        // First non-empty trimmed line is a reasonable summary.
-        result
-            .stderr
-            .lines()
-            .chain(result.stdout.lines())
-            .map(str::trim)
-            .find(|line| !line.is_empty())
-            .map(|s| s.to_string())
-    } else {
-        None
-    };
-    let suspected_files: Vec<PathBuf> = if !result.passed {
-        extract_suspected_files_from_text(&result.stdout, &result.stderr)
-    } else {
-        Vec::new()
-    };
-    let changed_files: Vec<PathBuf> = changed_files.iter().map(PathBuf::from).collect();
-    let draft = FeedbackFrameDraft {
-        command: Some(plan.command.clone()),
-        exit_code: result.exit_code,
-        kind,
-        stdout: result.stdout.clone(),
-        stderr: result.stderr.clone(),
-        primary_error,
-        suspected_files,
-        changed_files,
-    };
-    build_feedback_frame(draft, workspace_root)
-}
-
-/// Issue #457: convert an `AutoTestResult` into the `AnvilTestSummary` view
-/// consumed by `compute_anvil_score`. This is the orchestration boundary
-/// that prevents the session layer (`anvil_score.rs`) from learning about
-/// the agent-internal `AutoTestResult` type (DR3-002 in the design policy
-/// document — DR numbers in this file refer to its DR space, not CLAUDE.md's).
-///
-/// The match table follows AutoTestKind × passed dimensions strictly:
-///
-/// | (kind, passed)  | build_passed | tests_passed | compile_error_count | test_failure_count |
-/// |-----------------|--------------|--------------|---------------------|--------------------|
-/// | (Build, true)   | Some(true)   | None         | Some(0)             | None               |
-/// | (Build, false)  | Some(false)  | None         | count_compile_errors| None               |
-/// | (Test, true)    | None         | Some(true)   | None                | Some(0)            |
-/// | (Test, false)   | None         | Some(false)  | count_compile_errors| count_test_failures|
 fn raw_mode_safe_text(text: &str) -> String {
     text.replace('\n', "\r\n")
-}
-
-fn repo_edit_satisfies_artifact_recovery_target(
-    category: super::completion_evidence::RepoEditCategory,
-    relative_path: &str,
-    target: Option<&super::task_contract::RecoveryTarget>,
-) -> bool {
-    let Some(target) = target else {
-        return true;
-    };
-    let Some(role) = super::task_contract::role_from_repo_edit(category) else {
-        return false;
-    };
-    let target_path = target.path.replace('\\', "/");
-    if role != target.role {
-        return false;
-    }
-    if relative_path == target_path {
-        return true;
-    }
-    target.role == super::task_contract::ArtifactRole::Test
-        && test_artifact_path_family(relative_path)
-            .zip(test_artifact_path_family(&target_path))
-            .is_some_and(|(actual, expected)| actual == expected)
-}
-
-fn test_artifact_path_family(path: &str) -> Option<&'static str> {
-    let normalized = path.replace('\\', "/");
-    let name = std::path::Path::new(&normalized)
-        .file_name()
-        .and_then(|name| name.to_str())
-        .unwrap_or_default();
-    if normalized.starts_with("tests/") && normalized.ends_with(".rs") {
-        return Some("rust-integration");
-    }
-    if normalized.starts_with("tests/")
-        && normalized.ends_with(".py")
-        && (name.starts_with("test_") || name.ends_with("_test.py"))
-    {
-        return Some("pytest");
-    }
-    if normalized.ends_with(".test.ts") || normalized.ends_with(".spec.ts") {
-        return Some("typescript-test");
-    }
-    if normalized.ends_with(".test.js") || normalized.ends_with(".spec.js") {
-        return Some("javascript-test");
-    }
-    None
 }
 
 pub(super) fn extract_filename_with_suffix(text: &str, suffix: &str) -> Option<String> {
@@ -6975,7 +6866,7 @@ impl Agent {
         category: super::completion_evidence::RepoEditCategory,
         relative_path: &str,
     ) -> bool {
-        repo_edit_satisfies_artifact_recovery_target(
+        super::task_contract::repo_edit_satisfies_artifact_recovery_target(
             category,
             relative_path,
             self.current_artifact_recovery_target.as_ref(),
@@ -8922,7 +8813,12 @@ mod tests {
             stdout: String::new(),
             stderr: "AKIAIOSFODNN7EXAMPLE in stderr\nactual error\n".to_string(),
         };
-        let frame = super::build_feedback_for_auto_test(&plan, &result, dir.path(), &[]);
+        let frame = super::super::feedback_builders::build_feedback_for_auto_test(
+            &plan,
+            &result,
+            dir.path(),
+            &[],
+        );
         let pe = frame.primary_error.expect("primary_error");
         assert!(!pe.contains("AKIAIOSFODNN7EXAMPLE"), "leaked: {pe:?}");
     }
@@ -14001,11 +13897,14 @@ mod truncate_tests {
         scaffold_candidate_for_missing_role_from_snapshots, scaffold_command_matches_framework,
         scaffold_file_snapshot, task_or_plan_requires_nextjs_scaffold,
     };
-    use super::super::task_contract::{ArtifactRecoveryAction, ArtifactRole, TaskContract};
+    use super::super::task_contract::{
+        ArtifactRecoveryAction, ArtifactRole, TaskContract,
+        repo_edit_satisfies_artifact_recovery_target,
+    };
     use super::{
         changed_files_for_verifier, extract_filename_with_suffix, focused_edit_tool_policy_error,
-        repo_edit_satisfies_artifact_recovery_target, task_contract_needs_verification,
-        task_contract_verifier_repair_note, task_requires_nextjs_scaffold, truncate,
+        task_contract_needs_verification, task_contract_verifier_repair_note,
+        task_requires_nextjs_scaffold, truncate,
     };
     use crate::agent::orchestration::RepoVerification;
     use crate::agent::recovery::ActionExpectation;

--- a/src/agent/loop_run/verifier_orchestration.rs
+++ b/src/agent/loop_run/verifier_orchestration.rs
@@ -2352,8 +2352,12 @@ pub(super) fn handle_legacy_task_contract_verifier_selection(
             "reason": &plan.reason,
         }),
     );
-    let frame =
-        super::turn::build_feedback_for_auto_test(&plan, &result, &agent.work_root, changed_files);
+    let frame = super::feedback_builders::build_feedback_for_auto_test(
+        &plan,
+        &result,
+        &agent.work_root,
+        changed_files,
+    );
     agent.session.record_feedback_if_unset(frame);
     agent.record_task_contract_verifier_invocation(&result.command, result.exit_code);
     if result.passed {
@@ -2690,7 +2694,7 @@ pub(super) fn finish_structured_task_contract_verifier_selection(
         );
         return contamination.to_failure_outcome(result, &created_markers);
     }
-    let frame = super::turn::build_feedback_for_auto_test(
+    let frame = super::feedback_builders::build_feedback_for_auto_test(
         &selection.plan,
         &result,
         &agent.work_root,

--- a/src/agent/loop_run/verifier_skill.rs
+++ b/src/agent/loop_run/verifier_skill.rs
@@ -274,12 +274,13 @@ impl AgentSkill for VerifierSkill {
                                 Some(&summary),
                             );
                             let combined_output = combined_output_for_classify(&result);
-                            let feedback = Some(super::turn::build_feedback_for_auto_test(
-                                &plan,
-                                &result,
-                                inputs.workspace_root,
-                                inputs.changed_files,
-                            ));
+                            let feedback =
+                                Some(super::feedback_builders::build_feedback_for_auto_test(
+                                    &plan,
+                                    &result,
+                                    inputs.workspace_root,
+                                    inputs.changed_files,
+                                ));
                             return Ok(wrap_skill_output(VerifierOutcome::AutoTestRan {
                                 score,
                                 auto_test_kind: AutoTestKindView::from(plan.auto_test_kind()),
@@ -358,12 +359,13 @@ impl AgentSkill for VerifierSkill {
                         // `classify_auto_test` (via `build_feedback_for_auto_test`)
                         // and the second-pass confirmation in `success.rs`.
                         let combined_output = combined_output_for_classify(&result);
-                        let feedback = Some(super::turn::build_feedback_for_auto_test(
-                            &plan,
-                            &result,
-                            inputs.workspace_root,
-                            inputs.changed_files,
-                        ));
+                        let feedback =
+                            Some(super::feedback_builders::build_feedback_for_auto_test(
+                                &plan,
+                                &result,
+                                inputs.workspace_root,
+                                inputs.changed_files,
+                            ));
                         Ok(wrap_skill_output(VerifierOutcome::AutoTestRan {
                             score,
                             auto_test_kind: AutoTestKindView::from(plan.auto_test_kind()),
@@ -575,12 +577,13 @@ impl VerifierSkill {
                             Some(&summary),
                         );
                         let combined_output = combined_output_for_classify(&result);
-                        let feedback = Some(super::turn::build_feedback_for_auto_test(
-                            &plan,
-                            &result,
-                            inputs.workspace_root,
-                            inputs.changed_files,
-                        ));
+                        let feedback =
+                            Some(super::feedback_builders::build_feedback_for_auto_test(
+                                &plan,
+                                &result,
+                                inputs.workspace_root,
+                                inputs.changed_files,
+                            ));
                         VerifierOutcome::AutoTestRan {
                             score,
                             auto_test_kind: AutoTestKindView::from(plan.auto_test_kind()),
@@ -772,12 +775,13 @@ impl VerifierSkill {
                             Some(&summary),
                         );
                         let combined_output = combined_output_for_classify(&result);
-                        let feedback = Some(super::turn::build_feedback_for_auto_test(
-                            &plan,
-                            &result,
-                            inputs.workspace_root,
-                            inputs.changed_files,
-                        ));
+                        let feedback =
+                            Some(super::feedback_builders::build_feedback_for_auto_test(
+                                &plan,
+                                &result,
+                                inputs.workspace_root,
+                                inputs.changed_files,
+                            ));
                         VerifierOutcome::AutoTestRan {
                             score,
                             auto_test_kind: AutoTestKindView::from(plan.auto_test_kind()),


### PR DESCRIPTION
## Summary

Continue the meta-issue #680 reduction effort. Move two more clusters out of \`turn.rs\` into existing sibling modules — no new module created.

## Migrated to \`feedback_builders.rs\` (\`pub(super)\`)

- \`build_feedback_for_auto_test(&AutoTestPlan, &AutoTestResult, &Path, changed_files) -> FeedbackFrame\` — the auto-test FeedbackFrame builder. Had multiple external callers in \`verifier_skill.rs\` (4 sites) and \`verifier_orchestration.rs\` (2 sites).

## Migrated to \`task_contract.rs\` (\`pub(super)\` + private)

- \`pub(super) fn repo_edit_satisfies_artifact_recovery_target(category, relative_path, target) -> bool\` — naturally belongs with \`RecoveryTarget\`, \`ArtifactRole\`, and \`role_from_repo_edit\` SSOTs.
- \`fn test_artifact_path_family(path) -> Option<&'static str>\` — module-private supporting helper.

## \`turn.rs\` adjustments

- Removed the 3 fn definitions.
- Updated production caller of \`repo_edit_satisfies_artifact_recovery_target\` to \`super::task_contract::*\`.
- Test mod imports rewritten to \`super::super::{task_contract,feedback_builders}::*\`.
- Cleaned up \`super::auto_test::{...}\` import (removed \`AutoTestPlan\` / \`AutoTestResult\` / \`classify_auto_test\` — now only used in tests via \`super::auto_test::*\`).
- Gated \`FeedbackFrameDraft\` / \`build_feedback_frame\` imports with \`#[cfg(test)]\`.

## \`verifier_skill.rs\` / \`verifier_orchestration.rs\` adjustments

- Sweep \`super::turn::build_feedback_for_auto_test\` → \`super::feedback_builders::build_feedback_for_auto_test\` (6 caller sites total).

## LOC delta

- \`turn.rs\`: 28,496 → 28,395 (-101 LOC)
- \`feedback_builders.rs\`: 201 → 247 (+46 LOC)
- \`task_contract.rs\`: + ~60 LOC
- Cumulative \`turn.rs\`: 39,489 → 28,395 (**-11,094 LOC, -28.1%**)

## Test plan

- [x] \`cargo fmt\`
- [x] \`cargo clippy --lib --all-targets -- -D warnings\` clean
- [x] \`cargo test --lib\` 3,114 passed / 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)