### PR TITLE
Extract run_turn.rs from turn.rs (parent #680)

### DIFF
--- a/src/agent/loop_run.rs
+++ b/src/agent/loop_run.rs
@@ -149,6 +149,12 @@ mod handle_user_message;
 // and computes the initial TaskContract. `pub(super)` limited / no
 // facade re-export (DR3-001).
 mod prepare_actor_loop_state;
+// Per-turn driver extracted from `turn.rs` (parent #680). Hosts
+// `run_turn` as a free fn over `&mut Agent`. Pushes user message +
+// runs work-mode classify second-pass + plan stage refresh + photon
+// context-pack hook + actor loop entry. `pub(super)` limited / no
+// facade re-export (DR3-001).
+mod run_turn;
 // Issue #652: `ArtifactCompletionJob` + role-specific retry budget +
 // `ArtifactAttemptOutcome` 4-variant taxonomy +
 // `ArtifactCompletionFailureSnapshot` for #654. Module is intentionally

--- a/src/agent/loop_run/handle_user_message.rs
+++ b/src/agent/loop_run/handle_user_message.rs
@@ -169,7 +169,7 @@ pub(super) fn handle_user_message(
             .messages
             .push(ConversationMessage::system(hint));
     }
-    let result = agent.run_turn(input, stream_output, &mut monitor);
+    let result = super::run_turn::run_turn(agent, input, stream_output, &mut monitor);
     // Issue #663 (Phase B / AD2 / DR1-001): refresh the active
     // `ArtifactCompletionJob` Satisfied state from the ledger
     // projection. This is the SSOT chokepoint — no status guard

--- a/src/agent/loop_run/run_turn.rs
+++ b/src/agent/loop_run/run_turn.rs
@@ -1,0 +1,81 @@
+//! Per-turn driver extracted from `turn.rs` (parent #680).
+//!
+//! Hosts `run_turn` (pub(super)) — the turn-level driver invoked from
+//! `handle_user_message::handle_user_message` after the per-turn state
+//! resets. Pushes the user message, runs the work-mode classification
+//! second-pass + history compaction (Act mode), refreshes the plan
+//! stage, classifies the action expectation, fires the pre-turn photon
+//! context-pack hook, and finally enters `actor_loop_flow::run_actor_loop`.
+//!
+//! Originally an `impl Agent` method; converted to a free function
+//! taking `&mut Agent`, matching `actor_loop_flow` / `reply_retry` /
+//! `handle_user_message` pattern. `pub(super)` limited / no facade
+//! re-export (DR3-001).
+
+use super::Agent;
+use super::DEFAULT_KEEP_TAIL;
+use super::actor_loop_flow::run_actor_loop;
+use super::interrupt::InterruptMonitor;
+use super::summary::LoopResult;
+use crate::agent::recovery;
+use crate::logging::log_llm_event;
+use crate::modes::plan_act::ExecutionMode;
+
+pub(super) fn run_turn(
+    agent: &mut Agent,
+    input: &str,
+    stream_output: bool,
+    monitor: &mut InterruptMonitor,
+) -> LoopResult {
+    agent.push_user_message(input.to_string());
+    if agent.session.mode_state.mode != ExecutionMode::Plan {
+        // Issue #576: replace direct `classify_work_mode_json` + event
+        // emit with the shared `classify_with_confirmation` wrapper. The
+        // wrapper emits the existing `agent.work_mode.classified` event
+        // (now with `turn_index`) and drives the LLM second-pass via
+        // `maybe_invoke_work_mode_confirm`. Final (LLM-corrected when
+        // applicable) work_mode lives in `agent.session.mode_state.work_mode`.
+        let _ =
+            super::classify_confirm_flow::classify_with_confirmation(agent, input, "turn_start");
+        agent.maybe_compact_session(DEFAULT_KEEP_TAIL);
+    }
+    let _ = agent.refresh_plan_stage();
+
+    let mut action_expectation =
+        recovery::classify_action_expectation(input, agent.session.mode_state.mode);
+    if !agent.session.mode_state.policy().repo_edit_required {
+        action_expectation = recovery::ActionExpectation::None;
+    }
+    let requires_action = action_expectation != recovery::ActionExpectation::None;
+
+    // [Issue #556] pre-turn photon context_pack hook
+    if agent.session.mode_state.mode != ExecutionMode::Plan {
+        super::photon_feedback_derive::invoke_photon_context_pack(agent);
+    } else if agent.photon.is_some() {
+        // Issue #594: surface plan-mode skip via /photon-why.
+        agent.last_photon_context_pack_status =
+            crate::agent::loop_run::PhotonContextPackStatus::PlanMode;
+        // CB-003 (Issue #592): Plan-mode skip path must also clear stale
+        // inject tracking so a previous Act-turn's seed ids do not survive
+        // into a Plan turn and become "visible" to `/photon-thumbs-*`.
+        agent.last_injected_summary_ids.clear();
+        agent.last_injected_summary_turn_index = None;
+        log_llm_event(
+            "agent.photon_context_pack.skipped",
+            serde_json::json!({
+                "session_id": agent.session_store.session_id(),
+                "turn_index": agent.current_turn_index,
+                "reason": "plan_mode",
+            }),
+        );
+    }
+
+    run_actor_loop(
+        agent,
+        action_expectation,
+        requires_action,
+        stream_output,
+        false,
+        monitor,
+    )
+}

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -1,8 +1,7 @@
 use super::active_job_arbiter::{RecoveryOwner, build_active_job_selected_payload};
-use super::actor_loop_flow::{format_iteration_status, run_actor_loop};
+use super::actor_loop_flow::format_iteration_status;
 use super::auto_test::{AutoTestKind, AutoTestRunner};
 use super::completion_evidence::is_repo_edit_no_op;
-use super::interrupt::InterruptMonitor;
 use super::repair_driver::{
     VERIFIER_REPAIR_PASS_WALL_CLOCK_LIMIT_SECS, VerifierRepairPassOutcome,
     verifier_repair_pass_timeout_error,
@@ -33,7 +32,7 @@ use super::small_helpers::masked_path_hash_bounded_list;
 use super::small_helpers::{
     latest_tool_result_since_last_user, raw_mode_safe_text, rfc3339_now_utc, user_interrupt_result,
 };
-use super::summary::{ExitReason, LoopResult};
+use super::summary::ExitReason;
 use super::tool_display::progress_path_display;
 use super::tool_execution::{
     failed_outcome_for_call, rejected_outcome_for_call, success_outcome_for_call,
@@ -233,64 +232,6 @@ impl Agent {
         }
     }
 
-    pub(super) fn run_turn(
-        &mut self,
-        input: &str,
-        stream_output: bool,
-        monitor: &mut InterruptMonitor,
-    ) -> LoopResult {
-        self.push_user_message(input.to_string());
-        if self.session.mode_state.mode != ExecutionMode::Plan {
-            // Issue #576: replace direct `classify_work_mode_json` + event
-            // emit with the shared `classify_with_confirmation` wrapper. The
-            // wrapper emits the existing `agent.work_mode.classified` event
-            // (now with `turn_index`) and drives the LLM second-pass via
-            // `maybe_invoke_work_mode_confirm`. Final (LLM-corrected when
-            // applicable) work_mode lives in `self.session.mode_state.work_mode`.
-            let _ =
-                super::classify_confirm_flow::classify_with_confirmation(self, input, "turn_start");
-            self.maybe_compact_session(DEFAULT_KEEP_TAIL);
-        }
-        let _ = self.refresh_plan_stage();
-
-        let mut action_expectation =
-            recovery::classify_action_expectation(input, self.session.mode_state.mode);
-        if !self.session.mode_state.policy().repo_edit_required {
-            action_expectation = recovery::ActionExpectation::None;
-        }
-        let requires_action = action_expectation != recovery::ActionExpectation::None;
-
-        // [Issue #556] pre-turn photon context_pack hook
-        if self.session.mode_state.mode != ExecutionMode::Plan {
-            super::photon_feedback_derive::invoke_photon_context_pack(self);
-        } else if self.photon.is_some() {
-            // Issue #594: surface plan-mode skip via /photon-why.
-            self.last_photon_context_pack_status =
-                crate::agent::loop_run::PhotonContextPackStatus::PlanMode;
-            // CB-003 (Issue #592): Plan-mode skip path must also clear stale
-            // inject tracking so a previous Act-turn's seed ids do not survive
-            // into a Plan turn and become "visible" to `/photon-thumbs-*`.
-            self.last_injected_summary_ids.clear();
-            self.last_injected_summary_turn_index = None;
-            log_llm_event(
-                "agent.photon_context_pack.skipped",
-                serde_json::json!({
-                    "session_id": self.session_store.session_id(),
-                    "turn_index": self.current_turn_index,
-                    "reason": "plan_mode",
-                }),
-            );
-        }
-
-        run_actor_loop(
-            self,
-            action_expectation,
-            requires_action,
-            stream_output,
-            false,
-            monitor,
-        )
-    }
     pub(super) fn tool_policy_violation_exit_reason(recovery_owner: RecoveryOwner) -> ExitReason {
         if recovery_owner == RecoveryOwner::MissingVerifierJob {
             ExitReason::MissingVerification
@@ -3811,7 +3752,7 @@ impl Agent {
             .push(ConversationMessage::system(note));
     }
 
-    fn push_user_message(&mut self, content: String) {
+    pub(super) fn push_user_message(&mut self, content: String) {
         self.session
             .working_memory
             .set_active_task(Some(content.clone()));


### PR DESCRIPTION
## Summary

Fourteenth **vertical-slice extraction**: move the per-turn driver out of `turn.rs` into a new `src/agent/loop_run/run_turn.rs` sibling module.

### Migrated (1 `pub(super)` free fn)

- `run_turn(&mut Agent, &str, bool, &mut InterruptMonitor) -> LoopResult` — turn-level driver invoked from `handle_user_message` after the per-turn state resets. Pushes user message → work-mode classify second-pass + history compaction (Act mode only) → plan stage refresh → action expectation classification → pre-turn photon context-pack hook → enters `actor_loop_flow::run_actor_loop`.

### Visibility promotion in turn.rs (`impl Agent` method → `pub(super)`)
- `push_user_message`

No facade re-export (DR3-001).

### Caller update
- `handle_user_message.rs`: `agent.run_turn(input, stream_output, &mut monitor)` → `super::run_turn::run_turn(agent, input, stream_output, &mut monitor)`

`cargo fix --tests` pruned 3 newly-unused imports from `turn.rs`'s prelude.

## LOC delta

- `turn.rs`: 3,875 → **3,816 LOC** (-59 LOC)
- New `run_turn.rs`: 81 LOC
- **Cumulative from 39,489: -35,673 LOC (-90.3%)**

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --lib --all-targets -- -D warnings` clean
- [x] `cargo test --lib` (3,114 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)