### PR TITLE
Extract working_memory_messages.rs from turn.rs (parent #680)

### DIFF
--- a/src/agent/loop_run.rs
+++ b/src/agent/loop_run.rs
@@ -161,6 +161,12 @@ mod run_turn;
 // `current_active_job_selection` as free fns over `&mut Agent` /
 // `&Agent`. `pub(super)` limited / no facade re-export (DR3-001).
 mod active_job_emit;
+// Working-memory + repo-context prompt messages extracted from
+// `turn.rs` (parent #680). Hosts `refresh_working_memory`,
+// `working_memory_message`, `answer_only_fallback_response`, and
+// `repo_context_message` as free fns over `&mut Agent` / `&Agent`.
+// `pub(super)` limited / no facade re-export (DR3-001).
+mod working_memory_messages;
 // Issue #652: `ArtifactCompletionJob` + role-specific retry budget +
 // `ArtifactAttemptOutcome` 4-variant taxonomy +
 // `ArtifactCompletionFailureSnapshot` for #654. Module is intentionally

--- a/src/agent/loop_run/actor_loop_flow.rs
+++ b/src/agent/loop_run/actor_loop_flow.rs
@@ -458,7 +458,7 @@ pub(super) fn maybe_handle_answer_only_inadequate_recovery(
                     &agent.work_root,
                 ));
             return Some(PostReplyRecoveryOutcome::Finalize {
-                final_prose: agent.answer_only_fallback_response(),
+                final_prose: super::working_memory_messages::answer_only_fallback_response(agent),
                 exit_reason: ExitReason::Done,
                 error_text: String::new(),
             });
@@ -2646,7 +2646,7 @@ pub(super) fn maybe_handle_answer_only_future_work_recovery(
         *args.no_tool_retries += 1;
         if *args.no_tool_retries >= 1 {
             return Some(PostReplyRecoveryOutcome::Finalize {
-                final_prose: agent.answer_only_fallback_response(),
+                final_prose: super::working_memory_messages::answer_only_fallback_response(agent),
                 exit_reason: ExitReason::Done,
                 error_text: String::new(),
             });

--- a/src/agent/loop_run/build_request_messages.rs
+++ b/src/agent/loop_run/build_request_messages.rs
@@ -128,7 +128,7 @@ fn append_general_request_context_messages(
             recovery::empty_workspace_scaffold_note(),
         ));
     }
-    if let Some(memory_message) = agent.working_memory_message() {
+    if let Some(memory_message) = super::working_memory_messages::working_memory_message(agent) {
         messages.push(memory_message);
     }
     let case_injection = super::case_record_flow::try_inject_case_retrieval_message(agent);
@@ -140,7 +140,8 @@ fn append_general_request_context_messages(
         messages.push(inj.message.clone());
     }
     maybe_send_request_context_pack(agent, &case_injection, &anti_injection);
-    if let Some(repo_context_message) = agent.repo_context_message() {
+    if let Some(repo_context_message) = super::working_memory_messages::repo_context_message(agent)
+    {
         messages.push(repo_context_message);
     }
 }

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -11,9 +11,7 @@ use super::repair_patch_validation::{
     build_verifier_repair_pass_ledger_outcome, validate_accepted_repair_plan_authorizes_target,
 };
 
-use super::answer_only_mode::{
-    answer_only_script_command_allowed, answer_only_script_execution_fallback_response,
-};
+use super::answer_only_mode::answer_only_script_command_allowed;
 use super::feedback_builders::{
     build_feedback_for_bash, build_feedback_for_edit_failure,
     build_feedback_for_unsafe_block_reason,
@@ -25,13 +23,10 @@ use super::file_excerpt::{
 use super::path_helpers::normalize_memory_path;
 use super::photon_feedback_derive::request_explicitly_requests_script_execution;
 use super::plan_mode_helpers::assistant_model_for_mode;
-use super::precaution_relevance::select_precautions_for_prompt;
 use super::safe_stop_payload::{build_safe_stop_payload, collect_recent_action_labels};
 #[cfg(debug_assertions)]
 use super::small_helpers::masked_path_hash_bounded_list;
-use super::small_helpers::{
-    latest_tool_result_since_last_user, raw_mode_safe_text, rfc3339_now_utc, user_interrupt_result,
-};
+use super::small_helpers::{raw_mode_safe_text, rfc3339_now_utc, user_interrupt_result};
 use super::summary::ExitReason;
 use super::tool_display::progress_path_display;
 use super::tool_execution::{
@@ -3473,138 +3468,6 @@ impl Agent {
                 || name == "tests.py"
         })
     }
-
-    fn refresh_working_memory(&mut self) {
-        let constraints = self
-            .current_plan_contents()
-            .ok()
-            .flatten()
-            .map(|contents| lifecycle::extract_plan_constraints(&contents))
-            .unwrap_or_default();
-        self.session.working_memory.replace_constraints(constraints);
-    }
-
-    pub(super) fn working_memory_message(&mut self) -> Option<ConversationMessage> {
-        if !self.session.mode_state.policy().include_working_memory {
-            return None;
-        }
-        self.refresh_working_memory();
-
-        // Issue #453: build the per-prompt precaution slice from
-        // (active_precautions × mode × touched_files × last_feedback.suspected_files)
-        // before handing it to the renderer. The Reminder Sidecar path
-        // (handle_user_message → format_for_prompt() wrapper) keeps using the
-        // full active-only list (design judgment #5).
-        let suspected_owned: Option<Vec<PathBuf>> = self
-            .session
-            .last_feedback
-            .as_ref()
-            .map(|f| f.suspected_files.clone());
-        let precautions_for_prompt = select_precautions_for_prompt(
-            &self.session.working_memory.active_precautions,
-            self.session.mode_state.mode,
-            &self.session.working_memory.touched_files,
-            suspected_owned.as_deref(),
-        );
-        self.session
-            .working_memory
-            .format_for_prompt_with_precautions(&precautions_for_prompt)
-            .map(ConversationMessage::system)
-    }
-
-    pub(super) fn answer_only_fallback_response(&self) -> String {
-        let request = self.active_request_text().unwrap_or_default();
-        let lower = request.to_ascii_lowercase();
-        if request_explicitly_requests_script_execution(&request)
-            && let Some(output) = latest_tool_result_since_last_user(&self.session.messages, "Bash")
-        {
-            return answer_only_script_execution_fallback_response(output);
-        }
-        if lower.contains("modepolicy") || lower.contains("構造化状態") {
-            return "ファイルは変更せず、読み取り専用で整理します。\n\n利点:\n- モード判断を会話履歴から分離できるため、古い発話や回復プロンプトに引きずられにくい。\n- `repo_edit_required` や fallback 許可などを明示的な実行ポリシーとして扱えるため、ツール制御と品質ゲートを安定させやすい。\n- セッション保存や compaction 後も、必要な状態だけを小さく復元できる。\n\nリスク:\n- 状態更新の境界が曖昧だと、ユーザーの最新意図と ModePolicy がずれる。\n- ポリシーが強すぎると、読み取り専用のスクリプト実行など正当な作業まで止める。\n- LLM の自然言語判断と構造化状態の差分を観測できないと、誤分類の原因調査が難しい。\n\n方向性としては、ModePolicy は構造化状態で保持し、最新ユーザー要求から毎ターン再評価できるようにするのが妥当です。会話履歴へ埋め込むのは補助説明に留め、実際のツール許可と品質条件は構造化フィールドを正とするのが安定します。".to_string();
-        }
-        if lower.contains("rust") && lower.contains("cli") {
-            return "ファイルは変更せず、Rust CLI 化の構成案だけを整理します。\n\n- `Cargo.toml`: crate 名、依存、bin 設定を管理する。\n- `src/main.rs`: 引数解析と終了コード制御だけを置く。\n- `src/cli.rs`: CLI オプション、help、入力検証をまとめる。\n- `src/lib.rs`: 実処理をライブラリ化し、CLI 以外からもテスト可能にする。\n- `tests/cli.rs`: 代表コマンド、異常入力、終了コードを E2E 寄りに検証する。\n- `README.md`: インストール、実行例、検証コマンド、制約を記載する。\n\n方針としては、CLI 表層とドメイン処理を分離し、`cargo test` でロジック、必要なら `assert_cmd` 系でコマンド挙動を確認するのが扱いやすいです。".to_string();
-        }
-        if lower.contains("readme")
-            && (request.contains("要約") || lower.contains("summarize"))
-            && let Ok(readme) = std::fs::read_to_string(self.work_root.join("README.md"))
-        {
-            let summary = readme
-                .lines()
-                .map(str::trim)
-                .filter(|line| !line.is_empty())
-                .take(4)
-                .collect::<Vec<_>>()
-                .join(" ");
-            return format!(
-                "README の要約: {summary}\n\n設計上の課題: README から確認できる情報は概要レベルに限られており、内部構成、実行手順、検証方法、制約、fallback や session 管理の責務分担が文書化されていません。そのため、初見の開発者が変更範囲や品質確認方法を判断しにくい状態です。ファイルは変更していません。"
-            );
-        }
-        "ファイルは変更せず、読み取り専用の回答として整理します。目的、前提、推奨構成、検証方法、残リスクを分け、実装や編集が必要な場合だけ次のターンで明示的に依頼してください。".to_string()
-    }
-
-    pub(super) fn repo_context_message(&mut self) -> Option<ConversationMessage> {
-        if !self.session.mode_state.policy().allow_repo_context {
-            return None;
-        }
-        self.refresh_working_memory();
-        let task = self.session.working_memory.active_task.clone()?;
-
-        // Issue #469: cache key is widened to include graph ranking inputs.
-        let suspected_files: Vec<PathBuf> = self
-            .session
-            .last_feedback
-            .as_ref()
-            .map(|f| f.suspected_files.clone())
-            .unwrap_or_default();
-        let suspected_strings: Vec<String> = suspected_files
-            .iter()
-            .map(|p| p.to_string_lossy().to_string())
-            .collect();
-        let changed_files: Vec<String> = self.session.touched_files_at_turn_start.clone();
-        let last_feedback_kind: Option<String> = self
-            .session
-            .last_feedback
-            .as_ref()
-            .map(|f| format!("{:?}", f.kind));
-        let repo_graph_present = self.repo_graph.is_some();
-        let suspected_fp = super::fingerprint_paths(&suspected_strings);
-        let touched_fp = super::fingerprint_paths(&changed_files);
-
-        if let Some(cache) = &self.repo_context_cache
-            && cache.task == task
-            && cache.work_root == self.work_root
-            && cache.repo_graph_present == repo_graph_present
-            && cache.last_feedback_kind == last_feedback_kind
-            && cache.suspected_files_fingerprint == suspected_fp
-            && cache.touched_files_fingerprint == touched_fp
-        {
-            return cache.message.clone();
-        }
-
-        let session_id = self.session_store.session_id().to_string();
-        let model = self.models.main.clone();
-        let inputs = prompting::RepoContextInputs {
-            repo_graph: self.repo_graph.as_deref(),
-            suspected_files: &suspected_files,
-            changed_files: &changed_files,
-            session_id: &session_id,
-            model: Some(model.as_str()),
-        };
-        let message = prompting::repo_context_message(&self.work_root, Some(&task), &inputs);
-        self.repo_context_cache = Some(super::RepoContextCache {
-            task,
-            work_root: self.work_root.clone(),
-            repo_graph_present,
-            last_feedback_kind,
-            suspected_files_fingerprint: suspected_fp,
-            touched_files_fingerprint: touched_fp,
-            message: message.clone(),
-        });
-        message
-    }
-
     pub(super) fn prepare_tool_call(&self, mut tool_call: ToolCall) -> ToolCall {
         tool_call.arguments = normalize_tool_call_arguments(&tool_call.name, tool_call.arguments);
         if matches!(tool_call.name.as_str(), "Read" | "Write" | "Edit")

--- a/src/agent/loop_run/working_memory_messages.rs
+++ b/src/agent/loop_run/working_memory_messages.rs
@@ -1,0 +1,168 @@
+//! Working-memory + repo-context prompt messages extracted from
+//! `turn.rs` (parent #680).
+//!
+//! Hosts the read-only Agent state projections that build per-prompt
+//! conversational messages:
+//!
+//! - `refresh_working_memory` — re-extract plan constraints from the
+//!   active plan file and replace the session's working-memory
+//!   constraint list.
+//! - `working_memory_message` — render the working-memory snippet
+//!   (with per-prompt precaution filtering) as a `ConversationMessage`
+//!   when mode policy permits.
+//! - `answer_only_fallback_response` — `AnswerOnly` mode's canned read-
+//!   only response, selected from the current request text.
+//! - `repo_context_message` — produce the cached repo-context system
+//!   message (RepoGraph + suspected files + change history), bypassing
+//!   when the cache key matches.
+//!
+//! Originally `impl Agent` methods; converted to free functions taking
+//! `&mut Agent` / `&Agent`, matching `actor_loop_flow` / `reply_retry`
+//! / earlier vertical-slice patterns. `pub(super)` limited / no facade
+//! re-export (DR3-001).
+
+use std::path::PathBuf;
+
+use super::Agent;
+use super::answer_only_mode::answer_only_script_execution_fallback_response;
+use super::lifecycle;
+use super::photon_feedback_derive::request_explicitly_requests_script_execution;
+use super::precaution_relevance::select_precautions_for_prompt;
+use super::small_helpers::latest_tool_result_since_last_user;
+use crate::agent::prompting;
+use crate::session::store::ConversationMessage;
+
+pub(super) fn refresh_working_memory(agent: &mut Agent) {
+    let constraints = agent
+        .current_plan_contents()
+        .ok()
+        .flatten()
+        .map(|contents| lifecycle::extract_plan_constraints(&contents))
+        .unwrap_or_default();
+    agent
+        .session
+        .working_memory
+        .replace_constraints(constraints);
+}
+
+pub(super) fn working_memory_message(agent: &mut Agent) -> Option<ConversationMessage> {
+    if !agent.session.mode_state.policy().include_working_memory {
+        return None;
+    }
+    refresh_working_memory(agent);
+
+    // Issue #453: build the per-prompt precaution slice from
+    // (active_precautions × mode × touched_files × last_feedback.suspected_files)
+    // before handing it to the renderer. The Reminder Sidecar path
+    // (handle_user_message → format_for_prompt() wrapper) keeps using the
+    // full active-only list (design judgment #5).
+    let suspected_owned: Option<Vec<PathBuf>> = agent
+        .session
+        .last_feedback
+        .as_ref()
+        .map(|f| f.suspected_files.clone());
+    let precautions_for_prompt = select_precautions_for_prompt(
+        &agent.session.working_memory.active_precautions,
+        agent.session.mode_state.mode,
+        &agent.session.working_memory.touched_files,
+        suspected_owned.as_deref(),
+    );
+    agent
+        .session
+        .working_memory
+        .format_for_prompt_with_precautions(&precautions_for_prompt)
+        .map(ConversationMessage::system)
+}
+
+pub(super) fn answer_only_fallback_response(agent: &Agent) -> String {
+    let request = agent.active_request_text().unwrap_or_default();
+    let lower = request.to_ascii_lowercase();
+    if request_explicitly_requests_script_execution(&request)
+        && let Some(output) = latest_tool_result_since_last_user(&agent.session.messages, "Bash")
+    {
+        return answer_only_script_execution_fallback_response(output);
+    }
+    if lower.contains("modepolicy") || lower.contains("構造化状態") {
+        return "ファイルは変更せず、読み取り専用で整理します。\n\n利点:\n- モード判断を会話履歴から分離できるため、古い発話や回復プロンプトに引きずられにくい。\n- `repo_edit_required` や fallback 許可などを明示的な実行ポリシーとして扱えるため、ツール制御と品質ゲートを安定させやすい。\n- セッション保存や compaction 後も、必要な状態だけを小さく復元できる。\n\nリスク:\n- 状態更新の境界が曖昧だと、ユーザーの最新意図と ModePolicy がずれる。\n- ポリシーが強すぎると、読み取り専用のスクリプト実行など正当な作業まで止める。\n- LLM の自然言語判断と構造化状態の差分を観測できないと、誤分類の原因調査が難しい。\n\n方向性としては、ModePolicy は構造化状態で保持し、最新ユーザー要求から毎ターン再評価できるようにするのが妥当です。会話履歴へ埋め込むのは補助説明に留め、実際のツール許可と品質条件は構造化フィールドを正とするのが安定します。".to_string();
+    }
+    if lower.contains("rust") && lower.contains("cli") {
+        return "ファイルは変更せず、Rust CLI 化の構成案だけを整理します。\n\n- `Cargo.toml`: crate 名、依存、bin 設定を管理する。\n- `src/main.rs`: 引数解析と終了コード制御だけを置く。\n- `src/cli.rs`: CLI オプション、help、入力検証をまとめる。\n- `src/lib.rs`: 実処理をライブラリ化し、CLI 以外からもテスト可能にする。\n- `tests/cli.rs`: 代表コマンド、異常入力、終了コードを E2E 寄りに検証する。\n- `README.md`: インストール、実行例、検証コマンド、制約を記載する。\n\n方針としては、CLI 表層とドメイン処理を分離し、`cargo test` でロジック、必要なら `assert_cmd` 系でコマンド挙動を確認するのが扱いやすいです。".to_string();
+    }
+    if lower.contains("readme")
+        && (request.contains("要約") || lower.contains("summarize"))
+        && let Ok(readme) = std::fs::read_to_string(agent.work_root.join("README.md"))
+    {
+        let summary = readme
+            .lines()
+            .map(str::trim)
+            .filter(|line| !line.is_empty())
+            .take(4)
+            .collect::<Vec<_>>()
+            .join(" ");
+        return format!(
+            "README の要約: {summary}\n\n設計上の課題: README から確認できる情報は概要レベルに限られており、内部構成、実行手順、検証方法、制約、fallback や session 管理の責務分担が文書化されていません。そのため、初見の開発者が変更範囲や品質確認方法を判断しにくい状態です。ファイルは変更していません。"
+        );
+    }
+    "ファイルは変更せず、読み取り専用の回答として整理します。目的、前提、推奨構成、検証方法、残リスクを分け、実装や編集が必要な場合だけ次のターンで明示的に依頼してください。".to_string()
+}
+
+pub(super) fn repo_context_message(agent: &mut Agent) -> Option<ConversationMessage> {
+    if !agent.session.mode_state.policy().allow_repo_context {
+        return None;
+    }
+    refresh_working_memory(agent);
+    let task = agent.session.working_memory.active_task.clone()?;
+
+    // Issue #469: cache key is widened to include graph ranking inputs.
+    let suspected_files: Vec<PathBuf> = agent
+        .session
+        .last_feedback
+        .as_ref()
+        .map(|f| f.suspected_files.clone())
+        .unwrap_or_default();
+    let suspected_strings: Vec<String> = suspected_files
+        .iter()
+        .map(|p| p.to_string_lossy().to_string())
+        .collect();
+    let changed_files: Vec<String> = agent.session.touched_files_at_turn_start.clone();
+    let last_feedback_kind: Option<String> = agent
+        .session
+        .last_feedback
+        .as_ref()
+        .map(|f| format!("{:?}", f.kind));
+    let repo_graph_present = agent.repo_graph.is_some();
+    let suspected_fp = super::fingerprint_paths(&suspected_strings);
+    let touched_fp = super::fingerprint_paths(&changed_files);
+
+    if let Some(cache) = &agent.repo_context_cache
+        && cache.task == task
+        && cache.work_root == agent.work_root
+        && cache.repo_graph_present == repo_graph_present
+        && cache.last_feedback_kind == last_feedback_kind
+        && cache.suspected_files_fingerprint == suspected_fp
+        && cache.touched_files_fingerprint == touched_fp
+    {
+        return cache.message.clone();
+    }
+
+    let session_id = agent.session_store.session_id().to_string();
+    let model = agent.models.main.clone();
+    let inputs = prompting::RepoContextInputs {
+        repo_graph: agent.repo_graph.as_deref(),
+        suspected_files: &suspected_files,
+        changed_files: &changed_files,
+        session_id: &session_id,
+        model: Some(model.as_str()),
+    };
+    let message = prompting::repo_context_message(&agent.work_root, Some(&task), &inputs);
+    agent.repo_context_cache = Some(super::RepoContextCache {
+        task,
+        work_root: agent.work_root.clone(),
+        repo_graph_present,
+        last_feedback_kind,
+        suspected_files_fingerprint: suspected_fp,
+        touched_files_fingerprint: touched_fp,
+        message: message.clone(),
+    });
+    message
+}


### PR DESCRIPTION
## Summary

Sixteenth **vertical-slice extraction**: move the working-memory + repo-context prompt message builders out of `turn.rs` into a new `src/agent/loop_run/working_memory_messages.rs` sibling module.

### Migrated (4 `pub(super)` free fns)

- `refresh_working_memory(&mut Agent)` — re-extract plan constraints from the active plan file and replace the session's working-memory constraint list.
- `working_memory_message(&mut Agent) -> Option<ConversationMessage>` — render the working-memory snippet (with per-prompt precaution filtering) as a `ConversationMessage` when mode policy permits.
- `answer_only_fallback_response(&Agent) -> String` — `AnswerOnly` mode's canned read-only response, selected from the current request text.
- `repo_context_message(&mut Agent) -> Option<ConversationMessage>` — produce the cached repo-context system message (RepoGraph + suspected files + change history), bypassing when the cache key matches.

No facade re-export (DR3-001).

### Caller updates
- `build_request_messages.rs` ×2: `agent.working_memory_message()` / `agent.repo_context_message()` → free-fn form.
- `actor_loop_flow.rs` ×2: `agent.answer_only_fallback_response()` → `super::working_memory_messages::answer_only_fallback_response(agent)`.

`cargo fix --tests` pruned 3 newly-unused imports from `turn.rs`'s prelude.

## LOC delta

- `turn.rs`: 3,704 → **3,567 LOC** (-137 LOC)
- New `working_memory_messages.rs`: 168 LOC
- **Cumulative from 39,489: -35,922 LOC (-91.0%)** — crossed -91% milestone

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --lib --all-targets -- -D warnings` clean
- [x] `cargo test --lib` (3,114 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)