### PR TITLE
Extract python_markers.rs from turn.rs (parent #680)

### DIFF
--- a/src/agent/loop_run.rs
+++ b/src/agent/loop_run.rs
@@ -97,6 +97,11 @@ mod classify_confirm_flow;
 // over `&mut Agent` / `&Agent`. `pub(super)` limited / no facade
 // re-export (DR3-001).
 mod tester_invocation;
+// Python package-marker materialization extracted from `turn.rs`
+// (parent #680). Hosts 2 entry points + a shared materializer, all free
+// fns over `&mut Agent`. `pub(super)` limited / no facade re-export
+// (DR3-001).
+mod python_markers;
 // Issue #652: `ArtifactCompletionJob` + role-specific retry budget +
 // `ArtifactAttemptOutcome` 4-variant taxonomy +
 // `ArtifactCompletionFailureSnapshot` for #654. Module is intentionally

--- a/src/agent/loop_run/python_markers.rs
+++ b/src/agent/loop_run/python_markers.rs
@@ -1,0 +1,82 @@
+//! Python package-marker materialization extracted from `turn.rs`
+//! (parent #680).
+//!
+//! Hosts the two production entry points and their shared materializer:
+//!
+//! - `materialize_python_package_markers_for_external_import` — creates
+//!   `__init__.py` markers under the workspace for packages observed in
+//!   verifier stdout/stderr external-import diagnostics.
+//! - `materialize_python_package_markers_for_owned_test_imports` —
+//!   same materialization but seeded from the owned test artifact list.
+//! - `materialize_python_package_marker_candidates` — shared per-path
+//!   `create_new` writer + evidence/telemetry record.
+//!
+//! Originally `impl Agent` methods; converted to free functions taking
+//! `&mut Agent`, matching the `actor_loop_flow` / `anti_pattern_flow` /
+//! `case_record_flow` pattern. `pub(super)` limited / no facade
+//! re-export (DR3-001).
+
+use super::Agent;
+use super::auto_test;
+use crate::logging::{log_llm_event, stable_path_hash};
+
+pub(super) fn materialize_python_package_markers_for_external_import(
+    agent: &mut Agent,
+    stdout: &str,
+    stderr: &str,
+) -> Vec<String> {
+    let candidates = auto_test::python_package_marker_candidates_for_external_import(
+        &agent.work_root,
+        stdout,
+        stderr,
+    );
+    materialize_python_package_marker_candidates(agent, candidates)
+}
+
+pub(super) fn materialize_python_package_markers_for_owned_test_imports(
+    agent: &mut Agent,
+    owned_test_artifacts: &[String],
+) -> Vec<String> {
+    let candidates = auto_test::python_package_marker_candidates_for_owned_test_imports(
+        &agent.work_root,
+        owned_test_artifacts,
+    );
+    materialize_python_package_marker_candidates(agent, candidates)
+}
+
+fn materialize_python_package_marker_candidates(
+    agent: &mut Agent,
+    candidates: Vec<String>,
+) -> Vec<String> {
+    let mut created = Vec::new();
+    for relative_path in candidates {
+        let full_path = agent.work_root.join(&relative_path);
+        let Some(parent) = full_path.parent() else {
+            continue;
+        };
+        if !parent.is_dir() {
+            continue;
+        }
+        if std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&full_path)
+            .is_err()
+        {
+            continue;
+        }
+        agent.observe_evidence_from_repo_edit(&relative_path);
+        log_llm_event(
+            "agent.verifier.python_package_marker.created",
+            serde_json::json!({
+                "session_id": agent.session_store.session_id(),
+                "turn_index": agent.current_turn_index,
+                "path_hash": stable_path_hash(
+                    &crate::session::feedback::mask_secrets(&relative_path)
+                ),
+            }),
+        );
+        created.push(relative_path);
+    }
+    created
+}

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -644,67 +644,6 @@ impl Agent {
         }
     }
 
-    pub(super) fn materialize_python_package_markers_for_external_import(
-        &mut self,
-        stdout: &str,
-        stderr: &str,
-    ) -> Vec<String> {
-        let candidates = super::auto_test::python_package_marker_candidates_for_external_import(
-            &self.work_root,
-            stdout,
-            stderr,
-        );
-        self.materialize_python_package_marker_candidates(candidates)
-    }
-
-    pub(super) fn materialize_python_package_markers_for_owned_test_imports(
-        &mut self,
-        owned_test_artifacts: &[String],
-    ) -> Vec<String> {
-        let candidates = super::auto_test::python_package_marker_candidates_for_owned_test_imports(
-            &self.work_root,
-            owned_test_artifacts,
-        );
-        self.materialize_python_package_marker_candidates(candidates)
-    }
-
-    fn materialize_python_package_marker_candidates(
-        &mut self,
-        candidates: Vec<String>,
-    ) -> Vec<String> {
-        let mut created = Vec::new();
-        for relative_path in candidates {
-            let full_path = self.work_root.join(&relative_path);
-            let Some(parent) = full_path.parent() else {
-                continue;
-            };
-            if !parent.is_dir() {
-                continue;
-            }
-            if std::fs::OpenOptions::new()
-                .write(true)
-                .create_new(true)
-                .open(&full_path)
-                .is_err()
-            {
-                continue;
-            }
-            self.observe_evidence_from_repo_edit(&relative_path);
-            log_llm_event(
-                "agent.verifier.python_package_marker.created",
-                serde_json::json!({
-                    "session_id": self.session_store.session_id(),
-                    "turn_index": self.current_turn_index,
-                    "path_hash": stable_path_hash(
-                        &crate::session::feedback::mask_secrets(&relative_path)
-                    ),
-                }),
-            );
-            created.push(relative_path);
-        }
-        created
-    }
-
     fn handle_repair_job_verifier_pass(
         &mut self,
         args: TaskContractVerifierFlowArgs<'_, '_>,

--- a/src/agent/loop_run/verifier_orchestration.rs
+++ b/src/agent/loop_run/verifier_orchestration.rs
@@ -2601,7 +2601,8 @@ pub(super) fn handle_structured_task_contract_verifier_selection(
         return TaskContractVerifierOutcome::NoVerifier;
     };
     if selection.command.runner() == "python3" {
-        agent.materialize_python_package_markers_for_owned_test_imports(
+        super::python_markers::materialize_python_package_markers_for_owned_test_imports(
+            agent,
             &selection.bound_test_artifacts_paths,
         );
     }
@@ -2682,8 +2683,12 @@ pub(super) fn finish_structured_task_contract_verifier_selection(
             &result,
         )
     {
-        let created_markers = agent
-            .materialize_python_package_markers_for_external_import(&result.stdout, &result.stderr);
+        let created_markers =
+            super::python_markers::materialize_python_package_markers_for_external_import(
+                agent,
+                &result.stdout,
+                &result.stderr,
+            );
         let borrowed = contamination.borrowed_hashes();
         agent.emit_agent_verifier_external_import_rejected_if_first(
             selection.command.runner(),


### PR DESCRIPTION
## Summary

Fifth **vertical-slice extraction**: move the Python package-marker materialization helpers out of `turn.rs` into a new `src/agent/loop_run/python_markers.rs` sibling module.

### Migrated (all free fns over `&mut Agent`)

**Entry points (`pub(super)`):**
- `materialize_python_package_markers_for_external_import` — creates `__init__.py` markers under the workspace for packages observed in verifier stdout/stderr external-import diagnostics.
- `materialize_python_package_markers_for_owned_test_imports` — same materialization but seeded from the owned test artifact list.

**Private helper:**
- `materialize_python_package_marker_candidates` — shared per-path `create_new` writer + evidence/telemetry record.

The shared helper calls `agent.observe_evidence_from_repo_edit(...)` (still on `impl Agent` in `turn.rs`, `pub(super)`) to record the marker creation as evidence. No facade re-export (DR3-001).

### Caller updates (verifier_orchestration.rs ×2)
- `agent.materialize_python_package_markers_for_owned_test_imports(...)` → `super::python_markers::materialize_python_package_markers_for_owned_test_imports(agent, ...)`
- `agent.materialize_python_package_markers_for_external_import(...)` → `super::python_markers::materialize_python_package_markers_for_external_import(agent, ...)`

## LOC delta

- `turn.rs`: 5,944 → **5,883 LOC** (-61 LOC)
- New `python_markers.rs`: 82 LOC
- **Cumulative from 39,489: -33,606 LOC (-85.1%)**

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --lib --all-targets -- -D warnings` clean
- [x] `cargo test --lib` (3,114 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)