### PR TITLE
Extract plan_sections.rs from turn.rs (parent #680)

### DIFF
--- a/src/agent/loop_run.rs
+++ b/src/agent/loop_run.rs
@@ -298,6 +298,12 @@ mod deterministic_fallback_plan;
 // `sync_package_json_with_existing_lock`. `pub(super)` limited / no
 // facade re-export (DR3-001).
 mod path_helpers;
+// Plan-section progress helpers extracted from `turn.rs` (parent #680).
+// Hosts `join_sections_for_progress`, `plan_sections_with_content`,
+// `plan_section_body_for_progress` + the private heading normalization
+// SSOT (`plan_section_has_content`, `normalize_plan_heading_for_progress`).
+// `pub(super)` limited / no facade re-export (DR3-001).
+mod plan_sections;
 // Small standalone helpers extracted from `turn.rs` (parent #680). Hosts
 // `rfc3339_now_utc`, `masked_path_hash_bounded_list`,
 // `latest_tool_result_since_last_user`, `raw_mode_safe_text`,

--- a/src/agent/loop_run/actor_loop_flow.rs
+++ b/src/agent/loop_run/actor_loop_flow.rs
@@ -57,6 +57,9 @@ use super::active_job_arbiter::{LoopControlAction, RecoveryDispatchGate, Recover
 use super::interrupt::{InterruptFlag, InterruptMonitor};
 use super::lifecycle;
 use super::path_helpers::normalize_exploration_path;
+use super::plan_sections::{
+    join_sections_for_progress, plan_section_body_for_progress, plan_sections_with_content,
+};
 use super::progress_text::{
     format_progress_field, paint, progress_available_width, sanitize_for_progress, tool_color,
     tool_emoji, truncate,
@@ -71,8 +74,7 @@ use super::tool_history::focused_edit_target_already_read;
 use super::tool_history::is_plan_file_tool_call;
 use super::tool_policy::EffectiveToolPolicy;
 use super::turn::{
-    LOG_ARGS_MAX_CHARS, PLAN_REPEATED_EXPLORATION_BLOCK_THRESHOLD, join_sections_for_progress,
-    plan_section_body_for_progress, plan_sections_with_content, write_stdout_rendered,
+    LOG_ARGS_MAX_CHARS, PLAN_REPEATED_EXPLORATION_BLOCK_THRESHOLD, write_stdout_rendered,
 };
 use crate::agent::prompting;
 use crate::session::compact::approximate_token_count;

--- a/src/agent/loop_run/plan_sections.rs
+++ b/src/agent/loop_run/plan_sections.rs
@@ -1,0 +1,109 @@
+//! Plan-section progress helpers extracted from `turn.rs` (parent #680).
+//!
+//! Hosts the canonical plan-section names projection
+//! (`plan_sections_with_content`, `plan_section_body_for_progress`) used by
+//! the actor-loop progress renderer + tool_display, plus the shared
+//! `join_sections_for_progress` joiner. Private helpers
+//! (`plan_section_has_content`, `normalize_plan_heading_for_progress`)
+//! implement the heading normalization SSOT.
+//!
+//! `pub(super)` limited / no facade re-export (DR3-001).
+
+pub(super) fn join_sections_for_progress(sections: &[&str]) -> String {
+    match sections {
+        [] => String::new(),
+        [one] => (*one).to_string(),
+        [first, second] => format!("{first} and {second}"),
+        _ => {
+            let mut parts = sections[..sections.len() - 1]
+                .iter()
+                .map(|section| (*section).to_string())
+                .collect::<Vec<_>>();
+            parts.push(format!("and {}", sections[sections.len() - 1]));
+            parts.join(", ")
+        }
+    }
+}
+
+pub(super) fn plan_sections_with_content(contents: &str) -> Vec<&'static str> {
+    [
+        "Goal",
+        "Constraints",
+        "First Action",
+        "Verification",
+        "Deliverables",
+        "Acceptance Criteria",
+        "Quality Bar",
+        "Execution Plan",
+        "Verification Plan",
+        "Risks / Fallbacks",
+    ]
+    .into_iter()
+    .filter(|section| plan_section_has_content(contents, section))
+    .collect()
+}
+
+pub(super) fn plan_section_body_for_progress<'a>(
+    contents: &'a str,
+    section: &str,
+) -> Option<&'a str> {
+    let mut start = None;
+    let mut end = contents.len();
+    let mut offset = 0usize;
+    for line in contents.lines() {
+        let trimmed = line.trim();
+        if let Some(heading) = trimmed.strip_prefix("## ") {
+            if start.is_some() {
+                end = offset;
+                break;
+            }
+            if normalize_plan_heading_for_progress(heading) == section {
+                start = Some(offset + line.len());
+            }
+        }
+        offset += line.len() + 1;
+    }
+    start.map(|idx| &contents[idx..end])
+}
+
+fn plan_section_has_content(contents: &str, target: &str) -> bool {
+    let mut in_section = false;
+    for line in contents.lines() {
+        let trimmed = line.trim();
+        if let Some(heading) = trimmed.strip_prefix("## ") {
+            in_section = normalize_plan_heading_for_progress(heading) == target;
+            continue;
+        }
+        if !in_section {
+            continue;
+        }
+        if trimmed.is_empty()
+            || trimmed == "-"
+            || matches!(
+                trimmed,
+                "1." | "2."
+                    | "3."
+                    | "1. First slice:"
+                    | "2. Next phases:"
+                    | "3. Review checkpoint:"
+            )
+        {
+            continue;
+        }
+        return true;
+    }
+    false
+}
+
+fn normalize_plan_heading_for_progress(heading: &str) -> &str {
+    match heading.trim() {
+        "Next Step" | "First Step" | "Execution Plan" | "実行計画" | "実装計画"
+        | "実装フェーズ" => "First Action",
+        "Verification Plan" | "検証計画" => "Verification",
+        "Risks/Fallbacks" => "Risks / Fallbacks",
+        "リスク/フォールバック" | "リスク・フォールバック" | "リスク / フォールバック" => {
+            "Risks / Fallbacks"
+        }
+        other => other,
+    }
+}

--- a/src/agent/loop_run/tool_display.rs
+++ b/src/agent/loop_run/tool_display.rs
@@ -15,8 +15,8 @@ use crate::modes::plan_act::PlanStage;
 use crate::safety::path_guard::resolve_user_path;
 
 use super::lifecycle;
+use super::plan_sections::join_sections_for_progress;
 use super::progress_text::{sanitize_for_progress, truncate};
-use super::turn::join_sections_for_progress;
 
 /// Returns `(display_str, extra)` for the progress line. `display_str` is the
 /// main single-line description (path / command / pattern); `extra` is an

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -12063,22 +12063,6 @@ mod tests {
     }
 }
 
-pub(super) fn join_sections_for_progress(sections: &[&str]) -> String {
-    match sections {
-        [] => String::new(),
-        [one] => (*one).to_string(),
-        [first, second] => format!("{first} and {second}"),
-        _ => {
-            let mut parts = sections[..sections.len() - 1]
-                .iter()
-                .map(|section| (*section).to_string())
-                .collect::<Vec<_>>();
-            parts.push(format!("and {}", sections[sections.len() - 1]));
-            parts.join(", ")
-        }
-    }
-}
-
 pub(super) fn should_materialize_plan_after_timeout(
     mode: ExecutionMode,
     plan_model_override: Option<&str>,
@@ -12419,89 +12403,6 @@ fn collect_meaningful_workspace_files(
         }
     }
     Ok(())
-}
-
-pub(super) fn plan_sections_with_content(contents: &str) -> Vec<&'static str> {
-    [
-        "Goal",
-        "Constraints",
-        "First Action",
-        "Verification",
-        "Deliverables",
-        "Acceptance Criteria",
-        "Quality Bar",
-        "Execution Plan",
-        "Verification Plan",
-        "Risks / Fallbacks",
-    ]
-    .into_iter()
-    .filter(|section| plan_section_has_content(contents, section))
-    .collect()
-}
-
-pub(super) fn plan_section_body_for_progress<'a>(
-    contents: &'a str,
-    section: &str,
-) -> Option<&'a str> {
-    let mut start = None;
-    let mut end = contents.len();
-    let mut offset = 0usize;
-    for line in contents.lines() {
-        let trimmed = line.trim();
-        if let Some(heading) = trimmed.strip_prefix("## ") {
-            if start.is_some() {
-                end = offset;
-                break;
-            }
-            if normalize_plan_heading_for_progress(heading) == section {
-                start = Some(offset + line.len());
-            }
-        }
-        offset += line.len() + 1;
-    }
-    start.map(|idx| &contents[idx..end])
-}
-
-fn plan_section_has_content(contents: &str, target: &str) -> bool {
-    let mut in_section = false;
-    for line in contents.lines() {
-        let trimmed = line.trim();
-        if let Some(heading) = trimmed.strip_prefix("## ") {
-            in_section = normalize_plan_heading_for_progress(heading) == target;
-            continue;
-        }
-        if !in_section {
-            continue;
-        }
-        if trimmed.is_empty()
-            || trimmed == "-"
-            || matches!(
-                trimmed,
-                "1." | "2."
-                    | "3."
-                    | "1. First slice:"
-                    | "2. Next phases:"
-                    | "3. Review checkpoint:"
-            )
-        {
-            continue;
-        }
-        return true;
-    }
-    false
-}
-
-fn normalize_plan_heading_for_progress(heading: &str) -> &str {
-    match heading.trim() {
-        "Next Step" | "First Step" | "Execution Plan" | "実行計画" | "実装計画"
-        | "実装フェーズ" => "First Action",
-        "Verification Plan" | "検証計画" => "Verification",
-        "Risks/Fallbacks" => "Risks / Fallbacks",
-        "リスク/フォールバック" | "リスク・フォールバック" | "リスク / フォールバック" => {
-            "Risks / Fallbacks"
-        }
-        other => other,
-    }
 }
 
 /// Format a single-line per-iteration progress line. ANSI color is only


### PR DESCRIPTION
## Summary

Move the plan-section progress helpers out of `turn.rs` into a new `src/agent/loop_run/plan_sections.rs` sibling module, continuing the meta-issue #680 split.

Migrated:
- `join_sections_for_progress` (`pub(super)`)
- `plan_sections_with_content` (`pub(super)`)
- `plan_section_body_for_progress` (`pub(super)`)
- `plan_section_has_content` (private)
- `normalize_plan_heading_for_progress` (private)

All public items are `pub(super)`; no facade re-export (DR3-001).

Callers updated:
- `actor_loop_flow.rs`: switches the three helpers' imports from `super::turn` to `super::plan_sections`.
- `tool_display.rs`: switches `join_sections_for_progress` import from `super::turn` to `super::plan_sections`.
- `turn.rs`: drops the unused re-imports (these helpers are no longer called from `turn.rs` after migration).

## LOC delta

- `turn.rs`: 27,018 → 26,919 (-99 LOC)
- New `plan_sections.rs`: 109 LOC
- Cumulative from 39,489: -12,570 LOC (-31.8%)

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --lib --all-targets -- -D warnings` clean
- [x] `cargo test --lib` (3,114 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)