### PR TITLE
Extract workspace_walk.rs from turn.rs (parent #680)

### DIFF
--- a/src/agent/loop_run.rs
+++ b/src/agent/loop_run.rs
@@ -639,10 +639,15 @@ mod task_contract;
 // via `super::task_workspace_scope::*`.
 mod task_workspace_scope;
 mod tester;
+// Workspace walker helpers extracted from `turn.rs` (parent #680).
+// Hosts `workspace_appears_empty`, `meaningful_workspace_files`,
+// `collect_meaningful_workspace_files`. `pub(super)` limited / no
+// facade re-export (DR3-001).
 mod tool_policy;
 mod turn;
 pub(crate) mod verifier_skill;
 pub(crate) mod work_mode_confirm;
+mod workspace_walk;
 
 // Public re-exports so `lib.rs::run_cli` can hand a `FooterHandle` into
 // `Agent::new` and own the matching `FooterLease` for its scope (issue #430).

--- a/src/agent/loop_run/scaffold_pipeline.rs
+++ b/src/agent/loop_run/scaffold_pipeline.rs
@@ -63,9 +63,9 @@ use super::tool_history::{
 };
 use super::turn::{
     WrittenScaffoldArtifacts, extract_filename_with_suffix, last_read_tool_path,
-    latest_turn_preferred_read_edit_target, meaningful_workspace_files, tool_result_failed,
-    workspace_appears_empty, write_stdout_rendered,
+    latest_turn_preferred_read_edit_target, tool_result_failed, write_stdout_rendered,
 };
+use super::workspace_walk::{meaningful_workspace_files, workspace_appears_empty};
 use crate::agent::prompting;
 use crate::agent::recovery;
 use crate::logging::log_llm_event;

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -240,6 +240,7 @@ use super::work_mode_confirm::{
     self, WORK_MODE_CONFIRM_TIMEOUT_SECS, WorkModeConfirmInputs, WorkModeConfirmOutcome,
     run_work_mode_confirm_with_strategy,
 };
+use super::workspace_walk::{meaningful_workspace_files, workspace_appears_empty};
 use super::*;
 use crate::agent::orchestration::verify_repo_progress;
 use crate::logging::{log_llm_event, stable_path_hash};
@@ -12127,24 +12128,6 @@ pub(super) fn latest_turn_preferred_read_edit_target(
     latest_existing
 }
 
-pub(super) fn workspace_appears_empty(work_root: &Path) -> bool {
-    let Ok(entries) = std::fs::read_dir(work_root) else {
-        return false;
-    };
-    !entries.flatten().any(|entry| {
-        let name = entry.file_name();
-        let name = name.to_string_lossy();
-        !matches!(
-            name.as_ref(),
-            ".git" | ".anvil" | ".anvil-state" | "ANVIL.md" | "node_modules" | "target"
-        )
-    })
-}
-
-/// Issue #636: trim `s` so its byte length is at most `cap` while
-/// preserving the leading UTF-8 char boundary. Used by
-/// `bounded_post_edit_excerpt` to re-cap a post-masking string when
-/// redaction expanded it past `MAX_ARTIFACT_EXCERPT_BYTES`.
 /// Legacy un-scoped lookup kept for unit-test fixtures that exercise the
 /// `scaffold_candidate_priority` ordering independently of scope detection.
 /// Production code MUST use [`existing_workspace_candidate_for_role_in_scope`]
@@ -12227,44 +12210,6 @@ pub(super) fn existing_workspace_candidate_for_role_in_scope(
     candidates
         .first()
         .map(|path| path.to_string_lossy().replace('\\', "/"))
-}
-
-pub(super) fn meaningful_workspace_files(work_root: &Path, limit: usize) -> Option<Vec<PathBuf>> {
-    let mut files = Vec::new();
-    collect_meaningful_workspace_files(work_root, work_root, limit, &mut files).ok()?;
-    Some(files)
-}
-
-fn collect_meaningful_workspace_files(
-    root: &Path,
-    current: &Path,
-    limit: usize,
-    files: &mut Vec<PathBuf>,
-) -> std::io::Result<()> {
-    if files.len() > limit {
-        return Ok(());
-    }
-    for entry in std::fs::read_dir(current)? {
-        let entry = entry?;
-        let name = entry.file_name();
-        let name = name.to_string_lossy();
-        // Issue #646 (E1): single SSOT for ignored workspace directories.
-        if super::task_workspace_scope::is_workspace_ignored_dir(&name) {
-            continue;
-        }
-        let path = entry.path();
-        if path.is_dir() {
-            collect_meaningful_workspace_files(root, &path, limit, files)?;
-        } else if path.is_file()
-            && let Ok(relative) = path.strip_prefix(root)
-        {
-            files.push(relative.to_path_buf());
-            if files.len() > limit {
-                return Ok(());
-            }
-        }
-    }
-    Ok(())
 }
 
 /// Format a single-line per-iteration progress line. ANSI color is only

--- a/src/agent/loop_run/workspace_walk.rs
+++ b/src/agent/loop_run/workspace_walk.rs
@@ -1,0 +1,64 @@
+//! Workspace walker helpers extracted from `turn.rs` (parent #680).
+//!
+//! Hosts the bounded workspace traversal used to surface scaffold /
+//! artifact-recovery candidates (`meaningful_workspace_files`,
+//! `collect_meaningful_workspace_files`) and the `workspace_appears_empty`
+//! probe used by the empty-workspace scaffold gate. Honours
+//! `task_workspace_scope::is_workspace_ignored_dir` as the SSOT ignore
+//! list.
+//!
+//! `pub(super)` limited / no facade re-export (DR3-001).
+
+use std::path::{Path, PathBuf};
+
+pub(super) fn workspace_appears_empty(work_root: &Path) -> bool {
+    let Ok(entries) = std::fs::read_dir(work_root) else {
+        return false;
+    };
+    !entries.flatten().any(|entry| {
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        !matches!(
+            name.as_ref(),
+            ".git" | ".anvil" | ".anvil-state" | "ANVIL.md" | "node_modules" | "target"
+        )
+    })
+}
+
+pub(super) fn meaningful_workspace_files(work_root: &Path, limit: usize) -> Option<Vec<PathBuf>> {
+    let mut files = Vec::new();
+    collect_meaningful_workspace_files(work_root, work_root, limit, &mut files).ok()?;
+    Some(files)
+}
+
+fn collect_meaningful_workspace_files(
+    root: &Path,
+    current: &Path,
+    limit: usize,
+    files: &mut Vec<PathBuf>,
+) -> std::io::Result<()> {
+    if files.len() > limit {
+        return Ok(());
+    }
+    for entry in std::fs::read_dir(current)? {
+        let entry = entry?;
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        // Issue #646 (E1): single SSOT for ignored workspace directories.
+        if super::task_workspace_scope::is_workspace_ignored_dir(&name) {
+            continue;
+        }
+        let path = entry.path();
+        if path.is_dir() {
+            collect_meaningful_workspace_files(root, &path, limit, files)?;
+        } else if path.is_file()
+            && let Ok(relative) = path.strip_prefix(root)
+        {
+            files.push(relative.to_path_buf());
+            if files.len() > limit {
+                return Ok(());
+            }
+        }
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Move the workspace walker helpers out of `turn.rs` into a new `src/agent/loop_run/workspace_walk.rs` sibling module, continuing the meta-issue #680 split.

Migrated:
- `workspace_appears_empty` (`pub(super)`)
- `meaningful_workspace_files` (`pub(super)`)
- `collect_meaningful_workspace_files` (private)

The walker honours `task_workspace_scope::is_workspace_ignored_dir` as the SSOT ignore list. No facade re-export (DR3-001).

Callers updated:
- `scaffold_pipeline.rs`: switches `meaningful_workspace_files` / `workspace_appears_empty` from `super::turn` to `super::workspace_walk`.
- `turn.rs`: re-imports both for the remaining in-file callers.

The legacy un-scoped `existing_workspace_candidate_for_role` (test-only) and `existing_workspace_candidate_for_role_in_scope` are kept in `turn.rs` for now since they depend on `scaffold_pipeline::scaffold_candidate_priority` and `task_contract::ArtifactRole`; a follow-up PR can move them once a cleaner module sibling is identified.

## LOC delta

- `turn.rs`: 26,781 → 26,726 (-55 LOC)
- New `workspace_walk.rs`: 64 LOC
- Cumulative from 39,489: -12,763 LOC (-32.3%)

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --lib --all-targets -- -D warnings` clean
- [x] `cargo test --lib` (3,114 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)