### PR TITLE
Extract emit_verifier_events.rs from turn.rs (parent #680)

### DIFF
--- a/src/agent/loop_run.rs
+++ b/src/agent/loop_run.rs
@@ -102,6 +102,12 @@ mod tester_invocation;
 // fns over `&mut Agent`. `pub(super)` limited / no facade re-export
 // (DR3-001).
 mod python_markers;
+// Verifier event emitters extracted from `turn.rs` (parent #680). Hosts
+// `emit_agent_verifier_invoked_if_new` (per-turn payload-digest dedup)
+// + `emit_agent_verifier_external_import_rejected_if_first` (single
+// per-turn cap). Both apply `mask_payload_inplace` as final defence.
+// `pub(super)` limited / no facade re-export (DR3-001).
+mod emit_verifier_events;
 // Issue #652: `ArtifactCompletionJob` + role-specific retry budget +
 // `ArtifactAttemptOutcome` 4-variant taxonomy +
 // `ArtifactCompletionFailureSnapshot` for #654. Module is intentionally

--- a/src/agent/loop_run/emit_verifier_events.rs
+++ b/src/agent/loop_run/emit_verifier_events.rs
@@ -1,0 +1,103 @@
+//! Verifier-event emit helpers extracted from `turn.rs` (parent #680).
+//!
+//! Hosts the two `agent.verifier.*` event emitters previously sitting on
+//! `impl Agent`. Both apply `mask_payload_inplace` as the final defence
+//! line and respect per-turn dedup / single-shot caps via
+//! `Agent.last_verifier_invoked_payload_digest` and
+//! `Agent.external_import_rejected_emitted_this_turn`.
+//!
+//! Entry points (pub(super)):
+//! - `emit_agent_verifier_invoked_if_new` — pre-spawn
+//!   `agent.verifier.invoked` event with per-turn payload-digest dedup.
+//! - `emit_agent_verifier_external_import_rejected_if_first` —
+//!   `agent.verifier.external_import_rejected` event with single-shot
+//!   per-turn cap.
+//!
+//! Originally `impl Agent` methods; converted to free functions taking
+//! `&mut Agent`. `pub(super)` limited / no facade re-export (DR3-001).
+
+use super::Agent;
+use super::auto_test::{
+    VerifierInvokedSnapshot, build_agent_verifier_external_import_rejected_payload,
+    build_agent_verifier_invoked_payload,
+};
+use crate::logging::{compute_payload_digest, log_llm_event, mask_payload_inplace};
+
+/// Issue #661 iteration-4 Task 5.2 / DR1-005 emit ownership: pre-spawn
+/// `agent.verifier.invoked` event emit + per-turn dedup. The payload
+/// schema matches design Section 8-1 exactly. See
+/// [`build_agent_verifier_invoked_payload`] for the pure-fn builder
+/// (testable without an Agent instance) and the field-by-field schema.
+///
+/// Emit ownership rules (DR1-005 / DR1-004):
+/// - Caller MUST have built the snapshot at pre-spawn (before
+///   `run_structured` spawns `Command::new`)
+/// - `mask_payload_inplace` is the final defence line — applied here
+///   BEFORE the digest computation so the dedup key matches the
+///   post-mask representation log consumers see
+/// - Per-turn dedup: same digest as `last_verifier_invoked_payload_digest`
+///   suppresses re-emit; a different digest emits and replaces the
+///   field. Reset at `handle_user_message` head clears the digest.
+///
+/// Returns `true` if the event was emitted, `false` if suppressed by
+/// dedup (used by unit tests; production callers ignore the return
+/// value).
+pub(super) fn emit_agent_verifier_invoked_if_new(
+    agent: &mut Agent,
+    snapshot: &VerifierInvokedSnapshot,
+) -> bool {
+    let mut payload = build_agent_verifier_invoked_payload(
+        agent.session_store.session_id(),
+        agent.current_turn_index,
+        agent.session.iter_count_this_turn,
+        snapshot,
+    );
+    // DR1-004 step 1: apply mask_payload_inplace BEFORE digest so the
+    // dedup key matches the post-mask representation log consumers see.
+    mask_payload_inplace(&mut payload);
+    let digest = compute_payload_digest(&payload);
+    if agent.last_verifier_invoked_payload_digest == Some(digest) {
+        return false;
+    }
+    agent.last_verifier_invoked_payload_digest = Some(digest);
+    // log_llm_event masks again — idempotent for already-masked
+    // payloads (final defence line invariant).
+    log_llm_event("agent.verifier.invoked", payload);
+    true
+}
+
+/// Issue #661 iteration-5 Task 7.3: emit
+/// `agent.verifier.external_import_rejected` event subject to per-turn
+/// cap (`external_import_rejected_emitted_this_turn`). Caller passes the
+/// already-hashed module hashes + their static source labels so raw paths
+/// never reach the payload (DR4-005).
+///
+/// Returns `true` if emitted, `false` if suppressed by the per-turn cap.
+/// Caller (`run_task_contract_verifier_once`) wires both pre-execution
+/// (PYTHONPATH) and post-execution (stdout/stderr) detection through
+/// this single SSOT.
+pub(super) fn emit_agent_verifier_external_import_rejected_if_first(
+    agent: &mut Agent,
+    runner: &str,
+    reason: &'static str,
+    detected_hashes: &[(&str, &'static str)],
+    detected_count: usize,
+    detected_truncated: bool,
+) -> bool {
+    if agent.external_import_rejected_emitted_this_turn {
+        return false;
+    }
+    agent.external_import_rejected_emitted_this_turn = true;
+    let mut payload = build_agent_verifier_external_import_rejected_payload(
+        agent.session_store.session_id(),
+        agent.current_turn_index,
+        runner,
+        reason,
+        detected_hashes,
+        detected_count,
+        detected_truncated,
+    );
+    mask_payload_inplace(&mut payload);
+    log_llm_event("agent.verifier.external_import_rejected", payload);
+    true
+}

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -6,10 +6,7 @@ use super::actor_loop_flow::{
     TaskContractVerifierFlowOutcome, build_feedback_for_deterministic_content_fallback,
     format_iteration_status, repair_job_done_outcome, run_actor_loop,
 };
-use super::auto_test::{
-    AutoTestKind, AutoTestRunner, build_agent_verifier_external_import_rejected_payload,
-    build_agent_verifier_invoked_payload,
-};
+use super::auto_test::{AutoTestKind, AutoTestRunner};
 use super::completion_evidence::is_repo_edit_no_op;
 use super::interrupt::{InterruptEnv, InterruptFlag, InterruptMonitor};
 use super::model_request::{build_assistant_request_plan, request_non_streaming_assistant_reply};
@@ -1191,85 +1188,6 @@ impl Agent {
             return;
         };
         self.emit_repair_safe_stop_report(stop_reason);
-    }
-
-    /// Issue #661 iteration-4 Task 5.2 / DR1-005 emit ownership: pre-spawn
-    /// `agent.verifier.invoked` event emit + per-turn dedup. The payload
-    /// schema matches design Section 8-1 exactly. See
-    /// [`build_agent_verifier_invoked_payload`] for the pure-fn builder
-    /// (testable without an Agent instance) and the field-by-field schema.
-    ///
-    /// Emit ownership rules (DR1-005 / DR1-004):
-    /// - Caller MUST have built the snapshot at pre-spawn (before
-    ///   `run_structured` spawns `Command::new`)
-    /// - `mask_payload_inplace` is the final defence line — applied here
-    ///   BEFORE the digest computation so the dedup key matches the
-    ///   post-mask representation log consumers see
-    /// - Per-turn dedup: same digest as `last_verifier_invoked_payload_digest`
-    ///   suppresses re-emit; a different digest emits and replaces the
-    ///   field. Reset at `handle_user_message` head clears the digest.
-    ///
-    /// Returns `true` if the event was emitted, `false` if suppressed by
-    /// dedup (used by unit tests; production callers ignore the return
-    /// value).
-    pub(super) fn emit_agent_verifier_invoked_if_new(
-        &mut self,
-        snapshot: &super::auto_test::VerifierInvokedSnapshot,
-    ) -> bool {
-        let mut payload = build_agent_verifier_invoked_payload(
-            self.session_store.session_id(),
-            self.current_turn_index,
-            self.session.iter_count_this_turn,
-            snapshot,
-        );
-        // DR1-004 step 1: apply mask_payload_inplace BEFORE digest so the
-        // dedup key matches the post-mask representation log consumers see.
-        crate::logging::mask_payload_inplace(&mut payload);
-        let digest = crate::logging::compute_payload_digest(&payload);
-        if self.last_verifier_invoked_payload_digest == Some(digest) {
-            return false;
-        }
-        self.last_verifier_invoked_payload_digest = Some(digest);
-        // log_llm_event masks again — idempotent for already-masked
-        // payloads (final defence line invariant).
-        log_llm_event("agent.verifier.invoked", payload);
-        true
-    }
-
-    /// Issue #661 iteration-5 Task 7.3: emit
-    /// `agent.verifier.external_import_rejected` event subject to per-turn
-    /// cap (`external_import_rejected_emitted_this_turn`). Caller passes the
-    /// already-hashed module hashes + their static source labels so raw paths
-    /// never reach the payload (DR4-005).
-    ///
-    /// Returns `true` if emitted, `false` if suppressed by the per-turn cap.
-    /// Caller (`run_task_contract_verifier_once`) wires both pre-execution
-    /// (PYTHONPATH) and post-execution (stdout/stderr) detection through
-    /// this single SSOT.
-    pub(super) fn emit_agent_verifier_external_import_rejected_if_first(
-        &mut self,
-        runner: &str,
-        reason: &'static str,
-        detected_hashes: &[(&str, &'static str)],
-        detected_count: usize,
-        detected_truncated: bool,
-    ) -> bool {
-        if self.external_import_rejected_emitted_this_turn {
-            return false;
-        }
-        self.external_import_rejected_emitted_this_turn = true;
-        let mut payload = build_agent_verifier_external_import_rejected_payload(
-            self.session_store.session_id(),
-            self.current_turn_index,
-            runner,
-            reason,
-            detected_hashes,
-            detected_count,
-            detected_truncated,
-        );
-        crate::logging::mask_payload_inplace(&mut payload);
-        log_llm_event("agent.verifier.external_import_rejected", payload);
-        true
     }
 
     pub(super) fn record_task_contract_verifier_invocation(

--- a/src/agent/loop_run/turn_tests.rs
+++ b/src/agent/loop_run/turn_tests.rs
@@ -4229,7 +4229,9 @@ mod tests {
         let (mut agent, _temp) = test_agent_with_config(Config::default());
         assert!(agent.last_verifier_invoked_payload_digest.is_none());
         let snapshot = make_verifier_invoked_snapshot_cargo(&["tests/test_a.rs"]);
-        let emitted = agent.emit_agent_verifier_invoked_if_new(&snapshot);
+        let emitted = super::super::emit_verifier_events::emit_agent_verifier_invoked_if_new(
+            &mut agent, &snapshot,
+        );
         assert!(
             emitted,
             "first emit of the turn must return true (None -> Some transition)"
@@ -4243,9 +4245,15 @@ mod tests {
         use crate::config::Config;
         let (mut agent, _temp) = test_agent_with_config(Config::default());
         let snapshot = make_verifier_invoked_snapshot_cargo(&["tests/test_a.rs"]);
-        assert!(agent.emit_agent_verifier_invoked_if_new(&snapshot));
+        assert!(
+            super::super::emit_verifier_events::emit_agent_verifier_invoked_if_new(
+                &mut agent, &snapshot
+            )
+        );
         let digest_after_first = agent.last_verifier_invoked_payload_digest;
-        let again = agent.emit_agent_verifier_invoked_if_new(&snapshot);
+        let again = super::super::emit_verifier_events::emit_agent_verifier_invoked_if_new(
+            &mut agent, &snapshot,
+        );
         assert!(
             !again,
             "identical snapshot in the same turn must be deduped (returns false)"
@@ -4263,10 +4271,16 @@ mod tests {
         let (mut agent, _temp) = test_agent_with_config(Config::default());
         let snap_a = make_verifier_invoked_snapshot_cargo(&["tests/test_a.rs"]);
         let snap_b = make_verifier_invoked_snapshot_cargo(&["tests/test_b.rs"]);
-        assert!(agent.emit_agent_verifier_invoked_if_new(&snap_a));
+        assert!(
+            super::super::emit_verifier_events::emit_agent_verifier_invoked_if_new(
+                &mut agent, &snap_a
+            )
+        );
         let digest_a = agent.last_verifier_invoked_payload_digest;
         assert!(
-            agent.emit_agent_verifier_invoked_if_new(&snap_b),
+            super::super::emit_verifier_events::emit_agent_verifier_invoked_if_new(
+                &mut agent, &snap_b
+            ),
             "different bound_artifacts must re-emit"
         );
         assert_ne!(
@@ -4283,11 +4297,17 @@ mod tests {
         use crate::config::Config;
         let (mut agent, _temp) = test_agent_with_config(Config::default());
         let snapshot = make_verifier_invoked_snapshot_cargo(&["tests/test_a.rs"]);
-        assert!(agent.emit_agent_verifier_invoked_if_new(&snapshot));
+        assert!(
+            super::super::emit_verifier_events::emit_agent_verifier_invoked_if_new(
+                &mut agent, &snapshot
+            )
+        );
         // Simulate per-turn reset.
         agent.last_verifier_invoked_payload_digest = None;
         assert!(
-            agent.emit_agent_verifier_invoked_if_new(&snapshot),
+            super::super::emit_verifier_events::emit_agent_verifier_invoked_if_new(
+                &mut agent, &snapshot
+            ),
             "post-turn-reset emit of same snapshot must return true (None -> Some transition)"
         );
     }
@@ -4311,7 +4331,9 @@ mod tests {
             &snapshot,
         );
         let pre_mask_digest = crate::logging::compute_payload_digest(&pre_mask_payload);
-        agent.emit_agent_verifier_invoked_if_new(&snapshot);
+        super::super::emit_verifier_events::emit_agent_verifier_invoked_if_new(
+            &mut agent, &snapshot,
+        );
         // In Phase A there are no secret-like fields in the payload, so
         // the masked digest equals the pre-mask digest (mask is idempotent
         // on a clean payload). What matters is that the helper computes
@@ -4343,7 +4365,7 @@ mod tests {
         use crate::config::Config;
         let (mut agent, _temp) = test_agent_with_config(Config::default());
         assert!(!agent.external_import_rejected_emitted_this_turn);
-        let emitted = agent.emit_agent_verifier_external_import_rejected_if_first(
+        let emitted = super::super::emit_verifier_events::emit_agent_verifier_external_import_rejected_if_first(&mut agent,
             "python3",
             "external_pythonpath_rejected",
             &[("deadbeefcafef00d", "pythonpath")],
@@ -4359,7 +4381,7 @@ mod tests {
         use super::super::commands::test_agent_with_config;
         use crate::config::Config;
         let (mut agent, _temp) = test_agent_with_config(Config::default());
-        assert!(agent.emit_agent_verifier_external_import_rejected_if_first(
+        assert!(super::super::emit_verifier_events::emit_agent_verifier_external_import_rejected_if_first(&mut agent,
             "python3",
             "external_pythonpath_rejected",
             &[("hash1", "pythonpath")],
@@ -4368,7 +4390,7 @@ mod tests {
         ));
         // Second emit in the same turn (different reason / different hashes)
         // must be suppressed by the per-turn cap.
-        let again = agent.emit_agent_verifier_external_import_rejected_if_first(
+        let again = super::super::emit_verifier_events::emit_agent_verifier_external_import_rejected_if_first(&mut agent,
             "python3",
             "external_import_detected",
             &[("hash2", "stdout_stderr")],
@@ -4389,7 +4411,7 @@ mod tests {
         use super::super::commands::test_agent_with_config;
         use crate::config::Config;
         let (mut agent, _temp) = test_agent_with_config(Config::default());
-        assert!(agent.emit_agent_verifier_external_import_rejected_if_first(
+        assert!(super::super::emit_verifier_events::emit_agent_verifier_external_import_rejected_if_first(&mut agent,
             "python3",
             "external_pythonpath_rejected",
             &[("hashX", "pythonpath")],
@@ -4397,7 +4419,7 @@ mod tests {
             false,
         ));
         agent.external_import_rejected_emitted_this_turn = false;
-        let again = agent.emit_agent_verifier_external_import_rejected_if_first(
+        let again = super::super::emit_verifier_events::emit_agent_verifier_external_import_rejected_if_first(&mut agent,
             "python3",
             "external_pythonpath_rejected",
             &[("hashX", "pythonpath")],

--- a/src/agent/loop_run/verifier_orchestration.rs
+++ b/src/agent/loop_run/verifier_orchestration.rs
@@ -2611,10 +2611,11 @@ pub(super) fn handle_structured_task_contract_verifier_selection(
         &selection.command,
     );
     if let Some(snapshot) = invocation_report.snapshot.as_ref() {
-        agent.emit_agent_verifier_invoked_if_new(snapshot);
+        super::emit_verifier_events::emit_agent_verifier_invoked_if_new(agent, snapshot);
     }
     if let Some(hash) = invocation_report.rejected_pythonpath_hash.as_deref() {
-        agent.emit_agent_verifier_external_import_rejected_if_first(
+        super::emit_verifier_events::emit_agent_verifier_external_import_rejected_if_first(
+            agent,
             selection.command.runner(),
             "external_pythonpath_rejected",
             &[(hash, "pythonpath")],
@@ -2690,7 +2691,8 @@ pub(super) fn finish_structured_task_contract_verifier_selection(
                 &result.stderr,
             );
         let borrowed = contamination.borrowed_hashes();
-        agent.emit_agent_verifier_external_import_rejected_if_first(
+        super::emit_verifier_events::emit_agent_verifier_external_import_rejected_if_first(
+            agent,
             selection.command.runner(),
             "external_import_detected",
             &borrowed,


### PR DESCRIPTION
## Summary

Sixth **vertical-slice extraction**: move the two verifier-event emitters out of `turn.rs` into a new `src/agent/loop_run/emit_verifier_events.rs` sibling module.

### Migrated (all `pub(super)` free fns over `&mut Agent`)

- `emit_agent_verifier_invoked_if_new` — pre-spawn `agent.verifier.invoked` event with per-turn payload-digest dedup. Applies `mask_payload_inplace` **before** computing the digest so the dedup key matches the post-mask representation log consumers see (DR1-004).
- `emit_agent_verifier_external_import_rejected_if_first` — single-shot per-turn `agent.verifier.external_import_rejected` event. Both pre-exec (PYTHONPATH) and post-exec (stdout/stderr) external-import detectors wire through this SSOT.

Both functions consult `Agent.last_verifier_invoked_payload_digest` and `Agent.external_import_rejected_emitted_this_turn` fields (already `pub(in crate::agent::loop_run)`, no visibility change needed).

No facade re-export (DR3-001).

### Caller updates
- `verifier_orchestration.rs` ×3: `agent.X(...)` → `super::emit_verifier_events::X(agent, ...)`
- `turn_tests.rs` ×13 test sites: `agent.X(...)` → `super::super::emit_verifier_events::X(&mut agent, ...)`

## LOC delta

- `turn.rs`: 5,883 → **5,801 LOC** (-82 LOC)
- New `emit_verifier_events.rs`: 103 LOC
- **Cumulative from 39,489: -33,688 LOC (-85.3%)**

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --lib --all-targets -- -D warnings` clean
- [x] `cargo test --lib` (3,114 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)