### PR TITLE
Extract active_job_emit.rs from turn.rs (parent #680)

### DIFF
--- a/src/agent/loop_run.rs
+++ b/src/agent/loop_run.rs
@@ -155,6 +155,12 @@ mod prepare_actor_loop_state;
 // context-pack hook + actor loop entry. `pub(super)` limited / no
 // facade re-export (DR3-001).
 mod run_turn;
+// Active-job + behavior-contract event emit helpers extracted from
+// `turn.rs` (parent #680). Hosts `emit_active_job_selected_if_changed`,
+// `emit_behavior_contract_projected_if_changed`, and
+// `current_active_job_selection` as free fns over `&mut Agent` /
+// `&Agent`. `pub(super)` limited / no facade re-export (DR3-001).
+mod active_job_emit;
 // Issue #652: `ArtifactCompletionJob` + role-specific retry budget +
 // `ArtifactAttemptOutcome` 4-variant taxonomy +
 // `ArtifactCompletionFailureSnapshot` for #654. Module is intentionally

--- a/src/agent/loop_run/active_job_emit.rs
+++ b/src/agent/loop_run/active_job_emit.rs
@@ -1,0 +1,112 @@
+//! Active-job + behavior-contract event emit helpers extracted from
+//! `turn.rs` (parent #680).
+//!
+//! Hosts three production entry points that bridge per-turn state to
+//! observability:
+//!
+//! - `emit_active_job_selected_if_changed` — Issue #660 (Phase C / DD-4
+//!   / DR1-007) per-turn diff-based emit of
+//!   `agent.active_job.selected`.
+//! - `emit_behavior_contract_projected_if_changed` — Issue #665 (Phase
+//!   6 / S5-006 / S7-002) per-turn diff-based emit of
+//!   `agent.behavior_contract.projected`.
+//! - `current_active_job_selection` — Issue #660 (Phase C) pure
+//!   `ActiveJobSelection` computation over `&Agent`, used by the emit
+//!   site above and by tests.
+//!
+//! Originally `impl Agent` methods; converted to free functions taking
+//! `&mut Agent` / `&Agent`, matching `actor_loop_flow` / `reply_retry`
+//! / earlier vertical-slice patterns. `pub(super)` limited / no facade
+//! re-export (DR3-001).
+
+use super::Agent;
+use super::active_job_arbiter::{
+    ActiveJobSelection, build_active_job_selected_payload, select_active_job,
+};
+use super::required_behavior::{
+    BehaviorContractProjection, BehaviorProjectionEventKey, behavior_contract_projected_payload,
+};
+use crate::logging::log_llm_event;
+use crate::modes::plan_act::ExecutionMode;
+
+pub(super) fn emit_active_job_selected_if_changed(agent: &mut Agent, iteration_seq: u32) -> bool {
+    let selection = current_active_job_selection(agent);
+    if agent.last_active_job_selection.as_ref() == Some(&selection) {
+        return false;
+    }
+    let payload = build_active_job_selected_payload(
+        &selection,
+        iteration_seq,
+        agent.repair_job_artifact_attempts as u32,
+        agent
+            .artifact_completion_job
+            .as_ref()
+            .map(|job| job.attempts().len() as u32)
+            .unwrap_or(0),
+    );
+    log_llm_event("agent.active_job.selected", payload);
+    agent.last_active_job_selection = Some(selection);
+    true
+}
+
+/// Issue #665 (Phase 6 / S5-006 / S7-002): emit the
+/// `agent.behavior_contract.projected` event with per-turn diff-based
+/// dedup. Only emits when:
+/// - `projection` is `Some(...)` (i.e. consumed by a prompt site), AND
+/// - the payload-shaped key differs from
+///   `agent.last_behavior_contract_projection_event`.
+///
+/// **Per-turn rule** (DR1-007): `last_behavior_contract_projection_event`
+/// is reset to `None` at the head of every `handle_user_message`, so the
+/// first consumed projection in a new turn always emits.
+///
+/// **Security**: payload contains only `schema_version`, `session_id`,
+/// `turn_index`, `consumer`, `confidence`, `fields_used`. Raw `label` /
+/// `excerpt` are NEVER included (S5-006). `log_llm_event` →
+/// `mask_payload_inplace` is the final defense.
+///
+/// Returns `true` when the event was emitted, `false` when dedup skipped
+/// it or no projection was supplied.
+pub(super) fn emit_behavior_contract_projected_if_changed(
+    agent: &mut Agent,
+    projection: Option<&BehaviorContractProjection>,
+    consumer: &'static str,
+) -> bool {
+    let Some(proj) = projection else {
+        return false;
+    };
+    let key = BehaviorProjectionEventKey::from_projection(proj, consumer);
+    if agent.last_behavior_contract_projection_event.as_ref() == Some(&key) {
+        return false;
+    }
+    let session_id = agent.session_store.session_id().to_string();
+    let turn_index = agent.current_turn_index as u64;
+    let payload =
+        behavior_contract_projected_payload(&key, proj.confidence, &session_id, turn_index);
+    log_llm_event("agent.behavior_contract.projected", payload);
+    agent.last_behavior_contract_projection_event = Some(key);
+    true
+}
+
+/// Issue #660 (Phase C): compute the current `ActiveJobSelection`
+/// using the same `build_arbiter_candidates` + `select_active_job`
+/// pipeline as `effective_tool_policy()`. Pure on `&Agent` — no log
+/// emit, no state mutation.
+///
+/// Issue #660 (Codex CB-001 / §4): mirrors the `effective_tool_policy`
+/// pre-arbitration gate for `ExecutionMode::Plan`. The PAM gate at
+/// `src/tools/registry.rs::resolve_plan_mode_write_target` /
+/// `enforce_plan_stage_scope` is the authority for plan-file Write/Edit
+/// arbitration; the arbiter does not see any candidate while Plan mode
+/// is active, so observers see a `None` selection that accurately
+/// reflects the design.
+pub(super) fn current_active_job_selection(agent: &Agent) -> ActiveJobSelection {
+    if agent.session.mode_state.mode == ExecutionMode::Plan {
+        return ActiveJobSelection {
+            selected: None,
+            rejected: Vec::new(),
+        };
+    }
+    let candidates = super::effective_tool_policy_flow::build_arbiter_candidates(agent);
+    select_active_job(&candidates)
+}

--- a/src/agent/loop_run/actor_loop_flow.rs
+++ b/src/agent/loop_run/actor_loop_flow.rs
@@ -2841,7 +2841,7 @@ pub(super) fn run_actor_loop(
         // payload's `iteration_seq` so the field name and the value
         // semantics agree (previously the per-turn index was passed,
         // which collapsed all same-turn re-emits to a single value).
-        agent.emit_active_job_selected_if_changed(iter_count as u32);
+        super::active_job_emit::emit_active_job_selected_if_changed(agent, iter_count as u32);
 
         let (reply, recovery_dispatch_gate, missing_verifier_setup_turn, recovery_owner) =
             match drive_actor_loop_pre_reply_phase(

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -1,4 +1,4 @@
-use super::active_job_arbiter::{RecoveryOwner, build_active_job_selected_payload};
+use super::active_job_arbiter::RecoveryOwner;
 use super::actor_loop_flow::format_iteration_status;
 use super::auto_test::{AutoTestKind, AutoTestRunner};
 use super::completion_evidence::is_repo_edit_no_op;
@@ -436,121 +436,7 @@ impl Agent {
             .as_ref()
             .map(|j| j.attempts().len())
     }
-    /// Issue #660 (Phase C / DD-4): per-turn diff-based emit of
-    /// `agent.active_job.selected`. Computes the current
-    /// `ActiveJobSelection`, compares it with the previous emission stored
-    /// in `self.last_active_job_selection`, and emits a single structured
-    /// log event when the selection differs. Returns `true` when the event
-    /// was emitted, `false` when dedup skipped it.
-    ///
-    /// **Per-turn rule** (DR1-007): `self.last_active_job_selection` is
-    /// reset to `None` at the head of every `handle_user_message`, so the
-    /// first call of a new turn always emits.
-    ///
-    /// **Security** (Stage 4 DR4-001/002 / §7 of the design policy): the
-    /// payload contains only short type labels, sanitized
-    /// `EffectiveToolPolicyReason::as_str()` strings, counts, and
-    /// non-cryptographic `stable_path_hash(mask_secrets(...))` correlators.
-    /// Raw verifier commands / raw paths / raw recovery reasons are NEVER
-    /// included; emit goes through `log_llm_event` so
-    /// `mask_payload_inplace` is the final defense line.
-    ///
-    /// **`iteration_seq` semantics** (Codex CB-002): the caller passes the
-    /// actor-loop iteration counter (`run_actor_loop`'s `iter_count`) so
-    /// that the payload `iteration_seq` field name and value semantics
-    /// agree. Two re-emits within the same turn carry distinct
-    /// `iteration_seq` values, which lets #666 consumers identify the
-    /// iteration at which a selection change occurred.
-    pub(super) fn emit_active_job_selected_if_changed(&mut self, iteration_seq: u32) -> bool {
-        let selection = self.current_active_job_selection();
-        if self.last_active_job_selection.as_ref() == Some(&selection) {
-            return false;
-        }
-        let payload = build_active_job_selected_payload(
-            &selection,
-            iteration_seq,
-            self.repair_job_artifact_attempts as u32,
-            self.artifact_completion_job
-                .as_ref()
-                .map(|job| job.attempts().len() as u32)
-                .unwrap_or(0),
-        );
-        log_llm_event("agent.active_job.selected", payload);
-        self.last_active_job_selection = Some(selection);
-        true
-    }
 
-    /// Issue #665 (Phase 6 / S5-006 / S7-002): emit the
-    /// `agent.behavior_contract.projected` event with per-turn diff-based
-    /// dedup. Only emits when:
-    /// - `projection` is `Some(...)` (i.e. consumed by a prompt site), AND
-    /// - the payload-shaped key differs from
-    ///   `self.last_behavior_contract_projection_event`.
-    ///
-    /// **Per-turn rule** (DR1-007): `last_behavior_contract_projection_event`
-    /// is reset to `None` at the head of every `handle_user_message`, so the
-    /// first consumed projection in a new turn always emits.
-    ///
-    /// **Security**: payload contains only `schema_version`, `session_id`,
-    /// `turn_index`, `consumer`, `confidence`, `fields_used`. Raw `label` /
-    /// `excerpt` are NEVER included (S5-006). `log_llm_event` →
-    /// `mask_payload_inplace` is the final defense.
-    ///
-    /// Returns `true` when the event was emitted, `false` when dedup skipped
-    /// it or no projection was supplied.
-    pub(super) fn emit_behavior_contract_projected_if_changed(
-        &mut self,
-        projection: Option<&super::required_behavior::BehaviorContractProjection>,
-        consumer: &'static str,
-    ) -> bool {
-        let Some(proj) = projection else {
-            return false;
-        };
-        let key =
-            super::required_behavior::BehaviorProjectionEventKey::from_projection(proj, consumer);
-        if self.last_behavior_contract_projection_event.as_ref() == Some(&key) {
-            return false;
-        }
-        let session_id = self.session_store.session_id().to_string();
-        let turn_index = self.current_turn_index as u64;
-        let payload = super::required_behavior::behavior_contract_projected_payload(
-            &key,
-            proj.confidence,
-            &session_id,
-            turn_index,
-        );
-        log_llm_event("agent.behavior_contract.projected", payload);
-        self.last_behavior_contract_projection_event = Some(key);
-        true
-    }
-
-    /// Issue #660 (Phase C): compute the current `ActiveJobSelection`
-    /// using the same `build_arbiter_candidates` + `select_active_job`
-    /// pipeline as `effective_tool_policy()`. Pure on `self` — no log
-    /// emit, no state mutation. Recomputed on demand so callers
-    /// (`emit_active_job_selected_if_changed`) can observe the selection
-    /// independently of `effective_tool_policy()`.
-    ///
-    /// Issue #660 (Codex CB-001 / §4): mirrors the `effective_tool_policy`
-    /// pre-arbitration gate for `ExecutionMode::Plan`. The PAM gate at
-    /// `src/tools/registry.rs::resolve_plan_mode_write_target` /
-    /// `enforce_plan_stage_scope` is the authority for plan-file Write/Edit
-    /// arbitration; the arbiter does not see any candidate while Plan mode
-    /// is active, so observers (e.g. `emit_active_job_selected_if_changed`,
-    /// the `selected_skips_*` generic-retry guards in Phase D) see a
-    /// `None` selection that accurately reflects the design.
-    pub(super) fn current_active_job_selection(
-        &self,
-    ) -> super::active_job_arbiter::ActiveJobSelection {
-        if self.session.mode_state.mode == ExecutionMode::Plan {
-            return super::active_job_arbiter::ActiveJobSelection {
-                selected: None,
-                rejected: Vec::new(),
-            };
-        }
-        let candidates = super::effective_tool_policy_flow::build_arbiter_candidates(self);
-        super::active_job_arbiter::select_active_job(&candidates)
-    }
     pub(super) fn tool_specs_for_policy(&self, policy: &EffectiveToolPolicy) -> Vec<ToolSpec> {
         let mut specs = self.tool_registry.specs().to_vec();
         if let Some(allowed_tools) = policy.allowed_tool_names_for_prompt() {
@@ -789,7 +675,8 @@ impl Agent {
         let task_contract = super::task_contract::TaskContract::from_request(&active_request);
         let behavior_projection =
             super::required_behavior::project_behavior_contract(&task_contract);
-        self.emit_behavior_contract_projected_if_changed(
+        super::active_job_emit::emit_behavior_contract_projected_if_changed(
+            self,
             behavior_projection.as_ref(),
             super::required_behavior::BEHAVIOR_CONTRACT_CONSUMER_VERIFIER_DIAGNOSTIC,
         );
@@ -1406,7 +1293,8 @@ impl Agent {
         let task_contract = super::task_contract::TaskContract::from_request(&active_request);
         let behavior_projection =
             super::required_behavior::project_behavior_contract(&task_contract);
-        self.emit_behavior_contract_projected_if_changed(
+        super::active_job_emit::emit_behavior_contract_projected_if_changed(
+            self,
             behavior_projection.as_ref(),
             super::required_behavior::BEHAVIOR_CONTRACT_CONSUMER_VERIFIER_REPAIR,
         );

--- a/src/agent/loop_run/turn_tests.rs
+++ b/src/agent/loop_run/turn_tests.rs
@@ -2621,7 +2621,8 @@ mod tests {
 
         let (mut agent, _temp) = test_agent_with_config(Config::default());
         assert!(agent.last_active_job_selection.is_none());
-        let emitted = agent.emit_active_job_selected_if_changed(0);
+        let emitted =
+            super::super::active_job_emit::emit_active_job_selected_if_changed(&mut agent, 0);
         assert!(
             emitted,
             "first call after turn reset must emit (None -> Some transition)"
@@ -2642,8 +2643,10 @@ mod tests {
         use crate::config::Config;
 
         let (mut agent, _temp) = test_agent_with_config(Config::default());
-        let first = agent.emit_active_job_selected_if_changed(0);
-        let second = agent.emit_active_job_selected_if_changed(1);
+        let first =
+            super::super::active_job_emit::emit_active_job_selected_if_changed(&mut agent, 0);
+        let second =
+            super::super::active_job_emit::emit_active_job_selected_if_changed(&mut agent, 1);
         assert!(first, "first emit must succeed");
         assert!(
             !second,
@@ -2662,7 +2665,8 @@ mod tests {
         use crate::config::Config;
 
         let (mut agent, _temp) = test_agent_with_config(Config::default());
-        let first = agent.emit_active_job_selected_if_changed(0);
+        let first =
+            super::super::active_job_emit::emit_active_job_selected_if_changed(&mut agent, 0);
         assert!(first);
 
         // Install a concrete verifier-repair job so the next selection
@@ -2670,7 +2674,8 @@ mod tests {
         // flag alone is intentionally not a dispatch source anymore.
         agent.task_contract_verifier_repair_pending = true;
         agent.repair_job = Some(super::super::repair_job::RepairJob::new_for_test());
-        let second = agent.emit_active_job_selected_if_changed(1);
+        let second =
+            super::super::active_job_emit::emit_active_job_selected_if_changed(&mut agent, 1);
         assert!(
             second,
             "selection change (None -> VerifierRepair) MUST re-emit"
@@ -2687,13 +2692,14 @@ mod tests {
         use crate::config::Config;
 
         let (mut agent, _temp) = test_agent_with_config(Config::default());
-        agent.emit_active_job_selected_if_changed(0);
+        super::super::active_job_emit::emit_active_job_selected_if_changed(&mut agent, 0);
         assert!(agent.last_active_job_selection.is_some());
 
         // Simulate per-turn reset (same lines as handle_user_message head).
         agent.last_active_job_selection = None;
 
-        let after_reset = agent.emit_active_job_selected_if_changed(0);
+        let after_reset =
+            super::super::active_job_emit::emit_active_job_selected_if_changed(&mut agent, 0);
         assert!(
             after_reset,
             "post-turn-reset call must emit again (None -> Some transition)"
@@ -3372,7 +3378,7 @@ mod tests {
 
         // (2) ActiveJobSelection.selected MUST be Some (Phase C dedup state
         //     would observe an active job at the head of the next iteration).
-        let selection = agent.current_active_job_selection();
+        let selection = super::super::active_job_emit::current_active_job_selection(&agent);
         assert!(
             selection.selected.is_some(),
             "current_active_job_selection().selected must be Some(VerifierRepair)"
@@ -3487,7 +3493,7 @@ mod tests {
         );
 
         // (2) ActiveJobSelection.selected MUST be Some.
-        let selection = agent.current_active_job_selection();
+        let selection = super::super::active_job_emit::current_active_job_selection(&agent);
         assert!(
             selection.selected.is_some(),
             "current_active_job_selection().selected must be Some(ArtifactRecovery)"
@@ -3538,7 +3544,7 @@ mod tests {
             "CB-001: bare recovery target without a job MUST NOT yield ArtifactDirectedRecovery"
         );
 
-        let selection = agent.current_active_job_selection();
+        let selection = super::super::active_job_emit::current_active_job_selection(&agent);
         let chose_artifact_recovery = selection
             .selected
             .as_ref()
@@ -3702,7 +3708,7 @@ mod tests {
         );
 
         // (2) ActiveJobSelection.selected MUST be Some.
-        let selection = agent.current_active_job_selection();
+        let selection = super::super::active_job_emit::current_active_job_selection(&agent);
         assert!(
             selection.selected.is_some(),
             "current_active_job_selection().selected must be Some(ForcedSmallEditRecovery)"
@@ -3763,7 +3769,7 @@ mod tests {
             super::EffectiveToolPolicyReason::Unrestricted,
             "without any selectable job, effective_tool_policy must be Unrestricted"
         );
-        let selection = agent.current_active_job_selection();
+        let selection = super::super::active_job_emit::current_active_job_selection(&agent);
         assert!(
             selection.selected.is_none(),
             "without any selectable job, ActiveJobSelection.selected must be None"
@@ -3900,7 +3906,7 @@ mod tests {
         // return an empty selection — the registry-layer PAM gate is the
         // sole authority for write-target arbitration in Plan mode.
         agent.task_contract_verifier_repair_pending = true;
-        let selection = agent.current_active_job_selection();
+        let selection = super::super::active_job_emit::current_active_job_selection(&agent);
         assert!(
             selection.selected.is_none(),
             "Plan mode pre-arbitration gate MUST short-circuit \
@@ -3954,7 +3960,7 @@ mod tests {
         // Cross-check: `current_active_job_selection()` mirrors the same
         // gate so consumers (`emit_active_job_selected_if_changed`, generic-
         // retry guards) observe `None`.
-        let selection = agent.current_active_job_selection();
+        let selection = super::super::active_job_emit::current_active_job_selection(&agent);
         assert!(
             selection.selected.is_none(),
             "Plan mode pre-arbitration gate MUST also short-circuit \


### PR DESCRIPTION
## Summary

Fifteenth **vertical-slice extraction**: move the active-job + behavior-contract event emit helpers out of `turn.rs` into a new `src/agent/loop_run/active_job_emit.rs` sibling module.

### Migrated (3 `pub(super)` free fns)

- `emit_active_job_selected_if_changed(&mut Agent, u32) -> bool` — Issue #660 (Phase C / DD-4 / DR1-007) per-turn diff-based emit of `agent.active_job.selected`.
- `emit_behavior_contract_projected_if_changed(&mut Agent, Option<&BehaviorContractProjection>, &'static str) -> bool` — Issue #665 (Phase 6 / S5-006 / S7-002) per-turn diff-based emit of `agent.behavior_contract.projected`.
- `current_active_job_selection(&Agent) -> ActiveJobSelection` — Issue #660 (Phase C) pure ActiveJobSelection computation, used by the emit site above and by tests.

No facade re-export (DR3-001).

### Caller updates
- `turn.rs` ×3: `self.current_active_job_selection()` / `self.emit_behavior_contract_projected_if_changed(...)` → free-fn form.
- `actor_loop_flow.rs`: `agent.emit_active_job_selected_if_changed(...)` → `super::active_job_emit::emit_active_job_selected_if_changed(agent, ...)`.
- `turn_tests.rs` ×9: `agent.X(...)` → `super::super::active_job_emit::X(&mut agent, ...)` / `X(&agent)`.

`cargo fix --tests` pruned 1 newly-unused import from `turn.rs`'s prelude.

## LOC delta

- `turn.rs`: 3,816 → **3,704 LOC** (-112 LOC)
- New `active_job_emit.rs`: 112 LOC
- **Cumulative from 39,489: -35,785 LOC (-90.6%)**

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --lib --all-targets -- -D warnings` clean
- [x] `cargo test --lib` (3,114 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)