### PR TITLE
Extract reply_retry.rs from turn.rs (parent #680)

### DIFF
--- a/src/agent/loop_run.rs
+++ b/src/agent/loop_run.rs
@@ -1,7 +1,6 @@
 use std::io::{self, IsTerminal, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::thread;
 
 use crate::agent::prompting;
 use crate::agent::recovery;
@@ -114,6 +113,13 @@ mod emit_verifier_events;
 // `observe_task_contract_verifier_exit_zero_bound` — all free fns over
 // `&mut Agent`. `pub(super)` limited / no facade re-export (DR3-001).
 mod verifier_observation;
+// Assistant-reply retry orchestration extracted from `turn.rs` (parent
+// #680). Hosts the retry loop entry point + 10 branch-by-branch error
+// handlers (format-error / timeout / transport / native-tool downgrade /
+// generic retry + actual Ollama dispatch). `current_assistant_model`
+// stays on Agent (5+ external call sites). `pub(super)` limited / no
+// facade re-export (DR3-001).
+mod reply_retry;
 // Issue #652: `ArtifactCompletionJob` + role-specific retry budget +
 // `ArtifactAttemptOutcome` 4-variant taxonomy +
 // `ArtifactCompletionFailureSnapshot` for #654. Module is intentionally

--- a/src/agent/loop_run/actor_loop_flow.rs
+++ b/src/agent/loop_run/actor_loop_flow.rs
@@ -2030,7 +2030,8 @@ pub(super) fn request_actor_loop_pre_reply_model_turn(
     args: &ActorLoopPreReplyArgs<'_, '_>,
     control_state: ActorLoopPreReplyControlState,
 ) -> ActorLoopPreReplyOutcome {
-    match agent.request_assistant_reply_with_retry(
+    match super::reply_retry::request_assistant_reply_with_retry(
+        agent,
         args.stream_output,
         args.interrupt_flag,
         control_state.recovery_dispatch_gate,

--- a/src/agent/loop_run/reply_retry.rs
+++ b/src/agent/loop_run/reply_retry.rs
@@ -1,0 +1,416 @@
+//! Assistant-reply retry orchestration extracted from `turn.rs`
+//! (parent #680).
+//!
+//! Hosts the retry loop and its branch-by-branch error handlers:
+//!
+//! - `request_assistant_reply_with_retry` (pub(super) entry point) —
+//!   freezes the footer / starts the spinner / loops over
+//!   `request_assistant_reply` with branch-specific recovery.
+//! - `handle_assistant_reply_retry_error` — error-routing core.
+//! - `maybe_disable_native_tools_after_request_error` — opportunistic
+//!   protocol downgrade.
+//! - `maybe_handle_assistant_reply_format_error` — tool-call format
+//!   error recovery (scaffold materialization / deterministic edits /
+//!   capability-gated finish / retry-with-note).
+//! - `push_tool_call_format_retry_note` — focused-edit-aware note
+//!   builder.
+//! - `maybe_handle_assistant_reply_timeout_error` — timeout recovery
+//!   (deterministic fallback / focused-edit retry).
+//! - `maybe_handle_assistant_reply_transport_error` — transport-error
+//!   backoff + plan-mode fallback bridge.
+//! - `finish_assistant_reply_retry` — generic per-attempt backoff
+//!   terminator.
+//! - `request_assistant_reply` / `request_streaming_assistant_reply` —
+//!   actual Ollama dispatch.
+//! - `maybe_finish_after_edit_format_error` — Issue #634 generic
+//!   format-error-after-successful-edit terminator.
+//!
+//! Originally `impl Agent` methods; converted to free functions taking
+//! `&mut Agent` / `&Agent`, matching `actor_loop_flow` /
+//! `anti_pattern_flow` / `case_record_flow` pattern. `current_assistant_model`
+//! stays on `Agent` because it has 5+ external call sites; this module
+//! reaches it via `agent.current_assistant_model()`.
+//!
+//! `pub(super)` limited / no facade re-export (DR3-001).
+
+use std::io::{self, IsTerminal};
+use std::thread;
+use std::time::Duration;
+
+use super::Agent;
+use super::active_job_arbiter::RecoveryDispatchGate;
+use super::actor_loop_flow::build_feedback_for_deterministic_content_fallback;
+use super::interrupt::InterruptFlag;
+use super::lifecycle;
+use super::model_request::{build_assistant_request_plan, request_non_streaming_assistant_reply};
+use super::spinner::{Spinner, SpinnerStopSignal};
+use super::tool_display::progress_path_display;
+use super::tool_history::successful_non_plan_repo_edit_count;
+use super::turn::{AssistantReplyRetryDecision, AssistantReplyRetryState, USER_INTERRUPT_ERROR};
+use crate::agent::prompting;
+use crate::agent::recovery;
+use crate::model_capabilities::model_capabilities;
+use crate::modes::plan_act::ExecutionMode;
+use crate::ollama::client::AssistantReply;
+use crate::session::store::ConversationMessage;
+use crate::tools::registry::ToolSpec;
+
+pub(super) fn request_assistant_reply_with_retry(
+    agent: &mut Agent,
+    stream_output: bool,
+    interrupt_flag: &InterruptFlag,
+    recovery_dispatch_gate: RecoveryDispatchGate,
+) -> Result<AssistantReply, String> {
+    // Issue #430 Phase D: freeze the footer for the entire LLM call (the
+    // thinking spinner writes to stderr, but stream chunks land on stdout
+    // and would otherwise race the footer rewrite). Guard drops on
+    // function exit alongside the spinner, restoring redraws.
+    let _footer_freeze = agent.footer.freeze_for_inference();
+    // Start spinner once at function entry; retries share the same
+    // animation (no flicker between attempts). Dropped automatically on
+    // function exit (Ok / Err / early-return), clearing the line.
+    let sp = Spinner::start(format!("thinking... ({})", agent.current_assistant_model()));
+    let mut retry_state =
+        AssistantReplyRetryState::new(agent.config.chat_retries, agent.session.messages.len());
+    loop {
+        // Only streaming paths need first-chunk stop; oneshot blocks until
+        // the whole reply is assembled so Drop is sufficient.
+        let stop_signal = sp.stop_signal();
+        match request_assistant_reply(agent, stream_output, stop_signal, interrupt_flag) {
+            Ok(reply) => return Ok(reply),
+            Err(err) => match handle_assistant_reply_retry_error(
+                agent,
+                err,
+                recovery_dispatch_gate,
+                &mut retry_state,
+            )? {
+                AssistantReplyRetryDecision::Retry => continue,
+                AssistantReplyRetryDecision::ReturnReply(reply) => return Ok(reply),
+                AssistantReplyRetryDecision::Fail(err) => return Err(err),
+            },
+        }
+    }
+}
+
+fn handle_assistant_reply_retry_error(
+    agent: &mut Agent,
+    err: String,
+    recovery_dispatch_gate: RecoveryDispatchGate,
+    retry_state: &mut AssistantReplyRetryState,
+) -> Result<AssistantReplyRetryDecision, String> {
+    if err == USER_INTERRUPT_ERROR {
+        return Ok(AssistantReplyRetryDecision::Fail(err));
+    }
+    if maybe_disable_native_tools_after_request_error(agent, &err, retry_state) {
+        return Ok(AssistantReplyRetryDecision::Retry);
+    }
+    if let Some(decision) =
+        maybe_handle_assistant_reply_format_error(agent, &err, recovery_dispatch_gate, retry_state)?
+    {
+        return Ok(decision);
+    }
+    if let Some(decision) =
+        maybe_handle_assistant_reply_timeout_error(agent, &err, recovery_dispatch_gate, retry_state)
+    {
+        return Ok(decision);
+    }
+    if let Some(decision) = maybe_handle_assistant_reply_transport_error(agent, &err, retry_state)?
+    {
+        return Ok(decision);
+    }
+    Ok(finish_assistant_reply_retry(agent, err, retry_state))
+}
+
+fn maybe_disable_native_tools_after_request_error(
+    agent: &mut Agent,
+    err: &str,
+    retry_state: &mut AssistantReplyRetryState,
+) -> bool {
+    if agent.native_tools_enabled
+        && !retry_state.downgraded_native_tools
+        && (lifecycle::is_native_tool_parser_failure(err)
+            || lifecycle::is_native_tool_transport_failure(err))
+    {
+        retry_state.downgraded_native_tools = true;
+        agent.disable_native_tools_for_session();
+        return true;
+    }
+    false
+}
+
+fn maybe_handle_assistant_reply_format_error(
+    agent: &mut Agent,
+    err: &str,
+    recovery_dispatch_gate: RecoveryDispatchGate,
+    retry_state: &mut AssistantReplyRetryState,
+) -> Result<Option<AssistantReplyRetryDecision>, String> {
+    if let Some(reply) =
+        super::scaffold_pipeline::maybe_materialize_plan_after_tool_call_format_error(agent, err)?
+    {
+        return Ok(Some(AssistantReplyRetryDecision::ReturnReply(reply)));
+    }
+    // Issue #634: Format-error 経路の制御フロー不変条件 (SSOT)
+    //   (1) 評価順序固定: `maybe_apply_*` → `maybe_finish_*` の順で呼ぶ
+    //       (順序を変えると edit-then-finish の意味が崩れる)。
+    //   (2) flag off で apply は no-op (`Ok(None)`)。loop は次の
+    //       handler (`maybe_finish_*`) にフォールスルー。
+    //   (3) `maybe_finish_*` は capability gate (`finish_after_edit_format_error`)
+    //       のみで動く汎用 path (experimental flag 非依存)。
+    //       qwen3.5 ユーザーの format-error 後 finish は flag off
+    //       でも維持される。
+    if recovery_dispatch_gate.allows_deterministic_fallback()
+        && let Some(reply) =
+            super::scaffold_pipeline::maybe_apply_deterministic_edit_after_format_error(agent, err)?
+    {
+        return Ok(Some(AssistantReplyRetryDecision::ReturnReply(reply)));
+    }
+    if recovery_dispatch_gate.allows_generic_repo_change_recovery()
+        && let Some(reply) = maybe_finish_after_edit_format_error(agent, err)
+    {
+        return Ok(Some(AssistantReplyRetryDecision::ReturnReply(reply)));
+    }
+    if lifecycle::is_tool_call_format_error(err)
+        && retry_state.tool_call_format_retries_remaining > 0
+    {
+        retry_state.tool_call_format_retry_count += 1;
+        retry_state.tool_call_format_retries_remaining -= 1;
+        push_tool_call_format_retry_note(agent, err, retry_state.tool_call_format_retry_count);
+        return Ok(Some(AssistantReplyRetryDecision::Retry));
+    }
+    Ok(None)
+}
+
+fn push_tool_call_format_retry_note(agent: &mut Agent, err: &str, retry_count: usize) {
+    let lower_err = err.to_ascii_lowercase();
+    let effective_tool_policy = agent.effective_tool_policy();
+    if let Some(policy) = effective_tool_policy.focused_edit_policy() {
+        let target = &policy.target;
+        let target_already_read = policy.target_already_read;
+        let target_display = progress_path_display(
+            &target.display().to_string(),
+            &agent.work_root,
+            agent.session.mode_state.active_plan_path.as_deref(),
+            120,
+        );
+        if !target.is_file() {
+            agent.push_system_note(recovery::focused_edit_missing_target_recovery_note(
+                &target_display,
+                retry_count,
+            ));
+            return;
+        }
+        if lower_err.contains("truncated tool call") {
+            agent.push_system_note(recovery::focused_edit_truncated_tool_call_note(
+                &target_display,
+                target_already_read,
+                retry_count,
+            ));
+            return;
+        }
+        if lower_err.contains("unterminated <anvil_tool_call> block") {
+            agent.push_system_note(recovery::focused_edit_unterminated_tool_call_note(
+                &target_display,
+                target_already_read,
+                retry_count,
+            ));
+            return;
+        }
+    }
+    agent.push_system_note(recovery::tool_call_format_recovery_note(err, retry_count));
+}
+
+fn maybe_handle_assistant_reply_timeout_error(
+    agent: &mut Agent,
+    err: &str,
+    recovery_dispatch_gate: RecoveryDispatchGate,
+    retry_state: &mut AssistantReplyRetryState,
+) -> Option<AssistantReplyRetryDecision> {
+    if !err.to_ascii_lowercase().contains("timed out") {
+        return None;
+    }
+    if recovery_dispatch_gate.allows_deterministic_fallback()
+        && let Some(reply) =
+            super::scaffold_pipeline::maybe_apply_deterministic_polish_fallback_after_timeout(
+                agent, err,
+            )
+    {
+        agent
+            .session
+            .record_feedback_if_unset(build_feedback_for_deterministic_content_fallback(
+                &agent.work_root,
+            ));
+        return Some(AssistantReplyRetryDecision::ReturnReply(reply));
+    }
+    let timeout_focused_policy = agent.effective_tool_policy().focused_edit_policy().cloned();
+    if let Some(policy) = timeout_focused_policy {
+        if recovery_dispatch_gate.allows_deterministic_fallback()
+            && let Some(reply) =
+                super::scaffold_pipeline::maybe_apply_deterministic_quality_fallback_after_timeout(
+                    agent, err,
+                )
+        {
+            agent.session.record_feedback_if_unset(
+                build_feedback_for_deterministic_content_fallback(&agent.work_root),
+            );
+            return Some(AssistantReplyRetryDecision::ReturnReply(reply));
+        }
+        retry_state.focused_edit_timeout_retry_count += 1;
+        if retry_state.focused_edit_timeout_retry_count >= 2 {
+            return Some(AssistantReplyRetryDecision::Fail(err.to_string()));
+        }
+        agent.push_system_note(recovery::focused_edit_timeout_recovery_note(
+            &progress_path_display(
+                &policy.target.display().to_string(),
+                &agent.work_root,
+                agent.session.mode_state.active_plan_path.as_deref(),
+                120,
+            ),
+            policy.target_already_read,
+            retry_state.focused_edit_timeout_retry_count,
+        ));
+        return Some(AssistantReplyRetryDecision::Retry);
+    }
+    None
+}
+
+fn maybe_handle_assistant_reply_transport_error(
+    agent: &mut Agent,
+    err: &str,
+    retry_state: &mut AssistantReplyRetryState,
+) -> Result<Option<AssistantReplyRetryDecision>, String> {
+    if !lifecycle::is_transport_error(err) || retry_state.extra_transport_retries == 0 {
+        return Ok(None);
+    }
+    if let Some(reply) = super::scaffold_pipeline::maybe_materialize_plan_after_timeout(agent, err)?
+    {
+        return Ok(Some(AssistantReplyRetryDecision::ReturnReply(reply)));
+    }
+    if super::scaffold_pipeline::maybe_fallback_plan_model_after_timeout(agent, err) {
+        return Ok(Some(AssistantReplyRetryDecision::Retry));
+    }
+    retry_state.transport_retry_count += 1;
+    retry_state.extra_transport_retries -= 1;
+    thread::sleep(Duration::from_secs(
+        (retry_state.transport_retry_count as u64) * 4,
+    ));
+    Ok(Some(AssistantReplyRetryDecision::Retry))
+}
+
+fn finish_assistant_reply_retry(
+    agent: &Agent,
+    err: String,
+    retry_state: &mut AssistantReplyRetryState,
+) -> AssistantReplyRetryDecision {
+    if retry_state.retries_remaining == 0 {
+        return AssistantReplyRetryDecision::Fail(err);
+    }
+    let sleep_secs = (agent.config.chat_retries - retry_state.retries_remaining + 1) as u64 * 2;
+    retry_state.retries_remaining -= 1;
+    thread::sleep(Duration::from_secs(sleep_secs));
+    AssistantReplyRetryDecision::Retry
+}
+
+fn request_assistant_reply(
+    agent: &mut Agent,
+    stream_output: bool,
+    stop_signal: Option<SpinnerStopSignal>,
+    interrupt_flag: &InterruptFlag,
+) -> Result<AssistantReply, String> {
+    let protocol = prompting::ToolProtocol::from_native_tools_enabled(agent.native_tools_enabled);
+    let native_tools_enabled = protocol.native_tools_enabled();
+    let effective_tool_policy = agent.effective_tool_policy();
+    let focused_edit_target = effective_tool_policy
+        .focused_edit_policy()
+        .map(|policy| policy.target.as_path());
+    let messages = agent.build_request_messages(protocol, &effective_tool_policy);
+    let assistant_model = agent.current_assistant_model();
+    let request_plan = build_assistant_request_plan(
+        assistant_model.as_str(),
+        native_tools_enabled,
+        stream_output,
+        io::stdin().is_terminal(),
+        &agent.session.messages,
+        focused_edit_target,
+        &agent.work_root,
+    );
+    let tool_specs = agent.tool_specs_for_policy(&effective_tool_policy);
+
+    if request_plan.use_streaming_transport {
+        request_streaming_assistant_reply(
+            agent,
+            &messages,
+            &tool_specs,
+            native_tools_enabled,
+            stream_output,
+            stop_signal,
+            interrupt_flag,
+        )
+    } else {
+        request_non_streaming_assistant_reply(
+            &agent.client,
+            assistant_model.as_str(),
+            &messages,
+            &tool_specs,
+            native_tools_enabled,
+            request_plan.focused_edit_timeout_override,
+            request_plan.focused_edit_max_predict_override,
+        )
+    }
+}
+
+fn request_streaming_assistant_reply(
+    agent: &Agent,
+    messages: &[ConversationMessage],
+    tool_specs: &[ToolSpec],
+    native_tools_enabled: bool,
+    stream_output: bool,
+    stop_signal: Option<SpinnerStopSignal>,
+    interrupt_flag: &InterruptFlag,
+) -> Result<AssistantReply, String> {
+    let assistant_model = agent.current_assistant_model();
+    let mut render_state = super::streaming_reply::StreamingReplyRenderState::new();
+    let reply = agent.client.chat_streaming_with_mode(
+        assistant_model.as_str(),
+        messages,
+        tool_specs,
+        native_tools_enabled,
+        |chunk| {
+            super::streaming_reply::handle_streaming_assistant_chunk(
+                &mut render_state,
+                chunk,
+                stream_output,
+                stop_signal.as_ref(),
+                interrupt_flag,
+            )
+        },
+    )?;
+    super::streaming_reply::finish_streaming_assistant_reply(&mut render_state, stream_output);
+    Ok(reply)
+}
+
+/// Issue #634: 旧名 `maybe_finish_after_qwen35_edit_format_error`。
+/// 「format error でも edit success なら finish」というモデル非依存の汎用
+/// (experimental flag 非依存)。
+fn maybe_finish_after_edit_format_error(agent: &Agent, err: &str) -> Option<AssistantReply> {
+    if !lifecycle::is_tool_call_format_error(err)
+        || !model_capabilities(&agent.current_assistant_model()).finish_after_edit_format_error
+        || agent.session.mode_state.mode != ExecutionMode::Act
+    {
+        return None;
+    }
+    if agent.active_python_request_requires_tests() && !agent.python_test_artifact_exists() {
+        return None;
+    }
+    let edits = successful_non_plan_repo_edit_count(
+        &agent.session.messages,
+        &agent.work_root,
+        agent.session.mode_state.active_plan_path.as_deref(),
+    );
+    (edits > 0).then(|| AssistantReply {
+        content: "Applied the focused edit; stopping after a malformed follow-up tool call."
+            .to_string(),
+        tool_calls: Vec::new(),
+        prompt_tokens: None,
+        completion_tokens: None,
+    })
+}

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -1,15 +1,14 @@
 use super::active_job_arbiter::{
-    LoopControlAction, LoopControlInputs, RecoveryDispatchGate, RecoveryOwner,
-    build_active_job_selected_payload, determine_loop_control_action,
+    LoopControlAction, LoopControlInputs, RecoveryOwner, build_active_job_selected_payload,
+    determine_loop_control_action,
 };
 use super::actor_loop_flow::{
-    TaskContractVerifierFlowOutcome, build_feedback_for_deterministic_content_fallback,
-    format_iteration_status, repair_job_done_outcome, run_actor_loop,
+    TaskContractVerifierFlowOutcome, format_iteration_status, repair_job_done_outcome,
+    run_actor_loop,
 };
 use super::auto_test::{AutoTestKind, AutoTestRunner};
 use super::completion_evidence::is_repo_edit_no_op;
-use super::interrupt::{InterruptEnv, InterruptFlag, InterruptMonitor};
-use super::model_request::{build_assistant_request_plan, request_non_streaming_assistant_reply};
+use super::interrupt::{InterruptEnv, InterruptMonitor};
 use super::repair_driver::{
     VERIFIER_REPAIR_PASS_WALL_CLOCK_LIMIT_SECS, VerifierRepairPassOutcome,
     verifier_repair_pass_timeout_error,
@@ -49,7 +48,6 @@ use super::small_helpers::masked_path_hash_bounded_list;
 use super::small_helpers::{
     latest_tool_result_since_last_user, raw_mode_safe_text, rfc3339_now_utc, user_interrupt_result,
 };
-use super::spinner::{Spinner, SpinnerStopSignal};
 use super::summary::{ExitReason, LoopResult};
 use super::tool_display::progress_path_display;
 use super::tool_execution::{
@@ -125,24 +123,24 @@ const VERIFIER_DIAGNOSTIC_MAX_PREDICT: usize = 2_048;
 pub(super) const USER_INTERRUPT_ERROR: &str = "__anvil_user_interrupt__";
 
 #[derive(Debug, Clone, Copy)]
-struct AssistantReplyRetryState {
-    downgraded_native_tools: bool,
-    retries_remaining: usize,
-    tool_call_format_retries_remaining: usize,
-    extra_transport_retries: usize,
-    transport_retry_count: usize,
-    focused_edit_timeout_retry_count: usize,
-    tool_call_format_retry_count: usize,
+pub(super) struct AssistantReplyRetryState {
+    pub(super) downgraded_native_tools: bool,
+    pub(super) retries_remaining: usize,
+    pub(super) tool_call_format_retries_remaining: usize,
+    pub(super) extra_transport_retries: usize,
+    pub(super) transport_retry_count: usize,
+    pub(super) focused_edit_timeout_retry_count: usize,
+    pub(super) tool_call_format_retry_count: usize,
 }
 
-enum AssistantReplyRetryDecision {
+pub(super) enum AssistantReplyRetryDecision {
     Retry,
     ReturnReply(AssistantReply),
     Fail(String),
 }
 
 impl AssistantReplyRetryState {
-    fn new(chat_retries: usize, message_count: usize) -> Self {
+    pub(super) fn new(chat_retries: usize, message_count: usize) -> Self {
         Self {
             downgraded_native_tools: false,
             retries_remaining: chat_retries,
@@ -1187,345 +1185,6 @@ impl Agent {
         };
         self.emit_repair_safe_stop_report(stop_reason);
     }
-
-    pub(super) fn request_assistant_reply_with_retry(
-        &mut self,
-        stream_output: bool,
-        interrupt_flag: &InterruptFlag,
-        recovery_dispatch_gate: RecoveryDispatchGate,
-    ) -> Result<AssistantReply, String> {
-        // Issue #430 Phase D: freeze the footer for the entire LLM call (the
-        // thinking spinner writes to stderr, but stream chunks land on stdout
-        // and would otherwise race the footer rewrite). Guard drops on
-        // function exit alongside the spinner, restoring redraws.
-        let _footer_freeze = self.footer.freeze_for_inference();
-        // Start spinner once at function entry; retries share the same
-        // animation (no flicker between attempts). Dropped automatically on
-        // function exit (Ok / Err / early-return), clearing the line.
-        let sp = Spinner::start(format!("thinking... ({})", self.current_assistant_model()));
-        let mut retry_state =
-            AssistantReplyRetryState::new(self.config.chat_retries, self.session.messages.len());
-        loop {
-            // Only streaming paths need first-chunk stop; oneshot blocks until
-            // the whole reply is assembled so Drop is sufficient.
-            let stop_signal = sp.stop_signal();
-            match self.request_assistant_reply(stream_output, stop_signal, interrupt_flag) {
-                Ok(reply) => return Ok(reply),
-                Err(err) => match self.handle_assistant_reply_retry_error(
-                    err,
-                    recovery_dispatch_gate,
-                    &mut retry_state,
-                )? {
-                    AssistantReplyRetryDecision::Retry => continue,
-                    AssistantReplyRetryDecision::ReturnReply(reply) => return Ok(reply),
-                    AssistantReplyRetryDecision::Fail(err) => return Err(err),
-                },
-            }
-        }
-    }
-
-    fn handle_assistant_reply_retry_error(
-        &mut self,
-        err: String,
-        recovery_dispatch_gate: RecoveryDispatchGate,
-        retry_state: &mut AssistantReplyRetryState,
-    ) -> Result<AssistantReplyRetryDecision, String> {
-        if err == USER_INTERRUPT_ERROR {
-            return Ok(AssistantReplyRetryDecision::Fail(err));
-        }
-        if self.maybe_disable_native_tools_after_request_error(&err, retry_state) {
-            return Ok(AssistantReplyRetryDecision::Retry);
-        }
-        if let Some(decision) = self.maybe_handle_assistant_reply_format_error(
-            &err,
-            recovery_dispatch_gate,
-            retry_state,
-        )? {
-            return Ok(decision);
-        }
-        if let Some(decision) = self.maybe_handle_assistant_reply_timeout_error(
-            &err,
-            recovery_dispatch_gate,
-            retry_state,
-        ) {
-            return Ok(decision);
-        }
-        if let Some(decision) =
-            self.maybe_handle_assistant_reply_transport_error(&err, retry_state)?
-        {
-            return Ok(decision);
-        }
-        Ok(self.finish_assistant_reply_retry(err, retry_state))
-    }
-
-    fn maybe_disable_native_tools_after_request_error(
-        &mut self,
-        err: &str,
-        retry_state: &mut AssistantReplyRetryState,
-    ) -> bool {
-        if self.native_tools_enabled
-            && !retry_state.downgraded_native_tools
-            && (lifecycle::is_native_tool_parser_failure(err)
-                || lifecycle::is_native_tool_transport_failure(err))
-        {
-            retry_state.downgraded_native_tools = true;
-            self.disable_native_tools_for_session();
-            return true;
-        }
-        false
-    }
-
-    fn maybe_handle_assistant_reply_format_error(
-        &mut self,
-        err: &str,
-        recovery_dispatch_gate: RecoveryDispatchGate,
-        retry_state: &mut AssistantReplyRetryState,
-    ) -> Result<Option<AssistantReplyRetryDecision>, String> {
-        if let Some(reply) =
-            super::scaffold_pipeline::maybe_materialize_plan_after_tool_call_format_error(
-                self, err,
-            )?
-        {
-            return Ok(Some(AssistantReplyRetryDecision::ReturnReply(reply)));
-        }
-        // Issue #634: Format-error 経路の制御フロー不変条件 (SSOT)
-        //   (1) 評価順序固定: `maybe_apply_*` → `maybe_finish_*` の順で呼ぶ
-        //       (順序を変えると edit-then-finish の意味が崩れる)。
-        //   (2) flag off で apply は no-op (`Ok(None)`)。loop は次の
-        //       handler (`maybe_finish_*`) にフォールスルー。
-        //   (3) `maybe_finish_*` は capability gate (`finish_after_edit_format_error`)
-        //       のみで動く汎用 path (experimental flag 非依存)。
-        //       qwen3.5 ユーザーの format-error 後 finish は flag off
-        //       でも維持される。
-        if recovery_dispatch_gate.allows_deterministic_fallback()
-            && let Some(reply) =
-                super::scaffold_pipeline::maybe_apply_deterministic_edit_after_format_error(
-                    self, err,
-                )?
-        {
-            return Ok(Some(AssistantReplyRetryDecision::ReturnReply(reply)));
-        }
-        if recovery_dispatch_gate.allows_generic_repo_change_recovery()
-            && let Some(reply) = self.maybe_finish_after_edit_format_error(err)
-        {
-            return Ok(Some(AssistantReplyRetryDecision::ReturnReply(reply)));
-        }
-        if lifecycle::is_tool_call_format_error(err)
-            && retry_state.tool_call_format_retries_remaining > 0
-        {
-            retry_state.tool_call_format_retry_count += 1;
-            retry_state.tool_call_format_retries_remaining -= 1;
-            self.push_tool_call_format_retry_note(err, retry_state.tool_call_format_retry_count);
-            return Ok(Some(AssistantReplyRetryDecision::Retry));
-        }
-        Ok(None)
-    }
-
-    fn push_tool_call_format_retry_note(&mut self, err: &str, retry_count: usize) {
-        let lower_err = err.to_ascii_lowercase();
-        let effective_tool_policy = self.effective_tool_policy();
-        if let Some(policy) = effective_tool_policy.focused_edit_policy() {
-            let target = &policy.target;
-            let target_already_read = policy.target_already_read;
-            let target_display = progress_path_display(
-                &target.display().to_string(),
-                &self.work_root,
-                self.session.mode_state.active_plan_path.as_deref(),
-                120,
-            );
-            if !target.is_file() {
-                self.push_system_note(recovery::focused_edit_missing_target_recovery_note(
-                    &target_display,
-                    retry_count,
-                ));
-                return;
-            }
-            if lower_err.contains("truncated tool call") {
-                self.push_system_note(recovery::focused_edit_truncated_tool_call_note(
-                    &target_display,
-                    target_already_read,
-                    retry_count,
-                ));
-                return;
-            }
-            if lower_err.contains("unterminated <anvil_tool_call> block") {
-                self.push_system_note(recovery::focused_edit_unterminated_tool_call_note(
-                    &target_display,
-                    target_already_read,
-                    retry_count,
-                ));
-                return;
-            }
-        }
-        self.push_system_note(recovery::tool_call_format_recovery_note(err, retry_count));
-    }
-
-    fn maybe_handle_assistant_reply_timeout_error(
-        &mut self,
-        err: &str,
-        recovery_dispatch_gate: RecoveryDispatchGate,
-        retry_state: &mut AssistantReplyRetryState,
-    ) -> Option<AssistantReplyRetryDecision> {
-        if !err.to_ascii_lowercase().contains("timed out") {
-            return None;
-        }
-        if recovery_dispatch_gate.allows_deterministic_fallback()
-            && let Some(reply) =
-                super::scaffold_pipeline::maybe_apply_deterministic_polish_fallback_after_timeout(
-                    self, err,
-                )
-        {
-            self.session.record_feedback_if_unset(
-                build_feedback_for_deterministic_content_fallback(&self.work_root),
-            );
-            return Some(AssistantReplyRetryDecision::ReturnReply(reply));
-        }
-        let timeout_focused_policy = self.effective_tool_policy().focused_edit_policy().cloned();
-        if let Some(policy) = timeout_focused_policy {
-            if recovery_dispatch_gate.allows_deterministic_fallback()
-                && let Some(reply) =
-                    super::scaffold_pipeline::maybe_apply_deterministic_quality_fallback_after_timeout(self, err)
-            {
-                self.session.record_feedback_if_unset(
-                    build_feedback_for_deterministic_content_fallback(&self.work_root),
-                );
-                return Some(AssistantReplyRetryDecision::ReturnReply(reply));
-            }
-            retry_state.focused_edit_timeout_retry_count += 1;
-            if retry_state.focused_edit_timeout_retry_count >= 2 {
-                return Some(AssistantReplyRetryDecision::Fail(err.to_string()));
-            }
-            self.push_system_note(recovery::focused_edit_timeout_recovery_note(
-                &progress_path_display(
-                    &policy.target.display().to_string(),
-                    &self.work_root,
-                    self.session.mode_state.active_plan_path.as_deref(),
-                    120,
-                ),
-                policy.target_already_read,
-                retry_state.focused_edit_timeout_retry_count,
-            ));
-            return Some(AssistantReplyRetryDecision::Retry);
-        }
-        None
-    }
-
-    fn maybe_handle_assistant_reply_transport_error(
-        &mut self,
-        err: &str,
-        retry_state: &mut AssistantReplyRetryState,
-    ) -> Result<Option<AssistantReplyRetryDecision>, String> {
-        if !lifecycle::is_transport_error(err) || retry_state.extra_transport_retries == 0 {
-            return Ok(None);
-        }
-        if let Some(reply) =
-            super::scaffold_pipeline::maybe_materialize_plan_after_timeout(self, err)?
-        {
-            return Ok(Some(AssistantReplyRetryDecision::ReturnReply(reply)));
-        }
-        if super::scaffold_pipeline::maybe_fallback_plan_model_after_timeout(self, err) {
-            return Ok(Some(AssistantReplyRetryDecision::Retry));
-        }
-        retry_state.transport_retry_count += 1;
-        retry_state.extra_transport_retries -= 1;
-        thread::sleep(Duration::from_secs(
-            (retry_state.transport_retry_count as u64) * 4,
-        ));
-        Ok(Some(AssistantReplyRetryDecision::Retry))
-    }
-
-    fn finish_assistant_reply_retry(
-        &self,
-        err: String,
-        retry_state: &mut AssistantReplyRetryState,
-    ) -> AssistantReplyRetryDecision {
-        if retry_state.retries_remaining == 0 {
-            return AssistantReplyRetryDecision::Fail(err);
-        }
-        let sleep_secs = (self.config.chat_retries - retry_state.retries_remaining + 1) as u64 * 2;
-        retry_state.retries_remaining -= 1;
-        thread::sleep(Duration::from_secs(sleep_secs));
-        AssistantReplyRetryDecision::Retry
-    }
-
-    fn request_assistant_reply(
-        &mut self,
-        stream_output: bool,
-        stop_signal: Option<SpinnerStopSignal>,
-        interrupt_flag: &InterruptFlag,
-    ) -> Result<AssistantReply, String> {
-        let protocol =
-            prompting::ToolProtocol::from_native_tools_enabled(self.native_tools_enabled);
-        let native_tools_enabled = protocol.native_tools_enabled();
-        let effective_tool_policy = self.effective_tool_policy();
-        let focused_edit_target = effective_tool_policy
-            .focused_edit_policy()
-            .map(|policy| policy.target.as_path());
-        let messages = self.build_request_messages(protocol, &effective_tool_policy);
-        let assistant_model = self.current_assistant_model();
-        let request_plan = build_assistant_request_plan(
-            assistant_model.as_str(),
-            native_tools_enabled,
-            stream_output,
-            io::stdin().is_terminal(),
-            &self.session.messages,
-            focused_edit_target,
-            &self.work_root,
-        );
-        let tool_specs = self.tool_specs_for_policy(&effective_tool_policy);
-
-        if request_plan.use_streaming_transport {
-            self.request_streaming_assistant_reply(
-                &messages,
-                &tool_specs,
-                native_tools_enabled,
-                stream_output,
-                stop_signal,
-                interrupt_flag,
-            )
-        } else {
-            request_non_streaming_assistant_reply(
-                &self.client,
-                assistant_model.as_str(),
-                &messages,
-                &tool_specs,
-                native_tools_enabled,
-                request_plan.focused_edit_timeout_override,
-                request_plan.focused_edit_max_predict_override,
-            )
-        }
-    }
-
-    fn request_streaming_assistant_reply(
-        &self,
-        messages: &[ConversationMessage],
-        tool_specs: &[ToolSpec],
-        native_tools_enabled: bool,
-        stream_output: bool,
-        stop_signal: Option<SpinnerStopSignal>,
-        interrupt_flag: &InterruptFlag,
-    ) -> Result<AssistantReply, String> {
-        let assistant_model = self.current_assistant_model();
-        let mut render_state = super::streaming_reply::StreamingReplyRenderState::new();
-        let reply = self.client.chat_streaming_with_mode(
-            assistant_model.as_str(),
-            messages,
-            tool_specs,
-            native_tools_enabled,
-            |chunk| {
-                super::streaming_reply::handle_streaming_assistant_chunk(
-                    &mut render_state,
-                    chunk,
-                    stream_output,
-                    stop_signal.as_ref(),
-                    interrupt_flag,
-                )
-            },
-        )?;
-        super::streaming_reply::finish_streaming_assistant_reply(&mut render_state, stream_output);
-        Ok(reply)
-    }
-
     pub(super) fn current_assistant_model(&self) -> String {
         assistant_model_for_mode(
             self.session.mode_state.mode,
@@ -1533,36 +1192,7 @@ impl Agent {
             self.plan_model_override.as_deref(),
         )
     }
-
-    /// Issue #634: 旧名 `maybe_finish_after_qwen35_edit_format_error`。
-    /// 「format error でも edit success なら finish」というモデル非依存の汎用
-    /// 挙動を担う。`finish_after_edit_format_error` capability のみで gate される
-    /// (experimental flag 非依存)。
-    fn maybe_finish_after_edit_format_error(&self, err: &str) -> Option<AssistantReply> {
-        if !lifecycle::is_tool_call_format_error(err)
-            || !model_capabilities(&self.current_assistant_model()).finish_after_edit_format_error
-            || self.session.mode_state.mode != ExecutionMode::Act
-        {
-            return None;
-        }
-        if self.active_python_request_requires_tests() && !self.python_test_artifact_exists() {
-            return None;
-        }
-        let edits = successful_non_plan_repo_edit_count(
-            &self.session.messages,
-            &self.work_root,
-            self.session.mode_state.active_plan_path.as_deref(),
-        );
-        (edits > 0).then(|| AssistantReply {
-            content: "Applied the focused edit; stopping after a malformed follow-up tool call."
-                .to_string(),
-            tool_calls: Vec::new(),
-            prompt_tokens: None,
-            completion_tokens: None,
-        })
-    }
-
-    fn build_request_messages(
+    pub(super) fn build_request_messages(
         &mut self,
         protocol: prompting::ToolProtocol,
         effective_tool_policy: &EffectiveToolPolicy,
@@ -2471,7 +2101,7 @@ impl Agent {
         }
     }
 
-    fn tool_specs_for_policy(&self, policy: &EffectiveToolPolicy) -> Vec<ToolSpec> {
+    pub(super) fn tool_specs_for_policy(&self, policy: &EffectiveToolPolicy) -> Vec<ToolSpec> {
         let mut specs = self.tool_registry.specs().to_vec();
         if let Some(allowed_tools) = policy.allowed_tool_names_for_prompt() {
             specs.retain(|spec| allowed_tools.contains(&spec.function.name.as_str()));


### PR DESCRIPTION
## Summary

Eighth **vertical-slice extraction**: move the assistant-reply retry orchestration out of `turn.rs` into a new `src/agent/loop_run/reply_retry.rs` sibling module. Largest free-fn conversion in the series (11 methods).

### Migrated (all free fns over `&mut Agent` / `&Agent`)

**Entry point (`pub(super)`):**
- `request_assistant_reply_with_retry` — freezes footer, starts spinner, loops over `request_assistant_reply` with branch-specific recovery.

**Error-routing core + branch handlers (private):**
- `handle_assistant_reply_retry_error`
- `maybe_disable_native_tools_after_request_error`
- `maybe_handle_assistant_reply_format_error`
- `push_tool_call_format_retry_note`
- `maybe_handle_assistant_reply_timeout_error`
- `maybe_handle_assistant_reply_transport_error`
- `finish_assistant_reply_retry`

**Ollama dispatch (private):**
- `request_assistant_reply`
- `request_streaming_assistant_reply`

**Format-error terminator (private):**
- `maybe_finish_after_edit_format_error` (Issue #634)

`current_assistant_model` **stays on `impl Agent`** (5+ external call sites: turn.rs ×2, scaffold_pipeline.rs ×2, actor_loop_flow.rs ×1). The new module reaches it via `agent.current_assistant_model()`.

### Visibility promotions in turn.rs
- `AssistantReplyRetryState` struct + 7 fields → `pub(super)`
- `AssistantReplyRetryDecision` enum → `pub(super)`
- `AssistantReplyRetryState::new` → `pub(super)`
- `build_request_messages` method → `pub(super)`
- `tool_specs_for_policy` method → `pub(super)`

No facade re-export (DR3-001).

### Caller updates
- `actor_loop_flow.rs`: `agent.request_assistant_reply_with_retry(...)` → `super::reply_retry::request_assistant_reply_with_retry(agent, ...)`

`cargo fix --tests` pruned 7 newly-unused imports across turn.rs / loop_run.rs / the new module.

## LOC delta

- `turn.rs`: 5,736 → **5,366 LOC** (-370 LOC)
- New `reply_retry.rs`: 416 LOC
- **Cumulative from 39,489: -34,123 LOC (-86.4%)**

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --lib --all-targets -- -D warnings` clean
- [x] `cargo test --lib` (3,114 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)