### PR TITLE
Extract verifier_diagnostic_flow.rs from turn.rs (parent #680)

### DIFF
--- a/src/agent/loop_run.rs
+++ b/src/agent/loop_run.rs
@@ -205,6 +205,12 @@ mod artifact_state_projection;
 // owned-test-artifact collector. Free fns over `&mut Agent` / `&Agent`.
 // `pub(super)` limited / no facade re-export (DR3-001).
 mod safe_stop_emit;
+// Verifier-diagnostic pass flow extracted from `turn.rs` (parent #680).
+// Hosts the Issue #637 / #638 / #654 lifecycle: prepare → request →
+// failure → record_failure / record_unavailable, plus the stale-state
+// reset helper. Free fns over `&mut Agent` / `&Agent`. `pub(super)`
+// limited / no facade re-export (DR3-001).
+mod verifier_diagnostic_flow;
 // Issue #652: `ArtifactCompletionJob` + role-specific retry budget +
 // `ArtifactAttemptOutcome` 4-variant taxonomy +
 // `ArtifactCompletionFailureSnapshot` for #654. Module is intentionally

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -40,22 +40,18 @@ use super::tool_policy::{
     effective_tool_policy_error_for_call_with_scope, focused_edit_policy_violation_feedback_note,
     workspace_relative_path_for_tool_arg,
 };
-use super::verifier_diagnostic_attempt::{
-    VERIFIER_DIAGNOSTIC_ATTEMPT_LIMIT, verifier_diagnostic_attempt_spec,
-};
 use super::verifier_orchestration::{
-    PreparedVerifierDiagnosticPass, PreparedVerifierRepairPass, VerifierDiagnosticPassOutcome,
-    VerifierRepairAttemptProgress, build_verifier_exit_zero_evidence,
+    PreparedVerifierRepairPass, VerifierRepairAttemptProgress, build_verifier_exit_zero_evidence,
     emit_patch_proposal_legacy_validation_comparison_event,
     emit_patch_proposal_shadow_validation_event,
     synthesized_missing_implementation_target_path_for_request, task_contract_no_verifier_note,
     task_contract_verifier_targeted_edit_required_note,
-    validate_verifier_repair_intents_with_accepted_plan, verifier_diagnostic_messages,
-    verifier_repair_context_diagnostics, verifier_repair_diagnostic_pending_note,
-    verifier_repair_intent_limits, verifier_repair_pass_messages,
-    verifier_repair_pass_request_error_message, verifier_repair_safe_stop_message,
-    verifier_repair_target_display, verifier_repair_transition_message,
-    verifier_repair_unsafe_target_message, verifier_setup_policy_message,
+    validate_verifier_repair_intents_with_accepted_plan, verifier_repair_context_diagnostics,
+    verifier_repair_diagnostic_pending_note, verifier_repair_intent_limits,
+    verifier_repair_pass_messages, verifier_repair_pass_request_error_message,
+    verifier_repair_safe_stop_message, verifier_repair_target_display,
+    verifier_repair_transition_message, verifier_repair_unsafe_target_message,
+    verifier_setup_policy_message,
 };
 use super::verifier_repair_shadow::legacy_repair_brief_input_from_assessment;
 use super::workspace_candidates::existing_workspace_candidate_for_role_in_scope;
@@ -87,7 +83,6 @@ pub(super) const LOG_ARGS_MAX_CHARS: usize = 200;
 pub(super) const PLAN_REPEATED_EXPLORATION_BLOCK_THRESHOLD: usize = 2;
 pub(super) const TASK_CONTRACT_VERIFIER_ATTEMPT_LIMIT: usize = 3;
 pub(super) const TASK_CONTRACT_VERIFIER_REPAIR_ATTEMPT_LIMIT: usize = 6;
-const VERIFIER_DIAGNOSTIC_MAX_PREDICT: usize = 2_048;
 pub(super) const USER_INTERRUPT_ERROR: &str = "__anvil_user_interrupt__";
 
 #[derive(Debug, Clone, Copy)]
@@ -625,198 +620,6 @@ impl Agent {
             | super::repair_job::RepairNextAction::SafeStop { .. }
             | super::repair_job::RepairNextAction::VerifiedDone => false,
         }
-    }
-
-    pub(super) fn prepare_verifier_diagnostic_pass(
-        &mut self,
-    ) -> Result<PreparedVerifierDiagnosticPass, VerifierDiagnosticPassOutcome> {
-        self.reset_verifier_diagnostic_state_if_needed();
-        let Some(context) = self.repair_job.clone() else {
-            return Err(VerifierDiagnosticPassOutcome::Skipped);
-        };
-        if context.diagnostic_unavailable || context.assessment.is_some() {
-            return Err(VerifierDiagnosticPassOutcome::Skipped);
-        }
-        let Some(attempt_spec) = verifier_diagnostic_attempt_spec(
-            &self.models.main,
-            self.models.sidecar.as_deref(),
-            context.assessment_attempts,
-        ) else {
-            let error = context
-                .diagnostic_error
-                .clone()
-                .unwrap_or_else(|| "diagnostic attempts exhausted".to_string());
-            self.record_verifier_diagnostic_unavailable(error.clone());
-            return Err(VerifierDiagnosticPassOutcome::Unavailable { error });
-        };
-        if let Some(current) = self.repair_job.as_mut() {
-            current.diagnostic_attempted = true;
-            current.assessment_attempts = current.assessment_attempts.saturating_add(1);
-        }
-        let active_request = self.active_request_text().unwrap_or_default();
-        let task_contract = super::task_contract::TaskContract::from_request(&active_request);
-        let behavior_projection =
-            super::required_behavior::project_behavior_contract(&task_contract);
-        super::active_job_emit::emit_behavior_contract_projected_if_changed(
-            self,
-            behavior_projection.as_ref(),
-            super::required_behavior::BEHAVIOR_CONTRACT_CONSUMER_VERIFIER_DIAGNOSTIC,
-        );
-        Ok(PreparedVerifierDiagnosticPass {
-            context,
-            attempt_spec,
-            active_request,
-            behavior_projection,
-        })
-    }
-
-    fn reset_verifier_diagnostic_state_if_needed(&mut self) {
-        let stale_advance = self.repair_job.as_ref().is_some_and(|job| {
-            super::repair_job::has_stale_assessment_after_cluster_advance(job, &self.work_root)
-        });
-        let target_exhausted = self
-            .repair_job
-            .as_ref()
-            .is_some_and(|job| job.needs_diagnostic_after_target_exhaustion());
-        if (stale_advance || target_exhausted)
-            && let Some(current) = self.repair_job.as_mut()
-        {
-            current.assessment = None;
-            current.diagnostic_attempted = false;
-            if target_exhausted {
-                current.repair_target_hint = None;
-                current.assessment_bound_cluster_id = None;
-            }
-        }
-    }
-
-    pub(super) fn request_verifier_diagnostic_reply(
-        &mut self,
-        prepared: &PreparedVerifierDiagnosticPass,
-    ) -> Result<String, VerifierDiagnosticPassOutcome> {
-        let messages = verifier_diagnostic_messages(
-            &self.work_root,
-            &prepared.context,
-            &prepared.active_request,
-            prepared.behavior_projection.as_ref(),
-        );
-        let diagnostic_client = match self.client.clone_with_overrides(
-            prepared.attempt_spec.timeout_secs,
-            VERIFIER_DIAGNOSTIC_MAX_PREDICT,
-        ) {
-            Ok(client) => client,
-            Err(err) => {
-                return Err(self.handle_verifier_diagnostic_failure(
-                    format!("client clone failed: {err}"),
-                    prepared.attempt_spec.role,
-                ));
-            }
-        };
-        let reply = match diagnostic_client
-            .chat_text_json_control(&prepared.attempt_spec.model, &messages)
-        {
-            Ok(reply) => reply,
-            Err(err) => {
-                return Err(
-                    self.handle_verifier_diagnostic_failure(err, prepared.attempt_spec.role)
-                );
-            }
-        };
-        if !reply.tool_calls.is_empty() {
-            return Err(self.handle_verifier_diagnostic_failure(
-                "diagnostic reply contained unexpected tool calls".to_string(),
-                prepared.attempt_spec.role,
-            ));
-        }
-        Ok(reply.content)
-    }
-
-    pub(super) fn handle_verifier_diagnostic_failure(
-        &mut self,
-        error: String,
-        model_role: &'static str,
-    ) -> VerifierDiagnosticPassOutcome {
-        let compact = self.record_verifier_diagnostic_failure(error, model_role);
-        let attempts_done = self
-            .repair_job
-            .as_ref()
-            .map(|context| context.assessment_attempts)
-            .unwrap_or(VERIFIER_DIAGNOSTIC_ATTEMPT_LIMIT);
-        if verifier_diagnostic_attempt_spec(
-            &self.models.main,
-            self.models.sidecar.as_deref(),
-            attempts_done,
-        )
-        .is_some()
-        {
-            VerifierDiagnosticPassOutcome::RetryPending { error: compact }
-        } else {
-            self.record_verifier_diagnostic_unavailable(compact.clone());
-            VerifierDiagnosticPassOutcome::Unavailable { error: compact }
-        }
-    }
-
-    fn record_verifier_diagnostic_failure(
-        &mut self,
-        error: String,
-        model_role: &'static str,
-    ) -> String {
-        // Issue #637 (CB-002): sanitize at the RepairJob store boundary so
-        // the SSOT pipeline (mask_secrets + mask_header_family +
-        // control-char neutralization) is applied before the text reaches
-        // prompt payloads / log events.
-        let error = super::repair_job::sanitize_repair_job_text_with_char_cap(&error, 180);
-        if let Some(context) = self.repair_job.as_mut() {
-            context.repair_target_hint = None;
-            context.assessment = None;
-            context.diagnostic_error = Some(error.clone());
-            context.apply_event(super::repair_job::RepairJobEvent::DiagnosticMalformed);
-        }
-        // Issue #638 (CB-001 reflected): also refresh the bounded snapshot
-        // on every retry-pending diagnostic failure. Without this, attempts
-        // remaining mid-loop leave `repair_failure_snapshot` stale and the
-        // production wiring acceptance condition (work-plan Task 1.4) only
-        // holds at terminal `record_verifier_diagnostic_unavailable`.
-        self.repair_failure_snapshot = self.repair_job.as_ref().map(|job| job.failure_snapshot());
-        log_llm_event(
-            "agent.verifier_diagnostic.failed",
-            serde_json::json!({
-                "session_id": self.session_store.session_id(),
-                "role": model_role,
-                "error": error,
-            }),
-        );
-        error
-    }
-
-    fn record_verifier_diagnostic_unavailable(&mut self, error: String) {
-        // Issue #637 (CB-002): same SSOT sanitization as
-        // `record_verifier_diagnostic_failure`. We deliberately call the
-        // sanitizer (not the raw `compact_verifier_failure_text`) so the
-        // store-boundary invariant holds for every diagnostic_error write.
-        let error = super::repair_job::sanitize_repair_job_text_with_char_cap(&error, 180);
-        if let Some(context) = self.repair_job.as_mut() {
-            context.diagnostic_unavailable = true;
-            context.diagnostic_error = Some(error.clone());
-            context.apply_event(super::repair_job::RepairJobEvent::DiagnosticUnavailable);
-        }
-        // Issue #638 (Task 1.4): capture a bounded snapshot when diagnostic
-        // becomes unavailable. Turn-local only — not pushed to session.messages
-        // (design policy §5, A-only). Re-runs SSOT sanitizers as defence-in-depth.
-        self.repair_failure_snapshot = self.repair_job.as_ref().map(|job| job.failure_snapshot());
-        log_llm_event(
-            "agent.verifier_diagnostic.unavailable",
-            serde_json::json!({
-                "session_id": self.session_store.session_id(),
-                "error": error,
-            }),
-        );
-        // Issue #654: also emit the bounded structured safe stop report so
-        // downstream consumers (`/bug-fix`, semantic repair plan) can see
-        // role / expected target / actual actions / hypothesis ledger in a
-        // single structured event. Per-StopReason dedup is enforced by
-        // `record_safe_stop_report`.
-        super::safe_stop_emit::emit_safe_stop_report_for_diagnostic_target_missing(self);
     }
 
     pub(super) fn verifier_repair_pass_wall_clock_timeout_error(

--- a/src/agent/loop_run/verifier_diagnostic_flow.rs
+++ b/src/agent/loop_run/verifier_diagnostic_flow.rs
@@ -1,0 +1,233 @@
+//! Verifier-diagnostic pass flow extracted from `turn.rs` (parent
+//! #680).
+//!
+//! Hosts the Issue #637 / #638 / #654 verifier-diagnostic pass
+//! lifecycle for `repair_job.assessment`:
+//!
+//! - `prepare_verifier_diagnostic_pass` — clears stale assessment state,
+//!   reserves an attempt slot, derives `PreparedVerifierDiagnosticPass`,
+//!   and emits the behavior-contract projection event.
+//! - `request_verifier_diagnostic_reply` — invokes the verifier
+//!   diagnostic chat with overridden timeout / max_predict; surfaces
+//!   client / chat / tool-call errors via the failure handler.
+//! - `handle_verifier_diagnostic_failure` — records the failure +
+//!   decides between `RetryPending` and terminal `Unavailable`.
+//! - `record_verifier_diagnostic_failure` (private) — store-boundary
+//!   SSOT sanitize + repair-job mutate + bounded snapshot refresh + emit
+//!   `agent.verifier_diagnostic.failed`.
+//! - `record_verifier_diagnostic_unavailable` (private) — same
+//!   sanitize / snapshot / emit, then forwards to
+//!   `safe_stop_emit::emit_safe_stop_report_for_diagnostic_target_missing`.
+//! - `reset_verifier_diagnostic_state_if_needed` (private) — clears
+//!   stale assessment after cluster advance or target exhaustion.
+//!
+//! Originally `impl Agent` methods; converted to free functions taking
+//! `&mut Agent` / `&Agent`, matching the `actor_loop_flow` /
+//! `reply_retry` / earlier vertical-slice precedent. `pub(super)`
+//! limited / no facade re-export (DR3-001).
+
+use super::Agent;
+use super::verifier_diagnostic_attempt::{
+    VERIFIER_DIAGNOSTIC_ATTEMPT_LIMIT, verifier_diagnostic_attempt_spec,
+};
+use super::verifier_orchestration::{
+    PreparedVerifierDiagnosticPass, VerifierDiagnosticPassOutcome, verifier_diagnostic_messages,
+};
+use crate::logging::log_llm_event;
+
+const VERIFIER_DIAGNOSTIC_MAX_PREDICT: usize = 2_048;
+
+pub(super) fn prepare_verifier_diagnostic_pass(
+    agent: &mut Agent,
+) -> Result<PreparedVerifierDiagnosticPass, VerifierDiagnosticPassOutcome> {
+    reset_verifier_diagnostic_state_if_needed(agent);
+    let Some(context) = agent.repair_job.clone() else {
+        return Err(VerifierDiagnosticPassOutcome::Skipped);
+    };
+    if context.diagnostic_unavailable || context.assessment.is_some() {
+        return Err(VerifierDiagnosticPassOutcome::Skipped);
+    }
+    let Some(attempt_spec) = verifier_diagnostic_attempt_spec(
+        &agent.models.main,
+        agent.models.sidecar.as_deref(),
+        context.assessment_attempts,
+    ) else {
+        let error = context
+            .diagnostic_error
+            .clone()
+            .unwrap_or_else(|| "diagnostic attempts exhausted".to_string());
+        record_verifier_diagnostic_unavailable(agent, error.clone());
+        return Err(VerifierDiagnosticPassOutcome::Unavailable { error });
+    };
+    if let Some(current) = agent.repair_job.as_mut() {
+        current.diagnostic_attempted = true;
+        current.assessment_attempts = current.assessment_attempts.saturating_add(1);
+    }
+    let active_request = agent.active_request_text().unwrap_or_default();
+    let task_contract = super::task_contract::TaskContract::from_request(&active_request);
+    let behavior_projection = super::required_behavior::project_behavior_contract(&task_contract);
+    super::active_job_emit::emit_behavior_contract_projected_if_changed(
+        agent,
+        behavior_projection.as_ref(),
+        super::required_behavior::BEHAVIOR_CONTRACT_CONSUMER_VERIFIER_DIAGNOSTIC,
+    );
+    Ok(PreparedVerifierDiagnosticPass {
+        context,
+        attempt_spec,
+        active_request,
+        behavior_projection,
+    })
+}
+
+fn reset_verifier_diagnostic_state_if_needed(agent: &mut Agent) {
+    let stale_advance = agent.repair_job.as_ref().is_some_and(|job| {
+        super::repair_job::has_stale_assessment_after_cluster_advance(job, &agent.work_root)
+    });
+    let target_exhausted = agent
+        .repair_job
+        .as_ref()
+        .is_some_and(|job| job.needs_diagnostic_after_target_exhaustion());
+    if (stale_advance || target_exhausted)
+        && let Some(current) = agent.repair_job.as_mut()
+    {
+        current.assessment = None;
+        current.diagnostic_attempted = false;
+        if target_exhausted {
+            current.repair_target_hint = None;
+            current.assessment_bound_cluster_id = None;
+        }
+    }
+}
+
+pub(super) fn request_verifier_diagnostic_reply(
+    agent: &mut Agent,
+    prepared: &PreparedVerifierDiagnosticPass,
+) -> Result<String, VerifierDiagnosticPassOutcome> {
+    let messages = verifier_diagnostic_messages(
+        &agent.work_root,
+        &prepared.context,
+        &prepared.active_request,
+        prepared.behavior_projection.as_ref(),
+    );
+    let diagnostic_client = match agent.client.clone_with_overrides(
+        prepared.attempt_spec.timeout_secs,
+        VERIFIER_DIAGNOSTIC_MAX_PREDICT,
+    ) {
+        Ok(client) => client,
+        Err(err) => {
+            return Err(handle_verifier_diagnostic_failure(
+                agent,
+                format!("client clone failed: {err}"),
+                prepared.attempt_spec.role,
+            ));
+        }
+    };
+    let reply =
+        match diagnostic_client.chat_text_json_control(&prepared.attempt_spec.model, &messages) {
+            Ok(reply) => reply,
+            Err(err) => {
+                return Err(handle_verifier_diagnostic_failure(
+                    agent,
+                    err,
+                    prepared.attempt_spec.role,
+                ));
+            }
+        };
+    if !reply.tool_calls.is_empty() {
+        return Err(handle_verifier_diagnostic_failure(
+            agent,
+            "diagnostic reply contained unexpected tool calls".to_string(),
+            prepared.attempt_spec.role,
+        ));
+    }
+    Ok(reply.content)
+}
+
+pub(super) fn handle_verifier_diagnostic_failure(
+    agent: &mut Agent,
+    error: String,
+    model_role: &'static str,
+) -> VerifierDiagnosticPassOutcome {
+    let compact = record_verifier_diagnostic_failure(agent, error, model_role);
+    let attempts_done = agent
+        .repair_job
+        .as_ref()
+        .map(|context| context.assessment_attempts)
+        .unwrap_or(VERIFIER_DIAGNOSTIC_ATTEMPT_LIMIT);
+    if verifier_diagnostic_attempt_spec(
+        &agent.models.main,
+        agent.models.sidecar.as_deref(),
+        attempts_done,
+    )
+    .is_some()
+    {
+        VerifierDiagnosticPassOutcome::RetryPending { error: compact }
+    } else {
+        record_verifier_diagnostic_unavailable(agent, compact.clone());
+        VerifierDiagnosticPassOutcome::Unavailable { error: compact }
+    }
+}
+
+fn record_verifier_diagnostic_failure(
+    agent: &mut Agent,
+    error: String,
+    model_role: &'static str,
+) -> String {
+    // Issue #637 (CB-002): sanitize at the RepairJob store boundary so
+    // the SSOT pipeline (mask_secrets + mask_header_family +
+    // control-char neutralization) is applied before the text reaches
+    // prompt payloads / log events.
+    let error = super::repair_job::sanitize_repair_job_text_with_char_cap(&error, 180);
+    if let Some(context) = agent.repair_job.as_mut() {
+        context.repair_target_hint = None;
+        context.assessment = None;
+        context.diagnostic_error = Some(error.clone());
+        context.apply_event(super::repair_job::RepairJobEvent::DiagnosticMalformed);
+    }
+    // Issue #638 (CB-001 reflected): also refresh the bounded snapshot
+    // on every retry-pending diagnostic failure. Without this, attempts
+    // remaining mid-loop leave `repair_failure_snapshot` stale and the
+    // production wiring acceptance condition (work-plan Task 1.4) only
+    // holds at terminal `record_verifier_diagnostic_unavailable`.
+    agent.repair_failure_snapshot = agent.repair_job.as_ref().map(|job| job.failure_snapshot());
+    log_llm_event(
+        "agent.verifier_diagnostic.failed",
+        serde_json::json!({
+            "session_id": agent.session_store.session_id(),
+            "role": model_role,
+            "error": error,
+        }),
+    );
+    error
+}
+
+fn record_verifier_diagnostic_unavailable(agent: &mut Agent, error: String) {
+    // Issue #637 (CB-002): same SSOT sanitization as
+    // `record_verifier_diagnostic_failure`. We deliberately call the
+    // sanitizer (not the raw `compact_verifier_failure_text`) so the
+    // store-boundary invariant holds for every diagnostic_error write.
+    let error = super::repair_job::sanitize_repair_job_text_with_char_cap(&error, 180);
+    if let Some(context) = agent.repair_job.as_mut() {
+        context.diagnostic_unavailable = true;
+        context.diagnostic_error = Some(error.clone());
+        context.apply_event(super::repair_job::RepairJobEvent::DiagnosticUnavailable);
+    }
+    // Issue #638 (Task 1.4): capture a bounded snapshot when diagnostic
+    // becomes unavailable. Turn-local only — not pushed to
+    // session.messages (design policy §5, A-only). Re-runs SSOT
+    // sanitizers as defence-in-depth.
+    agent.repair_failure_snapshot = agent.repair_job.as_ref().map(|job| job.failure_snapshot());
+    log_llm_event(
+        "agent.verifier_diagnostic.unavailable",
+        serde_json::json!({
+            "session_id": agent.session_store.session_id(),
+            "error": error,
+        }),
+    );
+    // Issue #654: also emit the bounded structured safe stop report so
+    // downstream consumers (`/bug-fix`, semantic repair plan) can see
+    // role / expected target / actual actions / hypothesis ledger in a
+    // single structured event. Per-StopReason dedup is enforced by
+    // `record_safe_stop_report`.
+    super::safe_stop_emit::emit_safe_stop_report_for_diagnostic_target_missing(agent);
+}

--- a/src/agent/loop_run/verifier_orchestration.rs
+++ b/src/agent/loop_run/verifier_orchestration.rs
@@ -2995,18 +2995,21 @@ pub(super) fn record_controller_verifier_repair_invalid(
 }
 
 pub(super) fn run_verifier_diagnostic_pass(agent: &mut Agent) -> VerifierDiagnosticPassOutcome {
-    let prepared = match agent.prepare_verifier_diagnostic_pass() {
+    let prepared = match super::verifier_diagnostic_flow::prepare_verifier_diagnostic_pass(agent) {
         Ok(prepared) => prepared,
         Err(outcome) => return outcome,
     };
-    let reply_content = match agent.request_verifier_diagnostic_reply(&prepared) {
+    let reply_content = match super::verifier_diagnostic_flow::request_verifier_diagnostic_reply(
+        agent, &prepared,
+    ) {
         Ok(reply_content) => reply_content,
         Err(outcome) => return outcome,
     };
     let Some(mut parsed) =
         super::verifier_assessment_parser::parse_verifier_repair_assessment_reply(&reply_content)
     else {
-        return agent.handle_verifier_diagnostic_failure(
+        return super::verifier_diagnostic_flow::handle_verifier_diagnostic_failure(
+            agent,
             "diagnostic reply was malformed".to_string(),
             prepared.attempt_spec.role,
         );
@@ -3093,7 +3096,8 @@ pub(super) fn run_verifier_diagnostic_pass(agent: &mut Agent) -> VerifierDiagnos
     );
     let has_target = assessment.repair_target_hint.is_some();
     if !has_target {
-        return agent.handle_verifier_diagnostic_failure(
+        return super::verifier_diagnostic_flow::handle_verifier_diagnostic_failure(
+            agent,
             "diagnostic did not identify a safe repair target".to_string(),
             prepared.attempt_spec.role,
         );


### PR DESCRIPTION
## Summary

Continue the meta-issue #680 split: move the Issue #637 / #638 / #654
verifier-diagnostic pass flow out of \`turn.rs\` into a focused sibling
module so \`turn.rs\` keeps shrinking toward responsibility-focused units.

Three production helpers + three private helpers were extracted as free
functions taking \`&mut Agent\` (matching \`actor_loop_flow\` /
\`reply_retry\` / earlier vertical-slice precedent):

- \`prepare_verifier_diagnostic_pass\`
- \`request_verifier_diagnostic_reply\`
- \`handle_verifier_diagnostic_failure\`
- \`record_verifier_diagnostic_failure\` (private)
- \`record_verifier_diagnostic_unavailable\` (private)
- \`reset_verifier_diagnostic_state_if_needed\` (private)

The \`VERIFIER_DIAGNOSTIC_MAX_PREDICT\` constant moved with the cluster
(its only caller).

Behavior unchanged: same Issue #637 (CB-002) sanitize pipeline at every
\`diagnostic_error\` write boundary, same Issue #638 bounded snapshot
refresh on retry-pending + terminal paths, same Issue #654 cascade into
the safe-stop emit on the terminal path, same
\`VERIFIER_DIAGNOSTIC_ATTEMPT_LIMIT\` retry budget.

\`pub(super)\` limited / no facade re-export (DR3-001). Callers updated in
\`verifier_orchestration.rs\` (4 sites) to the free-fn form.

### LOC delta

- \`turn.rs\`: 2,397 → 2,200 (-197)
- new module: +233

Cumulative \`turn.rs\` reduction across the parent #680 split:
39,489 → 2,200 (-94.4%).

## Test plan

- [x] \`cargo build --lib\`
- [x] \`cargo fmt\`
- [x] \`cargo clippy --lib --all-targets -- -D warnings\`
- [x] \`cargo test --lib\` (3,114 passed, 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)