### PR TITLE
Extract deterministic_fallback_plan.rs sibling module (parent #680)

### DIFF
--- a/src/agent/loop_run.rs
+++ b/src/agent/loop_run.rs
@@ -279,6 +279,14 @@ mod precaution_relevance;
 // `log_*_confirm_outcome`, `override_feedback_kind_from_outcome`.
 // `pub(super)` limited / no facade re-export (DR3-001).
 mod confirmation_flow;
+// Deterministic fallback-plan generator extracted from `turn.rs`
+// (parent #680). Used by `scaffold_pipeline.rs::maybe_materialize_plan_after_timeout`
+// when the main planning model fails to produce a usable plan.
+// Hosts `deterministic_timeout_fallback_plan` + 3 supporting helpers
+// (`extract_requested_port`, `fallback_plan_request_label`,
+// `fallback_plan_platform_label`). `pub(super)` limited / no facade
+// re-export (DR3-001).
+mod deterministic_fallback_plan;
 // v0.4.13 Phase 6: verifier rerun progress classifier.
 mod repair_progress;
 mod safe_stop_payload;

--- a/src/agent/loop_run/deterministic_fallback_plan.rs
+++ b/src/agent/loop_run/deterministic_fallback_plan.rs
@@ -1,0 +1,88 @@
+//! Deterministic fallback-plan generator extracted from `turn.rs`
+//! (parent #680). Used by the planning-model timeout recovery path
+//! in `scaffold_pipeline.rs::maybe_materialize_plan_after_timeout`
+//! when the main planning model fails to produce a usable plan.
+//!
+//! Hosts:
+//!
+//! * `deterministic_timeout_fallback_plan(task, profile, work_root)
+//!   -> String` — renders a markdown plan with `## Goal` / `## Constraints`
+//!   / `## First Action` / `## Verification` sections, parameterised on
+//!   detected port / framework / worktree name.
+//! * `fallback_plan_request_label(task) -> String` — picks
+//!   "the requested Next.js app" vs. "the requested deliverable".
+//! * `fallback_plan_platform_label(task) -> &'static str` — picks
+//!   "Next.js app" vs. "local app".
+//! * `extract_requested_port(task) -> Option<String>` — first 2-5
+//!   digit run.
+//!
+//! `pub(super)` limited / no facade re-export (DR3-001).
+
+use std::path::Path;
+
+use crate::modes::plan_act::TaskProfile;
+
+pub(super) fn extract_requested_port(task: &str) -> Option<String> {
+    let bytes = task.as_bytes();
+    let mut i = 0usize;
+    while i < bytes.len() {
+        if !bytes[i].is_ascii_digit() {
+            i += 1;
+            continue;
+        }
+        let start = i;
+        while i < bytes.len() && bytes[i].is_ascii_digit() {
+            i += 1;
+        }
+        let candidate = &task[start..i];
+        if (2..=5).contains(&candidate.len()) {
+            return Some(candidate.to_string());
+        }
+    }
+    None
+}
+
+pub(super) fn fallback_plan_request_label(task: &str) -> String {
+    let lower = task.to_ascii_lowercase();
+    if lower.contains("next.js") {
+        "the requested Next.js app".to_string()
+    } else {
+        "the requested deliverable".to_string()
+    }
+}
+
+pub(super) fn fallback_plan_platform_label(task: &str) -> &'static str {
+    if task.to_ascii_lowercase().contains("next.js") {
+        "Next.js app"
+    } else {
+        "local app"
+    }
+}
+
+pub(super) fn deterministic_timeout_fallback_plan(
+    task: &str,
+    task_profile: TaskProfile,
+    work_root: &Path,
+) -> String {
+    let request_label = fallback_plan_request_label(task);
+    let platform_label = fallback_plan_platform_label(task);
+    let port = extract_requested_port(task)
+        .map(|port| format!("port {port}"))
+        .unwrap_or_else(|| "the requested port".to_string());
+    let worktree_name = work_root
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("the current repo");
+    let execution_focus = match task_profile {
+        TaskProfile::Ui => "strong visual identity, motion, and interaction polish",
+        TaskProfile::Content => "clear reader-facing output and quality copy",
+        TaskProfile::Research => "structured investigation and evidence capture",
+        TaskProfile::Coding | TaskProfile::Generic => {
+            "a playable vertical slice first, then layered polish"
+        }
+    };
+
+    format!(
+        "# Plan\n\n## Goal\n- Build {request_label} as a {platform_label} inside `{worktree_name}`.\n- Ensure the result runs locally on {port} and feels intentionally polished rather than placeholder-quality.\n\n## Constraints\n- Keep all work inside the current repository root and use repository-relative paths.\n- If the repository is empty, scaffold only the minimum project structure needed before implementing the requested feature.\n- Keep the implementation incremental and avoid placeholder-only output.\n\n## First Action\n- Confirm or scaffold the base app, then make the first concrete implementation edit in a primary artifact such as `src/app/page.tsx`, `app/page.tsx`, or the equivalent entry file.\n- Anchor `package.json` scripts and local startup behavior to {port} before final verification.\n\n## Verification\n- Install dependencies when needed and confirm the app boots locally on {port}.\n- Exercise the main interaction or user-facing flow end-to-end, including success and failure states where applicable.\n- If verification cannot run because of sandbox, network, or host constraints, report that exact constraint instead of treating the work as verified.\n\n<!-- runtime fallback plan: generated after repeated planning model timeouts; focus on {execution_focus}. -->\n"
+    )
+}

--- a/src/agent/loop_run/scaffold_pipeline.rs
+++ b/src/agent/loop_run/scaffold_pipeline.rs
@@ -43,6 +43,7 @@ use super::actor_loop_flow::{
 };
 use super::completion_evidence::{RepoEditCategory, classify_repo_edit_path};
 use super::deterministic;
+use super::deterministic_fallback_plan::deterministic_timeout_fallback_plan;
 use super::interrupt::InterruptFlag;
 use super::lifecycle;
 use super::quality::{
@@ -54,13 +55,12 @@ use super::tool_history::{
     focused_edit_target_already_read, has_successful_non_plan_repo_edit, latest_user_turn_slice,
 };
 use super::turn::{
-    WrittenScaffoldArtifacts, current_file_hash_for_relative_path,
-    deterministic_timeout_fallback_plan, extract_filename_with_suffix, last_read_tool_path,
-    latest_turn_preferred_read_edit_target, meaningful_workspace_files, normalize_memory_path,
-    progress_path_display, sha256_hex, should_fallback_plan_model_after_timeout,
-    should_materialize_plan_after_timeout, should_materialize_plan_after_tool_call_format_error,
-    sync_package_json_with_existing_lock, tool_result_failed, workspace_appears_empty,
-    write_stdout_rendered,
+    WrittenScaffoldArtifacts, current_file_hash_for_relative_path, extract_filename_with_suffix,
+    last_read_tool_path, latest_turn_preferred_read_edit_target, meaningful_workspace_files,
+    normalize_memory_path, progress_path_display, sha256_hex,
+    should_fallback_plan_model_after_timeout, should_materialize_plan_after_timeout,
+    should_materialize_plan_after_tool_call_format_error, sync_package_json_with_existing_lock,
+    tool_result_failed, workspace_appears_empty, write_stdout_rendered,
 };
 use crate::agent::prompting;
 use crate::agent::recovery;

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -211,9 +211,7 @@ use super::*;
 use crate::agent::orchestration::verify_repo_progress;
 use crate::logging::{log_llm_event, stable_path_hash};
 use crate::model_capabilities::model_capabilities;
-use crate::modes::plan_act::{
-    ModeClassification, PlanStage, TaskProfile, WorkMode, classify_work_mode_json,
-};
+use crate::modes::plan_act::{ModeClassification, PlanStage, WorkMode, classify_work_mode_json};
 use crate::ollama::xml_fallback::normalize_tool_call_arguments;
 use crate::session::feedback::{FeedbackFrame, FeedbackKind};
 #[cfg(test)]
@@ -599,71 +597,6 @@ fn user_interrupt_result() -> String {
 
 pub(super) fn tool_result_failed(result: &str) -> bool {
     result.starts_with("Error:") || result.contains("\ninterrupted=true\n")
-}
-
-fn extract_requested_port(task: &str) -> Option<String> {
-    let bytes = task.as_bytes();
-    let mut i = 0usize;
-    while i < bytes.len() {
-        if !bytes[i].is_ascii_digit() {
-            i += 1;
-            continue;
-        }
-        let start = i;
-        while i < bytes.len() && bytes[i].is_ascii_digit() {
-            i += 1;
-        }
-        let candidate = &task[start..i];
-        if (2..=5).contains(&candidate.len()) {
-            return Some(candidate.to_string());
-        }
-    }
-    None
-}
-
-fn fallback_plan_request_label(task: &str) -> String {
-    let lower = task.to_ascii_lowercase();
-    if lower.contains("next.js") {
-        "the requested Next.js app".to_string()
-    } else {
-        "the requested deliverable".to_string()
-    }
-}
-
-fn fallback_plan_platform_label(task: &str) -> &'static str {
-    if task.to_ascii_lowercase().contains("next.js") {
-        "Next.js app"
-    } else {
-        "local app"
-    }
-}
-
-pub(super) fn deterministic_timeout_fallback_plan(
-    task: &str,
-    task_profile: TaskProfile,
-    work_root: &Path,
-) -> String {
-    let request_label = fallback_plan_request_label(task);
-    let platform_label = fallback_plan_platform_label(task);
-    let port = extract_requested_port(task)
-        .map(|port| format!("port {port}"))
-        .unwrap_or_else(|| "the requested port".to_string());
-    let worktree_name = work_root
-        .file_name()
-        .and_then(|name| name.to_str())
-        .unwrap_or("the current repo");
-    let execution_focus = match task_profile {
-        TaskProfile::Ui => "strong visual identity, motion, and interaction polish",
-        TaskProfile::Content => "clear reader-facing output and quality copy",
-        TaskProfile::Research => "structured investigation and evidence capture",
-        TaskProfile::Coding | TaskProfile::Generic => {
-            "a playable vertical slice first, then layered polish"
-        }
-    };
-
-    format!(
-        "# Plan\n\n## Goal\n- Build {request_label} as a {platform_label} inside `{worktree_name}`.\n- Ensure the result runs locally on {port} and feels intentionally polished rather than placeholder-quality.\n\n## Constraints\n- Keep all work inside the current repository root and use repository-relative paths.\n- If the repository is empty, scaffold only the minimum project structure needed before implementing the requested feature.\n- Keep the implementation incremental and avoid placeholder-only output.\n\n## First Action\n- Confirm or scaffold the base app, then make the first concrete implementation edit in a primary artifact such as `src/app/page.tsx`, `app/page.tsx`, or the equivalent entry file.\n- Anchor `package.json` scripts and local startup behavior to {port} before final verification.\n\n## Verification\n- Install dependencies when needed and confirm the app boots locally on {port}.\n- Exercise the main interaction or user-facing flow end-to-end, including success and failure states where applicable.\n- If verification cannot run because of sandbox, network, or host constraints, report that exact constraint instead of treating the work as verified.\n\n<!-- runtime fallback plan: generated after repeated planning model timeouts; focus on {execution_focus}. -->\n"
-    )
 }
 
 pub(super) fn normalize_exploration_path(raw_path: &str, work_root: &Path) -> String {
@@ -7754,11 +7687,10 @@ mod tests {
         answer_only_script_execution_fallback_response, assistant_model_for_mode,
         build_task_contract_verifier_exit_zero_evidence,
         build_task_contract_verifier_exit_zero_evidence_bound, build_verifier_exit_zero_evidence,
-        classify_verifier_timeout, deterministic_timeout_fallback_plan,
-        effective_non_streaming_timeout_secs, latest_tool_result_since_last_user,
-        non_streaming_assistant_reply_timeout_secs, normalize_exploration_path,
-        repair_terminal_exit_reason, should_fallback_plan_model_after_timeout,
-        should_materialize_plan_after_timeout,
+        classify_verifier_timeout, effective_non_streaming_timeout_secs,
+        latest_tool_result_since_last_user, non_streaming_assistant_reply_timeout_secs,
+        normalize_exploration_path, repair_terminal_exit_reason,
+        should_fallback_plan_model_after_timeout, should_materialize_plan_after_timeout,
         should_materialize_plan_after_tool_call_format_error, should_use_streaming_transport,
         task_contract_structured_missing_outcome, verifier_repair_context_from_failure,
     };
@@ -8202,6 +8134,7 @@ mod tests {
 
     #[test]
     fn deterministic_timeout_fallback_plan_mentions_requested_port() {
+        use super::super::deterministic_fallback_plan::deterministic_timeout_fallback_plan;
         let temp = tempdir().unwrap();
         let plan = deterministic_timeout_fallback_plan(
             "ブラウザゲームを3011ポートで起動可能なnext.jsアプリとして開発してください。",


### PR DESCRIPTION
## Summary

Create new sibling module \`src/agent/loop_run/deterministic_fallback_plan.rs\` to host the deterministic fallback-plan generator used by the planning-model timeout recovery path. Small follow-on extraction in the meta-issue #680 reduction effort.

## Migrated to \`deterministic_fallback_plan.rs\` (\`pub(super)\`)

- \`extract_requested_port(task) -> Option<String>\` (first 2-5 digit run)
- \`fallback_plan_request_label(task) -> String\`
- \`fallback_plan_platform_label(task) -> &'static str\`
- \`deterministic_timeout_fallback_plan(task, &TaskProfile, work_root) -> String\` (renders the markdown plan with Goal / Constraints / First Action / Verification sections, parameterised on detected port + framework + worktree name + task profile)

## \`loop_run.rs\` adjustments

- Registered \`mod deterministic_fallback_plan;\` with a parent-#680 doc comment.

## \`turn.rs\` adjustments

- Removed the 4 fn definitions.
- Pruned \`deterministic_timeout_fallback_plan\` from existing test-mod \`use super::{...}\` block.
- Pruned now-unused \`TaskProfile\` from the existing \`use crate::modes::plan_act::{...}\` block.
- Test mod gained a \`use super::super::deterministic_fallback_plan::deterministic_timeout_fallback_plan;\` inside the single test that exercises it.

## \`scaffold_pipeline.rs\` adjustments

- Updated \`deterministic_timeout_fallback_plan\` import from \`super::turn::{...}\` group → standalone \`use super::deterministic_fallback_plan::deterministic_timeout_fallback_plan;\`.

## LOC delta

- \`turn.rs\`: 28,054 → 27,987 (-67 LOC)
- \`deterministic_fallback_plan.rs\`: 0 → 88 (new)
- Cumulative \`turn.rs\`: 39,489 → 27,987 (**-11,502 LOC, -29.1%**)

## Test plan

- [x] \`cargo fmt\`
- [x] \`cargo clippy --lib --all-targets -- -D warnings\` clean
- [x] \`cargo test --lib\` 3,114 passed / 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)