### PR TITLE
Extract set_artifact_recovery_target.rs from turn.rs (parent #680)

### DIFF
--- a/src/agent/loop_run.rs
+++ b/src/agent/loop_run.rs
@@ -174,6 +174,14 @@ mod working_memory_messages;
 // `artifact_recovery_target_path` as free fns over `&mut Agent` /
 // `&Agent`. `pub(super)` limited / no facade re-export (DR3-001).
 mod artifact_recovery_flow;
+// Artifact-recovery target installer (projection-write half)
+// extracted from `turn.rs` (parent #680). Hosts
+// `set_artifact_recovery_target_for_decision`,
+// `set_artifact_recovery_target_for_action`,
+// `set_artifact_recovery_target_from_hint`, and 2 private alignment /
+// synthesis helpers. Free fns over `&mut Agent` / `&Agent`.
+// `pub(super)` limited / no facade re-export (DR3-001).
+mod set_artifact_recovery_target;
 // Issue #652: `ArtifactCompletionJob` + role-specific retry budget +
 // `ArtifactAttemptOutcome` 4-variant taxonomy +
 // `ArtifactCompletionFailureSnapshot` for #654. Module is intentionally

--- a/src/agent/loop_run/actor_loop_flow.rs
+++ b/src/agent/loop_run/actor_loop_flow.rs
@@ -1242,7 +1242,8 @@ fn sync_post_tool_contract_recovery_target(
     match action {
         super::task_contract::ArtifactRecoveryAction::Continue { .. }
         | super::task_contract::ArtifactRecoveryAction::RepairArtifact { .. } => {
-            agent.set_artifact_recovery_target_for_action(
+            super::set_artifact_recovery_target::set_artifact_recovery_target_for_action(
+                agent,
                 &action,
                 args.contract_completion_retries.saturating_add(1),
             );
@@ -2119,7 +2120,8 @@ pub(super) fn handle_actor_loop_task_contract_continue_action(
         .clone()
         .or_else(|| agent.task_contract_recovery_target(&decision))
         .and_then(|hint| {
-            agent.set_artifact_recovery_target_from_hint(
+            super::set_artifact_recovery_target::set_artifact_recovery_target_from_hint(
+                agent,
                 hint,
                 (*args.contract_completion_retries).saturating_add(1),
             )
@@ -2150,7 +2152,8 @@ pub(super) fn handle_actor_loop_task_contract_continue_action(
         )
     {
         *args.contract_deterministic_fallback_materialized = true;
-        agent.set_artifact_recovery_target_for_decision(
+        super::set_artifact_recovery_target::set_artifact_recovery_target_for_decision(
+            agent,
             &decision,
             (*args.contract_completion_retries).saturating_add(1),
         );

--- a/src/agent/loop_run/prepare_actor_loop_state.rs
+++ b/src/agent/loop_run/prepare_actor_loop_state.rs
@@ -127,7 +127,11 @@ pub(super) fn prepare_actor_loop_turn_state(agent: &mut Agent) -> Option<TaskCon
     {
         let initial_decision = contract.evaluate(&EvidenceSet::new());
         if matches!(initial_decision, CompletionDecision::Continue { .. }) {
-            agent.set_artifact_recovery_target_for_decision(&initial_decision, 0);
+            super::set_artifact_recovery_target::set_artifact_recovery_target_for_decision(
+                agent,
+                &initial_decision,
+                0,
+            );
         }
     }
     task_contract

--- a/src/agent/loop_run/set_artifact_recovery_target.rs
+++ b/src/agent/loop_run/set_artifact_recovery_target.rs
@@ -1,0 +1,141 @@
+//! Artifact-recovery target installer helpers extracted from `turn.rs`
+//! (parent #680).
+//!
+//! Hosts the projection-write half of the artifact-recovery target
+//! lifecycle (the projection-read + clear half lives in
+//! `artifact_recovery_flow`). Three production entry points + two
+//! private helpers:
+//!
+//! - `set_artifact_recovery_target_for_decision` — decision → hint →
+//!   atomic-install via `set_artifact_recovery_target_from_hint`.
+//! - `set_artifact_recovery_target_for_action` — action → hint →
+//!   atomic-install.
+//! - `set_artifact_recovery_target_from_hint` — the SSOT atomic
+//!   installer. Orders: align → install/refresh job → commit
+//!   projection or atomic-clear on validation failure.
+//! - `synthesized_missing_implementation_target_path` (private) —
+//!   per-role synthesised target derivation.
+//! - `align_recovery_target_hint_to_request` (private) — Test-role
+//!   path alignment to the requested stack family.
+//!
+//! Originally `impl Agent` methods; converted to free functions taking
+//! `&mut Agent` / `&Agent`, matching `actor_loop_flow` / `reply_retry`
+//! / earlier vertical-slice patterns. `pub(super)` limited / no facade
+//! re-export (DR3-001).
+
+use super::Agent;
+use super::task_contract::{
+    ArtifactRecoveryAction, ArtifactRole, CompletionDecision, RecoveryTarget, RecoveryTargetHint,
+};
+use super::verifier_orchestration::{
+    JobInstallOutcome, synthesized_missing_test_target_path_for_request,
+    test_target_path_compatible_with_request,
+};
+use crate::logging::log_llm_event;
+
+pub(super) fn set_artifact_recovery_target_for_decision(
+    agent: &mut Agent,
+    decision: &CompletionDecision,
+    attempt: usize,
+) -> Option<RecoveryTargetHint> {
+    let hint = agent.task_contract_recovery_target(decision)?;
+    set_artifact_recovery_target_from_hint(agent, hint, attempt)
+}
+
+pub(super) fn set_artifact_recovery_target_for_action(
+    agent: &mut Agent,
+    action: &ArtifactRecoveryAction,
+    attempt: usize,
+) -> Option<RecoveryTargetHint> {
+    let hint = match action {
+        ArtifactRecoveryAction::Continue { target_hint, .. }
+        | ArtifactRecoveryAction::RepairArtifact { target_hint } => target_hint.clone()?,
+        _ => return None,
+    };
+    set_artifact_recovery_target_from_hint(agent, hint, attempt)
+}
+
+fn align_recovery_target_hint_to_request(
+    agent: &Agent,
+    mut hint: RecoveryTargetHint,
+) -> RecoveryTargetHint {
+    if hint.role != ArtifactRole::Test {
+        return hint;
+    }
+    let Some(request) = agent.active_request_text() else {
+        return hint;
+    };
+    let Some((target_path, stack_label)) =
+        synthesized_missing_test_target_path_for_request(&request)
+    else {
+        return hint;
+    };
+    if hint.path == target_path || test_target_path_compatible_with_request(&hint.path, &request) {
+        return hint;
+    }
+    hint.path = target_path.to_string();
+    hint.reason =
+        format!("synthesized test artifact aligned with requested {stack_label} project family");
+    hint
+}
+
+pub(super) fn set_artifact_recovery_target_from_hint(
+    agent: &mut Agent,
+    hint: RecoveryTargetHint,
+    attempt: usize,
+) -> Option<RecoveryTargetHint> {
+    let hint = align_recovery_target_hint_to_request(agent, hint);
+    // Issue #652 PR-001: the `ArtifactCompletionJob` is the SSOT for
+    // target + role-specific retry budget. We must NOT update
+    // `current_artifact_recovery_target` before the job has been
+    // validated and installed — otherwise a validation failure would
+    // leave the projection set with no job attached, and
+    // `EffectiveToolPolicy::artifact_directed` would grant write
+    // access for a target with no role-specific budget. Ordering:
+    //   1. attempt to install / refresh the job for the hint
+    //   2. on success → commit the projection (atomic SWAP from any
+    //      prior state)
+    //   3. on failure (only possible for Test role) → clear BOTH
+    //      the projection and the job so no stale slot remains.
+    let install =
+        super::artifact_recovery_flow::maybe_install_artifact_completion_job_for_hint(agent, &hint);
+    match install {
+        JobInstallOutcome::InstalledOrSkipped => {
+            let target = RecoveryTarget::from_hint(hint.clone(), attempt);
+            let changed = agent.current_artifact_recovery_target.as_ref() != Some(&target);
+            if changed {
+                log_llm_event(
+                    "agent.artifact_recovery_target.selected",
+                    serde_json::json!({
+                        "session_id": agent.session_store.session_id(),
+                        "turn_index": agent.current_turn_index,
+                        "role": target.role.label(),
+                        "path": target.path,
+                        "reason": target.reason,
+                        "attempt": target.attempt,
+                    }),
+                );
+            }
+            agent.current_artifact_recovery_target = Some(target);
+            Some(hint)
+        }
+        JobInstallOutcome::ValidationFailed => {
+            // PR-001 atomic clear: the new Test hint failed
+            // `ArtifactCompletionJob::new` validation. Drop the prior
+            // projection too — otherwise the artifact-directed
+            // policy would keep granting write permission for a
+            // target with no attached role-specific budget.
+            if agent.current_artifact_recovery_target.take().is_some() {
+                log_llm_event(
+                    "agent.artifact_recovery_target.cleared",
+                    serde_json::json!({
+                        "session_id": agent.session_store.session_id(),
+                        "turn_index": agent.current_turn_index,
+                        "reason": "artifact_completion_job_validation_failed",
+                    }),
+                );
+            }
+            None
+        }
+    }
+}

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -48,13 +48,12 @@ use super::verifier_diagnostic_attempt::{
     VERIFIER_DIAGNOSTIC_ATTEMPT_LIMIT, verifier_diagnostic_attempt_spec,
 };
 use super::verifier_orchestration::{
-    JobInstallOutcome, PreparedVerifierDiagnosticPass, PreparedVerifierRepairPass,
-    VerifierDiagnosticPassOutcome, VerifierRepairAttemptProgress,
-    build_verifier_exit_zero_evidence, emit_patch_proposal_legacy_validation_comparison_event,
+    PreparedVerifierDiagnosticPass, PreparedVerifierRepairPass, VerifierDiagnosticPassOutcome,
+    VerifierRepairAttemptProgress, build_verifier_exit_zero_evidence,
+    emit_patch_proposal_legacy_validation_comparison_event,
     emit_patch_proposal_shadow_validation_event,
-    synthesized_missing_implementation_target_path_for_request,
-    synthesized_missing_test_target_path_for_request, task_contract_no_verifier_note,
-    task_contract_verifier_targeted_edit_required_note, test_target_path_compatible_with_request,
+    synthesized_missing_implementation_target_path_for_request, task_contract_no_verifier_note,
+    task_contract_verifier_targeted_edit_required_note,
     validate_verifier_repair_intents_with_accepted_plan, verifier_diagnostic_messages,
     verifier_repair_context_diagnostics, verifier_repair_diagnostic_pending_note,
     verifier_repair_intent_limits, verifier_repair_pass_messages,
@@ -2973,7 +2972,11 @@ impl Agent {
                 });
             }
         }
-        if let Some(path) = self.synthesized_missing_implementation_target_path(role) {
+        if let Some(path) = self
+            .active_request_text()
+            .as_deref()
+            .and_then(|req| synthesized_missing_implementation_target_path_for_request(role, req))
+        {
             return Some(super::task_contract::RecoveryTargetHint {
                 role,
                 path,
@@ -2983,126 +2986,6 @@ impl Agent {
         None
     }
 
-    fn synthesized_missing_implementation_target_path(
-        &self,
-        role: super::task_contract::ArtifactRole,
-    ) -> Option<String> {
-        let request = self.active_request_text()?;
-        synthesized_missing_implementation_target_path_for_request(role, &request)
-    }
-
-    pub(super) fn set_artifact_recovery_target_for_decision(
-        &mut self,
-        decision: &super::task_contract::CompletionDecision,
-        attempt: usize,
-    ) -> Option<super::task_contract::RecoveryTargetHint> {
-        let hint = self.task_contract_recovery_target(decision)?;
-        self.set_artifact_recovery_target_from_hint(hint, attempt)
-    }
-
-    pub(super) fn set_artifact_recovery_target_for_action(
-        &mut self,
-        action: &super::task_contract::ArtifactRecoveryAction,
-        attempt: usize,
-    ) -> Option<super::task_contract::RecoveryTargetHint> {
-        let hint = match action {
-            super::task_contract::ArtifactRecoveryAction::Continue { target_hint, .. }
-            | super::task_contract::ArtifactRecoveryAction::RepairArtifact { target_hint } => {
-                target_hint.clone()?
-            }
-            _ => return None,
-        };
-        self.set_artifact_recovery_target_from_hint(hint, attempt)
-    }
-
-    fn align_recovery_target_hint_to_request(
-        &self,
-        mut hint: super::task_contract::RecoveryTargetHint,
-    ) -> super::task_contract::RecoveryTargetHint {
-        if hint.role != super::task_contract::ArtifactRole::Test {
-            return hint;
-        }
-        let Some(request) = self.active_request_text() else {
-            return hint;
-        };
-        let Some((target_path, stack_label)) =
-            synthesized_missing_test_target_path_for_request(&request)
-        else {
-            return hint;
-        };
-        if hint.path == target_path
-            || test_target_path_compatible_with_request(&hint.path, &request)
-        {
-            return hint;
-        }
-        hint.path = target_path.to_string();
-        hint.reason = format!(
-            "synthesized test artifact aligned with requested {stack_label} project family"
-        );
-        hint
-    }
-
-    pub(super) fn set_artifact_recovery_target_from_hint(
-        &mut self,
-        hint: super::task_contract::RecoveryTargetHint,
-        attempt: usize,
-    ) -> Option<super::task_contract::RecoveryTargetHint> {
-        let hint = self.align_recovery_target_hint_to_request(hint);
-        // Issue #652 PR-001: the `ArtifactCompletionJob` is the SSOT for
-        // target + role-specific retry budget. We must NOT update
-        // `current_artifact_recovery_target` before the job has been
-        // validated and installed — otherwise a validation failure would
-        // leave the projection set with no job attached, and
-        // `EffectiveToolPolicy::artifact_directed` would grant write
-        // access for a target with no role-specific budget. Ordering:
-        //   1. attempt to install / refresh the job for the hint
-        //   2. on success → commit the projection (atomic SWAP from any
-        //      prior state)
-        //   3. on failure (only possible for Test role) → clear BOTH
-        //      the projection and the job so no stale slot remains.
-        let install = super::artifact_recovery_flow::maybe_install_artifact_completion_job_for_hint(
-            self, &hint,
-        );
-        match install {
-            JobInstallOutcome::InstalledOrSkipped => {
-                let target = super::task_contract::RecoveryTarget::from_hint(hint.clone(), attempt);
-                let changed = self.current_artifact_recovery_target.as_ref() != Some(&target);
-                if changed {
-                    log_llm_event(
-                        "agent.artifact_recovery_target.selected",
-                        serde_json::json!({
-                            "session_id": self.session_store.session_id(),
-                            "turn_index": self.current_turn_index,
-                            "role": target.role.label(),
-                            "path": target.path,
-                            "reason": target.reason,
-                            "attempt": target.attempt,
-                        }),
-                    );
-                }
-                self.current_artifact_recovery_target = Some(target);
-                Some(hint)
-            }
-            JobInstallOutcome::ValidationFailed => {
-                // PR-001 atomic clear: the new Test hint failed
-                // `ArtifactCompletionJob::new` validation. Drop the prior
-                // projection too — otherwise the artifact-directed
-                // policy would keep granting write permission for a
-                // target with no attached role-specific budget.
-                if self.current_artifact_recovery_target.take().is_some() {
-                    log_llm_event(
-                        "agent.artifact_recovery_target.cleared",
-                        serde_json::json!({
-                            "session_id": self.session_store.session_id(),
-                            "turn_index": self.current_turn_index,
-                            "reason": "artifact_completion_job_validation_failed",
-                        }),
-                    );
-                }
-                None
-            }
-        }
-    }
     fn answer_only_policy_error(
         &self,
         name: &str,

--- a/src/agent/loop_run/turn_tests.rs
+++ b/src/agent/loop_run/turn_tests.rs
@@ -2435,7 +2435,9 @@ mod tests {
             path: "tests/test_foo.py".to_string(),
             reason: "missing test".to_string(),
         };
-        agent.set_artifact_recovery_target_from_hint(test_hint, 0);
+        super::super::set_artifact_recovery_target::set_artifact_recovery_target_from_hint(
+            &mut agent, test_hint, 0,
+        );
         assert!(
             agent.artifact_completion_job.is_some(),
             "fixture invariant: Test recovery target installs the job"
@@ -2445,7 +2447,9 @@ mod tests {
             path: "src/main.py".to_string(),
             reason: "missing implementation".to_string(),
         };
-        agent.set_artifact_recovery_target_from_hint(impl_hint, 0);
+        super::super::set_artifact_recovery_target::set_artifact_recovery_target_from_hint(
+            &mut agent, impl_hint, 0,
+        );
         // Issue #663 (Phase C / AD5): non-Test roles also install a job.
         // The Test job is replaced by the new Implementation job.
         let job = agent
@@ -2520,7 +2524,10 @@ mod tests {
             path: "node_modules/evil/test.js".to_string(),
             reason: "attacker-supplied".to_string(),
         };
-        let result = agent.set_artifact_recovery_target_from_hint(bad_hint, 0);
+        let result =
+            super::super::set_artifact_recovery_target::set_artifact_recovery_target_from_hint(
+                &mut agent, bad_hint, 0,
+            );
         assert!(
             result.is_none(),
             "PR-001: invalid Test hint must return None (no projection committed)"
@@ -2974,7 +2981,12 @@ mod tests {
             path: "tests/test_foo.py".to_string(),
             reason: "missing test".to_string(),
         };
-        let result = agent.set_artifact_recovery_target_from_hint(good_hint.clone(), 0);
+        let result =
+            super::super::set_artifact_recovery_target::set_artifact_recovery_target_from_hint(
+                &mut agent,
+                good_hint.clone(),
+                0,
+            );
         assert!(result.is_some(), "valid Test hint must return Some(hint)");
         let job = agent
             .artifact_completion_job
@@ -3008,7 +3020,10 @@ mod tests {
             path: "src/main.py".to_string(),
             reason: "missing implementation".to_string(),
         };
-        let result = agent.set_artifact_recovery_target_from_hint(impl_hint, 0);
+        let result =
+            super::super::set_artifact_recovery_target::set_artifact_recovery_target_from_hint(
+                &mut agent, impl_hint, 0,
+            );
         assert!(
             result.is_some(),
             "valid non-Test hint must commit the projection"
@@ -3044,7 +3059,9 @@ mod tests {
             path: "tests/initial.py".to_string(),
             reason: "missing test".to_string(),
         };
-        agent.set_artifact_recovery_target_from_hint(good_hint, 0);
+        super::super::set_artifact_recovery_target::set_artifact_recovery_target_from_hint(
+            &mut agent, good_hint, 0,
+        );
         assert!(agent.artifact_completion_job.is_some());
         assert!(agent.current_artifact_recovery_target.is_some());
         // Now a bad new hint:
@@ -3053,7 +3070,10 @@ mod tests {
             path: "node_modules/evil/test.js".to_string(),
             reason: "attacker-supplied".to_string(),
         };
-        let result = agent.set_artifact_recovery_target_from_hint(bad_hint, 1);
+        let result =
+            super::super::set_artifact_recovery_target::set_artifact_recovery_target_from_hint(
+                &mut agent, bad_hint, 1,
+            );
         assert!(result.is_none(), "PR-001: invalid Test hint returns None");
         assert!(
             agent.current_artifact_recovery_target.is_none(),


### PR DESCRIPTION
## Summary

Continue the meta-issue #680 split: move the projection-write half of the
artifact-recovery target lifecycle out of `turn.rs` into a focused sibling
module so `turn.rs` keeps shrinking toward responsibility-focused units.

Three production entry points + two private helpers were extracted as
free functions taking `&mut Agent` / `&Agent` (matching
`actor_loop_flow` / `reply_retry` / earlier vertical-slice precedent):

- `set_artifact_recovery_target_for_decision`
- `set_artifact_recovery_target_for_action`
- `set_artifact_recovery_target_from_hint` (SSOT atomic installer)
- `align_recovery_target_hint_to_request` (private)

The thin wrapper `synthesized_missing_implementation_target_path` (just
`active_request_text` + `synthesized_missing_implementation_target_path_for_request`)
was inlined into its one remaining call site in `turn.rs` instead of
surviving as a free fn.

Behavior unchanged: same ordering (align → install/refresh job → commit
projection or atomic-clear on validation failure), same `log_llm_event`
emit shapes (`agent.artifact_recovery_target.selected` / `.cleared`),
same Issue #652 PR-001 atomic invariant (projection only commits after
the `ArtifactCompletionJob` validates).

`pub(super)` limited / no facade re-export (DR3-001). Callers updated in
`actor_loop_flow.rs`, `prepare_actor_loop_state.rs`, and
`turn_tests.rs` to the free-fn form.

### LOC delta

- `turn.rs`: 3,393 → 3,272 (-121)
- new module: +141

Cumulative `turn.rs` reduction across the parent #680 split:
39,489 → 3,272 (-91.7%).

## Test plan

- [x] `cargo build --lib`
- [x] `cargo fmt`
- [x] `cargo clippy --lib --all-targets -- -D warnings`
- [x] `cargo test --lib` (3,114 passed, 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)