### PR TITLE
Extract workspace_candidates.rs from turn.rs (parent #680)

### DIFF
--- a/src/agent/loop_run.rs
+++ b/src/agent/loop_run.rs
@@ -648,6 +648,13 @@ mod turn;
 pub(crate) mod verifier_skill;
 pub(crate) mod work_mode_confirm;
 mod workspace_walk;
+// Workspace candidate lookup helpers extracted from `turn.rs` (parent
+// #680). Hosts `existing_workspace_candidate_for_role_in_scope` (the
+// scope-aware lookup used by `task_contract_artifact_states` /
+// `task_contract_recovery_target`) plus the test-only legacy un-scoped
+// variant and `target_path_in_scope`. `pub(super)` limited / no facade
+// re-export (DR3-001).
+mod workspace_candidates;
 
 // Public re-exports so `lib.rs::run_cli` can hand a `FooterHandle` into
 // `Agent::new` and own the matching `FooterLease` for its scope (issue #430).

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -129,7 +129,6 @@ use super::safe_stop_payload::{build_safe_stop_payload, collect_recent_action_la
 use super::scaffold_pipeline::PlanExplorationKey;
 #[cfg(test)]
 use super::scaffold_pipeline::recent_deterministic_framework_app_fallback_seen;
-use super::scaffold_pipeline::scaffold_candidate_priority;
 #[cfg(test)]
 use super::scaffold_pipeline::task_requires_nextjs_scaffold;
 #[cfg(test)]
@@ -240,7 +239,10 @@ use super::work_mode_confirm::{
     self, WORK_MODE_CONFIRM_TIMEOUT_SECS, WorkModeConfirmInputs, WorkModeConfirmOutcome,
     run_work_mode_confirm_with_strategy,
 };
-use super::workspace_walk::{meaningful_workspace_files, workspace_appears_empty};
+use super::workspace_candidates::existing_workspace_candidate_for_role_in_scope;
+#[cfg(test)]
+use super::workspace_candidates::{existing_workspace_candidate_for_role, target_path_in_scope};
+use super::workspace_walk::workspace_appears_empty;
 use super::*;
 use crate::agent::orchestration::verify_repo_progress;
 use crate::logging::{log_llm_event, stable_path_hash};
@@ -12126,90 +12128,6 @@ pub(super) fn latest_turn_preferred_read_edit_target(
         }
     }
     latest_existing
-}
-
-/// Legacy un-scoped lookup kept for unit-test fixtures that exercise the
-/// `scaffold_candidate_priority` ordering independently of scope detection.
-/// Production code MUST use [`existing_workspace_candidate_for_role_in_scope`]
-/// so out-of-scope nested-subtree files cannot leak into completion evidence
-/// (Issue #646).
-#[cfg(test)]
-fn existing_workspace_candidate_for_role(
-    work_root: &Path,
-    role: super::task_contract::ArtifactRole,
-) -> Option<String> {
-    let mut candidates = meaningful_workspace_files(work_root, 64)?
-        .into_iter()
-        .filter(|path| {
-            super::task_contract::role_from_repo_edit(
-                super::completion_evidence::classify_repo_edit_path(path),
-            )
-            .is_some_and(|candidate| candidate == role)
-        })
-        .collect::<Vec<_>>();
-    candidates.sort_by_key(|path| {
-        scaffold_candidate_priority(work_root, role, &path.to_string_lossy().replace('\\', "/"))
-    });
-    candidates
-        .first()
-        .map(|path| path.to_string_lossy().replace('\\', "/"))
-}
-
-/// v0.4.11: after an invalid controller repair proposal is recorded in the
-/// repair ledger, the next policy decision may have advanced to a fresh
-/// diagnostic or a different concrete target. Only those transitions count as
-/// useful control-flow progress. Staying on the same target is still a retry
-/// against the outer terminal budget; otherwise malformed proposals can loop
-/// until `max_iterations`.
-///
-/// Issue #646: confirm that an absolute repair target lies inside the active
-/// workspace scope. The path is normalized against `work_root` and the
-/// resulting relative form is handed to [`TaskWorkspaceScope::contains`].
-/// Targets that fail to strip the prefix (escape via canonical/symlink) are
-/// treated as out-of-scope.
-#[cfg(test)]
-fn target_path_in_scope(
-    target: &Path,
-    work_root: &Path,
-    scope: &super::task_workspace_scope::TaskWorkspaceScope,
-) -> bool {
-    let root_canon = std::fs::canonicalize(work_root).unwrap_or_else(|_| work_root.to_path_buf());
-    let target_canon = std::fs::canonicalize(target).unwrap_or_else(|_| target.to_path_buf());
-    let Ok(relative) = target_canon.strip_prefix(&root_canon) else {
-        return false;
-    };
-    scope.contains(&relative.to_string_lossy().replace('\\', "/"))
-}
-
-/// Issue #646: scope-aware variant of [`existing_workspace_candidate_for_role`].
-///
-/// Filters workspace files through `scope.contains(...)` before priority
-/// sorting so candidates inside out-of-scope nested subtrees (the
-/// fresh-session-parent-directory bug case) are never surfaced. Used by
-/// `task_contract_artifact_states` and `task_contract_recovery_target`;
-/// the legacy un-scoped function is preserved for unit-test fixtures that
-/// exercise the priority logic independently.
-pub(super) fn existing_workspace_candidate_for_role_in_scope(
-    work_root: &Path,
-    role: super::task_contract::ArtifactRole,
-    scope: &super::task_workspace_scope::TaskWorkspaceScope,
-) -> Option<String> {
-    let mut candidates = meaningful_workspace_files(work_root, 64)?
-        .into_iter()
-        .filter(|path| {
-            super::task_contract::role_from_repo_edit(
-                super::completion_evidence::classify_repo_edit_path(path),
-            )
-            .is_some_and(|candidate| candidate == role)
-        })
-        .filter(|path| scope.contains(&path.to_string_lossy().replace('\\', "/")))
-        .collect::<Vec<_>>();
-    candidates.sort_by_key(|path| {
-        scaffold_candidate_priority(work_root, role, &path.to_string_lossy().replace('\\', "/"))
-    });
-    candidates
-        .first()
-        .map(|path| path.to_string_lossy().replace('\\', "/"))
 }
 
 /// Format a single-line per-iteration progress line. ANSI color is only

--- a/src/agent/loop_run/workspace_candidates.rs
+++ b/src/agent/loop_run/workspace_candidates.rs
@@ -1,0 +1,94 @@
+//! Workspace candidate lookup helpers extracted from `turn.rs` (parent
+//! #680).
+//!
+//! Hosts the scoped + legacy variants of `existing_workspace_candidate_for_role*`
+//! used by `task_contract_artifact_states` /
+//! `task_contract_recovery_target` and the test-only `target_path_in_scope`
+//! probe. The walker delegates to
+//! `workspace_walk::meaningful_workspace_files` for traversal, sorts by
+//! `scaffold_pipeline::scaffold_candidate_priority`, and filters through
+//! `task_workspace_scope::TaskWorkspaceScope::contains` (Issue #646) so
+//! out-of-scope nested subtrees cannot leak into completion evidence.
+//!
+//! `pub(super)` limited / no facade re-export (DR3-001).
+
+use std::path::Path;
+
+use super::completion_evidence::classify_repo_edit_path;
+use super::scaffold_pipeline::scaffold_candidate_priority;
+use super::task_contract::{ArtifactRole, role_from_repo_edit};
+use super::task_workspace_scope::TaskWorkspaceScope;
+use super::workspace_walk::meaningful_workspace_files;
+
+/// Legacy un-scoped lookup kept for unit-test fixtures that exercise the
+/// `scaffold_candidate_priority` ordering independently of scope detection.
+/// Production code MUST use [`existing_workspace_candidate_for_role_in_scope`]
+/// so out-of-scope nested-subtree files cannot leak into completion evidence
+/// (Issue #646).
+#[cfg(test)]
+pub(super) fn existing_workspace_candidate_for_role(
+    work_root: &Path,
+    role: ArtifactRole,
+) -> Option<String> {
+    let mut candidates = meaningful_workspace_files(work_root, 64)?
+        .into_iter()
+        .filter(|path| {
+            role_from_repo_edit(classify_repo_edit_path(path))
+                .is_some_and(|candidate| candidate == role)
+        })
+        .collect::<Vec<_>>();
+    candidates.sort_by_key(|path| {
+        scaffold_candidate_priority(work_root, role, &path.to_string_lossy().replace('\\', "/"))
+    });
+    candidates
+        .first()
+        .map(|path| path.to_string_lossy().replace('\\', "/"))
+}
+
+/// Issue #646: confirm that an absolute repair target lies inside the active
+/// workspace scope. The path is normalized against `work_root` and the
+/// resulting relative form is handed to [`TaskWorkspaceScope::contains`].
+/// Targets that fail to strip the prefix (escape via canonical/symlink) are
+/// treated as out-of-scope.
+#[cfg(test)]
+pub(super) fn target_path_in_scope(
+    target: &Path,
+    work_root: &Path,
+    scope: &TaskWorkspaceScope,
+) -> bool {
+    let root_canon = std::fs::canonicalize(work_root).unwrap_or_else(|_| work_root.to_path_buf());
+    let target_canon = std::fs::canonicalize(target).unwrap_or_else(|_| target.to_path_buf());
+    let Ok(relative) = target_canon.strip_prefix(&root_canon) else {
+        return false;
+    };
+    scope.contains(&relative.to_string_lossy().replace('\\', "/"))
+}
+
+/// Issue #646: scope-aware variant of [`existing_workspace_candidate_for_role`].
+///
+/// Filters workspace files through `scope.contains(...)` before priority
+/// sorting so candidates inside out-of-scope nested subtrees (the
+/// fresh-session-parent-directory bug case) are never surfaced. Used by
+/// `task_contract_artifact_states` and `task_contract_recovery_target`;
+/// the legacy un-scoped function is preserved for unit-test fixtures that
+/// exercise the priority logic independently.
+pub(super) fn existing_workspace_candidate_for_role_in_scope(
+    work_root: &Path,
+    role: ArtifactRole,
+    scope: &TaskWorkspaceScope,
+) -> Option<String> {
+    let mut candidates = meaningful_workspace_files(work_root, 64)?
+        .into_iter()
+        .filter(|path| {
+            role_from_repo_edit(classify_repo_edit_path(path))
+                .is_some_and(|candidate| candidate == role)
+        })
+        .filter(|path| scope.contains(&path.to_string_lossy().replace('\\', "/")))
+        .collect::<Vec<_>>();
+    candidates.sort_by_key(|path| {
+        scaffold_candidate_priority(work_root, role, &path.to_string_lossy().replace('\\', "/"))
+    });
+    candidates
+        .first()
+        .map(|path| path.to_string_lossy().replace('\\', "/"))
+}


### PR DESCRIPTION
## Summary

Move the workspace candidate lookup helpers out of `turn.rs` into a new `src/agent/loop_run/workspace_candidates.rs` sibling module, continuing the meta-issue #680 split.

Migrated:
- `existing_workspace_candidate_for_role` (`#[cfg(test)]` `pub(super)`, legacy un-scoped lookup kept for priority-ordering test fixtures)
- `target_path_in_scope` (`#[cfg(test)]` `pub(super)`)
- `existing_workspace_candidate_for_role_in_scope` (`pub(super)`)

The cluster filters workspace files through `task_workspace_scope::TaskWorkspaceScope::contains` (Issue #646) and sorts by `scaffold_pipeline::scaffold_candidate_priority`. No facade re-export (DR3-001).

Callers updated:
- `turn.rs`: re-imports `existing_workspace_candidate_for_role_in_scope` for production callers; the two test-only fns are gated `#[cfg(test)]`.
- Drops unused `super::scaffold_pipeline::scaffold_candidate_priority` import from `turn.rs` (only the migrated cluster called it).
- Drops `meaningful_workspace_files` from `turn.rs`'s `workspace_walk` import (only the migrated cluster called it).

## LOC delta

- `turn.rs`: 26,726 → 26,644 (-82 LOC)
- New `workspace_candidates.rs`: 94 LOC
- Cumulative from 39,489: -12,845 LOC (-32.5%)

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --lib --all-targets -- -D warnings` clean
- [x] `cargo test --lib` (3,114 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)