### PR TITLE
Extract artifact_ledger_state.rs from turn.rs (parent #680)

### DIFF
--- a/src/agent/loop_run.rs
+++ b/src/agent/loop_run.rs
@@ -182,6 +182,13 @@ mod artifact_recovery_flow;
 // synthesis helpers. Free fns over `&mut Agent` / `&Agent`.
 // `pub(super)` limited / no facade re-export (DR3-001).
 mod set_artifact_recovery_target;
+// Per-turn artifact-ledger state management (parent #680). Hosts the
+// per-turn lifecycle of `Agent::artifact_ledger`: reset + observability
+// stamp, end-of-turn summary emit, four seed helpers (Existing /
+// Scaffold / RepoEdit / VerifierObservation), dual-source divergence
+// assertion + release-mode emitter. Free fns over `&mut Agent` /
+// `&Agent`. `pub(super)` limited / no facade re-export (DR3-001).
+mod artifact_ledger_state;
 // Issue #652: `ArtifactCompletionJob` + role-specific retry budget +
 // `ArtifactAttemptOutcome` 4-variant taxonomy +
 // `ArtifactCompletionFailureSnapshot` for #654. Module is intentionally
@@ -1248,7 +1255,9 @@ pub(crate) fn seed_artifact_ledger_repo_edit_for_test(agent: &mut Agent, path: S
     };
 
     let scope = agent.current_workspace_scope();
-    agent.seed_artifact_ledger_repo_edit(&path, role, &scope);
+    crate::agent::loop_run::artifact_ledger_state::seed_artifact_ledger_repo_edit(
+        agent, &path, role, &scope,
+    );
 }
 
 // Issue #664 — in-crate `#[cfg(test)]` test seams for the Bash/Setup

--- a/src/agent/loop_run/actor_loop_flow.rs
+++ b/src/agent/loop_run/actor_loop_flow.rs
@@ -3918,8 +3918,8 @@ pub(super) fn run_actor_loop(
     // assertion runs adjacent so the adapter-period contract
     // (`turn_edited_relative_paths` == ledger RepoEdit projection) is
     // pinned at the same boundary that the summary publishes.
-    agent.assert_dual_source_alignment_at_turn_end();
-    agent.record_turn_end_artifact_ledger_summary();
+    super::artifact_ledger_state::assert_dual_source_alignment_at_turn_end(agent);
+    super::artifact_ledger_state::record_turn_end_artifact_ledger_summary(agent);
 
     log_llm_event(
         "agent.milestone.turn_completed",

--- a/src/agent/loop_run/artifact_ledger_phase2_tests.rs
+++ b/src/agent/loop_run/artifact_ledger_phase2_tests.rs
@@ -182,7 +182,7 @@ fn handle_user_message_clears_ledger_at_turn_start() {
     // Drive a single `clear_per_turn_ledger_state` call (the same helper
     // `handle_user_message` invokes) so the per-turn reset can be verified
     // without spinning up a real Ollama roundtrip.
-    agent.clear_per_turn_ledger_state();
+    super::artifact_ledger_state::clear_per_turn_ledger_state(&mut agent);
     assert_eq!(agent.artifact_ledger.event_count(), 0);
     assert_eq!(agent.artifact_ledger.dropped_count(), 0);
     assert!(!agent.artifact_ledger.overflowed());
@@ -192,7 +192,7 @@ fn handle_user_message_clears_ledger_at_turn_start() {
 fn turn_summary_emitted_once_at_turn_end() {
     let session_id = unique_session_id("summary-once");
     let (mut agent, dir) = build_agent(&session_id);
-    agent.clear_per_turn_ledger_state();
+    super::artifact_ledger_state::clear_per_turn_ledger_state(&mut agent);
     let work_root = dir.path();
     std::fs::create_dir_all(work_root.join("tests")).unwrap();
     std::fs::write(work_root.join("tests/test_b.py"), "").unwrap();
@@ -210,7 +210,7 @@ fn turn_summary_emitted_once_at_turn_end() {
         &session_id,
     )
     .len();
-    agent.record_turn_end_artifact_ledger_summary();
+    super::artifact_ledger_state::record_turn_end_artifact_ledger_summary(&agent);
     let after_count = read_log_events_by_event_name_and_session(
         "agent.artifact_ledger.turn_summary",
         &session_id,
@@ -238,8 +238,18 @@ fn existing_seed_invokes_record_existing_event_per_required_artifact() {
     std::fs::write(work_root.join("src/lib.rs"), "").unwrap();
 
     let scope = single_root_scope();
-    agent.seed_artifact_ledger_existing("tests/test_c.py", ArtifactRole::Test, &scope);
-    agent.seed_artifact_ledger_existing("src/lib.rs", ArtifactRole::Implementation, &scope);
+    super::artifact_ledger_state::seed_artifact_ledger_existing(
+        &mut agent,
+        "tests/test_c.py",
+        ArtifactRole::Test,
+        &scope,
+    );
+    super::artifact_ledger_state::seed_artifact_ledger_existing(
+        &mut agent,
+        "src/lib.rs",
+        ArtifactRole::Implementation,
+        &scope,
+    );
 
     let count = agent.artifact_ledger.event_count();
     assert!(count >= 2, "expected at least 2 events, got {count}");
@@ -254,7 +264,12 @@ fn existing_seed_is_idempotent_across_evaluations() {
     let scope = single_root_scope();
 
     for _ in 0..5 {
-        agent.seed_artifact_ledger_existing("README.md", ArtifactRole::UsageDocs, &scope);
+        super::artifact_ledger_state::seed_artifact_ledger_existing(
+            &mut agent,
+            "README.md",
+            ArtifactRole::UsageDocs,
+            &scope,
+        );
     }
     assert_eq!(
         agent.artifact_ledger.event_count(),
@@ -273,7 +288,12 @@ fn existing_seed_ignores_controller_owned_state() {
     std::fs::write(work_root.join(rel), "# generated\n").unwrap();
     let scope = single_root_scope();
 
-    agent.seed_artifact_ledger_existing(rel, ArtifactRole::UsageDocs, &scope);
+    super::artifact_ledger_state::seed_artifact_ledger_existing(
+        &mut agent,
+        rel,
+        ArtifactRole::UsageDocs,
+        &scope,
+    );
 
     assert_eq!(
         agent.artifact_ledger.event_count(),
@@ -295,7 +315,13 @@ fn scaffold_seed_passes_post_scaffold_delta() {
     std::fs::write(work_root.join("app/main.py"), "").unwrap();
     let scope = single_root_scope();
 
-    agent.seed_artifact_ledger_scaffold("app/main.py", ArtifactRole::Implementation, true, &scope);
+    super::artifact_ledger_state::seed_artifact_ledger_scaffold(
+        &mut agent,
+        "app/main.py",
+        ArtifactRole::Implementation,
+        true,
+        &scope,
+    );
     assert_eq!(agent.artifact_ledger.event_count(), 1);
 }
 
@@ -308,8 +334,20 @@ fn scaffold_unchanged_retains_baseline_with_delta_false() {
     std::fs::write(work_root.join("app/cfg.py"), "").unwrap();
     let scope = single_root_scope();
 
-    agent.seed_artifact_ledger_scaffold("app/cfg.py", ArtifactRole::Implementation, false, &scope);
-    agent.seed_artifact_ledger_scaffold("app/cfg.py", ArtifactRole::Implementation, false, &scope);
+    super::artifact_ledger_state::seed_artifact_ledger_scaffold(
+        &mut agent,
+        "app/cfg.py",
+        ArtifactRole::Implementation,
+        false,
+        &scope,
+    );
+    super::artifact_ledger_state::seed_artifact_ledger_scaffold(
+        &mut agent,
+        "app/cfg.py",
+        ArtifactRole::Implementation,
+        false,
+        &scope,
+    );
     assert_eq!(
         agent.artifact_ledger.event_count(),
         1,
@@ -327,7 +365,13 @@ fn scaffold_seed_ignores_controller_owned_state() {
     std::fs::write(work_root.join(rel), "print('generated')\n").unwrap();
     let scope = single_root_scope();
 
-    agent.seed_artifact_ledger_scaffold(rel, ArtifactRole::Implementation, true, &scope);
+    super::artifact_ledger_state::seed_artifact_ledger_scaffold(
+        &mut agent,
+        rel,
+        ArtifactRole::Implementation,
+        true,
+        &scope,
+    );
 
     assert_eq!(
         agent.artifact_ledger.event_count(),
@@ -349,7 +393,12 @@ fn repo_edit_seed_synchronizes_legacy_set() {
     std::fs::write(work_root.join("tests/test_sync.py"), "").unwrap();
     let scope = single_root_scope();
 
-    agent.seed_artifact_ledger_repo_edit("tests/test_sync.py", ArtifactRole::Test, &scope);
+    super::artifact_ledger_state::seed_artifact_ledger_repo_edit(
+        &mut agent,
+        "tests/test_sync.py",
+        ArtifactRole::Test,
+        &scope,
+    );
 
     assert!(
         agent
@@ -373,7 +422,12 @@ fn repo_edit_seed_ignores_controller_owned_state() {
     std::fs::write(work_root.join(rel), "").unwrap();
     let scope = single_root_scope();
 
-    agent.seed_artifact_ledger_repo_edit(rel, ArtifactRole::Test, &scope);
+    super::artifact_ledger_state::seed_artifact_ledger_repo_edit(
+        &mut agent,
+        rel,
+        ArtifactRole::Test,
+        &scope,
+    );
 
     assert!(
         !agent.turn_edited_relative_paths.contains(rel),
@@ -418,7 +472,12 @@ fn repo_edit_no_op_does_not_seed_ledger() {
     // Drive a control call so the test isn't vacuous: the helper *does*
     // populate both sources when actually invoked, proving the absence
     // above is due to the missing call, not a silent rejection.
-    agent.seed_artifact_ledger_repo_edit("src/noop.rs", ArtifactRole::Implementation, &scope);
+    super::artifact_ledger_state::seed_artifact_ledger_repo_edit(
+        &mut agent,
+        "src/noop.rs",
+        ArtifactRole::Implementation,
+        &scope,
+    );
     assert!(agent.artifact_ledger.event_count() >= 1);
     assert!(agent.turn_edited_relative_paths.contains("src/noop.rs"));
 }
@@ -437,7 +496,12 @@ fn verifier_observation_recorded_for_bound_path() {
     let scope = single_root_scope();
 
     let bound_paths = vec!["tests/test_bound.py".to_string()];
-    agent.seed_artifact_ledger_verifier_observation(&bound_paths, VerifierOutcome::Pass, &scope);
+    super::artifact_ledger_state::seed_artifact_ledger_verifier_observation(
+        &mut agent,
+        &bound_paths,
+        VerifierOutcome::Pass,
+        &scope,
+    );
     let obs = agent
         .artifact_ledger
         .verifier_observation_for("tests/test_bound.py")
@@ -461,7 +525,12 @@ fn verifier_observation_skipped_for_legacy_path() {
     // Legacy / unbound verifier: caller passes an empty path list because
     // no path-binding occurred (e.g. legacy `AutoTestRunner::run`).
     // Projection must interpret absence as NotRun (i.e. no record).
-    agent.seed_artifact_ledger_verifier_observation(&[], VerifierOutcome::Pass, &scope);
+    super::artifact_ledger_state::seed_artifact_ledger_verifier_observation(
+        &mut agent,
+        &[],
+        VerifierOutcome::Pass,
+        &scope,
+    );
     assert!(
         agent
             .artifact_ledger
@@ -481,7 +550,8 @@ fn verifier_observation_ignores_controller_owned_state() {
     std::fs::write(work_root.join(rel), "").unwrap();
     let scope = single_root_scope();
 
-    agent.seed_artifact_ledger_verifier_observation(
+    super::artifact_ledger_state::seed_artifact_ledger_verifier_observation(
+        &mut agent,
         &[rel.to_string()],
         VerifierOutcome::Fail,
         &scope,
@@ -513,9 +583,14 @@ fn divergence_assertion_passes_when_aligned() {
     std::fs::create_dir_all(work_root.join("tests")).unwrap();
     std::fs::write(work_root.join("tests/test_aligned.py"), "").unwrap();
     let scope = single_root_scope();
-    agent.seed_artifact_ledger_repo_edit("tests/test_aligned.py", ArtifactRole::Test, &scope);
+    super::artifact_ledger_state::seed_artifact_ledger_repo_edit(
+        &mut agent,
+        "tests/test_aligned.py",
+        ArtifactRole::Test,
+        &scope,
+    );
     // Both sources see "tests/test_aligned.py"; the assertion must not panic.
-    agent.assert_dual_source_alignment_at_turn_end();
+    super::artifact_ledger_state::assert_dual_source_alignment_at_turn_end(&agent);
 }
 
 #[test]
@@ -540,7 +615,7 @@ fn divergence_emit_includes_authority_legacy() {
     // the caller. The shell `emit_artifact_ledger_divergence_if_any`
     // is the release shape — debug-build alignment is asserted by the
     // companion test above.
-    agent.emit_artifact_ledger_divergence_if_any();
+    super::artifact_ledger_state::emit_artifact_ledger_divergence_if_any(&agent);
     let after = read_log_events_by_event_name("agent.artifact_ledger.divergence_detected").len();
     assert!(
         after > before,
@@ -586,7 +661,12 @@ fn divergence_panic_message_does_not_leak_raw_paths() {
     // the write-through helper. We achieve this by inserting the ledger
     // event directly via the public seed and then surgically deleting it
     // from the legacy mirror so `ledger - legacy` is non-empty.
-    agent.seed_artifact_ledger_repo_edit(&leak_path, ArtifactRole::Test, &scope);
+    super::artifact_ledger_state::seed_artifact_ledger_repo_edit(
+        &mut agent,
+        &leak_path,
+        ArtifactRole::Test,
+        &scope,
+    );
     let _ = agent.turn_edited_relative_paths.remove(&leak_path);
 
     // Drive the assertion under catch_unwind. A custom panic hook swaps
@@ -608,7 +688,7 @@ fn divergence_panic_message_does_not_leak_raw_paths() {
         *captured_for_hook.lock().unwrap() = Some(text);
     }));
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        agent.assert_dual_source_alignment_at_turn_end();
+        super::artifact_ledger_state::assert_dual_source_alignment_at_turn_end(&agent);
     }));
     std::panic::set_hook(prev_hook);
     assert!(
@@ -670,8 +750,13 @@ fn event_recorded_payload_includes_turn_index_pr001() {
     // session_id. We drive `current_turn_index = 5` to exercise the
     // u32 narrowing path in the seed helper.
     agent.current_turn_index = 5;
-    agent.clear_per_turn_ledger_state();
-    agent.seed_artifact_ledger_repo_edit(&path, ArtifactRole::Test, &scope);
+    super::artifact_ledger_state::clear_per_turn_ledger_state(&mut agent);
+    super::artifact_ledger_state::seed_artifact_ledger_repo_edit(
+        &mut agent,
+        &path,
+        ArtifactRole::Test,
+        &scope,
+    );
 
     // Compute the expected path_hash (mask_secrets→DefaultHasher→16-hex).
     use std::collections::hash_map::DefaultHasher;
@@ -717,15 +802,20 @@ fn turn_summary_payload_includes_turn_index_pr001() {
     let scope = single_root_scope();
 
     agent.current_turn_index = 11;
-    agent.clear_per_turn_ledger_state();
-    agent.seed_artifact_ledger_repo_edit(path, ArtifactRole::Test, &scope);
+    super::artifact_ledger_state::clear_per_turn_ledger_state(&mut agent);
+    super::artifact_ledger_state::seed_artifact_ledger_repo_edit(
+        &mut agent,
+        path,
+        ArtifactRole::Test,
+        &scope,
+    );
 
     let before = read_log_events_by_event_name_and_session(
         "agent.artifact_ledger.turn_summary",
         &session_id,
     )
     .len();
-    agent.record_turn_end_artifact_ledger_summary();
+    super::artifact_ledger_state::record_turn_end_artifact_ledger_summary(&agent);
     let events = read_log_events_by_event_name_and_session(
         "agent.artifact_ledger.turn_summary",
         &session_id,
@@ -773,7 +863,7 @@ fn divergence_detected_payload_includes_bounded_masked_path_hashes_pr001() {
     }
 
     let before = read_log_events_by_event_name("agent.artifact_ledger.divergence_detected").len();
-    agent.emit_artifact_ledger_divergence_if_any();
+    super::artifact_ledger_state::emit_artifact_ledger_divergence_if_any(&agent);
     let events = read_log_events_by_event_name("agent.artifact_ledger.divergence_detected");
     assert!(
         events.len() > before,
@@ -878,9 +968,14 @@ fn handle_user_message_stamps_upcoming_turn_index_on_ledger() {
     // Mirror the production order exactly: increment THEN stamp.
     agent.current_turn_index = agent.current_turn_index.saturating_add(1);
     let upcoming_u32 = u32::try_from(agent.current_turn_index).unwrap_or(u32::MAX);
-    agent.clear_per_turn_ledger_state_for_turn(upcoming_u32);
+    super::artifact_ledger_state::clear_per_turn_ledger_state_for_turn(&mut agent, upcoming_u32);
 
-    agent.seed_artifact_ledger_repo_edit(&path, ArtifactRole::Test, &scope);
+    super::artifact_ledger_state::seed_artifact_ledger_repo_edit(
+        &mut agent,
+        &path,
+        ArtifactRole::Test,
+        &scope,
+    );
 
     use std::collections::hash_map::DefaultHasher;
     use std::hash::{Hash, Hasher};

--- a/src/agent/loop_run/artifact_ledger_phase3_tests.rs
+++ b/src/agent/loop_run/artifact_ledger_phase3_tests.rs
@@ -134,9 +134,24 @@ fn legacy_set_matches_ledger_projection() {
     std::fs::write(work_root.join("src/lib.rs"), "").unwrap();
 
     let scope = single_root_scope();
-    agent.seed_artifact_ledger_repo_edit("tests/test_a.py", ArtifactRole::Test, &scope);
-    agent.seed_artifact_ledger_repo_edit("tests/test_b.py", ArtifactRole::Test, &scope);
-    agent.seed_artifact_ledger_repo_edit("src/lib.rs", ArtifactRole::Implementation, &scope);
+    super::artifact_ledger_state::seed_artifact_ledger_repo_edit(
+        &mut agent,
+        "tests/test_a.py",
+        ArtifactRole::Test,
+        &scope,
+    );
+    super::artifact_ledger_state::seed_artifact_ledger_repo_edit(
+        &mut agent,
+        "tests/test_b.py",
+        ArtifactRole::Test,
+        &scope,
+    );
+    super::artifact_ledger_state::seed_artifact_ledger_repo_edit(
+        &mut agent,
+        "src/lib.rs",
+        ArtifactRole::Implementation,
+        &scope,
+    );
 
     let legacy: std::collections::BTreeSet<String> =
         agent.turn_edited_relative_paths.iter().cloned().collect();
@@ -166,7 +181,12 @@ fn caller_signature_unchanged_for_turn_edited_relative_paths() {
     std::fs::create_dir_all(work_root.join("tests")).unwrap();
     std::fs::write(work_root.join("tests/test_sig.py"), "").unwrap();
     let scope = single_root_scope();
-    agent.seed_artifact_ledger_repo_edit("tests/test_sig.py", ArtifactRole::Test, &scope);
+    super::artifact_ledger_state::seed_artifact_ledger_repo_edit(
+        &mut agent,
+        "tests/test_sig.py",
+        ArtifactRole::Test,
+        &scope,
+    );
 
     // Compile-time witness: the field must keep its HashSet<String>
     // shape. If the type changes (e.g. to `BTreeSet<String>` or behind a
@@ -224,7 +244,12 @@ fn task_contract_artifact_states_uses_ledger_projection() {
     std::fs::create_dir_all(work_root.join("tests")).unwrap();
     std::fs::write(work_root.join("tests/test_ledger.py"), "x = 1\n").unwrap();
     let scope = single_root_scope();
-    agent.seed_artifact_ledger_repo_edit("tests/test_ledger.py", ArtifactRole::Test, &scope);
+    super::artifact_ledger_state::seed_artifact_ledger_repo_edit(
+        &mut agent,
+        "tests/test_ledger.py",
+        ArtifactRole::Test,
+        &scope,
+    );
 
     // Use a Build-class contract so `required_artifacts` includes Test.
     let contract =
@@ -275,7 +300,12 @@ fn owned_test_artifacts_for_verifier_matches_issue651_behavior() {
     std::fs::create_dir_all(work_root.join("tests")).unwrap();
     std::fs::write(work_root.join("tests/test_match.py"), "x = 1\n").unwrap();
     let scope = single_root_scope();
-    agent.seed_artifact_ledger_repo_edit("tests/test_match.py", ArtifactRole::Test, &scope);
+    super::artifact_ledger_state::seed_artifact_ledger_repo_edit(
+        &mut agent,
+        "tests/test_match.py",
+        ArtifactRole::Test,
+        &scope,
+    );
 
     let contract =
         TaskContract::from_request("FastAPIでCRUD APIを作成してREADMEとテストも追加してください");

--- a/src/agent/loop_run/artifact_ledger_phase5_tests.rs
+++ b/src/agent/loop_run/artifact_ledger_phase5_tests.rs
@@ -153,8 +153,14 @@ fn nested_test_paths_classify_as_owned_via_generic_predicates() {
     std::fs::write(work_root.join("crates/foo/tests/test_foo.rs"), "").unwrap();
 
     let scope = single_root_scope();
-    agent.seed_artifact_ledger_repo_edit("app/tests/test_app.py", ArtifactRole::Test, &scope);
-    agent.seed_artifact_ledger_repo_edit(
+    super::artifact_ledger_state::seed_artifact_ledger_repo_edit(
+        &mut agent,
+        "app/tests/test_app.py",
+        ArtifactRole::Test,
+        &scope,
+    );
+    super::artifact_ledger_state::seed_artifact_ledger_repo_edit(
+        &mut agent,
         "crates/foo/tests/test_foo.rs",
         ArtifactRole::Test,
         &scope,
@@ -337,7 +343,12 @@ fn log_llm_event_masks_artifact_ledger_event_recorded_payload() {
     // path. The payload contract (§7.1) is: raw `path` MUST NOT appear
     // in the payload — only `path_hash` (deterministic hash of the
     // mask_secrets'd value) and `path_len` (length).
-    agent.seed_artifact_ledger_repo_edit("tests/test_secret.py", ArtifactRole::Test, &scope);
+    super::artifact_ledger_state::seed_artifact_ledger_repo_edit(
+        &mut agent,
+        "tests/test_secret.py",
+        ArtifactRole::Test,
+        &scope,
+    );
 
     // Read back every `event_recorded` log line and check that the raw
     // workspace path does not appear in the payload as a leaf string —
@@ -444,9 +455,24 @@ fn event_recorded_emitted_once_per_admitted_event() {
         })
         .collect();
 
-    agent.seed_artifact_ledger_repo_edit(&p1, ArtifactRole::Test, &scope);
-    agent.seed_artifact_ledger_repo_edit(&p2, ArtifactRole::Test, &scope);
-    agent.seed_artifact_ledger_repo_edit(&p3, ArtifactRole::Test, &scope);
+    super::artifact_ledger_state::seed_artifact_ledger_repo_edit(
+        &mut agent,
+        &p1,
+        ArtifactRole::Test,
+        &scope,
+    );
+    super::artifact_ledger_state::seed_artifact_ledger_repo_edit(
+        &mut agent,
+        &p2,
+        ArtifactRole::Test,
+        &scope,
+    );
+    super::artifact_ledger_state::seed_artifact_ledger_repo_edit(
+        &mut agent,
+        &p3,
+        ArtifactRole::Test,
+        &scope,
+    );
 
     // Count event_recorded entries whose `path_hash` matches one of the
     // three we seeded. Each successful admit must emit exactly one.
@@ -526,7 +552,8 @@ fn owned_projection_for_nested_test_path_returns_owned_ownership() {
     std::fs::write(work_root.join("crates/bar/tests/test_bar.rs"), "").unwrap();
     let scope = single_root_scope();
 
-    agent.seed_artifact_ledger_repo_edit(
+    super::artifact_ledger_state::seed_artifact_ledger_repo_edit(
+        &mut agent,
         "crates/bar/tests/test_bar.rs",
         ArtifactRole::Test,
         &scope,

--- a/src/agent/loop_run/artifact_ledger_state.rs
+++ b/src/agent/loop_run/artifact_ledger_state.rs
@@ -1,0 +1,251 @@
+//! Per-turn artifact-ledger state management extracted from `turn.rs`
+//! (parent #680).
+//!
+//! Hosts the per-turn lifecycle of `Agent::artifact_ledger` (Issue #659):
+//! - per-turn reset + observability stamp
+//! - end-of-turn `agent.artifact_ledger.turn_summary` emit
+//! - four seed helpers (`existing` / `scaffold` / `repo_edit` /
+//!   `verifier_observation`) that admit events through
+//!   `classify_ownership` and (for `repo_edit`) keep the legacy
+//!   `turn_edited_relative_paths` set in lockstep
+//! - dual-source divergence assertion + release-mode emitter +
+//!   private collection / event helpers
+//!
+//! Originally `impl Agent` methods; converted to free functions taking
+//! `&mut Agent` / `&Agent`, matching the
+//! `actor_loop_flow` / `reply_retry` / earlier vertical-slice precedent.
+//! `pub(super)` limited / no facade re-export (DR3-001).
+
+use super::Agent;
+use crate::logging::log_llm_event;
+use crate::util::workspace_paths::is_ignored_workspace_display_path;
+
+/// Issue #659 PR-002 — per-turn reset + observability stamp. Callers
+/// pass `upcoming_turn_index` explicitly so stamp timing is decoupled
+/// from `current_turn_index` mutation in `handle_user_message`.
+pub(super) fn clear_per_turn_ledger_state_for_turn(agent: &mut Agent, upcoming_turn_index: u32) {
+    agent.artifact_ledger.clear();
+    let session_id = agent.session_store.session_id().to_string();
+    agent
+        .artifact_ledger
+        .set_log_context(super::artifact_ledger::ArtifactLedgerLogContext::new(
+            session_id,
+            upcoming_turn_index,
+        ));
+}
+
+/// Issue #659 PR-002 — back-compat shim for unit tests that already
+/// position `agent.current_turn_index` to the value they want stamped
+/// before calling the per-turn reset. Production code MUST use
+/// `clear_per_turn_ledger_state_for_turn(upcoming_turn_index)` so the
+/// upcoming index is explicit at the call site.
+#[cfg(test)]
+pub(super) fn clear_per_turn_ledger_state(agent: &mut Agent) {
+    let upcoming = u32::try_from(agent.current_turn_index).unwrap_or(u32::MAX);
+    clear_per_turn_ledger_state_for_turn(agent, upcoming);
+}
+
+/// Issue #659 (Task 2.2) — emit the end-of-turn
+/// `agent.artifact_ledger.turn_summary` event exactly once.
+pub(super) fn record_turn_end_artifact_ledger_summary(agent: &Agent) {
+    agent.artifact_ledger.emit_turn_summary();
+}
+
+/// Issue #659 (Task 2.3) — admit an Existing-origin event for a
+/// workspace-relative path that came from the task-contract candidate
+/// iteration / workspace scan SSOT.
+pub(super) fn seed_artifact_ledger_existing(
+    agent: &mut Agent,
+    relative_path: &str,
+    role: super::task_contract::ArtifactRole,
+    scope: &super::task_workspace_scope::TaskWorkspaceScope,
+) {
+    if is_ignored_workspace_display_path(relative_path) {
+        return;
+    }
+    let ctx = super::artifact_ledger::LedgerAdmissionContext::new(&agent.work_root, scope);
+    let _ = agent
+        .artifact_ledger
+        .record_existing_event(&ctx, relative_path.to_string(), role);
+}
+
+/// Issue #659 (Task 2.4) — admit a Scaffold-origin event. The caller
+/// MUST pass `post_scaffold_delta` from
+/// `repo_edit_has_post_scaffold_delta(...)` so the seed stays
+/// consistent with the production no-op gate.
+pub(super) fn seed_artifact_ledger_scaffold(
+    agent: &mut Agent,
+    relative_path: &str,
+    role: super::task_contract::ArtifactRole,
+    post_scaffold_delta: bool,
+    scope: &super::task_workspace_scope::TaskWorkspaceScope,
+) {
+    if is_ignored_workspace_display_path(relative_path) {
+        return;
+    }
+    let ctx = super::artifact_ledger::LedgerAdmissionContext::new(&agent.work_root, scope);
+    let _ = agent.artifact_ledger.record_scaffold_event(
+        &ctx,
+        relative_path.to_string(),
+        role,
+        post_scaffold_delta,
+    );
+}
+
+/// Issue #659 (Task 2.5) — write-through adapter for a successful,
+/// non-no-op Write/Edit observation. The legacy
+/// `turn_edited_relative_paths` set is updated in the same instruction
+/// so adapter-period divergence (Task 2.7) is detectable at turn end.
+pub(super) fn seed_artifact_ledger_repo_edit(
+    agent: &mut Agent,
+    relative_path: &str,
+    role: super::task_contract::ArtifactRole,
+    scope: &super::task_workspace_scope::TaskWorkspaceScope,
+) {
+    if is_ignored_workspace_display_path(relative_path) {
+        return;
+    }
+    // Write-through adapter (divergence anchor): keep the legacy set
+    // in lockstep with the ledger seed. Caller-facing decisions stay
+    // on the legacy authority during the adapter period (Phase 6.1).
+    agent
+        .turn_edited_relative_paths
+        .insert(relative_path.to_string());
+    let ctx = super::artifact_ledger::LedgerAdmissionContext::new(&agent.work_root, scope);
+    let _ =
+        agent
+            .artifact_ledger
+            .record_repo_edit_event(&ctx, relative_path.to_string(), role, true);
+}
+
+/// Issue #659 (Task 2.6) — record verifier observations for each bound
+/// test path produced by a structured `VerifierCommand`. Unbound
+/// verifier paths (empty `bound_paths`) intentionally produce no
+/// observation so the projection-side absence-as-`NotRun` rule stays
+/// consistent.
+pub(super) fn seed_artifact_ledger_verifier_observation(
+    agent: &mut Agent,
+    bound_paths: &[String],
+    last_outcome: super::artifact_ledger::VerifierOutcome,
+    scope: &super::task_workspace_scope::TaskWorkspaceScope,
+) {
+    if bound_paths.is_empty() {
+        return;
+    }
+    let ctx = super::artifact_ledger::LedgerAdmissionContext::new(&agent.work_root, scope);
+    for path in bound_paths {
+        if is_ignored_workspace_display_path(path) {
+            continue;
+        }
+        let _ = agent.artifact_ledger.record_verifier_observation(
+            &ctx,
+            path,
+            super::artifact_ledger::VerifierObservation {
+                argv_path_matched: true,
+                last_outcome,
+            },
+        );
+    }
+}
+
+/// Issue #659 (Task 2.7) — dual-source divergence assertion. See the
+/// extracted method's original doc comment in `turn.rs` history for the
+/// adapter-period contract and CB-004 panic-message redaction.
+pub(super) fn assert_dual_source_alignment_at_turn_end(agent: &Agent) {
+    let (legacy, ledger) = collect_dual_source_repo_edit_sets(agent);
+    let ledger_only: std::collections::BTreeSet<&String> = ledger.difference(&legacy).collect();
+    #[cfg(debug_assertions)]
+    {
+        // CB-004: the panic message must not leak raw workspace-relative
+        // paths (they may contain LLM-injected secrets). Mirror the
+        // release-shape observability schema: counts + masked path
+        // hashes only.
+        assert!(
+            ledger_only.is_empty(),
+            "DR3 dual-source divergence: ledger admitted paths absent from legacy set \
+             (write-through adapter bug). legacy_count={legacy_count}, \
+             ledger_count={ledger_count}, ledger_only_count={only_count}, \
+             ledger_only_hashes={hashes:?}",
+            legacy_count = legacy.len(),
+            ledger_count = ledger.len(),
+            only_count = ledger_only.len(),
+            hashes = super::small_helpers::masked_path_hash_bounded_list(
+                ledger_only.iter().map(|s| s.as_str())
+            ),
+        );
+        if legacy != ledger {
+            // Stricter-ledger case: legitimate gating difference. Still
+            // emit the observability event so dataset consumers can
+            // count how often the ledger rejects what legacy accepts.
+            emit_artifact_ledger_divergence_event(agent, &legacy, &ledger);
+        }
+    }
+    #[cfg(not(debug_assertions))]
+    {
+        let _ = ledger_only;
+        if legacy != ledger {
+            emit_artifact_ledger_divergence_event(agent, &legacy, &ledger);
+        }
+    }
+}
+
+/// Issue #659 (Task 2.7) — release-shape divergence helper. Always
+/// emits the event (no panic) when sources disagree. Exposed so the
+/// in-crate test suite can drive the release shape regardless of the
+/// `debug_assertions` cfg under which `cargo test` actually runs.
+#[allow(dead_code)]
+pub(super) fn emit_artifact_ledger_divergence_if_any(agent: &Agent) {
+    let (legacy, ledger) = collect_dual_source_repo_edit_sets(agent);
+    if legacy != ledger {
+        emit_artifact_ledger_divergence_event(agent, &legacy, &ledger);
+    }
+}
+
+fn collect_dual_source_repo_edit_sets(
+    agent: &Agent,
+) -> (
+    std::collections::BTreeSet<String>,
+    std::collections::BTreeSet<String>,
+) {
+    let legacy: std::collections::BTreeSet<String> =
+        agent.turn_edited_relative_paths.iter().cloned().collect();
+    // Issue #659 Task 3.1: route through the ledger's SSOT projection
+    // method so the divergence helper and the Phase 3 internal-switch
+    // helpers share a single source of truth (`repo_edit_projection_set`).
+    let ledger = agent.artifact_ledger.repo_edit_projection_set();
+    (legacy, ledger)
+}
+
+#[allow(dead_code)] // invoked from release-build `assert_dual_source_alignment_at_turn_end` and the in-crate test seam.
+fn emit_artifact_ledger_divergence_event(
+    agent: &Agent,
+    legacy: &std::collections::BTreeSet<String>,
+    ledger: &std::collections::BTreeSet<String>,
+) {
+    let only_legacy: Vec<String> = legacy.difference(ledger).cloned().collect();
+    let only_ledger: Vec<String> = ledger.difference(legacy).cloned().collect();
+    // Issue #659 PR-001: emit bounded masked path-hash lists per
+    // Section 7.1 of the design policy. The hash space matches
+    // `event_recorded.path_hash` exactly (mask_secrets → DefaultHasher,
+    // 16-char hex) so dataset consumers can join divergence rows back
+    // to per-event rows. Hard cap at 16 entries each (raw path is
+    // never emitted).
+    let legacy_path_hashes =
+        super::artifact_ledger::bounded_masked_path_hashes(legacy.iter().map(String::as_str));
+    let ledger_path_hashes =
+        super::artifact_ledger::bounded_masked_path_hashes(ledger.iter().map(String::as_str));
+    log_llm_event(
+        "agent.artifact_ledger.divergence_detected",
+        serde_json::json!({
+            "session_id": agent.session_store.session_id(),
+            "turn_index": agent.current_turn_index,
+            "authority": "legacy",
+            "legacy_count": legacy.len() as u32,
+            "ledger_count": ledger.len() as u32,
+            "only_legacy_count": only_legacy.len() as u32,
+            "only_ledger_count": only_ledger.len() as u32,
+            "legacy_path_hashes": legacy_path_hashes,
+            "ledger_path_hashes": ledger_path_hashes,
+        }),
+    );
+}

--- a/src/agent/loop_run/handle_user_message.rs
+++ b/src/agent/loop_run/handle_user_message.rs
@@ -123,7 +123,7 @@ pub(super) fn handle_user_message(
     // shares `(session_id, turn_index)` join keys with sibling
     // observability events.
     let upcoming_turn_index = u32::try_from(agent.current_turn_index).unwrap_or(u32::MAX);
-    agent.clear_per_turn_ledger_state_for_turn(upcoming_turn_index);
+    super::artifact_ledger_state::clear_per_turn_ledger_state_for_turn(agent, upcoming_turn_index);
     // Issue #556: clear per-turn photon context_pack response.
     agent.photon_context_pack_response = None;
     // Issue #558: clear context_pack_id (turn boundary).

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -24,8 +24,6 @@ use super::path_helpers::normalize_memory_path;
 use super::photon_feedback_derive::request_explicitly_requests_script_execution;
 use super::plan_mode_helpers::assistant_model_for_mode;
 use super::safe_stop_payload::{build_safe_stop_payload, collect_recent_action_labels};
-#[cfg(debug_assertions)]
-use super::small_helpers::masked_path_hash_bounded_list;
 use super::small_helpers::{raw_mode_safe_text, rfc3339_now_utc, user_interrupt_result};
 use super::summary::ExitReason;
 use super::tool_display::progress_path_display;
@@ -2096,7 +2094,11 @@ impl Agent {
         }
         self.evidence_set_this_turn
             .push(super::completion_evidence::CompletionEvidence::RepoEdit { category, count: 1 });
-        if self.repo_edit_satisfies_current_artifact_target(category, &relative_path) {
+        if super::task_contract::repo_edit_satisfies_artifact_recovery_target(
+            category,
+            &relative_path,
+            self.current_artifact_recovery_target.as_ref(),
+        ) {
             self.task_contract_evidence_set_this_turn.push(
                 super::completion_evidence::CompletionEvidence::RepoEdit { category, count: 1 },
             );
@@ -2129,300 +2131,13 @@ impl Agent {
         // into a role) does not inject an ambiguous event.
         if let Some(role) = super::task_contract::role_from_repo_edit(category) {
             let scope = self.current_workspace_scope();
-            self.seed_artifact_ledger_repo_edit(&relative_path, role, &scope);
-        }
-    }
-
-    /// Issue #659 (Task 2.2) — per-turn reset of `artifact_ledger`. Caller
-    /// (`handle_user_message` head) invokes this alongside the existing
-    /// `turn_edited_relative_paths.clear()` / `turn_pre_tool_file_hashes.clear()`
-    /// resets. Kept as its own helper so the test seam in
-    /// `artifact_ledger_phase2_tests` can drive the reset without spinning
-    /// up the full `handle_user_message` pipeline.
-    ///
-    /// Issue #659 PR-001: after the reset, stamp the per-turn observability
-    /// log context (`session_id`, `turn_index`) so every subsequent
-    /// `event_recorded` / `turn_summary` payload carries the join keys
-    /// required by Section 7.1 of the design policy.
-    ///
-    /// Issue #659 PR-002 (Option B): callers pass `upcoming_turn_index`
-    /// **explicitly** rather than letting this helper read
-    /// `self.current_turn_index`. Decoupling production sequencing
-    /// (`current_turn_index.saturating_add(1)` happens later in
-    /// `handle_user_message`) from stamp timing fixes the off-by-one that
-    /// caused `event_recorded` / `turn_summary` to carry a `turn_index`
-    /// one less than the matching `agent.work_mode.classified` and other
-    /// observability events on the same user turn. The parameter is
-    /// `u32` because the ledger payload schema declares `turn_index` as
-    /// `u32`; callers using `usize` should narrow via `try_into`, saturating
-    /// to `u32::MAX` for pathological session lengths beyond 4B turns
-    /// (losing granularity is acceptable; wrapping is not).
-    pub(super) fn clear_per_turn_ledger_state_for_turn(&mut self, upcoming_turn_index: u32) {
-        self.artifact_ledger.clear();
-        let session_id = self.session_store.session_id().to_string();
-        self.artifact_ledger.set_log_context(
-            super::artifact_ledger::ArtifactLedgerLogContext::new(session_id, upcoming_turn_index),
-        );
-    }
-
-    /// Issue #659 PR-002 — back-compat shim for unit tests that already
-    /// position `self.current_turn_index` to the value they want stamped
-    /// before calling the per-turn reset. Production code MUST use
-    /// `clear_per_turn_ledger_state_for_turn(upcoming_turn_index)` so the
-    /// upcoming index is explicit at the call site (decoupling production
-    /// sequencing from stamp timing). This shim narrows `current_turn_index`
-    /// the same way the original helper did.
-    #[cfg(test)]
-    pub(super) fn clear_per_turn_ledger_state(&mut self) {
-        let upcoming = u32::try_from(self.current_turn_index).unwrap_or(u32::MAX);
-        self.clear_per_turn_ledger_state_for_turn(upcoming);
-    }
-
-    /// Issue #659 (Task 2.2) — emit the end-of-turn
-    /// `agent.artifact_ledger.turn_summary` event exactly once. Caller
-    /// (`run_actor_loop` tail, next to `agent.milestone.turn_completed`)
-    /// invokes this on every termination path so SafeStop / Done turns
-    /// share a single observability surface. The event itself is masked by
-    /// `log_llm_event` (final-defence `mask_payload_inplace`).
-    pub(super) fn record_turn_end_artifact_ledger_summary(&self) {
-        self.artifact_ledger.emit_turn_summary();
-    }
-
-    /// Issue #659 (Task 2.3) — admit an Existing-origin event into the
-    /// ledger for a workspace-relative path that came from the
-    /// task-contract candidate iteration / workspace scan SSOT
-    /// (`existing_workspace_candidate_for_role_in_scope`). Baseline seeds
-    /// are idempotent on `(origin, role, path)` so repeated contract
-    /// evaluations during the same turn do NOT inflate the event count.
-    pub(super) fn seed_artifact_ledger_existing(
-        &mut self,
-        relative_path: &str,
-        role: super::task_contract::ArtifactRole,
-        scope: &super::task_workspace_scope::TaskWorkspaceScope,
-    ) {
-        if is_ignored_workspace_display_path(relative_path) {
-            return;
-        }
-        let ctx = super::artifact_ledger::LedgerAdmissionContext::new(&self.work_root, scope);
-        let _ = self
-            .artifact_ledger
-            .record_existing_event(&ctx, relative_path.to_string(), role);
-    }
-
-    /// Issue #659 (Task 2.4) — admit a Scaffold-origin event into the
-    /// ledger for a workspace-relative path that came from the
-    /// `scaffold_candidate_for_missing_role` / `scaffold_artifact_snapshots`
-    /// SSOT. `post_scaffold_delta` should be the **caller-computed**
-    /// signal (`repo_edit_has_post_scaffold_delta(...)`) so the seed is
-    /// always consistent with the production no-op gate. Baseline seeds
-    /// are idempotent on `(origin, role, path)`.
-    pub(super) fn seed_artifact_ledger_scaffold(
-        &mut self,
-        relative_path: &str,
-        role: super::task_contract::ArtifactRole,
-        post_scaffold_delta: bool,
-        scope: &super::task_workspace_scope::TaskWorkspaceScope,
-    ) {
-        if is_ignored_workspace_display_path(relative_path) {
-            return;
-        }
-        let ctx = super::artifact_ledger::LedgerAdmissionContext::new(&self.work_root, scope);
-        let _ = self.artifact_ledger.record_scaffold_event(
-            &ctx,
-            relative_path.to_string(),
-            role,
-            post_scaffold_delta,
-        );
-    }
-
-    /// Issue #659 (Task 2.5) — write-through adapter for a successful,
-    /// non-no-op Write/Edit observation. The legacy
-    /// `turn_edited_relative_paths` set is updated in the **same**
-    /// instruction so adapter-period divergence (Task 2.7) is detectable
-    /// at turn end. Callers MUST have already passed the no-op /
-    /// scaffold-delta guards in `observe_evidence_from_repo_edit` so the
-    /// seed never promotes a content-unchanged write to Owned.
-    pub(super) fn seed_artifact_ledger_repo_edit(
-        &mut self,
-        relative_path: &str,
-        role: super::task_contract::ArtifactRole,
-        scope: &super::task_workspace_scope::TaskWorkspaceScope,
-    ) {
-        if is_ignored_workspace_display_path(relative_path) {
-            return;
-        }
-        // Write-through adapter (divergence anchor): keep the legacy set
-        // in lockstep with the ledger seed. Caller-facing decisions stay
-        // on the legacy authority during the adapter period (Phase 6.1).
-        self.turn_edited_relative_paths
-            .insert(relative_path.to_string());
-        let ctx = super::artifact_ledger::LedgerAdmissionContext::new(&self.work_root, scope);
-        let _ = self.artifact_ledger.record_repo_edit_event(
-            &ctx,
-            relative_path.to_string(),
-            role,
-            true,
-        );
-    }
-
-    /// Issue #659 (Task 2.6) — record a verifier observation for each
-    /// bound test path produced by a structured `VerifierCommand`. Legacy
-    /// / unbound verifier paths (empty `bound_paths`) intentionally
-    /// produce no observation so the projection-side absence-as-`NotRun`
-    /// rule stays consistent.
-    pub(super) fn seed_artifact_ledger_verifier_observation(
-        &mut self,
-        bound_paths: &[String],
-        last_outcome: super::artifact_ledger::VerifierOutcome,
-        scope: &super::task_workspace_scope::TaskWorkspaceScope,
-    ) {
-        if bound_paths.is_empty() {
-            return;
-        }
-        let ctx = super::artifact_ledger::LedgerAdmissionContext::new(&self.work_root, scope);
-        for path in bound_paths {
-            if is_ignored_workspace_display_path(path) {
-                continue;
-            }
-            let _ = self.artifact_ledger.record_verifier_observation(
-                &ctx,
-                path,
-                super::artifact_ledger::VerifierObservation {
-                    argv_path_matched: true,
-                    last_outcome,
-                },
+            super::artifact_ledger_state::seed_artifact_ledger_repo_edit(
+                self,
+                &relative_path,
+                role,
+                &scope,
             );
         }
-    }
-
-    /// Issue #659 (Task 2.7) — dual-source divergence assertion. Adapter-
-    /// period contract (Section 6.1 of design policy): the legacy
-    /// `turn_edited_relative_paths` set remains the caller-facing
-    /// authority while the ledger applies a **stricter** admission gate
-    /// (`classify_ownership` re-validates workspace-relative / scope /
-    /// control-char / role-mismatch). Legitimate divergence is therefore
-    /// "ledger is a SUBSET of legacy": the ledger may reject a path the
-    /// legacy set kept (e.g. an LLM-supplied path with embedded control
-    /// chars that passed the legacy `workspace_relative_path_for_tool_arg`
-    /// guard but failed `classify_ownership`).
-    ///
-    /// Hard fail (panic in debug builds) is reserved for the **inverse**
-    /// case — the ledger admits a path the legacy set does NOT carry,
-    /// which would be a write-through adapter bug since the seed helper
-    /// inserts into both sources in the same instruction. In release
-    /// builds the same condition emits a masked
-    /// `agent.artifact_ledger.divergence_detected` event WITHOUT
-    /// panicking, preserving the agent loop.
-    pub(super) fn assert_dual_source_alignment_at_turn_end(&self) {
-        let (legacy, ledger) = self.collect_dual_source_repo_edit_sets();
-        let ledger_only: std::collections::BTreeSet<&String> = ledger.difference(&legacy).collect();
-        #[cfg(debug_assertions)]
-        {
-            // CB-004: the panic message must not leak raw workspace-relative
-            // paths (they may contain LLM-injected secrets). Mirror the
-            // release-shape observability schema: counts + masked path
-            // hashes only.
-            assert!(
-                ledger_only.is_empty(),
-                "DR3 dual-source divergence: ledger admitted paths absent from legacy set \
-                 (write-through adapter bug). legacy_count={legacy_count}, \
-                 ledger_count={ledger_count}, ledger_only_count={only_count}, \
-                 ledger_only_hashes={hashes:?}",
-                legacy_count = legacy.len(),
-                ledger_count = ledger.len(),
-                only_count = ledger_only.len(),
-                hashes = masked_path_hash_bounded_list(ledger_only.iter().map(|s| s.as_str())),
-            );
-            if legacy != ledger {
-                // Stricter-ledger case: legitimate gating difference. Still
-                // emit the observability event so dataset consumers can
-                // count how often the ledger rejects what legacy accepts.
-                self.emit_artifact_ledger_divergence_event(&legacy, &ledger);
-            }
-        }
-        #[cfg(not(debug_assertions))]
-        {
-            let _ = ledger_only;
-            if legacy != ledger {
-                self.emit_artifact_ledger_divergence_event(&legacy, &ledger);
-            }
-        }
-    }
-
-    /// Issue #659 (Task 2.7) — release-shape divergence helper. Always
-    /// emits the event (no panic) when sources disagree. Exposed so the
-    /// in-crate test suite can drive the release shape regardless of the
-    /// `debug_assertions` cfg under which `cargo test` actually runs. The
-    /// production code path goes through `assert_dual_source_alignment_at_turn_end`
-    /// which compiles to a `debug_assert_eq!`-style panic in debug builds
-    /// and dispatches to this emitter in release builds.
-    #[allow(dead_code)]
-    pub(super) fn emit_artifact_ledger_divergence_if_any(&self) {
-        let (legacy, ledger) = self.collect_dual_source_repo_edit_sets();
-        if legacy != ledger {
-            self.emit_artifact_ledger_divergence_event(&legacy, &ledger);
-        }
-    }
-
-    fn collect_dual_source_repo_edit_sets(
-        &self,
-    ) -> (
-        std::collections::BTreeSet<String>,
-        std::collections::BTreeSet<String>,
-    ) {
-        let legacy: std::collections::BTreeSet<String> =
-            self.turn_edited_relative_paths.iter().cloned().collect();
-        // Issue #659 Task 3.1: route through the ledger's SSOT projection
-        // method so the divergence helper and the Phase 3 internal-switch
-        // helpers share a single source of truth (`repo_edit_projection_set`).
-        let ledger = self.artifact_ledger.repo_edit_projection_set();
-        (legacy, ledger)
-    }
-
-    #[allow(dead_code)] // invoked from release-build `assert_dual_source_alignment_at_turn_end` and the in-crate test seam.
-    fn emit_artifact_ledger_divergence_event(
-        &self,
-        legacy: &std::collections::BTreeSet<String>,
-        ledger: &std::collections::BTreeSet<String>,
-    ) {
-        let only_legacy: Vec<String> = legacy.difference(ledger).cloned().collect();
-        let only_ledger: Vec<String> = ledger.difference(legacy).cloned().collect();
-        // Issue #659 PR-001: emit bounded masked path-hash lists per
-        // Section 7.1 of the design policy. The hash space matches
-        // `event_recorded.path_hash` exactly (mask_secrets → DefaultHasher,
-        // 16-char hex) so dataset consumers can join divergence rows back
-        // to per-event rows. Hard cap at 16 entries each (raw path is
-        // never emitted).
-        let legacy_path_hashes =
-            super::artifact_ledger::bounded_masked_path_hashes(legacy.iter().map(String::as_str));
-        let ledger_path_hashes =
-            super::artifact_ledger::bounded_masked_path_hashes(ledger.iter().map(String::as_str));
-        log_llm_event(
-            "agent.artifact_ledger.divergence_detected",
-            serde_json::json!({
-                "session_id": self.session_store.session_id(),
-                "turn_index": self.current_turn_index,
-                "authority": "legacy",
-                "legacy_count": legacy.len() as u32,
-                "ledger_count": ledger.len() as u32,
-                "only_legacy_count": only_legacy.len() as u32,
-                "only_ledger_count": only_ledger.len() as u32,
-                "legacy_path_hashes": legacy_path_hashes,
-                "ledger_path_hashes": ledger_path_hashes,
-            }),
-        );
-    }
-
-    fn repo_edit_satisfies_current_artifact_target(
-        &self,
-        category: super::completion_evidence::RepoEditCategory,
-        relative_path: &str,
-    ) -> bool {
-        super::task_contract::repo_edit_satisfies_artifact_recovery_target(
-            category,
-            relative_path,
-            self.current_artifact_recovery_target.as_ref(),
-        )
     }
 
     /// Issue #636: read a workspace-confined, cap-bounded excerpt of
@@ -2554,7 +2269,13 @@ impl Agent {
                 // `observe_evidence_from_repo_edit`.
                 let post_scaffold_delta =
                     super::scaffold_pipeline::repo_edit_has_post_scaffold_delta(self, &path);
-                self.seed_artifact_ledger_scaffold(&path, *role, post_scaffold_delta, &scope);
+                super::artifact_ledger_state::seed_artifact_ledger_scaffold(
+                    self,
+                    &path,
+                    *role,
+                    post_scaffold_delta,
+                    &scope,
+                );
                 states.push(super::task_contract::ArtifactState::scaffold(*role, path));
             }
             // Issue #646: an existing workspace artifact only enters as
@@ -2588,7 +2309,9 @@ impl Agent {
                 // admission re-runs `classify_ownership`, so role-mismatch
                 // / OutOfScope downgrades happen at admission time;
                 // baseline seed is idempotent across repeated evaluations.
-                self.seed_artifact_ledger_existing(&path, *role, &scope);
+                super::artifact_ledger_state::seed_artifact_ledger_existing(
+                    self, &path, *role, &scope,
+                );
                 if matches!(
                     ownership,
                     super::artifact_ownership::ArtifactOwnership::Owned

--- a/src/agent/loop_run/verifier_orchestration.rs
+++ b/src/agent/loop_run/verifier_orchestration.rs
@@ -2729,7 +2729,8 @@ pub(super) fn finish_structured_task_contract_verifier_selection(
         super::artifact_ledger::VerifierOutcome::Fail
     };
     let scope_for_seed = workspace_scope.clone();
-    agent.seed_artifact_ledger_verifier_observation(
+    super::artifact_ledger_state::seed_artifact_ledger_verifier_observation(
+        agent,
         &selection.bound_test_artifacts_paths,
         last_outcome,
         &scope_for_seed,


### PR DESCRIPTION
## Summary

Continue the meta-issue #680 split: move the per-turn `ArtifactLedger`
lifecycle (Issue #659) out of `turn.rs` into a focused sibling module so
`turn.rs` keeps shrinking toward responsibility-focused units.

Nine production helpers were extracted as free functions taking
`&mut Agent` / `&Agent` (matching `actor_loop_flow` / `reply_retry` /
earlier vertical-slice precedent):

- `clear_per_turn_ledger_state_for_turn` (PR-002 per-turn reset + stamp)
- `clear_per_turn_ledger_state` (`#[cfg(test)]` back-compat shim)
- `record_turn_end_artifact_ledger_summary`
- `seed_artifact_ledger_existing`
- `seed_artifact_ledger_scaffold`
- `seed_artifact_ledger_repo_edit`
- `seed_artifact_ledger_verifier_observation`
- `assert_dual_source_alignment_at_turn_end`
- `emit_artifact_ledger_divergence_if_any` (test seam)

Plus two private helpers (`collect_dual_source_repo_edit_sets`,
`emit_artifact_ledger_divergence_event`).

The thin wrapper `repo_edit_satisfies_current_artifact_target` (just a
forward to `super::task_contract::repo_edit_satisfies_artifact_recovery_target`)
was inlined at its single call site in `observe_evidence_from_repo_edit`
instead of surviving as a free fn.

Behavior unchanged: same admission gates, same write-through adapter
invariant (Phase 6.1), same CB-004 panic-message redaction, same
`agent.artifact_ledger.divergence_detected` emit shape (legacy + ledger
path-hash lists, `mask_payload_inplace` final defence).

`pub(super)` limited / no facade re-export (DR3-001). Callers updated in
`turn.rs`, `actor_loop_flow.rs`, `verifier_orchestration.rs`,
`handle_user_message.rs`, `loop_run.rs` (test seam), and three test
files (`artifact_ledger_phase{2,3,5}_tests.rs`) to the free-fn form.

### LOC delta

- `turn.rs`: 3,275 → 2,998 (-277)
- new module: +251

Cumulative `turn.rs` reduction across the parent #680 split:
39,489 → 2,998 (-92.4%). Crosses the -92% milestone.

## Test plan

- [x] \`cargo build --lib\`
- [x] \`cargo fmt\`
- [x] \`cargo clippy --lib --all-targets -- -D warnings\`
- [x] \`cargo test --lib\` (3,114 passed, 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)