### PR TITLE
Extract verifier_observation.rs from turn.rs (parent #680)

### DIFF
--- a/src/agent/loop_run.rs
+++ b/src/agent/loop_run.rs
@@ -108,6 +108,12 @@ mod python_markers;
 // per-turn cap). Both apply `mask_payload_inplace` as final defence.
 // `pub(super)` limited / no facade re-export (DR3-001).
 mod emit_verifier_events;
+// Task-contract verifier observation hooks extracted from `turn.rs`
+// (parent #680). Hosts `record_task_contract_verifier_invocation`,
+// `observe_task_contract_verifier_exit_zero`, and
+// `observe_task_contract_verifier_exit_zero_bound` — all free fns over
+// `&mut Agent`. `pub(super)` limited / no facade re-export (DR3-001).
+mod verifier_observation;
 // Issue #652: `ArtifactCompletionJob` + role-specific retry budget +
 // `ArtifactAttemptOutcome` 4-variant taxonomy +
 // `ArtifactCompletionFailureSnapshot` for #654. Module is intentionally

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -75,9 +75,7 @@ use super::verifier_driver::TaskContractVerifierOutcome;
 use super::verifier_orchestration::{
     JobInstallOutcome, PreparedVerifierDiagnosticPass, PreparedVerifierRepairPass,
     TaskContractVerifierFlowArgs, VerifierDiagnosticPassOutcome, VerifierRepairAttemptProgress,
-    build_task_contract_verifier_exit_zero_evidence,
-    build_task_contract_verifier_exit_zero_evidence_bound, build_verifier_exit_zero_evidence,
-    emit_patch_proposal_legacy_validation_comparison_event,
+    build_verifier_exit_zero_evidence, emit_patch_proposal_legacy_validation_comparison_event,
     emit_patch_proposal_shadow_validation_event, emit_repair_progress_classified_event,
     repair_terminal_exit_reason, synthesized_missing_implementation_target_path_for_request,
     synthesized_missing_test_target_path_for_request, task_contract_needs_verification,
@@ -1190,69 +1188,6 @@ impl Agent {
         self.emit_repair_safe_stop_report(stop_reason);
     }
 
-    pub(super) fn record_task_contract_verifier_invocation(
-        &mut self,
-        command: &str,
-        exit_code: Option<i32>,
-    ) {
-        let redacted = crate::session::feedback::redact_verifier_command_for_storage(command);
-        if redacted.trim().is_empty() {
-            return;
-        }
-        self.session.last_verifier_command = Some(redacted.clone());
-        self.session.last_verifier_invocation =
-            Some(crate::session::store::VerifierInvocationRecord {
-                command: redacted,
-                exit_code: exit_code.unwrap_or(-1),
-                recorded_at: rfc3339_now_utc(),
-            });
-    }
-
-    pub(super) fn observe_task_contract_verifier_exit_zero(&mut self, command: &str) {
-        if let Some(evidence) = build_task_contract_verifier_exit_zero_evidence(command) {
-            self.evidence_set_this_turn.push(evidence.clone());
-            self.task_contract_evidence_set_this_turn.push(evidence);
-            crate::logging::log_completion_evidence_observed(
-                self.current_turn_index,
-                0,
-                "verifier_exit_zero",
-                serde_json::json!({
-                    "command_class": "build_test",
-                    "source": "task_contract_verifier",
-                }),
-            );
-        }
-    }
-
-    /// Issue #651 PR-001: structured-runner variant of
-    /// `observe_task_contract_verifier_exit_zero`. Records a verifier
-    /// success that came through `AutoTestRunner::run_structured`, i.e.
-    /// the runner's argv was validated against the owned test artifact
-    /// list. The recorded `bound_test_artifacts_count` is the only proof
-    /// `TaskContract::evaluate_with_owned_test_artifacts` accepts to
-    /// satisfy `test_execution_required = true`.
-    pub(super) fn observe_task_contract_verifier_exit_zero_bound(
-        &mut self,
-        command: &str,
-        bound_count: usize,
-    ) {
-        if let Some(evidence) =
-            build_task_contract_verifier_exit_zero_evidence_bound(command, bound_count)
-        {
-            self.evidence_set_this_turn.push(evidence.clone());
-            self.task_contract_evidence_set_this_turn.push(evidence);
-            crate::logging::log_completion_evidence_observed(
-                self.current_turn_index,
-                0,
-                "verifier_exit_zero",
-                serde_json::json!({
-                    "command_class": "build_test",
-                    "source": "task_contract_verifier_structured",
-                    "bound_test_artifacts_count": bound_count,
-                }),
-            );
-        }
-    }
     pub(super) fn request_assistant_reply_with_retry(
         &mut self,
         stream_output: bool,

--- a/src/agent/loop_run/verifier_observation.rs
+++ b/src/agent/loop_run/verifier_observation.rs
@@ -1,0 +1,93 @@
+//! Task-contract verifier observation hooks extracted from `turn.rs`
+//! (parent #680).
+//!
+//! Hosts three production entry points that record the outcome of a
+//! task-contract verifier invocation onto Agent state:
+//!
+//! - `record_task_contract_verifier_invocation` — capture the
+//!   most-recent verifier command + exit code in session state for
+//!   downstream consumers (case_photon_bridge, eval_log).
+//! - `observe_task_contract_verifier_exit_zero` — record a
+//!   verifier_exit_zero completion-evidence entry from a non-bound run.
+//! - `observe_task_contract_verifier_exit_zero_bound` — Issue #651 PR-001
+//!   structured-runner variant; records a bound `bound_test_artifacts_count`
+//!   so `TaskContract::evaluate_with_owned_test_artifacts` can satisfy
+//!   `test_execution_required = true`.
+//!
+//! Originally `impl Agent` methods; converted to free functions taking
+//! `&mut Agent`, matching the `actor_loop_flow` / `python_markers` /
+//! `emit_verifier_events` pattern. `pub(super)` limited / no facade
+//! re-export (DR3-001).
+
+use super::Agent;
+use super::small_helpers::rfc3339_now_utc;
+use super::verifier_orchestration::{
+    build_task_contract_verifier_exit_zero_evidence,
+    build_task_contract_verifier_exit_zero_evidence_bound,
+};
+use crate::logging::log_completion_evidence_observed;
+use crate::session::feedback::redact_verifier_command_for_storage;
+use crate::session::store::VerifierInvocationRecord;
+
+pub(super) fn record_task_contract_verifier_invocation(
+    agent: &mut Agent,
+    command: &str,
+    exit_code: Option<i32>,
+) {
+    let redacted = redact_verifier_command_for_storage(command);
+    if redacted.trim().is_empty() {
+        return;
+    }
+    agent.session.last_verifier_command = Some(redacted.clone());
+    agent.session.last_verifier_invocation = Some(VerifierInvocationRecord {
+        command: redacted,
+        exit_code: exit_code.unwrap_or(-1),
+        recorded_at: rfc3339_now_utc(),
+    });
+}
+
+pub(super) fn observe_task_contract_verifier_exit_zero(agent: &mut Agent, command: &str) {
+    if let Some(evidence) = build_task_contract_verifier_exit_zero_evidence(command) {
+        agent.evidence_set_this_turn.push(evidence.clone());
+        agent.task_contract_evidence_set_this_turn.push(evidence);
+        log_completion_evidence_observed(
+            agent.current_turn_index,
+            0,
+            "verifier_exit_zero",
+            serde_json::json!({
+                "command_class": "build_test",
+                "source": "task_contract_verifier",
+            }),
+        );
+    }
+}
+
+/// Issue #651 PR-001: structured-runner variant of
+/// `observe_task_contract_verifier_exit_zero`. Records a verifier
+/// success that came through `AutoTestRunner::run_structured`, i.e.
+/// the runner's argv was validated against the owned test artifact
+/// list. The recorded `bound_test_artifacts_count` is the only proof
+/// `TaskContract::evaluate_with_owned_test_artifacts` accepts to
+/// satisfy `test_execution_required = true`.
+pub(super) fn observe_task_contract_verifier_exit_zero_bound(
+    agent: &mut Agent,
+    command: &str,
+    bound_count: usize,
+) {
+    if let Some(evidence) =
+        build_task_contract_verifier_exit_zero_evidence_bound(command, bound_count)
+    {
+        agent.evidence_set_this_turn.push(evidence.clone());
+        agent.task_contract_evidence_set_this_turn.push(evidence);
+        log_completion_evidence_observed(
+            agent.current_turn_index,
+            0,
+            "verifier_exit_zero",
+            serde_json::json!({
+                "command_class": "build_test",
+                "source": "task_contract_verifier_structured",
+                "bound_test_artifacts_count": bound_count,
+            }),
+        );
+    }
+}

--- a/src/agent/loop_run/verifier_orchestration.rs
+++ b/src/agent/loop_run/verifier_orchestration.rs
@@ -2359,9 +2359,16 @@ pub(super) fn handle_legacy_task_contract_verifier_selection(
         changed_files,
     );
     agent.session.record_feedback_if_unset(frame);
-    agent.record_task_contract_verifier_invocation(&result.command, result.exit_code);
+    super::verifier_observation::record_task_contract_verifier_invocation(
+        agent,
+        &result.command,
+        result.exit_code,
+    );
     if result.passed {
-        agent.observe_task_contract_verifier_exit_zero(&result.command);
+        super::verifier_observation::observe_task_contract_verifier_exit_zero(
+            agent,
+            &result.command,
+        );
     }
     super::verifier_driver::task_contract_auto_test_result_to_outcome(result)
 }
@@ -2708,7 +2715,11 @@ pub(super) fn finish_structured_task_contract_verifier_selection(
         changed_files,
     );
     agent.session.record_feedback_if_unset(frame);
-    agent.record_task_contract_verifier_invocation(&result.command, result.exit_code);
+    super::verifier_observation::record_task_contract_verifier_invocation(
+        agent,
+        &result.command,
+        result.exit_code,
+    );
     let last_outcome = if result.passed {
         super::artifact_ledger::VerifierOutcome::Pass
     } else {
@@ -2721,7 +2732,8 @@ pub(super) fn finish_structured_task_contract_verifier_selection(
         &scope_for_seed,
     );
     if result.passed {
-        agent.observe_task_contract_verifier_exit_zero_bound(
+        super::verifier_observation::observe_task_contract_verifier_exit_zero_bound(
+            agent,
             &result.command,
             selection.bound_test_artifacts_count,
         );


### PR DESCRIPTION
## Summary

Seventh **vertical-slice extraction**: move the task-contract verifier observation hooks out of `turn.rs` into a new `src/agent/loop_run/verifier_observation.rs` sibling module.

### Migrated (all `pub(super)` free fns over `&mut Agent`)

- `record_task_contract_verifier_invocation` — capture most-recent verifier command + exit code in session state for downstream consumers (case_photon_bridge, eval_log). Uses `session::feedback::redact_verifier_command_for_storage` as SSOT redactor.
- `observe_task_contract_verifier_exit_zero` — record a `verifier_exit_zero` completion-evidence entry from a non-bound run.
- `observe_task_contract_verifier_exit_zero_bound` — Issue #651 PR-001 structured-runner variant. Records a bound `bound_test_artifacts_count` so `TaskContract::evaluate_with_owned_test_artifacts` can satisfy `test_execution_required = true`.

No facade re-export (DR3-001).

### Caller updates
- `verifier_orchestration.rs` ×4: `agent.X(...)` → `super::verifier_observation::X(agent, ...)`

`cargo fix --tests` pruned 1 newly-unused import from `turn.rs`'s prelude.

## LOC delta

- `turn.rs`: 5,801 → **5,736 LOC** (-65 LOC)
- New `verifier_observation.rs`: 93 LOC
- **Cumulative from 39,489: -33,753 LOC (-85.5%)**

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --lib --all-targets -- -D warnings` clean
- [x] `cargo test --lib` (3,114 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)