### PR TITLE
Extract small_helpers.rs from turn.rs (parent #680)

### DIFF
--- a/src/agent/loop_run.rs
+++ b/src/agent/loop_run.rs
@@ -293,6 +293,12 @@ mod deterministic_fallback_plan;
 // `sync_package_json_with_existing_lock`. `pub(super)` limited / no
 // facade re-export (DR3-001).
 mod path_helpers;
+// Small standalone helpers extracted from `turn.rs` (parent #680). Hosts
+// `rfc3339_now_utc`, `masked_path_hash_bounded_list`,
+// `latest_tool_result_since_last_user`, `raw_mode_safe_text`,
+// `user_interrupt_result`, `anti_pattern_failed_action_summary`.
+// `pub(super)` limited / no facade re-export (DR3-001).
+mod small_helpers;
 // v0.4.13 Phase 6: verifier rerun progress classifier.
 mod repair_progress;
 mod safe_stop_payload;

--- a/src/agent/loop_run/small_helpers.rs
+++ b/src/agent/loop_run/small_helpers.rs
@@ -1,0 +1,81 @@
+//! Small standalone helpers extracted from `turn.rs` (parent #680).
+//!
+//! - `rfc3339_now_utc`: wall-clock timestamp for verifier invocation records
+//! - `masked_path_hash_bounded_list`: debug-only panic / log path hash projection
+//! - `latest_tool_result_since_last_user`: tool-result scan within current turn
+//! - `raw_mode_safe_text`: LF -> CRLF rewriter for raw-mode TTY output
+//! - `user_interrupt_result`: canonical interrupt tool-result text
+//! - `anti_pattern_failed_action_summary`: feedback frame -> short action summary
+//!
+//! `pub(super)` limited / no facade re-export (DR3-001).
+
+use crate::session::feedback::FeedbackFrame;
+use crate::session::store::ConversationMessage;
+
+/// Issue #659 / #664 sidecar: produce an RFC 3339 UTC timestamp from system
+/// wall-clock. Delegates to `case_photon_bridge::format_rfc3339_utc` (which
+/// already implements the no-chrono civil-from-days algorithm). Pure helper
+/// for the `last_verifier_invocation.recorded_at` field.
+pub(super) fn rfc3339_now_utc() -> String {
+    let secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    crate::session::case_photon_bridge::format_rfc3339_utc(secs)
+}
+
+/// CB-004: bounded, masked-hash projection of an iterator of paths for use
+/// in panic / log messages. Each path is masked via
+/// `session::feedback::mask_secrets` and then hashed with the same stable
+/// `DefaultHasher` shape `artifact_ledger::stable_path_hash` uses, so the
+/// hash space is identical between debug-build panics and release-build
+/// observability events. Output is hard-capped at 16 entries so a flood of
+/// divergent paths cannot blow up the panic message size.
+#[cfg(debug_assertions)]
+pub(super) fn masked_path_hash_bounded_list<'a, I>(paths: I) -> Vec<String>
+where
+    I: IntoIterator<Item = &'a str>,
+{
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+    const MAX_PANIC_HASH_ENTRIES: usize = 16;
+    let mut out: Vec<String> = Vec::new();
+    for p in paths.into_iter().take(MAX_PANIC_HASH_ENTRIES) {
+        let masked = crate::session::feedback::mask_secrets(p);
+        let mut hasher = DefaultHasher::new();
+        masked.hash(&mut hasher);
+        out.push(format!("{:016x}", hasher.finish()));
+    }
+    out
+}
+
+pub(super) fn latest_tool_result_since_last_user<'a>(
+    messages: &'a [ConversationMessage],
+    tool_name: &str,
+) -> Option<&'a str> {
+    for message in messages.iter().rev() {
+        if message.role == "user" {
+            break;
+        }
+        if message.role == "tool" && message.name.as_deref() == Some(tool_name) {
+            return Some(message.content.as_str());
+        }
+    }
+    None
+}
+
+pub(super) fn raw_mode_safe_text(text: &str) -> String {
+    text.replace('\n', "\r\n")
+}
+
+pub(super) fn user_interrupt_result() -> String {
+    "exit_code=-1\ninterrupted=true\ninterrupt requested by user".to_string()
+}
+
+pub(super) fn anti_pattern_failed_action_summary(frame: &FeedbackFrame) -> String {
+    frame
+        .primary_error
+        .clone()
+        .or_else(|| frame.command().map(|s| s.to_string()))
+        .unwrap_or_else(|| format!("{:?}", frame.kind))
+}

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -121,6 +121,12 @@ use super::semantic_repair_planning::{
     build_semantic_repair_plan_from_report, default_spec_authority_input,
     sort_admitted_by_authority_role_priority,
 };
+#[cfg(debug_assertions)]
+use super::small_helpers::masked_path_hash_bounded_list;
+use super::small_helpers::{
+    anti_pattern_failed_action_summary, latest_tool_result_since_last_user, raw_mode_safe_text,
+    rfc3339_now_utc, user_interrupt_result,
+};
 use super::spinner::{Spinner, SpinnerStopSignal};
 use super::summary::{ExitReason, LoopResult};
 use super::tester;
@@ -491,62 +497,6 @@ mod v0421_repair_runner_contract_tests {
     }
 }
 
-/// Issue #608 Phase α-2 (AP-09): RFC3339 UTC timestamp for the current
-/// wall-clock. Delegates to `case_photon_bridge::format_rfc3339_utc` (which
-/// already implements the no-chrono civil-from-days algorithm). Pure helper
-/// for the `last_verifier_invocation.recorded_at` field.
-fn rfc3339_now_utc() -> String {
-    let secs = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0);
-    crate::session::case_photon_bridge::format_rfc3339_utc(secs)
-}
-
-/// CB-004: bounded, masked-hash projection of an iterator of paths for use
-/// in panic / log messages. Each path is masked via
-/// `session::feedback::mask_secrets` and then hashed with the same stable
-/// `DefaultHasher` shape `artifact_ledger::stable_path_hash` uses, so the
-/// hash space is identical between debug-build panics and release-build
-/// observability events. Output is hard-capped at 16 entries so a flood of
-/// divergent paths cannot blow up the panic message size.
-#[cfg(debug_assertions)]
-fn masked_path_hash_bounded_list<'a, I>(paths: I) -> Vec<String>
-where
-    I: IntoIterator<Item = &'a str>,
-{
-    use std::collections::hash_map::DefaultHasher;
-    use std::hash::{Hash, Hasher};
-    const MAX_PANIC_HASH_ENTRIES: usize = 16;
-    let mut out: Vec<String> = Vec::new();
-    for p in paths.into_iter().take(MAX_PANIC_HASH_ENTRIES) {
-        let masked = crate::session::feedback::mask_secrets(p);
-        let mut hasher = DefaultHasher::new();
-        masked.hash(&mut hasher);
-        out.push(format!("{:016x}", hasher.finish()));
-    }
-    out
-}
-
-fn latest_tool_result_since_last_user<'a>(
-    messages: &'a [ConversationMessage],
-    tool_name: &str,
-) -> Option<&'a str> {
-    for message in messages.iter().rev() {
-        if message.role == "user" {
-            break;
-        }
-        if message.role == "tool" && message.name.as_deref() == Some(tool_name) {
-            return Some(message.content.as_str());
-        }
-    }
-    None
-}
-
-fn raw_mode_safe_text(text: &str) -> String {
-    text.replace('\n', "\r\n")
-}
-
 pub(super) fn extract_filename_with_suffix(text: &str, suffix: &str) -> Option<String> {
     text.split(|ch: char| {
         ch.is_whitespace()
@@ -592,10 +542,6 @@ pub(super) fn write_stdout_rendered(text: &str, trailing_newline: bool) {
     let _ = out.flush();
 }
 
-fn user_interrupt_result() -> String {
-    "exit_code=-1\ninterrupted=true\ninterrupt requested by user".to_string()
-}
-
 pub(super) fn tool_result_failed(result: &str) -> bool {
     result.starts_with("Error:") || result.contains("\ninterrupted=true\n")
 }
@@ -609,14 +555,6 @@ pub(super) struct RetrievalInjection {
 }
 
 pub(super) type WrittenScaffoldArtifacts = (Vec<PathBuf>, Vec<ScaffoldArtifactFileSnapshot>);
-
-fn anti_pattern_failed_action_summary(frame: &FeedbackFrame) -> String {
-    frame
-        .primary_error
-        .clone()
-        .or_else(|| frame.command().map(|s| s.to_string()))
-        .unwrap_or_else(|| format!("{:?}", frame.kind))
-}
 
 /// Issue #580: SSoT memoization key for the Quality-gate second-pass adapter.
 /// Hashes `(request, full_content)` with `DefaultHasher` (per design judgement


### PR DESCRIPTION
## Summary

Move 6 standalone helpers out of `turn.rs` into a new `src/agent/loop_run/small_helpers.rs` sibling module, continuing the meta-issue #680 split of the monolithic `turn.rs`.

Migrated:
- `rfc3339_now_utc` — wall-clock RFC3339 UTC timestamp (for `last_verifier_invocation.recorded_at`)
- `masked_path_hash_bounded_list` — debug-only panic / log path hash projection (CB-004)
- `latest_tool_result_since_last_user` — current-turn tool result scan
- `raw_mode_safe_text` — LF → CRLF rewrite for raw-mode TTY output
- `user_interrupt_result` — canonical interrupt tool-result text
- `anti_pattern_failed_action_summary` — feedback frame → short summary

All 6 fns are `pub(super)`, no facade re-export (DR3-001). `turn.rs` is the only in-crate consumer. The test mod in `turn.rs` continues to reach them via `super::<name>` since they are re-imported into `turn.rs` scope.

## LOC delta

- `turn.rs`: 27,801 → 27,739 (-62 LOC)
- New `small_helpers.rs`: 81 LOC
- Cumulative from 39,489: -11,750 LOC (-29.8%)

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --lib --all-targets -- -D warnings` clean
- [x] `cargo test --lib` (3,114 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)