### PR TITLE
Extract effective_tool_policy_flow.rs from turn.rs (parent #680)

### DIFF
--- a/src/agent/loop_run.rs
+++ b/src/agent/loop_run.rs
@@ -131,6 +131,12 @@ mod repair_job_dispatch;
 // message appenders). All free fns over `&mut Agent` / `&Agent`.
 // `pub(super)` limited / no facade re-export (DR3-001).
 mod build_request_messages;
+// Effective-tool-policy + arbiter candidate selection extracted from
+// `turn.rs` (parent #680). Hosts `effective_tool_policy` (pub(super)
+// entry point), `build_arbiter_candidates` (pub(super)), and 5 private
+// helpers as free fns over `&Agent`. Replaces former `impl Agent`
+// methods. `pub(super)` limited / no facade re-export (DR3-001).
+mod effective_tool_policy_flow;
 // Issue #652: `ArtifactCompletionJob` + role-specific retry budget +
 // `ArtifactAttemptOutcome` 4-variant taxonomy +
 // `ArtifactCompletionFailureSnapshot` for #654. Module is intentionally

--- a/src/agent/loop_run/actor_loop_flow.rs
+++ b/src/agent/loop_run/actor_loop_flow.rs
@@ -1751,7 +1751,7 @@ pub(super) fn drive_actor_loop_tool_preparation_phase(
         .collect::<Vec<_>>();
     record_actor_loop_tool_call_summaries(&prepared_tool_calls, args.tool_call_summaries);
 
-    let effective_tool_policy = agent.effective_tool_policy();
+    let effective_tool_policy = super::effective_tool_policy_flow::effective_tool_policy(agent);
     if effective_tool_policy
         .allowed_tool_names_for_prompt()
         .is_some()

--- a/src/agent/loop_run/effective_tool_policy_flow.rs
+++ b/src/agent/loop_run/effective_tool_policy_flow.rs
@@ -1,0 +1,300 @@
+//! Effective-tool-policy + arbiter candidate selection extracted from
+//! `turn.rs` (parent #680).
+//!
+//! Hosts the `EffectiveToolPolicy` decision pipeline:
+//!
+//! - `effective_tool_policy` (pub(super) entry point) — pre-arbitration
+//!   gates (AnswerOnly / Plan mode) + the arbiter-based shell over
+//!   `build_arbiter_candidates` + `select_active_job` + `project_policy`.
+//! - `build_arbiter_candidates` (pub(super)) — composes the priority-1
+//!   through priority-6 candidate list per #660 design.
+//! - `priority_one_arbiter_candidates` (private) — VerifierRepair /
+//!   MissingVerifierCreate branches via `determine_loop_control_action`.
+//! - `setup_bootstrap_candidate` (private) — Issue #664 (AD22)
+//!   SetupBootstrap policy decision tree (`TaskContract` +
+//!   `BehaviorContractProjection` + `VerifierPrerequisiteSignal`).
+//! - `push_focused_edit_candidate` (private) — shared focused-edit
+//!   candidate builder.
+//! - `verifier_repair_policy_for_next_action` (private) — RepairJob
+//!   next-action → EffectiveToolPolicy branching.
+//! - `focused_edit_policy_for_target` (private) — Write/Edit/Read+Edit
+//!   policy by target existence + already_read state.
+//!
+//! Originally `impl Agent` methods; converted to free functions taking
+//! `&Agent`, matching `actor_loop_flow` / `reply_retry` / earlier
+//! vertical-slice patterns. `pub(super)` limited / no facade re-export
+//! (DR3-001).
+
+use std::path::PathBuf;
+
+use super::Agent;
+use super::active_job_arbiter::{
+    ActiveJobKind, Budget, DesiredAction, JobCandidate, LoopControlAction, LoopControlInputs,
+    determine_loop_control_action, project_policy, select_active_job,
+    should_install_setup_bootstrap,
+};
+use super::tool_history::focused_edit_target_already_read;
+use super::tool_policy::{EffectiveToolPolicy, EffectiveToolPolicyReason};
+use super::verifier_orchestration::verifier_repair_policy_for_target_hint;
+use crate::modes::plan_act::{ExecutionMode, WorkMode};
+
+pub(super) fn effective_tool_policy(agent: &Agent) -> EffectiveToolPolicy {
+    // Issue #660: `AnswerOnlyMode` is a pre-arbitration gate (priority 0
+    // in §4 of the design policy). The arbiter never sees it; we early-
+    // return before constructing any selectable `JobCandidate`.
+    if agent.answer_only_mode_active() {
+        if agent.workspace_appears_empty() {
+            return EffectiveToolPolicy::restricted(
+                EffectiveToolPolicyReason::AnswerOnly,
+                Vec::new(),
+            );
+        }
+        if agent.script_execution_requested() {
+            return EffectiveToolPolicy::restricted(
+                EffectiveToolPolicyReason::AnswerOnly,
+                vec!["Read", "Glob", "Grep", "Bash"],
+            );
+        } else {
+            return EffectiveToolPolicy::restricted(
+                EffectiveToolPolicyReason::AnswerOnly,
+                vec!["Read", "Glob", "Grep"],
+            );
+        }
+    }
+
+    // Issue #660 (Codex CB-001 / §4 design table): `PlanModeGate` is also
+    // a pre-arbitration gate, not a selectable arbitration kind. The
+    // Plan-file Write/Edit exception is the authority of
+    // `src/tools/registry.rs::resolve_plan_mode_write_target` /
+    // `enforce_plan_stage_scope`; the arbiter must not pre-empt that
+    // decision with stale `task_contract_verifier_repair_pending` or
+    // other selectable state.
+    if agent.session.mode_state.mode == ExecutionMode::Plan {
+        return EffectiveToolPolicy::unrestricted();
+    }
+
+    // Issue #660 (Phase E): arbiter is the **sole authority** for write
+    // owner selection. `effective_tool_policy` is now a thin shell over
+    // `build_arbiter_candidates` + `select_active_job` + `project_policy`.
+    let candidates = build_arbiter_candidates(agent);
+    let selection = select_active_job(&candidates);
+    project_policy(&selection)
+}
+
+/// Issue #660: build the arbiter candidate list from the same source
+/// signals the legacy chain reads. Per DR1-004 only candidates with a
+/// determined `desired_action` are pushed — there is no
+/// `RejectionReason::NoDesiredAction`.
+pub(super) fn build_arbiter_candidates(agent: &Agent) -> Vec<JobCandidate> {
+    if let Some(candidates) = priority_one_arbiter_candidates(agent) {
+        return candidates;
+    }
+
+    let mut candidates: Vec<JobCandidate> = Vec::new();
+
+    // Priority 2: ForcedSmallEditRecovery.
+    if let Some(target) = agent.forced_small_edit_recovery_target() {
+        push_focused_edit_candidate(
+            agent,
+            &mut candidates,
+            target,
+            ActiveJobKind::ForcedSmallEditRecovery,
+            EffectiveToolPolicyReason::FocusedEditRecovery,
+        );
+    }
+
+    // Priority 3: ArtifactRecovery.
+    if let (Some(target), Some(job)) = (
+        agent.artifact_recovery_target_path(),
+        agent.artifact_completion_job.as_ref(),
+    ) {
+        let target_already_read =
+            focused_edit_target_already_read(&agent.session.messages, &target, &agent.work_root);
+        let policy = EffectiveToolPolicy::artifact_directed_from_job(
+            target.clone(),
+            target_already_read,
+            job.allowed_write_actions(),
+            job.allowed_read_scope(),
+        );
+        let write_actions = job.allowed_write_actions().clone();
+        let read_scope = job.allowed_read_scope().clone();
+        candidates.push(JobCandidate {
+            kind: ActiveJobKind::ArtifactRecovery,
+            desired_action: DesiredAction::ArtifactDirected {
+                target,
+                already_read: target_already_read,
+                write_actions,
+                read_scope,
+            },
+            policy,
+            budget: Budget::Unbounded,
+        });
+    }
+
+    // Issue #664 (Priority 4 / AD22): SetupBootstrap candidate.
+    if let Some(candidate) = setup_bootstrap_candidate(agent) {
+        candidates.push(candidate);
+    }
+
+    // Priority 5: FocusedEditRecovery.
+    if let Some(target) = agent.focused_edit_recovery_target() {
+        push_focused_edit_candidate(
+            agent,
+            &mut candidates,
+            target,
+            ActiveJobKind::FocusedEditRecovery,
+            EffectiveToolPolicyReason::FocusedEditRecovery,
+        );
+    }
+
+    // Priority 6: LocalLlmSmallEditAfterRead.
+    if let Some(target) = agent.local_llm_small_edit_target() {
+        push_focused_edit_candidate(
+            agent,
+            &mut candidates,
+            target,
+            ActiveJobKind::LocalLlmSmallEditAfterRead,
+            EffectiveToolPolicyReason::LocalLlmSmallEditAfterRead,
+        );
+    }
+
+    candidates
+}
+
+fn priority_one_arbiter_candidates(agent: &Agent) -> Option<Vec<JobCandidate>> {
+    match determine_loop_control_action(LoopControlInputs {
+        mode: agent.session.mode_state.mode,
+        task_contract_verifier_repair_pending: agent.task_contract_verifier_repair_pending,
+        repair_next_action: agent.repair_job.as_ref().map(|job| job.next_action()),
+        missing_verifier_next_action: agent
+            .missing_verifier_job
+            .as_ref()
+            .map(|job| job.next_action()),
+        task_contract_action: None,
+    }) {
+        LoopControlAction::ContinueRepairJob { next_action } => {
+            let target_hint = match &next_action {
+                super::repair_job::RepairNextAction::RequestPatch { target_hint } => {
+                    Some(target_hint.clone())
+                }
+                _ => None,
+            };
+            Some(vec![JobCandidate {
+                kind: ActiveJobKind::VerifierRepair,
+                desired_action: DesiredAction::VerifierRepair {
+                    command: String::new(),
+                    target_hint,
+                },
+                policy: verifier_repair_policy_for_next_action(agent, &next_action),
+                budget: Budget::Unbounded,
+            }])
+        }
+        LoopControlAction::ContinueMissingVerifierJob { next_action } => {
+            if matches!(
+                next_action,
+                super::repair_job::VerifierBootstrapNextAction::RequestSetupEdit
+            ) && let Some(job) = agent.missing_verifier_job.as_ref()
+            {
+                return Some(vec![JobCandidate {
+                    kind: ActiveJobKind::VerifierRepair,
+                    desired_action: DesiredAction::MissingVerifierCreate,
+                    policy: EffectiveToolPolicy::restricted(
+                        EffectiveToolPolicyReason::VerifierRepair,
+                        job.allowed_tool_names().to_vec(),
+                    ),
+                    budget: Budget::Unbounded,
+                }]);
+            }
+            Some(Vec::new())
+        }
+        LoopControlAction::RunVerifier | LoopControlAction::RequestModelTurn => None,
+    }
+}
+
+fn push_focused_edit_candidate(
+    agent: &Agent,
+    candidates: &mut Vec<JobCandidate>,
+    target: PathBuf,
+    kind: ActiveJobKind,
+    reason: EffectiveToolPolicyReason,
+) {
+    let already_read =
+        focused_edit_target_already_read(&agent.session.messages, &target, &agent.work_root);
+    candidates.push(JobCandidate {
+        kind,
+        desired_action: DesiredAction::FocusedEdit {
+            target: target.clone(),
+            already_read,
+        },
+        policy: focused_edit_policy_for_target(agent, target, reason),
+        budget: Budget::Unbounded,
+    });
+}
+
+fn setup_bootstrap_candidate(agent: &Agent) -> Option<JobCandidate> {
+    if matches!(
+        agent.session.mode_state.work_mode,
+        WorkMode::Docs | WorkMode::AnswerOnly
+    ) {
+        return None;
+    }
+    let request = agent.active_request_text()?;
+    let task_contract = super::task_contract::TaskContract::from_request(&request);
+    let behavior_projection = super::required_behavior::project_behavior_contract(&task_contract);
+    let verifier_signal = super::task_contract::VerifierPrerequisiteSignal::from_sources(
+        agent.owned_test_verifier_missing_observed_this_turn,
+        behavior_projection.as_ref(),
+    );
+    if !should_install_setup_bootstrap(
+        &task_contract,
+        behavior_projection.as_ref(),
+        &verifier_signal,
+        agent.artifact_ledger.overflowed(),
+    ) {
+        return None;
+    }
+    Some(JobCandidate {
+        kind: ActiveJobKind::SetupBootstrap,
+        desired_action: DesiredAction::SetupBash,
+        policy: EffectiveToolPolicy::setup_bootstrap(),
+        budget: Budget::Unbounded,
+    })
+}
+
+fn verifier_repair_policy_for_next_action(
+    agent: &Agent,
+    action: &super::repair_job::RepairNextAction,
+) -> EffectiveToolPolicy {
+    match action {
+        super::repair_job::RepairNextAction::RequestPatch { target_hint } => {
+            verifier_repair_policy_for_target_hint(
+                target_hint,
+                &agent.session.messages,
+                &agent.work_root,
+            )
+        }
+        super::repair_job::RepairNextAction::RequestDiagnostic
+        | super::repair_job::RepairNextAction::Replan
+        | super::repair_job::RepairNextAction::RerunVerifier
+        | super::repair_job::RepairNextAction::SafeStop { .. }
+        | super::repair_job::RepairNextAction::VerifiedDone => {
+            EffectiveToolPolicy::restricted(EffectiveToolPolicyReason::VerifierRepair, Vec::new())
+        }
+    }
+}
+
+fn focused_edit_policy_for_target(
+    agent: &Agent,
+    target: PathBuf,
+    reason: EffectiveToolPolicyReason,
+) -> EffectiveToolPolicy {
+    let target_already_read =
+        focused_edit_target_already_read(&agent.session.messages, &target, &agent.work_root);
+    if !target.is_file() {
+        EffectiveToolPolicy::focused_edit(reason, vec!["Write"], target, target_already_read)
+    } else if target_already_read {
+        EffectiveToolPolicy::focused_edit(reason, vec!["Edit"], target, target_already_read)
+    } else {
+        EffectiveToolPolicy::focused_edit(reason, vec!["Read", "Edit"], target, target_already_read)
+    }
+}

--- a/src/agent/loop_run/repair_runner_contract_tests.rs
+++ b/src/agent/loop_run/repair_runner_contract_tests.rs
@@ -199,17 +199,19 @@ mod v0421_repair_runner_contract_tests {
 
     #[test]
     fn production_repair_dispatch_does_not_call_legacy_decision_bridge() {
-        let turn_src = include_str!("turn.rs");
         let actor_loop_flow_src = include_str!("actor_loop_flow.rs");
+        // After parent #680: `build_arbiter_candidates` lives in
+        // `effective_tool_policy_flow.rs` as a `pub(super)` free fn.
+        let arbiter_src = include_str!("effective_tool_policy_flow.rs");
         let run_actor_loop = function_body(
             actor_loop_flow_src,
             "\npub(super) fn run_actor_loop(",
             "\n    let mut last_iter = 0usize;\n",
         );
         let arbiter_candidates = function_body(
-            turn_src,
-            "\n    fn build_arbiter_candidates(",
-            "\n    pub(super) fn current_workspace_scope(",
+            arbiter_src,
+            "\npub(super) fn build_arbiter_candidates(",
+            "\nfn priority_one_arbiter_candidates(",
         );
 
         for (label, body) in [

--- a/src/agent/loop_run/reply_retry.rs
+++ b/src/agent/loop_run/reply_retry.rs
@@ -182,7 +182,7 @@ fn maybe_handle_assistant_reply_format_error(
 
 fn push_tool_call_format_retry_note(agent: &mut Agent, err: &str, retry_count: usize) {
     let lower_err = err.to_ascii_lowercase();
-    let effective_tool_policy = agent.effective_tool_policy();
+    let effective_tool_policy = super::effective_tool_policy_flow::effective_tool_policy(agent);
     if let Some(policy) = effective_tool_policy.focused_edit_policy() {
         let target = &policy.target;
         let target_already_read = policy.target_already_read;
@@ -241,7 +241,9 @@ fn maybe_handle_assistant_reply_timeout_error(
             ));
         return Some(AssistantReplyRetryDecision::ReturnReply(reply));
     }
-    let timeout_focused_policy = agent.effective_tool_policy().focused_edit_policy().cloned();
+    let timeout_focused_policy = super::effective_tool_policy_flow::effective_tool_policy(agent)
+        .focused_edit_policy()
+        .cloned();
     if let Some(policy) = timeout_focused_policy {
         if recovery_dispatch_gate.allows_deterministic_fallback()
             && let Some(reply) =
@@ -318,7 +320,7 @@ fn request_assistant_reply(
 ) -> Result<AssistantReply, String> {
     let protocol = prompting::ToolProtocol::from_native_tools_enabled(agent.native_tools_enabled);
     let native_tools_enabled = protocol.native_tools_enabled();
-    let effective_tool_policy = agent.effective_tool_policy();
+    let effective_tool_policy = super::effective_tool_policy_flow::effective_tool_policy(agent);
     let focused_edit_target = effective_tool_policy
         .focused_edit_policy()
         .map(|policy| policy.target.as_path());

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -1,7 +1,4 @@
-use super::active_job_arbiter::{
-    LoopControlAction, LoopControlInputs, RecoveryOwner, build_active_job_selected_payload,
-    determine_loop_control_action,
-};
+use super::active_job_arbiter::{RecoveryOwner, build_active_job_selected_payload};
 use super::actor_loop_flow::{format_iteration_status, run_actor_loop};
 use super::auto_test::{AutoTestKind, AutoTestRunner};
 use super::completion_evidence::is_repo_edit_no_op;
@@ -69,10 +66,9 @@ use super::verifier_orchestration::{
     validate_verifier_repair_intents_with_accepted_plan, verifier_diagnostic_messages,
     verifier_repair_context_diagnostics, verifier_repair_diagnostic_pending_note,
     verifier_repair_intent_limits, verifier_repair_pass_messages,
-    verifier_repair_pass_request_error_message, verifier_repair_policy_for_target_hint,
-    verifier_repair_safe_stop_message, verifier_repair_target_display,
-    verifier_repair_transition_message, verifier_repair_unsafe_target_message,
-    verifier_setup_policy_message,
+    verifier_repair_pass_request_error_message, verifier_repair_safe_stop_message,
+    verifier_repair_target_display, verifier_repair_transition_message,
+    verifier_repair_unsafe_target_message, verifier_setup_policy_message,
 };
 use super::verifier_repair_shadow::legacy_repair_brief_input_from_assessment;
 use super::workspace_candidates::existing_workspace_candidate_for_role_in_scope;
@@ -681,7 +677,7 @@ impl Agent {
     /// before crossing the `pub(crate)` boundary.
     #[cfg(test)]
     pub(super) fn effective_tool_policy_pub_for_test(&self) -> EffectiveToolPolicy {
-        self.effective_tool_policy()
+        super::effective_tool_policy_flow::effective_tool_policy(self)
     }
 
     /// Issue #664 test seam: `pub(super)` wrapper over the private
@@ -694,7 +690,7 @@ impl Agent {
     pub(super) fn build_arbiter_candidates_pub_for_test(
         &self,
     ) -> Vec<super::active_job_arbiter::JobCandidate> {
-        self.build_arbiter_candidates()
+        super::effective_tool_policy_flow::build_arbiter_candidates(self)
     }
 
     /// Issue #664 iteration-3 (CB2-003) test seam: drive the
@@ -816,292 +812,6 @@ impl Agent {
             .as_ref()
             .map(|j| j.attempts().len())
     }
-
-    pub(super) fn effective_tool_policy(&self) -> EffectiveToolPolicy {
-        // Issue #660: `AnswerOnlyMode` is a pre-arbitration gate (priority 0
-        // in §4 of the design policy). The arbiter never sees it; we early-
-        // return before constructing any selectable `JobCandidate`.
-        if self.answer_only_mode_active() {
-            if self.workspace_appears_empty() {
-                return EffectiveToolPolicy::restricted(
-                    EffectiveToolPolicyReason::AnswerOnly,
-                    Vec::new(),
-                );
-            }
-            if self.script_execution_requested() {
-                return EffectiveToolPolicy::restricted(
-                    EffectiveToolPolicyReason::AnswerOnly,
-                    vec!["Read", "Glob", "Grep", "Bash"],
-                );
-            } else {
-                return EffectiveToolPolicy::restricted(
-                    EffectiveToolPolicyReason::AnswerOnly,
-                    vec!["Read", "Glob", "Grep"],
-                );
-            }
-        }
-
-        // Issue #660 (Codex CB-001 / §4 design table): `PlanModeGate` is also
-        // a pre-arbitration gate, not a selectable arbitration kind. The
-        // Plan-file Write/Edit exception is the authority of
-        // `src/tools/registry.rs::resolve_plan_mode_write_target` /
-        // `enforce_plan_stage_scope`; the arbiter must not pre-empt that
-        // decision with stale `task_contract_verifier_repair_pending` or
-        // other selectable state. Returning `unrestricted()` keeps the
-        // tool-spec surface and recovery-target gating out of the arbiter
-        // while the registry-layer PAM gate enforces actual write target.
-        if self.session.mode_state.mode == ExecutionMode::Plan {
-            return EffectiveToolPolicy::unrestricted();
-        }
-
-        // Issue #660 (Phase E): arbiter is the **sole authority** for write
-        // owner selection. The legacy if-elif chain, the
-        // `#[cfg(debug_assertions)]` dual-source assertion, and the
-        // `agent.active_job.divergence_detected` event emit that lived here
-        // during Phase A+B-D have all been removed. `effective_tool_policy`
-        // is now a thin shell over `build_arbiter_candidates` +
-        // `select_active_job` + `project_policy`.
-        //
-        // The `agent.active_job.selected` event is emitted by
-        // `emit_active_job_selected_if_changed` from the agent loop driver
-        // (see L5352 `run_actor_loop` site) — `effective_tool_policy` stays
-        // a pure read so it can be called freely without log-emit side
-        // effects.
-        let candidates = self.build_arbiter_candidates();
-        let selection = super::active_job_arbiter::select_active_job(&candidates);
-        super::active_job_arbiter::project_policy(&selection)
-    }
-
-    /// Issue #660: build the arbiter candidate list from the same source
-    /// signals the legacy chain reads. Per DR1-004 only candidates with a
-    /// determined `desired_action` are pushed — there is no
-    /// `RejectionReason::NoDesiredAction`.
-    ///
-    /// Each branch mirrors a single legacy `if let Some(target) = ...`
-    /// arm. The policy attached to the candidate is the exact value the
-    /// legacy chain would have returned, so `project_policy(selection)`
-    /// is value-equal to the legacy result.
-    fn build_arbiter_candidates(&self) -> Vec<super::active_job_arbiter::JobCandidate> {
-        use super::active_job_arbiter::{ActiveJobKind, Budget, DesiredAction, JobCandidate};
-
-        if let Some(candidates) = self.priority_one_arbiter_candidates() {
-            return candidates;
-        }
-
-        let mut candidates: Vec<JobCandidate> = Vec::new();
-
-        // Priority 2: ForcedSmallEditRecovery.
-        if let Some(target) = self.forced_small_edit_recovery_target() {
-            self.push_focused_edit_candidate(
-                &mut candidates,
-                target,
-                ActiveJobKind::ForcedSmallEditRecovery,
-                EffectiveToolPolicyReason::FocusedEditRecovery,
-            );
-        }
-
-        // Priority 3: ArtifactRecovery.
-        // Issue #663 (Phase C / AD5 / DR1-006 / CB-001 fix): ArtifactRecovery
-        // candidate is generated ONLY when an `ArtifactCompletionJob` is
-        // installed. The job is the single source of truth for
-        // `AllowedWriteActions` / `AllowedReadScope` / role-specific budget,
-        // and the policy is always built via `artifact_directed_from_job`.
-        // The previous fallback to the generic write-capable
-        // `artifact_directed` policy (when target was set but job was None)
-        // bypassed target validation and role-specific budget, so it is
-        // removed: a bare `current_artifact_recovery_target` without a job
-        // produces no write-capable candidate.
-        if let (Some(target), Some(job)) = (
-            self.artifact_recovery_target_path(),
-            self.artifact_completion_job.as_ref(),
-        ) {
-            let target_already_read =
-                focused_edit_target_already_read(&self.session.messages, &target, &self.work_root);
-            let policy = EffectiveToolPolicy::artifact_directed_from_job(
-                target.clone(),
-                target_already_read,
-                job.allowed_write_actions(),
-                job.allowed_read_scope(),
-            );
-            let write_actions = job.allowed_write_actions().clone();
-            let read_scope = job.allowed_read_scope().clone();
-            candidates.push(JobCandidate {
-                kind: ActiveJobKind::ArtifactRecovery,
-                desired_action: DesiredAction::ArtifactDirected {
-                    target,
-                    already_read: target_already_read,
-                    write_actions,
-                    read_scope,
-                },
-                policy,
-                budget: Budget::Unbounded,
-            });
-        }
-
-        // Issue #664 (Priority 4 / AD22): SetupBootstrap candidate. Built
-        // pure from `TaskContract` + behavior projection + verifier
-        // prerequisite signal + ledger overflow. `should_install_setup_bootstrap`
-        // is the SSOT decision tree (pure-fn; arbiter does not observe
-        // Agent state).
-        //
-        // **Issue #664 iteration-2 (CB-001) — Stage A + Stage B both wired**:
-        //
-        // - **Stage A live observation**: `OwnedTestVerifierPlan::Missing`
-        //   is observed in `run_task_contract_verifier_once` and recorded
-        //   into the per-turn flag `owned_test_verifier_missing_observed_this_turn`
-        //   (single producer). Reading the flag from `&self` is O(1) so the
-        //   pure-`&self` candidate builder can consume the live signal at
-        //   every `effective_tool_policy()` evaluation without traversing
-        //   the workspace. Reset at `handle_user_message` head (per-turn
-        //   rule).
-        //
-        // - **Stage B (BehaviorContractProjection verifier capability label)**:
-        //   the behavior projection is passed to
-        //   `VerifierPrerequisiteSignal::from_sources(stage_a, Some(&p))`.
-        //   `should_install_setup_bootstrap` refines the OR-composed
-        //   signal so Stage B alone (label-only) is insufficient — it
-        //   only fires via the Setup-label fallback (step 4) when the
-        //   projection also carries an explicit setup keyword. This
-        //   suppresses the false positive on plain "add tests" requests
-        //   where `verification_expectations = ["test"]` would otherwise
-        //   trip step (2). Stage A live alone always passes step (2);
-        //   `required_artifacts::Setup` is unaffected (step 1, no gate).
-        if let Some(candidate) = self.setup_bootstrap_candidate() {
-            candidates.push(candidate);
-        }
-
-        // Priority 5: FocusedEditRecovery.
-        if let Some(target) = self.focused_edit_recovery_target() {
-            self.push_focused_edit_candidate(
-                &mut candidates,
-                target,
-                ActiveJobKind::FocusedEditRecovery,
-                EffectiveToolPolicyReason::FocusedEditRecovery,
-            );
-        }
-
-        // Priority 6: LocalLlmSmallEditAfterRead.
-        if let Some(target) = self.local_llm_small_edit_target() {
-            self.push_focused_edit_candidate(
-                &mut candidates,
-                target,
-                ActiveJobKind::LocalLlmSmallEditAfterRead,
-                EffectiveToolPolicyReason::LocalLlmSmallEditAfterRead,
-            );
-        }
-
-        candidates
-    }
-
-    fn priority_one_arbiter_candidates(
-        &self,
-    ) -> Option<Vec<super::active_job_arbiter::JobCandidate>> {
-        use super::active_job_arbiter::{ActiveJobKind, Budget, DesiredAction, JobCandidate};
-
-        match determine_loop_control_action(LoopControlInputs {
-            mode: self.session.mode_state.mode,
-            task_contract_verifier_repair_pending: self.task_contract_verifier_repair_pending,
-            repair_next_action: self.repair_job.as_ref().map(|job| job.next_action()),
-            missing_verifier_next_action: self
-                .missing_verifier_job
-                .as_ref()
-                .map(|job| job.next_action()),
-            task_contract_action: None,
-        }) {
-            LoopControlAction::ContinueRepairJob { next_action } => {
-                let target_hint = match &next_action {
-                    super::repair_job::RepairNextAction::RequestPatch { target_hint } => {
-                        Some(target_hint.clone())
-                    }
-                    _ => None,
-                };
-                Some(vec![JobCandidate {
-                    kind: ActiveJobKind::VerifierRepair,
-                    desired_action: DesiredAction::VerifierRepair {
-                        command: String::new(),
-                        target_hint,
-                    },
-                    policy: self.verifier_repair_policy_for_next_action(&next_action),
-                    budget: Budget::Unbounded,
-                }])
-            }
-            LoopControlAction::ContinueMissingVerifierJob { next_action } => {
-                if matches!(
-                    next_action,
-                    super::repair_job::VerifierBootstrapNextAction::RequestSetupEdit
-                ) && let Some(job) = self.missing_verifier_job.as_ref()
-                {
-                    return Some(vec![JobCandidate {
-                        kind: ActiveJobKind::VerifierRepair,
-                        desired_action: DesiredAction::MissingVerifierCreate,
-                        policy: EffectiveToolPolicy::restricted(
-                            EffectiveToolPolicyReason::VerifierRepair,
-                            job.allowed_tool_names().to_vec(),
-                        ),
-                        budget: Budget::Unbounded,
-                    }]);
-                }
-                Some(Vec::new())
-            }
-            LoopControlAction::RunVerifier | LoopControlAction::RequestModelTurn => None,
-        }
-    }
-
-    fn push_focused_edit_candidate(
-        &self,
-        candidates: &mut Vec<super::active_job_arbiter::JobCandidate>,
-        target: PathBuf,
-        kind: super::active_job_arbiter::ActiveJobKind,
-        reason: EffectiveToolPolicyReason,
-    ) {
-        use super::active_job_arbiter::{Budget, DesiredAction, JobCandidate};
-
-        let already_read =
-            focused_edit_target_already_read(&self.session.messages, &target, &self.work_root);
-        candidates.push(JobCandidate {
-            kind,
-            desired_action: DesiredAction::FocusedEdit {
-                target: target.clone(),
-                already_read,
-            },
-            policy: self.focused_edit_policy_for_target(target, reason),
-            budget: Budget::Unbounded,
-        });
-    }
-
-    fn setup_bootstrap_candidate(&self) -> Option<super::active_job_arbiter::JobCandidate> {
-        use super::active_job_arbiter::{ActiveJobKind, Budget, DesiredAction, JobCandidate};
-
-        if matches!(
-            self.session.mode_state.work_mode,
-            WorkMode::Docs | WorkMode::AnswerOnly
-        ) {
-            return None;
-        }
-        let request = self.active_request_text()?;
-        let task_contract = super::task_contract::TaskContract::from_request(&request);
-        let behavior_projection =
-            super::required_behavior::project_behavior_contract(&task_contract);
-        let verifier_signal = super::task_contract::VerifierPrerequisiteSignal::from_sources(
-            self.owned_test_verifier_missing_observed_this_turn,
-            behavior_projection.as_ref(),
-        );
-        if !super::active_job_arbiter::should_install_setup_bootstrap(
-            &task_contract,
-            behavior_projection.as_ref(),
-            &verifier_signal,
-            self.artifact_ledger.overflowed(),
-        ) {
-            return None;
-        }
-        Some(JobCandidate {
-            kind: ActiveJobKind::SetupBootstrap,
-            desired_action: DesiredAction::SetupBash,
-            policy: EffectiveToolPolicy::setup_bootstrap(),
-            budget: Budget::Unbounded,
-        })
-    }
-
     /// Issue #660 (Phase C / DD-4): per-turn diff-based emit of
     /// `agent.active_job.selected`. Computes the current
     /// `ActiveJobSelection`, compares it with the previous emission stored
@@ -1214,54 +924,9 @@ impl Agent {
                 rejected: Vec::new(),
             };
         }
-        let candidates = self.build_arbiter_candidates();
+        let candidates = super::effective_tool_policy_flow::build_arbiter_candidates(self);
         super::active_job_arbiter::select_active_job(&candidates)
     }
-
-    fn verifier_repair_policy_for_next_action(
-        &self,
-        action: &super::repair_job::RepairNextAction,
-    ) -> EffectiveToolPolicy {
-        match action {
-            super::repair_job::RepairNextAction::RequestPatch { target_hint } => {
-                verifier_repair_policy_for_target_hint(
-                    target_hint,
-                    &self.session.messages,
-                    &self.work_root,
-                )
-            }
-            super::repair_job::RepairNextAction::RequestDiagnostic
-            | super::repair_job::RepairNextAction::Replan
-            | super::repair_job::RepairNextAction::RerunVerifier
-            | super::repair_job::RepairNextAction::SafeStop { .. }
-            | super::repair_job::RepairNextAction::VerifiedDone => EffectiveToolPolicy::restricted(
-                EffectiveToolPolicyReason::VerifierRepair,
-                Vec::new(),
-            ),
-        }
-    }
-
-    fn focused_edit_policy_for_target(
-        &self,
-        target: PathBuf,
-        reason: EffectiveToolPolicyReason,
-    ) -> EffectiveToolPolicy {
-        let target_already_read =
-            focused_edit_target_already_read(&self.session.messages, &target, &self.work_root);
-        if !target.is_file() {
-            EffectiveToolPolicy::focused_edit(reason, vec!["Write"], target, target_already_read)
-        } else if target_already_read {
-            EffectiveToolPolicy::focused_edit(reason, vec!["Edit"], target, target_already_read)
-        } else {
-            EffectiveToolPolicy::focused_edit(
-                reason,
-                vec!["Read", "Edit"],
-                target,
-                target_already_read,
-            )
-        }
-    }
-
     pub(super) fn tool_specs_for_policy(&self, policy: &EffectiveToolPolicy) -> Vec<ToolSpec> {
         let mut specs = self.tool_registry.specs().to_vec();
         if let Some(allowed_tools) = policy.allowed_tool_names_for_prompt() {
@@ -1270,7 +935,7 @@ impl Agent {
         specs
     }
 
-    fn local_llm_small_edit_target(&self) -> Option<PathBuf> {
+    pub(super) fn local_llm_small_edit_target(&self) -> Option<PathBuf> {
         if !model_capabilities(&self.current_assistant_model()).read_after_small_edit_protocol {
             return None;
         }
@@ -4085,7 +3750,7 @@ impl Agent {
         true
     }
 
-    fn artifact_recovery_target_path(&self) -> Option<PathBuf> {
+    pub(super) fn artifact_recovery_target_path(&self) -> Option<PathBuf> {
         // Issue #652 PR-001 SSOT: when an `ArtifactCompletionJob` is
         // active, read the target straight from the job — that is the
         // single source of truth for the in-flight artifact-completion
@@ -4140,7 +3805,7 @@ impl Agent {
         self.session.mode_state.work_mode == WorkMode::AnswerOnly
     }
 
-    fn script_execution_requested(&self) -> bool {
+    pub(super) fn script_execution_requested(&self) -> bool {
         self.active_request_text()
             .as_deref()
             .is_some_and(request_explicitly_requests_script_execution)
@@ -4151,7 +3816,7 @@ impl Agent {
         name: &str,
         arguments: &serde_json::Value,
     ) -> Option<String> {
-        let effective_tool_policy = self.effective_tool_policy();
+        let effective_tool_policy = super::effective_tool_policy_flow::effective_tool_policy(self);
         let scope = if self.missing_verifier_job.is_some() {
             Some(self.current_workspace_scope())
         } else {
@@ -4436,7 +4101,7 @@ impl Agent {
             && let Ok(resolved) = resolve_user_path(&self.work_root, raw_path)
         {
             let resolved = if tool_call.name == "Read" {
-                self.effective_tool_policy()
+                super::effective_tool_policy_flow::effective_tool_policy(self)
                     .focused_edit_policy()
                     .and_then(|policy| {
                         focused_read_target_for_directory(&resolved, &policy.target)

--- a/src/agent/loop_run/turn_tests.rs
+++ b/src/agent/loop_run/turn_tests.rs
@@ -3363,7 +3363,7 @@ mod tests {
         agent.repair_job = Some(super::super::repair_job::RepairJob::new_for_test());
 
         // (1) Arbiter must surface a VerifierRepair-derived policy.
-        let policy = agent.effective_tool_policy();
+        let policy = super::super::effective_tool_policy_flow::effective_tool_policy(&agent);
         assert_eq!(
             policy.reason(),
             super::EffectiveToolPolicyReason::VerifierRepair,
@@ -3479,7 +3479,7 @@ mod tests {
         });
 
         // (1) Arbiter must surface an artifact-directed-recovery policy.
-        let policy = agent.effective_tool_policy();
+        let policy = super::super::effective_tool_policy_flow::effective_tool_policy(&agent);
         assert_eq!(
             policy.reason(),
             super::EffectiveToolPolicyReason::ArtifactDirectedRecovery,
@@ -3531,7 +3531,7 @@ mod tests {
         // Intentionally do NOT install an ArtifactCompletionJob.
         assert!(agent.artifact_completion_job.is_none());
 
-        let policy = agent.effective_tool_policy();
+        let policy = super::super::effective_tool_policy_flow::effective_tool_policy(&agent);
         assert_ne!(
             policy.reason(),
             super::EffectiveToolPolicyReason::ArtifactDirectedRecovery,
@@ -3571,7 +3571,7 @@ mod tests {
             "docs-only README work must not be captured by Bash-only setup bootstrap"
         );
         assert_eq!(
-            agent.effective_tool_policy().reason(),
+            super::super::effective_tool_policy_flow::effective_tool_policy(&agent).reason(),
             super::EffectiveToolPolicyReason::Unrestricted,
             "with no artifact job installed yet, docs-only turns should stay open for the task contract to select README.md"
         );
@@ -3694,7 +3694,7 @@ mod tests {
 
         // (1) Arbiter must surface a focused-edit-recovery policy
         //     (ForcedSmallEditRecovery uses the FocusedEditRecovery reason).
-        let policy = agent.effective_tool_policy();
+        let policy = super::super::effective_tool_policy_flow::effective_tool_policy(&agent);
         assert_eq!(
             policy.reason(),
             super::EffectiveToolPolicyReason::FocusedEditRecovery,
@@ -3757,7 +3757,7 @@ mod tests {
 
         // No verifier_repair, no recovery_target, no truncated-tool-call,
         // no focused / local-llm target -> no selectable active job.
-        let policy = agent.effective_tool_policy();
+        let policy = super::super::effective_tool_policy_flow::effective_tool_policy(&agent);
         assert_eq!(
             policy.reason(),
             super::EffectiveToolPolicyReason::Unrestricted,
@@ -3807,7 +3807,7 @@ mod tests {
         agent.task_contract_verifier_repair_pending = true;
         agent.repair_job = Some(super::super::repair_job::RepairJob::new_for_test());
 
-        let policy = agent.effective_tool_policy();
+        let policy = super::super::effective_tool_policy_flow::effective_tool_policy(&agent);
         assert_eq!(
             policy.reason(),
             super::EffectiveToolPolicyReason::VerifierRepair,
@@ -3851,7 +3851,7 @@ mod tests {
 
         // Sanity: VerifierRepair owns the turn.
         assert_eq!(
-            agent.effective_tool_policy().reason(),
+            super::super::effective_tool_policy_flow::effective_tool_policy(&agent).reason(),
             super::EffectiveToolPolicyReason::VerifierRepair,
         );
 
@@ -3916,7 +3916,7 @@ mod tests {
         // tool-spec surface and recovery-target gating stay out of the
         // arbiter while the registry-layer PAM gate enforces the actual
         // write target.
-        let policy = agent.effective_tool_policy();
+        let policy = super::super::effective_tool_policy_flow::effective_tool_policy(&agent);
         assert_eq!(
             policy.reason(),
             super::EffectiveToolPolicyReason::Unrestricted,
@@ -3944,7 +3944,7 @@ mod tests {
         agent.session.mode_state.mode = ExecutionMode::Plan;
         agent.task_contract_verifier_repair_pending = true;
 
-        let policy = agent.effective_tool_policy();
+        let policy = super::super::effective_tool_policy_flow::effective_tool_policy(&agent);
         assert_eq!(
             policy.reason(),
             super::EffectiveToolPolicyReason::Unrestricted,


### PR DESCRIPTION
## Summary

Eleventh **vertical-slice extraction**: move the `EffectiveToolPolicy` decision pipeline + arbiter candidate selection out of `turn.rs` into a new `src/agent/loop_run/effective_tool_policy_flow.rs` sibling module.

### Migrated (7 methods, all free fns over `&Agent`)

**Entry points (`pub(super)`):**
- `effective_tool_policy` — pre-arbitration gates (AnswerOnly / Plan mode) + arbiter-based shell over `build_arbiter_candidates` + `select_active_job` + `project_policy`.
- `build_arbiter_candidates` — composes priority-1 through priority-6 candidate list per #660 design.

**Private helpers:**
- `priority_one_arbiter_candidates` — VerifierRepair / MissingVerifierCreate branches via `determine_loop_control_action`.
- `setup_bootstrap_candidate` — Issue #664 (AD22) SetupBootstrap policy decision tree.
- `push_focused_edit_candidate` — shared focused-edit candidate builder.
- `verifier_repair_policy_for_next_action` — RepairJob next-action → `EffectiveToolPolicy` branching.
- `focused_edit_policy_for_target` — Write / Edit / Read+Edit policy by target existence + already_read state.

### Visibility promotions in turn.rs (`impl Agent` methods → `pub(super)`)
- `script_execution_requested`
- `artifact_recovery_target_path`
- `local_llm_small_edit_target`

No facade re-export (DR3-001).

### Caller updates
- `turn.rs` ×5: `self.effective_tool_policy()` / `self.build_arbiter_candidates()` → free-fn form.
- `actor_loop_flow.rs` ×1: `agent.effective_tool_policy()` → free-fn.
- `reply_retry.rs` ×3: `agent.effective_tool_policy()` → free-fn.
- `turn_tests.rs` ×10: `agent.effective_tool_policy()` → `super::super::effective_tool_policy_flow::effective_tool_policy(&agent)`.
- `repair_runner_contract_tests.rs::production_repair_dispatch_does_not_call_legacy_decision_bridge`: `include_str!("turn.rs")` → `include_str!("effective_tool_policy_flow.rs")`; markers updated for free-fn signature.

`cargo fix --tests` pruned 2 newly-unused imports from `turn.rs`.

## LOC delta

- `turn.rs`: 4,527 → **4,192 LOC** (-335 LOC)
- New `effective_tool_policy_flow.rs`: 300 LOC
- **Cumulative from 39,489: -35,297 LOC (-89.4%)**

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --lib --all-targets -- -D warnings` clean
- [x] `cargo test --lib` (3,114 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)