### PR TITLE
Extract plan_mode_helpers.rs from turn.rs (parent #680)

### DIFF
--- a/src/agent/loop_run.rs
+++ b/src/agent/loop_run.rs
@@ -304,6 +304,14 @@ mod path_helpers;
 // SSOT (`plan_section_has_content`, `normalize_plan_heading_for_progress`).
 // `pub(super)` limited / no facade re-export (DR3-001).
 mod plan_sections;
+// Plan-mode helpers extracted from `turn.rs` (parent #680). Hosts
+// `should_materialize_plan_after_timeout`,
+// `should_materialize_plan_after_tool_call_format_error`,
+// `should_fallback_plan_model_after_timeout`, `assistant_model_for_mode`,
+// `plan_file_alias`, `prune_plan_mode_messages`,
+// `is_plan_mode_only_system_note`. `pub(super)` limited / no facade
+// re-export (DR3-001).
+mod plan_mode_helpers;
 // Small standalone helpers extracted from `turn.rs` (parent #680). Hosts
 // `rfc3339_now_utc`, `masked_path_hash_bounded_list`,
 // `latest_tool_result_since_last_user`, `raw_mode_safe_text`,

--- a/src/agent/loop_run/commands.rs
+++ b/src/agent/loop_run/commands.rs
@@ -816,7 +816,7 @@ impl Agent {
             return Err("plan file is not ready for approval yet".to_string());
         }
         self.session.mode_state.approve();
-        super::turn::prune_plan_mode_messages(&mut self.session.messages);
+        super::plan_mode_helpers::prune_plan_mode_messages(&mut self.session.messages);
         self.push_system_note(format!(
             "[Act Mode / {}] Execute the accepted plan in phases and keep the work aligned with its acceptance criteria and quality bar.\n\n{}",
             self.session.mode_state.task_profile.as_str(),

--- a/src/agent/loop_run/plan_mode_helpers.rs
+++ b/src/agent/loop_run/plan_mode_helpers.rs
@@ -1,0 +1,90 @@
+//! Plan-mode helpers extracted from `turn.rs` (parent #680).
+//!
+//! Hosts the small pure helpers that gate plan-mode behaviour:
+//! `should_materialize_plan_after_timeout`,
+//! `should_materialize_plan_after_tool_call_format_error`,
+//! `should_fallback_plan_model_after_timeout`, `assistant_model_for_mode`,
+//! `plan_file_alias`, `prune_plan_mode_messages`,
+//! `is_plan_mode_only_system_note`.
+//!
+//! `pub(super)` limited / no facade re-export (DR3-001).
+
+use std::path::Path;
+
+use crate::modes::plan_act::ExecutionMode;
+use crate::session::store::ConversationMessage;
+
+use super::lifecycle;
+
+pub(super) fn should_materialize_plan_after_timeout(
+    mode: ExecutionMode,
+    plan_model_override: Option<&str>,
+    err: &str,
+) -> bool {
+    let _ = plan_model_override;
+    mode == ExecutionMode::Plan && err.to_ascii_lowercase().contains("timed out")
+}
+
+pub(super) fn should_materialize_plan_after_tool_call_format_error(
+    mode: ExecutionMode,
+    err: &str,
+) -> bool {
+    mode == ExecutionMode::Plan && lifecycle::is_tool_call_format_error(err)
+}
+
+pub(super) fn assistant_model_for_mode(
+    mode: ExecutionMode,
+    main_model: &str,
+    plan_model_override: Option<&str>,
+) -> String {
+    if mode == ExecutionMode::Plan
+        && let Some(model) = plan_model_override
+    {
+        return model.to_string();
+    }
+    main_model.to_string()
+}
+
+pub(super) fn should_fallback_plan_model_after_timeout(
+    mode: ExecutionMode,
+    plan_model_override: Option<&str>,
+    err: &str,
+    sidecar_model: &str,
+) -> bool {
+    if mode != ExecutionMode::Plan {
+        return false;
+    }
+    if plan_model_override.is_some() {
+        return false;
+    }
+    if sidecar_model.trim().is_empty() {
+        return false;
+    }
+    err.to_ascii_lowercase().contains("timed out")
+}
+
+pub(super) fn plan_file_alias(path: &Path) -> String {
+    path.file_name()
+        .map(|name| format!("plans/{}", name.to_string_lossy()))
+        .unwrap_or_else(|| "plans/plan.md".to_string())
+}
+
+pub(super) fn prune_plan_mode_messages(messages: &mut Vec<ConversationMessage>) {
+    messages.retain(|message| {
+        if message.role != "system" {
+            return true;
+        }
+        !is_plan_mode_only_system_note(&message.content)
+    });
+}
+
+fn is_plan_mode_only_system_note(note: &str) -> bool {
+    let trimmed = note.trim_start();
+    trimmed.starts_with("[Plan Mode /")
+        || trimmed.starts_with("[Plan File Alias]")
+        || trimmed.contains("plan_no_tool_attempt=")
+        || trimmed.contains("plan_progress_attempt=")
+        || trimmed.starts_with("Main planning model timed out.")
+        || trimmed.starts_with("The plan is still incomplete.")
+        || trimmed.starts_with("You are still in Plan mode")
+}

--- a/src/agent/loop_run/scaffold_pipeline.rs
+++ b/src/agent/loop_run/scaffold_pipeline.rs
@@ -47,6 +47,10 @@ use super::deterministic_fallback_plan::deterministic_timeout_fallback_plan;
 use super::interrupt::InterruptFlag;
 use super::lifecycle;
 use super::path_helpers::{normalize_memory_path, sync_package_json_with_existing_lock};
+use super::plan_mode_helpers::{
+    should_fallback_plan_model_after_timeout, should_materialize_plan_after_timeout,
+    should_materialize_plan_after_tool_call_format_error,
+};
 use super::quality::{
     first_existing_impl_target, implementation_quality_issue_for_request,
     package_json_with_requested_port, react_dev_wrapper_for_requested_port,
@@ -59,9 +63,7 @@ use super::tool_history::{
 use super::turn::{
     WrittenScaffoldArtifacts, current_file_hash_for_relative_path, extract_filename_with_suffix,
     last_read_tool_path, latest_turn_preferred_read_edit_target, meaningful_workspace_files,
-    sha256_hex, should_fallback_plan_model_after_timeout, should_materialize_plan_after_timeout,
-    should_materialize_plan_after_tool_call_format_error, tool_result_failed,
-    workspace_appears_empty, write_stdout_rendered,
+    sha256_hex, tool_result_failed, workspace_appears_empty, write_stdout_rendered,
 };
 use crate::agent::prompting;
 use crate::agent::recovery;

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -107,6 +107,12 @@ use super::path_helpers::normalize_memory_path;
 use super::photon_feedback_derive::{
     build_rerun_prompt_hint_if_eligible, request_explicitly_requests_script_execution,
 };
+use super::plan_mode_helpers::{assistant_model_for_mode, plan_file_alias};
+#[cfg(test)]
+use super::plan_mode_helpers::{
+    prune_plan_mode_messages, should_fallback_plan_model_after_timeout,
+    should_materialize_plan_after_timeout, should_materialize_plan_after_tool_call_format_error,
+};
 use super::precaution_relevance::select_precautions_for_prompt;
 #[cfg(test)]
 use super::repair_patch_validation::VerifierRepairIntent;
@@ -12061,79 +12067,6 @@ mod tests {
             "external-import callback MUST fire with PythonpathRejected for an external PYTHONPATH component; got {external_import_calls:?}"
         );
     }
-}
-
-pub(super) fn should_materialize_plan_after_timeout(
-    mode: ExecutionMode,
-    plan_model_override: Option<&str>,
-    err: &str,
-) -> bool {
-    let _ = plan_model_override;
-    mode == ExecutionMode::Plan && err.to_ascii_lowercase().contains("timed out")
-}
-
-pub(super) fn should_materialize_plan_after_tool_call_format_error(
-    mode: ExecutionMode,
-    err: &str,
-) -> bool {
-    mode == ExecutionMode::Plan && lifecycle::is_tool_call_format_error(err)
-}
-
-fn assistant_model_for_mode(
-    mode: ExecutionMode,
-    main_model: &str,
-    plan_model_override: Option<&str>,
-) -> String {
-    if mode == ExecutionMode::Plan
-        && let Some(model) = plan_model_override
-    {
-        return model.to_string();
-    }
-    main_model.to_string()
-}
-
-pub(super) fn should_fallback_plan_model_after_timeout(
-    mode: ExecutionMode,
-    plan_model_override: Option<&str>,
-    err: &str,
-    sidecar_model: &str,
-) -> bool {
-    if mode != ExecutionMode::Plan {
-        return false;
-    }
-    if plan_model_override.is_some() {
-        return false;
-    }
-    if sidecar_model.trim().is_empty() {
-        return false;
-    }
-    err.to_ascii_lowercase().contains("timed out")
-}
-
-fn plan_file_alias(path: &Path) -> String {
-    path.file_name()
-        .map(|name| format!("plans/{}", name.to_string_lossy()))
-        .unwrap_or_else(|| "plans/plan.md".to_string())
-}
-
-pub(super) fn prune_plan_mode_messages(messages: &mut Vec<ConversationMessage>) {
-    messages.retain(|message| {
-        if message.role != "system" {
-            return true;
-        }
-        !is_plan_mode_only_system_note(&message.content)
-    });
-}
-
-fn is_plan_mode_only_system_note(note: &str) -> bool {
-    let trimmed = note.trim_start();
-    trimmed.starts_with("[Plan Mode /")
-        || trimmed.starts_with("[Plan File Alias]")
-        || trimmed.contains("plan_no_tool_attempt=")
-        || trimmed.contains("plan_progress_attempt=")
-        || trimmed.starts_with("Main planning model timed out.")
-        || trimmed.starts_with("The plan is still incomplete.")
-        || trimmed.starts_with("You are still in Plan mode")
 }
 
 pub(super) fn last_read_tool_path(messages: &[ConversationMessage]) -> Option<String> {


### PR DESCRIPTION
## Summary

Move the plan-mode pure helpers out of `turn.rs` into a new `src/agent/loop_run/plan_mode_helpers.rs` sibling module, continuing the meta-issue #680 split.

Migrated (all `pub(super)` except the last private helper):
- `should_materialize_plan_after_timeout`
- `should_materialize_plan_after_tool_call_format_error`
- `assistant_model_for_mode`
- `should_fallback_plan_model_after_timeout`
- `plan_file_alias`
- `prune_plan_mode_messages`
- `is_plan_mode_only_system_note` (private)

No facade re-export (DR3-001).

Callers updated:
- `scaffold_pipeline.rs`: switches three `should_*` imports from `super::turn` to `super::plan_mode_helpers`.
- `commands.rs`: switches `prune_plan_mode_messages` to `super::plan_mode_helpers::`.
- `turn.rs`: re-imports `assistant_model_for_mode` + `plan_file_alias` for production callers, plus `#[cfg(test)]` re-imports for nested test-mod references.

## LOC delta

- `turn.rs`: 26,919 → 26,852 (-67 LOC)
- New `plan_mode_helpers.rs`: 90 LOC
- Cumulative from 39,489: -12,637 LOC (-32.0%)

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --lib --all-targets -- -D warnings` clean
- [x] `cargo test --lib` (3,114 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)