### PR TITLE
Extract tool_display.rs from turn.rs (parent #680)

### DIFF
--- a/src/agent/loop_run.rs
+++ b/src/agent/loop_run.rs
@@ -319,6 +319,12 @@ pub mod slash_commands;
 mod spec_authority;
 mod spinner;
 mod success;
+// Per-iteration progress line rendering extracted from `turn.rs` (parent
+// #680). Hosts `ProgressDisplay`, `progress_path_display`, `tool_display`
+// (entry point) and the per-tool projection helpers (write/edit/read/bash/
+// search/default plus plan_read/workspace_read shells). `pub(super)` limited
+// / no facade re-export (DR3-001).
+mod tool_display;
 // v0.4.25: tool-call history projection helpers. Keeps conversation evidence
 // lookup out of both the actor loop dispatcher and RepairJob state machine.
 mod tool_history;

--- a/src/agent/loop_run/actor_loop_flow.rs
+++ b/src/agent/loop_run/actor_loop_flow.rs
@@ -66,13 +66,13 @@ use super::scaffold_pipeline::PlanExplorationKey;
 use super::spinner::Spinner;
 use super::success::DETERMINISTIC_CONTENT_FALLBACK_TAG;
 use super::summary::{ExitReason, LoopResult, LoopStats};
+use super::tool_display::tool_display;
 use super::tool_history::focused_edit_target_already_read;
 use super::tool_history::is_plan_file_tool_call;
 use super::tool_policy::EffectiveToolPolicy;
 use super::turn::{
     LOG_ARGS_MAX_CHARS, PLAN_REPEATED_EXPLORATION_BLOCK_THRESHOLD, join_sections_for_progress,
-    plan_section_body_for_progress, plan_sections_with_content, tool_display,
-    write_stdout_rendered,
+    plan_section_body_for_progress, plan_sections_with_content, write_stdout_rendered,
 };
 use crate::agent::prompting;
 use crate::session::compact::approximate_token_count;

--- a/src/agent/loop_run/scaffold_pipeline.rs
+++ b/src/agent/loop_run/scaffold_pipeline.rs
@@ -52,15 +52,16 @@ use super::quality::{
     package_json_with_requested_port, react_dev_wrapper_for_requested_port,
 };
 use super::task_contract::{ArtifactRole, CompletionDecision};
+use super::tool_display::progress_path_display;
 use super::tool_history::{
     focused_edit_target_already_read, has_successful_non_plan_repo_edit, latest_user_turn_slice,
 };
 use super::turn::{
     WrittenScaffoldArtifacts, current_file_hash_for_relative_path, extract_filename_with_suffix,
     last_read_tool_path, latest_turn_preferred_read_edit_target, meaningful_workspace_files,
-    progress_path_display, sha256_hex, should_fallback_plan_model_after_timeout,
-    should_materialize_plan_after_timeout, should_materialize_plan_after_tool_call_format_error,
-    tool_result_failed, workspace_appears_empty, write_stdout_rendered,
+    sha256_hex, should_fallback_plan_model_after_timeout, should_materialize_plan_after_timeout,
+    should_materialize_plan_after_tool_call_format_error, tool_result_failed,
+    workspace_appears_empty, write_stdout_rendered,
 };
 use crate::agent::prompting;
 use crate::agent::recovery;

--- a/src/agent/loop_run/tool_display.rs
+++ b/src/agent/loop_run/tool_display.rs
@@ -1,0 +1,368 @@
+//! Per-iteration progress line rendering extracted from `turn.rs` (parent
+//! #680).
+//!
+//! Hosts `ProgressDisplay`, `progress_path_display`, `tool_display` (entry
+//! point) and the per-tool projection helpers (`tool_display_{write, edit,
+//! read, plan_read, workspace_read, bash, search, default}`, plus
+//! `tool_display_preview_note`, `tool_display_str_arg`, `summarize_plan_read`,
+//! `read_line_suffix`, `text_preview`, `read_preview`, `compact_progress_path`).
+//!
+//! `pub(super)` limited / no facade re-export (DR3-001).
+
+use std::path::Path;
+
+use crate::modes::plan_act::PlanStage;
+use crate::safety::path_guard::resolve_user_path;
+
+use super::lifecycle;
+use super::progress_text::{sanitize_for_progress, truncate};
+use super::turn::join_sections_for_progress;
+
+/// Returns `(display_str, extra)` for the progress line. `display_str` is the
+/// main single-line description (path / command / pattern); `extra` is an
+/// optional parenthesized suffix (e.g. `"5B"` for Write byte count). Paths are
+/// made relative to `work_root` when possible. All model-derived strings pass
+/// through `sanitize_for_progress` to prevent terminal injection.
+///
+/// `arg_budget` caps the Bash command display length (issue #432). Other tool
+/// arms currently ignore this budget; the uniform signature lets the caller
+/// compute the budget once via `progress_available_width`.
+pub(super) struct ProgressDisplay {
+    pub(super) action: String,
+    pub(super) path: Option<String>,
+    pub(super) note: Option<String>,
+    pub(super) status: Option<String>,
+}
+
+pub(super) fn progress_path_display(
+    raw_path: &str,
+    work_root: &Path,
+    plan_path: Option<&Path>,
+    max_chars: usize,
+) -> String {
+    if raw_path.is_empty() {
+        return "<missing path>".to_string();
+    }
+    if super::actor_loop_flow::plan_path_matches(raw_path, work_root, plan_path) {
+        return compact_progress_path(
+            &sanitize_for_progress(&plan_path.unwrap().display().to_string()),
+            max_chars,
+        );
+    }
+    let relative = std::path::Path::new(raw_path)
+        .strip_prefix(work_root)
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|_| raw_path.to_string());
+    compact_progress_path(&sanitize_for_progress(&relative), max_chars)
+}
+
+pub(super) fn tool_display(
+    tool_name: &str,
+    arguments: &serde_json::Value,
+    work_root: &std::path::Path,
+    plan_path: Option<&Path>,
+    current_stage: PlanStage,
+    arg_budget: usize,
+) -> ProgressDisplay {
+    let raw_path = tool_display_str_arg(arguments, "path");
+    let path_display = progress_path_display(raw_path, work_root, plan_path, arg_budget.max(48));
+    match tool_name {
+        "Write" => tool_display_write(
+            arguments,
+            raw_path,
+            path_display,
+            work_root,
+            plan_path,
+            current_stage,
+        ),
+        "Edit" => tool_display_edit(
+            arguments,
+            raw_path,
+            path_display,
+            work_root,
+            plan_path,
+            current_stage,
+        ),
+        "Read" => tool_display_read(
+            arguments,
+            raw_path,
+            path_display,
+            work_root,
+            plan_path,
+            current_stage,
+            arg_budget,
+        ),
+        "Bash" => tool_display_bash(arguments, arg_budget),
+        "Glob" | "Grep" => tool_display_search(arguments, arg_budget),
+        _ => tool_display_default(tool_name, arg_budget),
+    }
+}
+
+fn tool_display_str_arg<'a>(arguments: &'a serde_json::Value, key: &str) -> &'a str {
+    arguments
+        .get(key)
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_default()
+}
+
+fn tool_display_write(
+    arguments: &serde_json::Value,
+    raw_path: &str,
+    path_display: String,
+    work_root: &Path,
+    plan_path: Option<&Path>,
+    current_stage: PlanStage,
+) -> ProgressDisplay {
+    let content = tool_display_str_arg(arguments, "content");
+    let (action, note, status) =
+        if super::actor_loop_flow::plan_path_matches(raw_path, work_root, plan_path) {
+            let summary = super::actor_loop_flow::summarize_plan_write(
+                "Write",
+                raw_path,
+                content,
+                work_root,
+                plan_path,
+                current_stage,
+            );
+            (summary.action, summary.note, summary.status)
+        } else {
+            (
+                "Write file".to_string(),
+                tool_display_preview_note(content),
+                Some(format!("{}B", content.len())),
+            )
+        };
+    ProgressDisplay {
+        action,
+        path: Some(path_display),
+        note,
+        status,
+    }
+}
+
+fn tool_display_edit(
+    arguments: &serde_json::Value,
+    raw_path: &str,
+    path_display: String,
+    work_root: &Path,
+    plan_path: Option<&Path>,
+    current_stage: PlanStage,
+) -> ProgressDisplay {
+    let new_text = tool_display_str_arg(arguments, "new_string");
+    let (action, note, status) =
+        if super::actor_loop_flow::plan_path_matches(raw_path, work_root, plan_path) {
+            let summary = super::actor_loop_flow::summarize_plan_write(
+                "Edit",
+                raw_path,
+                new_text,
+                work_root,
+                plan_path,
+                current_stage,
+            );
+            (summary.action, summary.note, summary.status)
+        } else {
+            (
+                "Revise file".to_string(),
+                tool_display_preview_note(new_text),
+                None,
+            )
+        };
+    ProgressDisplay {
+        action,
+        path: Some(path_display),
+        note,
+        status,
+    }
+}
+
+fn tool_display_preview_note(contents: &str) -> Option<String> {
+    let preview = text_preview(contents, 72);
+    (!preview.is_empty()).then(|| format!("Preview: {preview}"))
+}
+
+fn tool_display_read(
+    arguments: &serde_json::Value,
+    raw_path: &str,
+    path_display: String,
+    work_root: &Path,
+    plan_path: Option<&Path>,
+    current_stage: PlanStage,
+    arg_budget: usize,
+) -> ProgressDisplay {
+    let line_suffix = read_line_suffix(arguments);
+    let path = format!("{path_display}{line_suffix}");
+    let (action, note, status) =
+        if super::actor_loop_flow::plan_path_matches(raw_path, work_root, plan_path) {
+            tool_display_plan_read(plan_path, current_stage)
+        } else {
+            tool_display_workspace_read(raw_path, work_root, &line_suffix)
+        };
+    ProgressDisplay {
+        action,
+        path: Some(compact_progress_path(&path, arg_budget.max(48))),
+        note,
+        status,
+    }
+}
+
+fn tool_display_plan_read(
+    plan_path: Option<&Path>,
+    current_stage: PlanStage,
+) -> (String, Option<String>, Option<String>) {
+    let contents = plan_path
+        .and_then(|path| std::fs::read_to_string(path).ok())
+        .unwrap_or_default();
+    let (action, note) = summarize_plan_read(&contents);
+    let status = if lifecycle::current_plan_stage(&contents) == PlanStage::Ready {
+        Some("Approval ready".to_string())
+    } else {
+        let next = lifecycle::plan_next_stage_sections(&contents);
+        (!next.is_empty()).then(|| {
+            format!(
+                "Current phase: {}",
+                super::actor_loop_flow::plan_phase_from_sections(&next, current_stage, false)
+            )
+        })
+    };
+    (action, note, status)
+}
+
+fn tool_display_workspace_read(
+    raw_path: &str,
+    work_root: &Path,
+    line_suffix: &str,
+) -> (String, Option<String>, Option<String>) {
+    let (preview, extra) = read_preview(raw_path, work_root);
+    let action = if line_suffix.is_empty() {
+        "Read file".to_string()
+    } else {
+        format!("Read lines {}", line_suffix.trim_start_matches(':'))
+    };
+    (
+        action,
+        preview.map(|preview| format!("Preview: {preview}")),
+        extra,
+    )
+}
+
+fn tool_display_bash(arguments: &serde_json::Value, arg_budget: usize) -> ProgressDisplay {
+    let sanitized = sanitize_for_progress(tool_display_str_arg(arguments, "command"));
+    ProgressDisplay {
+        action: format!("Run {}", truncate(&sanitized, arg_budget.saturating_sub(4))),
+        path: None,
+        note: None,
+        status: None,
+    }
+}
+
+fn tool_display_search(arguments: &serde_json::Value, arg_budget: usize) -> ProgressDisplay {
+    ProgressDisplay {
+        action: format!(
+            "Search {}",
+            truncate(
+                &sanitize_for_progress(tool_display_str_arg(arguments, "pattern")),
+                arg_budget.saturating_sub(7)
+            )
+        ),
+        path: None,
+        note: None,
+        status: None,
+    }
+}
+
+fn tool_display_default(tool_name: &str, arg_budget: usize) -> ProgressDisplay {
+    ProgressDisplay {
+        action: truncate(&sanitize_for_progress(tool_name), arg_budget),
+        path: None,
+        note: None,
+        status: None,
+    }
+}
+
+fn summarize_plan_read(contents: &str) -> (String, Option<String>) {
+    let missing = lifecycle::plan_missing_sections(contents);
+    if missing.is_empty() {
+        (
+            "Review completed plan".to_string(),
+            Some("Approval ready; review the final plan before /approve".to_string()),
+        )
+    } else {
+        let next = lifecycle::plan_next_stage_sections(contents);
+        let note = if !next.is_empty() {
+            format!("Next focus: {}", join_sections_for_progress(&next))
+        } else {
+            format!("Missing: {}", join_sections_for_progress(&missing))
+        };
+        ("Review plan draft".to_string(), Some(note))
+    }
+}
+
+fn read_line_suffix(arguments: &serde_json::Value) -> String {
+    let start = arguments
+        .get("start_line")
+        .and_then(serde_json::Value::as_u64);
+    let end = arguments
+        .get("end_line")
+        .and_then(serde_json::Value::as_u64);
+    match (start, end) {
+        (Some(start), Some(end)) if start == end => format!(":{start}"),
+        (Some(start), Some(end)) => format!(":{start}-{end}"),
+        (Some(start), None) => format!(":{start}-"),
+        (None, Some(end)) => format!(":1-{end}"),
+        (None, None) => String::new(),
+    }
+}
+
+fn text_preview(text: &str, max_chars: usize) -> String {
+    let collapsed = sanitize_for_progress(text)
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ");
+    truncate(&collapsed, max_chars)
+}
+
+fn read_preview(raw_path: &str, work_root: &Path) -> (Option<String>, Option<String>) {
+    if raw_path.is_empty() {
+        return (None, None);
+    }
+    let Ok(path) = resolve_user_path(work_root, raw_path) else {
+        return (None, None);
+    };
+    let Ok(metadata) = std::fs::metadata(&path) else {
+        return (None, None);
+    };
+    if !metadata.is_file() || metadata.len() > 64 * 1024 {
+        return (None, None);
+    }
+    let Ok(contents) = std::fs::read_to_string(&path) else {
+        return (None, None);
+    };
+    let preview = text_preview(&contents, 50);
+    (
+        (!preview.is_empty()).then_some(preview),
+        Some(format!("{}B", metadata.len())),
+    )
+}
+
+fn compact_progress_path(path: &str, max_chars: usize) -> String {
+    let char_count = path.chars().count();
+    if char_count <= max_chars {
+        return path.to_string();
+    }
+    if let Some((_, suffix)) = path.rsplit_once("/plans/") {
+        let collapsed = format!(".../plans/{suffix}");
+        if collapsed.chars().count() <= max_chars {
+            return collapsed;
+        }
+    }
+    let keep = max_chars.saturating_sub(3);
+    let tail = path
+        .chars()
+        .rev()
+        .take(keep)
+        .collect::<String>()
+        .chars()
+        .rev()
+        .collect::<String>();
+    format!("...{tail}")
+}

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -130,6 +130,9 @@ use super::small_helpers::{
 use super::spinner::{Spinner, SpinnerStopSignal};
 use super::summary::{ExitReason, LoopResult};
 use super::tester;
+use super::tool_display::progress_path_display;
+#[cfg(test)]
+use super::tool_display::tool_display;
 use super::tool_execution::{
     failed_outcome_for_call, rejected_outcome_for_call, success_outcome_for_call,
 };
@@ -218,7 +221,7 @@ use super::*;
 use crate::agent::orchestration::verify_repo_progress;
 use crate::logging::{log_llm_event, stable_path_hash};
 use crate::model_capabilities::model_capabilities;
-use crate::modes::plan_act::{ModeClassification, PlanStage, WorkMode, classify_work_mode_json};
+use crate::modes::plan_act::{ModeClassification, WorkMode, classify_work_mode_json};
 use crate::ollama::xml_fallback::normalize_tool_call_arguments;
 use crate::session::feedback::{FeedbackFrame, FeedbackKind};
 #[cfg(test)]
@@ -238,6 +241,7 @@ use super::deterministic::empty_framework_app_files as deterministic_empty_frame
 use super::deterministic::empty_framework_game_files as deterministic_empty_framework_game_files;
 #[cfg(test)]
 use super::progress_text::{is_utf8_locale, tool_color, tool_emoji};
+#[cfg(test)]
 use super::progress_text::{sanitize_for_progress, truncate};
 use super::quality::{
     first_existing_impl_target, quality_first_pass_observation, repo_change_request_text,
@@ -12048,44 +12052,6 @@ mod tests {
     }
 }
 
-/// Returns `(display_str, extra)` for the progress line. `display_str` is the
-/// main single-line description (path / command / pattern); `extra` is an
-/// optional parenthesized suffix (e.g. `"5B"` for Write byte count). Paths are
-/// made relative to `work_root` when possible. All model-derived strings pass
-/// through `sanitize_for_progress` to prevent terminal injection.
-///
-/// `arg_budget` caps the Bash command display length (issue #432). Other tool
-/// arms currently ignore this budget; the uniform signature lets the caller
-/// compute the budget once via `progress_available_width`.
-pub(super) struct ProgressDisplay {
-    pub(super) action: String,
-    pub(super) path: Option<String>,
-    pub(super) note: Option<String>,
-    pub(super) status: Option<String>,
-}
-
-pub(super) fn progress_path_display(
-    raw_path: &str,
-    work_root: &Path,
-    plan_path: Option<&Path>,
-    max_chars: usize,
-) -> String {
-    if raw_path.is_empty() {
-        return "<missing path>".to_string();
-    }
-    if super::actor_loop_flow::plan_path_matches(raw_path, work_root, plan_path) {
-        return compact_progress_path(
-            &sanitize_for_progress(&plan_path.unwrap().display().to_string()),
-            max_chars,
-        );
-    }
-    let relative = std::path::Path::new(raw_path)
-        .strip_prefix(work_root)
-        .map(|p| p.display().to_string())
-        .unwrap_or_else(|_| raw_path.to_string());
-    compact_progress_path(&sanitize_for_progress(&relative), max_chars)
-}
-
 pub(super) fn join_sections_for_progress(sections: &[&str]) -> String {
     match sections {
         [] => String::new(),
@@ -12872,247 +12838,6 @@ pub(super) fn plan_section_body_for_progress<'a>(
     start.map(|idx| &contents[idx..end])
 }
 
-fn summarize_plan_read(contents: &str) -> (String, Option<String>) {
-    let missing = lifecycle::plan_missing_sections(contents);
-    if missing.is_empty() {
-        (
-            "Review completed plan".to_string(),
-            Some("Approval ready; review the final plan before /approve".to_string()),
-        )
-    } else {
-        let next = lifecycle::plan_next_stage_sections(contents);
-        let note = if !next.is_empty() {
-            format!("Next focus: {}", join_sections_for_progress(&next))
-        } else {
-            format!("Missing: {}", join_sections_for_progress(&missing))
-        };
-        ("Review plan draft".to_string(), Some(note))
-    }
-}
-
-pub(super) fn tool_display(
-    tool_name: &str,
-    arguments: &serde_json::Value,
-    work_root: &std::path::Path,
-    plan_path: Option<&Path>,
-    current_stage: PlanStage,
-    arg_budget: usize,
-) -> ProgressDisplay {
-    let raw_path = tool_display_str_arg(arguments, "path");
-    let path_display = progress_path_display(raw_path, work_root, plan_path, arg_budget.max(48));
-    match tool_name {
-        "Write" => tool_display_write(
-            arguments,
-            raw_path,
-            path_display,
-            work_root,
-            plan_path,
-            current_stage,
-        ),
-        "Edit" => tool_display_edit(
-            arguments,
-            raw_path,
-            path_display,
-            work_root,
-            plan_path,
-            current_stage,
-        ),
-        "Read" => tool_display_read(
-            arguments,
-            raw_path,
-            path_display,
-            work_root,
-            plan_path,
-            current_stage,
-            arg_budget,
-        ),
-        "Bash" => tool_display_bash(arguments, arg_budget),
-        "Glob" | "Grep" => tool_display_search(arguments, arg_budget),
-        _ => tool_display_default(tool_name, arg_budget),
-    }
-}
-
-fn tool_display_str_arg<'a>(arguments: &'a serde_json::Value, key: &str) -> &'a str {
-    arguments
-        .get(key)
-        .and_then(serde_json::Value::as_str)
-        .unwrap_or_default()
-}
-
-fn tool_display_write(
-    arguments: &serde_json::Value,
-    raw_path: &str,
-    path_display: String,
-    work_root: &Path,
-    plan_path: Option<&Path>,
-    current_stage: PlanStage,
-) -> ProgressDisplay {
-    let content = tool_display_str_arg(arguments, "content");
-    let (action, note, status) =
-        if super::actor_loop_flow::plan_path_matches(raw_path, work_root, plan_path) {
-            let summary = super::actor_loop_flow::summarize_plan_write(
-                "Write",
-                raw_path,
-                content,
-                work_root,
-                plan_path,
-                current_stage,
-            );
-            (summary.action, summary.note, summary.status)
-        } else {
-            (
-                "Write file".to_string(),
-                tool_display_preview_note(content),
-                Some(format!("{}B", content.len())),
-            )
-        };
-    ProgressDisplay {
-        action,
-        path: Some(path_display),
-        note,
-        status,
-    }
-}
-
-fn tool_display_edit(
-    arguments: &serde_json::Value,
-    raw_path: &str,
-    path_display: String,
-    work_root: &Path,
-    plan_path: Option<&Path>,
-    current_stage: PlanStage,
-) -> ProgressDisplay {
-    let new_text = tool_display_str_arg(arguments, "new_string");
-    let (action, note, status) =
-        if super::actor_loop_flow::plan_path_matches(raw_path, work_root, plan_path) {
-            let summary = super::actor_loop_flow::summarize_plan_write(
-                "Edit",
-                raw_path,
-                new_text,
-                work_root,
-                plan_path,
-                current_stage,
-            );
-            (summary.action, summary.note, summary.status)
-        } else {
-            (
-                "Revise file".to_string(),
-                tool_display_preview_note(new_text),
-                None,
-            )
-        };
-    ProgressDisplay {
-        action,
-        path: Some(path_display),
-        note,
-        status,
-    }
-}
-
-fn tool_display_preview_note(contents: &str) -> Option<String> {
-    let preview = text_preview(contents, 72);
-    (!preview.is_empty()).then(|| format!("Preview: {preview}"))
-}
-
-fn tool_display_read(
-    arguments: &serde_json::Value,
-    raw_path: &str,
-    path_display: String,
-    work_root: &Path,
-    plan_path: Option<&Path>,
-    current_stage: PlanStage,
-    arg_budget: usize,
-) -> ProgressDisplay {
-    let line_suffix = read_line_suffix(arguments);
-    let path = format!("{path_display}{line_suffix}");
-    let (action, note, status) =
-        if super::actor_loop_flow::plan_path_matches(raw_path, work_root, plan_path) {
-            tool_display_plan_read(plan_path, current_stage)
-        } else {
-            tool_display_workspace_read(raw_path, work_root, &line_suffix)
-        };
-    ProgressDisplay {
-        action,
-        path: Some(compact_progress_path(&path, arg_budget.max(48))),
-        note,
-        status,
-    }
-}
-
-fn tool_display_plan_read(
-    plan_path: Option<&Path>,
-    current_stage: PlanStage,
-) -> (String, Option<String>, Option<String>) {
-    let contents = plan_path
-        .and_then(|path| std::fs::read_to_string(path).ok())
-        .unwrap_or_default();
-    let (action, note) = summarize_plan_read(&contents);
-    let status = if lifecycle::current_plan_stage(&contents) == PlanStage::Ready {
-        Some("Approval ready".to_string())
-    } else {
-        let next = lifecycle::plan_next_stage_sections(&contents);
-        (!next.is_empty()).then(|| {
-            format!(
-                "Current phase: {}",
-                super::actor_loop_flow::plan_phase_from_sections(&next, current_stage, false)
-            )
-        })
-    };
-    (action, note, status)
-}
-
-fn tool_display_workspace_read(
-    raw_path: &str,
-    work_root: &Path,
-    line_suffix: &str,
-) -> (String, Option<String>, Option<String>) {
-    let (preview, extra) = read_preview(raw_path, work_root);
-    let action = if line_suffix.is_empty() {
-        "Read file".to_string()
-    } else {
-        format!("Read lines {}", line_suffix.trim_start_matches(':'))
-    };
-    (
-        action,
-        preview.map(|preview| format!("Preview: {preview}")),
-        extra,
-    )
-}
-
-fn tool_display_bash(arguments: &serde_json::Value, arg_budget: usize) -> ProgressDisplay {
-    let sanitized = sanitize_for_progress(tool_display_str_arg(arguments, "command"));
-    ProgressDisplay {
-        action: format!("Run {}", truncate(&sanitized, arg_budget.saturating_sub(4))),
-        path: None,
-        note: None,
-        status: None,
-    }
-}
-
-fn tool_display_search(arguments: &serde_json::Value, arg_budget: usize) -> ProgressDisplay {
-    ProgressDisplay {
-        action: format!(
-            "Search {}",
-            truncate(
-                &sanitize_for_progress(tool_display_str_arg(arguments, "pattern")),
-                arg_budget.saturating_sub(7)
-            )
-        ),
-        path: None,
-        note: None,
-        status: None,
-    }
-}
-
-fn tool_display_default(tool_name: &str, arg_budget: usize) -> ProgressDisplay {
-    ProgressDisplay {
-        action: truncate(&sanitize_for_progress(tool_name), arg_budget),
-        path: None,
-        note: None,
-        status: None,
-    }
-}
-
 fn plan_section_has_content(contents: &str, target: &str) -> bool {
     let mut in_section = false;
     for line in contents.lines() {
@@ -13153,76 +12878,6 @@ fn normalize_plan_heading_for_progress(heading: &str) -> &str {
         }
         other => other,
     }
-}
-
-fn read_line_suffix(arguments: &serde_json::Value) -> String {
-    let start = arguments
-        .get("start_line")
-        .and_then(serde_json::Value::as_u64);
-    let end = arguments
-        .get("end_line")
-        .and_then(serde_json::Value::as_u64);
-    match (start, end) {
-        (Some(start), Some(end)) if start == end => format!(":{start}"),
-        (Some(start), Some(end)) => format!(":{start}-{end}"),
-        (Some(start), None) => format!(":{start}-"),
-        (None, Some(end)) => format!(":1-{end}"),
-        (None, None) => String::new(),
-    }
-}
-
-fn text_preview(text: &str, max_chars: usize) -> String {
-    let collapsed = sanitize_for_progress(text)
-        .split_whitespace()
-        .collect::<Vec<_>>()
-        .join(" ");
-    truncate(&collapsed, max_chars)
-}
-
-fn read_preview(raw_path: &str, work_root: &Path) -> (Option<String>, Option<String>) {
-    if raw_path.is_empty() {
-        return (None, None);
-    }
-    let Ok(path) = resolve_user_path(work_root, raw_path) else {
-        return (None, None);
-    };
-    let Ok(metadata) = std::fs::metadata(&path) else {
-        return (None, None);
-    };
-    if !metadata.is_file() || metadata.len() > 64 * 1024 {
-        return (None, None);
-    }
-    let Ok(contents) = std::fs::read_to_string(&path) else {
-        return (None, None);
-    };
-    let preview = text_preview(&contents, 50);
-    (
-        (!preview.is_empty()).then_some(preview),
-        Some(format!("{}B", metadata.len())),
-    )
-}
-
-fn compact_progress_path(path: &str, max_chars: usize) -> String {
-    let char_count = path.chars().count();
-    if char_count <= max_chars {
-        return path.to_string();
-    }
-    if let Some((_, suffix)) = path.rsplit_once("/plans/") {
-        let collapsed = format!(".../plans/{suffix}");
-        if collapsed.chars().count() <= max_chars {
-            return collapsed;
-        }
-    }
-    let keep = max_chars.saturating_sub(3);
-    let tail = path
-        .chars()
-        .rev()
-        .take(keep)
-        .collect::<String>()
-        .chars()
-        .rev()
-        .collect::<String>();
-    format!("...{tail}")
 }
 
 /// Format a single-line per-iteration progress line. ANSI color is only


### PR DESCRIPTION
## Summary

Move the per-iteration progress line rendering cluster out of `turn.rs` into a new `src/agent/loop_run/tool_display.rs` sibling module, continuing the meta-issue #680 split.

Migrated:
- `ProgressDisplay` struct
- `progress_path_display` (`pub(super)`)
- `tool_display` (`pub(super)`, entry point) + per-tool projection helpers (`tool_display_{write, edit, preview_note, read, plan_read, workspace_read, bash, search, default}` + `tool_display_str_arg`)
- `summarize_plan_read`, `read_line_suffix`, `text_preview`, `read_preview`, `compact_progress_path` (private helpers)

All items `pub(super)`; no facade re-export (DR3-001).

Callers updated:
- `turn.rs`: imports `progress_path_display` (cfg(test): `tool_display`)
- `actor_loop_flow.rs`: `tool_display` now from `super::tool_display`
- `scaffold_pipeline.rs`: `progress_path_display` now from `super::tool_display`

Cleaned unused turn.rs imports (`PlanStage`, `sanitize_for_progress`, `truncate` are now test-only after the migration).

## LOC delta

- `turn.rs`: 27,739 → 27,394 (-345 LOC)
- New `tool_display.rs`: 368 LOC
- Cumulative from 39,489: -12,095 LOC (-30.6%)

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --lib --all-targets -- -D warnings` clean
- [x] `cargo test --lib` (3,114 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)