### PR TITLE
Extract path_helpers.rs sibling module (parent #680)

### DIFF
--- a/src/agent/loop_run.rs
+++ b/src/agent/loop_run.rs
@@ -287,6 +287,12 @@ mod confirmation_flow;
 // `fallback_plan_platform_label`). `pub(super)` limited / no facade
 // re-export (DR3-001).
 mod deterministic_fallback_plan;
+// Workspace-relative path normalization + package.json/lock sync
+// helpers extracted from `turn.rs` (parent #680). Hosts
+// `normalize_memory_path`, `normalize_exploration_path`,
+// `sync_package_json_with_existing_lock`. `pub(super)` limited / no
+// facade re-export (DR3-001).
+mod path_helpers;
 // v0.4.13 Phase 6: verifier rerun progress classifier.
 mod repair_progress;
 mod safe_stop_payload;

--- a/src/agent/loop_run/actor_loop_flow.rs
+++ b/src/agent/loop_run/actor_loop_flow.rs
@@ -56,6 +56,7 @@ use super::Agent;
 use super::active_job_arbiter::{LoopControlAction, RecoveryDispatchGate, RecoveryOwner};
 use super::interrupt::{InterruptFlag, InterruptMonitor};
 use super::lifecycle;
+use super::path_helpers::normalize_exploration_path;
 use super::progress_text::{
     format_progress_field, paint, progress_available_width, sanitize_for_progress, tool_color,
     tool_emoji, truncate,
@@ -70,8 +71,8 @@ use super::tool_history::is_plan_file_tool_call;
 use super::tool_policy::EffectiveToolPolicy;
 use super::turn::{
     LOG_ARGS_MAX_CHARS, PLAN_REPEATED_EXPLORATION_BLOCK_THRESHOLD, join_sections_for_progress,
-    normalize_exploration_path, plan_section_body_for_progress, plan_sections_with_content,
-    tool_display, write_stdout_rendered,
+    plan_section_body_for_progress, plan_sections_with_content, tool_display,
+    write_stdout_rendered,
 };
 use crate::agent::prompting;
 use crate::session::compact::approximate_token_count;

--- a/src/agent/loop_run/path_helpers.rs
+++ b/src/agent/loop_run/path_helpers.rs
@@ -1,0 +1,128 @@
+//! Workspace-relative path normalization + package.json/lock sync
+//! helpers extracted from `turn.rs` (parent #680).
+//!
+//! Hosts:
+//!
+//! * `normalize_memory_path(raw_path, work_root) -> String` — projects
+//!   a raw path token into a workspace-relative key suitable for
+//!   `WorkingMemory.touched_files` (slash-normalized, prefix-stripped).
+//!   Used as the SSOT for keying touched-file relevance lookups.
+//! * `normalize_exploration_path(raw_path, work_root) -> String` —
+//!   similar shape but tuned for the plan-mode exploration repeat
+//!   detector (component-filter pass + canonical-root fallback).
+//! * `sync_package_json_with_existing_lock(work_root, relative, content)
+//!   -> String` — when a deterministic scaffold rewrites
+//!   `package.json` in a worktree that already has a `package-lock.json`,
+//!   replace dependency sections so the lock stays internally
+//!   consistent.
+//!
+//! `pub(super)` limited / no facade re-export (DR3-001).
+
+use std::path::Path;
+
+use crate::safety::path_guard::resolve_user_path;
+
+pub(super) fn normalize_exploration_path(raw_path: &str, work_root: &Path) -> String {
+    let input = Path::new(raw_path);
+    if input.is_relative() {
+        let cleaned = input
+            .components()
+            .filter_map(|component| match component {
+                std::path::Component::Normal(part) => Some(part.to_string_lossy().to_string()),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        if !cleaned.is_empty() {
+            return cleaned.join("/");
+        }
+    }
+
+    if let Ok(resolved) = resolve_user_path(work_root, raw_path) {
+        let canonical_root = std::fs::canonicalize(work_root).ok();
+        let canonical_resolved = std::fs::canonicalize(&resolved).ok();
+        if let (Some(root), Some(resolved_path)) = (canonical_root, canonical_resolved)
+            && let Ok(relative) = resolved_path.strip_prefix(root)
+        {
+            return relative.to_string_lossy().replace('\\', "/");
+        }
+        if let Ok(relative) = resolved.strip_prefix(work_root) {
+            return relative.to_string_lossy().replace('\\', "/");
+        }
+        return resolved.to_string_lossy().replace('\\', "/");
+    }
+
+    raw_path.trim().replace('\\', "/")
+}
+
+pub(super) fn sync_package_json_with_existing_lock(
+    work_root: &Path,
+    relative: &Path,
+    package_content: String,
+) -> String {
+    if relative != Path::new("package.json") {
+        return package_content;
+    }
+    let Ok(lock_content) = std::fs::read_to_string(work_root.join("package-lock.json")) else {
+        return package_content;
+    };
+    let Ok(mut package) = serde_json::from_str::<serde_json::Value>(&package_content) else {
+        return package_content;
+    };
+    let Ok(lock) = serde_json::from_str::<serde_json::Value>(&lock_content) else {
+        return package_content;
+    };
+    let Some(root_package) = lock
+        .get("packages")
+        .and_then(|packages| packages.get(""))
+        .and_then(serde_json::Value::as_object)
+    else {
+        return package_content;
+    };
+    let Some(package_object) = package.as_object_mut() else {
+        return package_content;
+    };
+
+    let mut replaced_any = false;
+    for section in [
+        "dependencies",
+        "devDependencies",
+        "optionalDependencies",
+        "peerDependencies",
+    ] {
+        if let Some(lock_section) = root_package.get(section) {
+            package_object.insert(section.to_string(), lock_section.clone());
+            replaced_any = true;
+        } else {
+            package_object.remove(section);
+        }
+    }
+    if !replaced_any {
+        return package_content;
+    }
+
+    serde_json::to_string_pretty(&package)
+        .map(|json| format!("{json}\n"))
+        .unwrap_or(package_content)
+}
+
+pub(super) fn normalize_memory_path(raw_path: &str, work_root: &Path) -> String {
+    let path = Path::new(raw_path);
+    if let Ok(resolved) = resolve_user_path(work_root, raw_path)
+        && let Ok(relative) = resolved.strip_prefix(work_root)
+    {
+        return relative.to_string_lossy().replace('\\', "/");
+    }
+    let canonical_root = std::fs::canonicalize(work_root).ok();
+    let canonical_path = std::fs::canonicalize(path)
+        .ok()
+        .or_else(|| resolve_user_path(work_root, raw_path).ok());
+    if let (Some(root), Some(candidate)) = (canonical_root, canonical_path)
+        && let Ok(relative) = candidate.strip_prefix(root)
+    {
+        return relative.to_string_lossy().replace('\\', "/");
+    }
+    if let Ok(relative) = path.strip_prefix(work_root) {
+        return relative.to_string_lossy().replace('\\', "/");
+    }
+    raw_path.replace('\\', "/")
+}

--- a/src/agent/loop_run/scaffold_pipeline.rs
+++ b/src/agent/loop_run/scaffold_pipeline.rs
@@ -46,6 +46,7 @@ use super::deterministic;
 use super::deterministic_fallback_plan::deterministic_timeout_fallback_plan;
 use super::interrupt::InterruptFlag;
 use super::lifecycle;
+use super::path_helpers::{normalize_memory_path, sync_package_json_with_existing_lock};
 use super::quality::{
     first_existing_impl_target, implementation_quality_issue_for_request,
     package_json_with_requested_port, react_dev_wrapper_for_requested_port,
@@ -57,9 +58,8 @@ use super::tool_history::{
 use super::turn::{
     WrittenScaffoldArtifacts, current_file_hash_for_relative_path, extract_filename_with_suffix,
     last_read_tool_path, latest_turn_preferred_read_edit_target, meaningful_workspace_files,
-    normalize_memory_path, progress_path_display, sha256_hex,
-    should_fallback_plan_model_after_timeout, should_materialize_plan_after_timeout,
-    should_materialize_plan_after_tool_call_format_error, sync_package_json_with_existing_lock,
+    progress_path_display, sha256_hex, should_fallback_plan_model_after_timeout,
+    should_materialize_plan_after_timeout, should_materialize_plan_after_tool_call_format_error,
     tool_result_failed, workspace_appears_empty, write_stdout_rendered,
 };
 use crate::agent::prompting;

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -91,6 +91,7 @@ use super::feedback_builders::{
     build_feedback_for_bash, build_feedback_for_edit_failure,
     build_feedback_for_unsafe_block_reason, extract_current_request_paths,
 };
+use super::path_helpers::normalize_memory_path;
 use super::photon_feedback_derive::{
     build_rerun_prompt_hint_if_eligible, request_explicitly_requests_script_execution,
 };
@@ -597,111 +598,6 @@ fn user_interrupt_result() -> String {
 
 pub(super) fn tool_result_failed(result: &str) -> bool {
     result.starts_with("Error:") || result.contains("\ninterrupted=true\n")
-}
-
-pub(super) fn normalize_exploration_path(raw_path: &str, work_root: &Path) -> String {
-    let input = Path::new(raw_path);
-    if input.is_relative() {
-        let cleaned = input
-            .components()
-            .filter_map(|component| match component {
-                std::path::Component::Normal(part) => Some(part.to_string_lossy().to_string()),
-                _ => None,
-            })
-            .collect::<Vec<_>>();
-        if !cleaned.is_empty() {
-            return cleaned.join("/");
-        }
-    }
-
-    if let Ok(resolved) = resolve_user_path(work_root, raw_path) {
-        let canonical_root = std::fs::canonicalize(work_root).ok();
-        let canonical_resolved = std::fs::canonicalize(&resolved).ok();
-        if let (Some(root), Some(resolved_path)) = (canonical_root, canonical_resolved)
-            && let Ok(relative) = resolved_path.strip_prefix(root)
-        {
-            return relative.to_string_lossy().replace('\\', "/");
-        }
-        if let Ok(relative) = resolved.strip_prefix(work_root) {
-            return relative.to_string_lossy().replace('\\', "/");
-        }
-        return resolved.to_string_lossy().replace('\\', "/");
-    }
-
-    raw_path.trim().replace('\\', "/")
-}
-
-pub(super) fn sync_package_json_with_existing_lock(
-    work_root: &Path,
-    relative: &Path,
-    package_content: String,
-) -> String {
-    if relative != Path::new("package.json") {
-        return package_content;
-    }
-    let Ok(lock_content) = std::fs::read_to_string(work_root.join("package-lock.json")) else {
-        return package_content;
-    };
-    let Ok(mut package) = serde_json::from_str::<serde_json::Value>(&package_content) else {
-        return package_content;
-    };
-    let Ok(lock) = serde_json::from_str::<serde_json::Value>(&lock_content) else {
-        return package_content;
-    };
-    let Some(root_package) = lock
-        .get("packages")
-        .and_then(|packages| packages.get(""))
-        .and_then(serde_json::Value::as_object)
-    else {
-        return package_content;
-    };
-    let Some(package_object) = package.as_object_mut() else {
-        return package_content;
-    };
-
-    let mut replaced_any = false;
-    for section in [
-        "dependencies",
-        "devDependencies",
-        "optionalDependencies",
-        "peerDependencies",
-    ] {
-        if let Some(lock_section) = root_package.get(section) {
-            package_object.insert(section.to_string(), lock_section.clone());
-            replaced_any = true;
-        } else {
-            package_object.remove(section);
-        }
-    }
-    if !replaced_any {
-        return package_content;
-    }
-
-    serde_json::to_string_pretty(&package)
-        .map(|json| format!("{json}\n"))
-        .unwrap_or(package_content)
-}
-
-pub(super) fn normalize_memory_path(raw_path: &str, work_root: &Path) -> String {
-    let path = Path::new(raw_path);
-    if let Ok(resolved) = resolve_user_path(work_root, raw_path)
-        && let Ok(relative) = resolved.strip_prefix(work_root)
-    {
-        return relative.to_string_lossy().replace('\\', "/");
-    }
-    let canonical_root = std::fs::canonicalize(work_root).ok();
-    let canonical_path = std::fs::canonicalize(path)
-        .ok()
-        .or_else(|| resolve_user_path(work_root, raw_path).ok());
-    if let (Some(root), Some(candidate)) = (canonical_root, canonical_path)
-        && let Ok(relative) = candidate.strip_prefix(root)
-    {
-        return relative.to_string_lossy().replace('\\', "/");
-    }
-    if let Ok(relative) = path.strip_prefix(work_root) {
-        return relative.to_string_lossy().replace('\\', "/");
-    }
-    raw_path.replace('\\', "/")
 }
 
 /// Issue #555: carries a retrieval message and the IDs of the selected
@@ -7607,8 +7503,8 @@ mod tests {
         build_task_contract_verifier_exit_zero_evidence_bound, build_verifier_exit_zero_evidence,
         classify_verifier_timeout, effective_non_streaming_timeout_secs,
         latest_tool_result_since_last_user, non_streaming_assistant_reply_timeout_secs,
-        normalize_exploration_path, repair_terminal_exit_reason,
-        should_fallback_plan_model_after_timeout, should_materialize_plan_after_timeout,
+        repair_terminal_exit_reason, should_fallback_plan_model_after_timeout,
+        should_materialize_plan_after_timeout,
         should_materialize_plan_after_tool_call_format_error, should_use_streaming_transport,
         task_contract_structured_missing_outcome, verifier_repair_context_from_failure,
     };
@@ -7795,7 +7691,8 @@ mod tests {
     #[test]
     fn normalizes_relative_path_without_touching_missing_file() {
         let temp = tempdir().unwrap();
-        let normalized = normalize_exploration_path("docs/plan.md", temp.path());
+        let normalized =
+            super::super::path_helpers::normalize_exploration_path("docs/plan.md", temp.path());
         assert_eq!(normalized, "docs/plan.md");
     }
 
@@ -14073,9 +13970,8 @@ mod progress_tests {
         recent_truncated_tool_call_attempt, repo_change_request_text,
         request_needs_playable_ui_quality_gate, sanitize_for_progress, sha256_hex,
         should_use_streaming_transport, strip_read_line_number_prefix,
-        successful_non_plan_repo_edit_count, successful_repo_edit_count,
-        sync_package_json_with_existing_lock, tool_color, tool_display, tool_emoji,
-        unicode_supported, validate_accepted_repair_plan_authorizes_target,
+        successful_non_plan_repo_edit_count, successful_repo_edit_count, tool_color, tool_display,
+        tool_emoji, unicode_supported, validate_accepted_repair_plan_authorizes_target,
         verifier_diagnostic_attempt_spec, verifier_repair_context_from_failure,
         verifier_repair_intent_fingerprint, verifier_repair_intents_fingerprint,
         verifier_repair_invalid_can_continue, verifier_repair_preferred_local_import_source,
@@ -14150,7 +14046,7 @@ mod progress_tests {
 }
 "#;
 
-        let synced = sync_package_json_with_existing_lock(
+        let synced = super::super::path_helpers::sync_package_json_with_existing_lock(
             work_root,
             Path::new("package.json"),
             generated.to_string(),

--- a/src/agent/loop_run/verifier_orchestration.rs
+++ b/src/agent/loop_run/verifier_orchestration.rs
@@ -48,6 +48,7 @@ use super::patch_proposal::PatchProposal;
 use super::patch_provider::{
     PatchProviderKind, PatchProviderOutput, PatchProviderRequest, admit_patch_provider_output,
 };
+use super::path_helpers::normalize_memory_path;
 use super::progress_text::truncate;
 use super::repair_attempt_outcome::RepairAttemptOutcome;
 use super::repair_authority::AuthorityEvidence;
@@ -87,7 +88,6 @@ use super::tool_history::focused_edit_target_already_read;
 use super::tool_policy::{EffectiveToolPolicy, EffectiveToolPolicyReason};
 use super::turn::{
     TASK_CONTRACT_VERIFIER_ATTEMPT_LIMIT, TASK_CONTRACT_VERIFIER_REPAIR_ATTEMPT_LIMIT,
-    normalize_memory_path,
 };
 use super::verifier_assessment_parser::{
     ParsedVerifierRepairAssessment, verifier_failure_type_for_diagnostic_kind,


### PR DESCRIPTION
## Summary

Create new sibling module \`src/agent/loop_run/path_helpers.rs\` to host the workspace-relative path normalization + package.json/lock sync helpers. Small follow-on extraction in the meta-issue #680 reduction effort.

## Migrated to \`path_helpers.rs\` (\`pub(super)\`)

- \`normalize_memory_path(raw_path, work_root) -> String\` — projects a raw path token into a workspace-relative key for \`WorkingMemory.touched_files\`. SSOT used by 1 \`turn.rs\` caller + \`verifier_orchestration.rs\` + \`scaffold_pipeline.rs\`.
- \`normalize_exploration_path(raw_path, work_root) -> String\` — plan-mode exploration repeat-detector projection. Caller: \`actor_loop_flow.rs\`.
- \`sync_package_json_with_existing_lock(work_root, relative, content) -> String\` — keeps deterministic-scaffold \`package.json\` in sync with an existing \`package-lock.json\`. Caller: \`scaffold_pipeline.rs\`.

## \`loop_run.rs\` adjustments

- Registered \`mod path_helpers;\` with a parent-#680 doc comment.

## \`turn.rs\` adjustments

- Removed the 3 fn definitions.
- Added \`use super::path_helpers::normalize_memory_path;\` for the production caller.
- Test mod call sites rewritten to \`super::super::path_helpers::*\`.

## Sibling adjustments

- \`verifier_orchestration.rs\` / \`actor_loop_flow.rs\` / \`scaffold_pipeline.rs\` switched from \`super::turn::{...}\` group imports to dedicated \`super::path_helpers::*\` imports.

## LOC delta

- \`turn.rs\`: 27,905 → 27,801 (-104 LOC)
- \`path_helpers.rs\`: 0 → 128 (new)
- Cumulative \`turn.rs\`: 39,489 → 27,801 (**-11,688 LOC, -29.6%**)

## Test plan

- [x] \`cargo fmt\`
- [x] \`cargo clippy --lib --all-targets -- -D warnings\` clean
- [x] \`cargo test --lib\` 3,114 passed / 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)