### PR TITLE
Extract artifact_completion_record.rs from turn.rs (parent #680)

### DIFF
--- a/src/agent/loop_run.rs
+++ b/src/agent/loop_run.rs
@@ -221,6 +221,15 @@ mod verifier_diagnostic_flow;
 // Free fns over `&mut Agent` / `&Agent`. `pub(super)` limited / no
 // facade re-export (DR3-001).
 mod verifier_repair_pass_flow;
+// Artifact-completion attempt-recording cluster extracted from `turn.rs`
+// (parent #680). Hosts `push_artifact_directed_recovery_note` (system
+// note push gated by focused-edit target) + `record_artifact_completion_attempt`
+// + `record_artifact_completion_bash_violation` + the shared
+// `record_artifact_completion_outcome` core (append outcome + trigger
+// turn-local `artifact_completion_failed` diagnostic on Exhausted
+// transition). Free fns over `&mut Agent`. `pub(super)` limited / no
+// facade re-export (DR3-001).
+mod artifact_completion_record;
 // Issue #652: `ArtifactCompletionJob` + role-specific retry budget +
 // `ArtifactAttemptOutcome` 4-variant taxonomy +
 // `ArtifactCompletionFailureSnapshot` for #654. Module is intentionally

--- a/src/agent/loop_run/actor_loop_flow.rs
+++ b/src/agent/loop_run/actor_loop_flow.rs
@@ -735,7 +735,7 @@ pub(super) fn push_missing_repo_edit_retry_note(agent: &mut Agent, attempt: usiz
         agent.push_system_note(note);
         return;
     }
-    if !agent.push_artifact_directed_recovery_note(attempt) {
+    if !super::artifact_completion_record::push_artifact_directed_recovery_note(agent, attempt) {
         agent.push_system_note(recovery::repo_change_recovery_note(attempt));
     }
 }
@@ -1107,12 +1107,15 @@ fn handle_empty_missing_repo_change_retry(
     agent: &mut Agent,
     repo_change_retries: usize,
 ) -> ActorLoopNoToolReplyOutcome {
-    if !agent.push_artifact_directed_recovery_note(repo_change_retries)
-        && !agent.push_repo_change_no_edit_recovery_note(repo_change_retries)
+    if !super::artifact_completion_record::push_artifact_directed_recovery_note(
+        agent,
+        repo_change_retries,
+    ) && !agent.push_repo_change_no_edit_recovery_note(repo_change_retries)
     {
         agent.push_system_note(recovery::repo_change_recovery_note(repo_change_retries));
     }
-    if agent.record_artifact_completion_attempt(
+    if super::artifact_completion_record::record_artifact_completion_attempt(
+        agent,
         super::artifact_completion_job::ArtifactAttemptOutcomeKind::NoTool,
         Vec::new(),
     ) {
@@ -1134,14 +1137,17 @@ fn handle_prose_only_missing_repo_change_retry(
             repo_change_retries,
         );
         agent.push_system_note(note);
-    } else if !agent.push_artifact_directed_recovery_note(repo_change_retries)
-        && !agent.push_repo_change_no_edit_recovery_note(repo_change_retries)
+    } else if !super::artifact_completion_record::push_artifact_directed_recovery_note(
+        agent,
+        repo_change_retries,
+    ) && !agent.push_repo_change_no_edit_recovery_note(repo_change_retries)
     {
         agent.push_system_note(recovery::repo_change_no_tool_recovery_note(
             repo_change_retries,
         ));
     }
-    if agent.record_artifact_completion_attempt(
+    if super::artifact_completion_record::record_artifact_completion_attempt(
+        agent,
         super::artifact_completion_job::ArtifactAttemptOutcomeKind::ProseOnly,
         Vec::new(),
     ) {
@@ -1155,8 +1161,10 @@ fn handle_actor_loop_missing_repo_change_retry_exhausted(
     args: ActorLoopMissingRepoChangeRetryExhaustedArgs<'_>,
 ) -> ActorLoopNoToolReplyOutcome {
     if args.repo_change_retries == 2
-        && (agent.push_artifact_directed_recovery_note(args.repo_change_retries)
-            || agent.push_repo_change_no_edit_recovery_note(args.repo_change_retries))
+        && (super::artifact_completion_record::push_artifact_directed_recovery_note(
+            agent,
+            args.repo_change_retries,
+        ) || agent.push_repo_change_no_edit_recovery_note(args.repo_change_retries))
     {
         super::turn::write_stdout_rendered(
             &format_iteration_status(
@@ -2190,7 +2198,11 @@ pub(super) fn handle_actor_loop_task_contract_tool_recovery(
     } else {
         super::artifact_completion_job::ArtifactAttemptOutcomeKind::ProseOnly
     };
-    if agent.record_artifact_completion_attempt(kind, Vec::new()) {
+    if super::artifact_completion_record::record_artifact_completion_attempt(
+        agent,
+        kind,
+        Vec::new(),
+    ) {
         return ActorLoopTaskContractReplyOutcome::Exit {
             reason: ExitReason::MissingRepoEdits,
             error_text: ARTIFACT_COMPLETION_BUDGET_EXHAUSTED_TEXT.to_string(),
@@ -2233,7 +2245,10 @@ pub(super) fn handle_actor_loop_task_contract_tool_recovery(
         ),
         true,
     );
-    if !agent.push_artifact_directed_recovery_note(artifact_attempt) {
+    if !super::artifact_completion_record::push_artifact_directed_recovery_note(
+        agent,
+        artifact_attempt,
+    ) {
         let note = super::task_contract::render_contract_recovery_note_with_hint(
             args.decision,
             agent.active_request_text().as_deref().unwrap_or_default(),
@@ -2366,7 +2381,10 @@ pub(super) fn handle_actor_loop_task_contract_repair_artifact(
         true,
     );
     if !agent.push_verifier_repair_recovery_note(*verifier_repair_retries)
-        && !agent.push_artifact_directed_recovery_note(*verifier_repair_retries)
+        && !super::artifact_completion_record::push_artifact_directed_recovery_note(
+            agent,
+            *verifier_repair_retries,
+        )
     {
         agent.push_system_note(task_contract_verifier_edit_required_note(
             *verifier_repair_retries,
@@ -2534,7 +2552,8 @@ pub(super) fn maybe_handle_rejected_tool_batch_artifact(
         .as_ref()
         .map(|target| target.role)
         .unwrap_or(super::task_contract::ArtifactRole::Implementation);
-    if agent.record_artifact_completion_attempt(
+    if super::artifact_completion_record::record_artifact_completion_attempt(
+        agent,
         super::artifact_completion_job::ArtifactAttemptOutcomeKind::RolePolicyViolation,
         vec!["focused_edit_batch_reject".to_string()],
     ) {
@@ -2580,7 +2599,10 @@ pub(super) fn maybe_handle_rejected_tool_batch_artifact(
         ),
         true,
     );
-    if !agent.push_artifact_directed_recovery_note(artifact_attempt) {
+    if !super::artifact_completion_record::push_artifact_directed_recovery_note(
+        agent,
+        artifact_attempt,
+    ) {
         agent.push_system_note(format!(
             "[Artifact Completion] Previous tool call was rejected and was not executed. Missing role: {}. Emit exactly one allowed tool call on the current target path now. artifact_completion_attempt={artifact_attempt}/{attempt_limit}",
             role.label()

--- a/src/agent/loop_run/artifact_completion_record.rs
+++ b/src/agent/loop_run/artifact_completion_record.rs
@@ -1,0 +1,121 @@
+//! Artifact-completion attempt-recording cluster extracted from
+//! `turn.rs` (parent #680).
+//!
+//! Hosts the Issue #652 / #664 lifecycle for pushing the
+//! `artifact_directed_recovery` system note + appending attempt
+//! outcomes to the active `ArtifactCompletionJob`:
+//!
+//! - `push_artifact_directed_recovery_note` — pushes the recovery
+//!   system note unless a focused-edit target is already selected.
+//! - `record_artifact_completion_attempt` — appends a regular outcome.
+//! - `record_artifact_completion_bash_violation` (private) — appends a
+//!   bash-policy-violation outcome; raw command bytes are sanitised at
+//!   `ArtifactAttemptOutcome::new` (`mask_secrets` + length cap +
+//!   control-char neutralize) and hashed at projection time (AD5 /
+//!   CB-004).
+//! - `record_artifact_completion_outcome` (private) — shared core that
+//!   appends the outcome + triggers the turn-local
+//!   `artifact_completion_failed` diagnostic on Exhausted transition.
+//!
+//! Originally `impl Agent` methods; converted to free functions taking
+//! `&mut Agent`, matching the `actor_loop_flow` / `reply_retry` /
+//! earlier vertical-slice precedent. `pub(super)` limited / no facade
+//! re-export (DR3-001).
+
+use super::Agent;
+use crate::agent::recovery;
+
+pub(super) fn push_artifact_directed_recovery_note(agent: &mut Agent, attempt: usize) -> bool {
+    if agent.focused_edit_recovery_target().is_some() {
+        return false;
+    }
+    let Some(target) = agent.current_artifact_recovery_target.as_ref() else {
+        return false;
+    };
+    let note =
+        recovery::artifact_directed_recovery_note(target.role.label(), &target.path, attempt);
+    agent.push_system_note(note);
+    true
+}
+
+/// Issue #652: record an attempt against the active
+/// `ArtifactCompletionJob` (no-op when no job exists). Triggers the
+/// turn-local `artifact_completion_failed` diagnostic when the
+/// recording causes the job to transition to `Exhausted`.
+pub(super) fn record_artifact_completion_attempt(
+    agent: &mut Agent,
+    kind: super::artifact_completion_job::ArtifactAttemptOutcomeKind,
+    actual_actions: Vec<String>,
+) -> bool {
+    let expected_target = match agent.artifact_completion_job.as_ref() {
+        Some(job) => job.target_path().to_string(),
+        None => return false,
+    };
+    let outcome = super::artifact_completion_job::ArtifactAttemptOutcome::new(
+        kind,
+        actual_actions,
+        expected_target,
+    );
+    record_artifact_completion_outcome(agent, outcome)
+}
+
+/// Issue #664 iteration-2 (CB-003): record a Bash policy violation
+/// against the active `ArtifactCompletionJob`. The outcome carries the
+/// non-raw `bash_policy_violation = true` marker so
+/// `attempt_outcome_to_json_value` emits
+/// `category = "bash_out_of_policy"`.
+///
+/// Raw command bytes are NOT stored verbatim — `actual_actions` is
+/// sanitized at `ArtifactAttemptOutcome::new` (`mask_secrets` + length
+/// cap + control-char neutralize) and hashed via `stable_path_hash` at
+/// projection time (AD5 / CB-004).
+pub(super) fn record_artifact_completion_bash_violation(
+    agent: &mut Agent,
+    actual_actions: Vec<String>,
+) -> bool {
+    let expected_target = match agent.artifact_completion_job.as_ref() {
+        Some(job) => job.target_path().to_string(),
+        None => return false,
+    };
+    let outcome = super::artifact_completion_job::ArtifactAttemptOutcome::new_bash_policy_violation(
+        actual_actions,
+        expected_target,
+    );
+    record_artifact_completion_outcome(agent, outcome)
+}
+
+/// Shared core: append `outcome` to the active job's attempt history
+/// and trigger the turn-local exhaustion diagnostic when the job
+/// transitions to `Exhausted`.
+fn record_artifact_completion_outcome(
+    agent: &mut Agent,
+    outcome: super::artifact_completion_job::ArtifactAttemptOutcome,
+) -> bool {
+    let status_after = match agent.artifact_completion_job.as_mut() {
+        Some(job) => job.record_attempt(outcome),
+        None => return false,
+    };
+    if matches!(
+        status_after,
+        super::artifact_completion_job::ArtifactCompletionStatus::Exhausted { .. }
+    )
+    // Issue #663 (Phase A): with 5 variants the `Exhausted` match
+    // remains the only terminal-failure trigger; new states do not
+    // alter the diagnostic surface.
+    {
+        // CB-002: tag the turn so the actor loop terminates with
+        // `MissingRepoEdits` even on call paths that previously
+        // dropped the return value (artifact-directed policy
+        // WrongTarget). Emit the diagnostic only once per
+        // exhaustion (`maybe_emit_..._diagnostic` is gated by the
+        // same flag).
+        let first_exhaustion = !agent.artifact_completion_exhausted_this_turn;
+        agent.artifact_completion_exhausted_this_turn = true;
+        if first_exhaustion {
+            super::artifact_recovery_flow::maybe_emit_artifact_completion_failed_diagnostic(agent);
+        }
+        true
+    } else {
+        false
+    }
+}

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -329,14 +329,15 @@ impl Agent {
                         .and_then(serde_json::Value::as_str)
                         .unwrap_or("")
                         .to_string();
-                    let _ = self.record_artifact_completion_bash_violation(vec![command_arg]);
+                    let _ = super::artifact_completion_record::record_artifact_completion_bash_violation(self, vec![command_arg]);
                 } else {
                     let actual_path = arguments
                         .get("path")
                         .and_then(serde_json::Value::as_str)
                         .unwrap_or("")
                         .to_string();
-                    let _ = self.record_artifact_completion_attempt(
+                    let _ = super::artifact_completion_record::record_artifact_completion_attempt(
+                        self,
                         super::artifact_completion_job::ArtifactAttemptOutcomeKind::WrongTarget,
                         vec![format!("{name} on {actual_path}")],
                     );
@@ -350,7 +351,11 @@ impl Agent {
                     .and_then(serde_json::Value::as_str)
                     .unwrap_or("")
                     .to_string();
-                let _ = self.record_artifact_completion_bash_violation(vec![command_arg]);
+                let _ =
+                    super::artifact_completion_record::record_artifact_completion_bash_violation(
+                        self,
+                        vec![command_arg],
+                    );
             }
         }
         let after = self
@@ -604,103 +609,6 @@ impl Agent {
             super::repair_job::RepairNextAction::RerunVerifier
             | super::repair_job::RepairNextAction::SafeStop { .. }
             | super::repair_job::RepairNextAction::VerifiedDone => false,
-        }
-    }
-
-    pub(super) fn push_artifact_directed_recovery_note(&mut self, attempt: usize) -> bool {
-        if self.focused_edit_recovery_target().is_some() {
-            return false;
-        }
-        let Some(target) = self.current_artifact_recovery_target.as_ref() else {
-            return false;
-        };
-        self.push_system_note(recovery::artifact_directed_recovery_note(
-            target.role.label(),
-            &target.path,
-            attempt,
-        ));
-        true
-    }
-
-    /// Issue #652: record an attempt against the active
-    /// `ArtifactCompletionJob` (no-op when no job exists). Triggers the
-    /// turn-local `artifact_completion_failed` diagnostic when the
-    /// recording causes the job to transition to `Exhausted`.
-    pub(super) fn record_artifact_completion_attempt(
-        &mut self,
-        kind: super::artifact_completion_job::ArtifactAttemptOutcomeKind,
-        actual_actions: Vec<String>,
-    ) -> bool {
-        let expected_target = match self.artifact_completion_job.as_ref() {
-            Some(job) => job.target_path().to_string(),
-            None => return false,
-        };
-        let outcome = super::artifact_completion_job::ArtifactAttemptOutcome::new(
-            kind,
-            actual_actions,
-            expected_target,
-        );
-        self.record_artifact_completion_outcome(outcome)
-    }
-
-    /// Issue #664 iteration-2 (CB-003): record a Bash policy violation
-    /// against the active `ArtifactCompletionJob`. The outcome carries the
-    /// non-raw `bash_policy_violation = true` marker so
-    /// `attempt_outcome_to_json_value` emits
-    /// `category = "bash_out_of_policy"`.
-    ///
-    /// Raw command bytes are NOT stored verbatim — `actual_actions` is
-    /// sanitized at `ArtifactAttemptOutcome::new` (`mask_secrets` + length
-    /// cap + control-char neutralize) and hashed via `stable_path_hash`
-    /// at projection time (AD5 / CB-004).
-    fn record_artifact_completion_bash_violation(&mut self, actual_actions: Vec<String>) -> bool {
-        let expected_target = match self.artifact_completion_job.as_ref() {
-            Some(job) => job.target_path().to_string(),
-            None => return false,
-        };
-        let outcome =
-            super::artifact_completion_job::ArtifactAttemptOutcome::new_bash_policy_violation(
-                actual_actions,
-                expected_target,
-            );
-        self.record_artifact_completion_outcome(outcome)
-    }
-
-    /// Shared core: append `outcome` to the active job's attempt history
-    /// and trigger the turn-local exhaustion diagnostic when the job
-    /// transitions to `Exhausted`.
-    fn record_artifact_completion_outcome(
-        &mut self,
-        outcome: super::artifact_completion_job::ArtifactAttemptOutcome,
-    ) -> bool {
-        let status_after = match self.artifact_completion_job.as_mut() {
-            Some(job) => job.record_attempt(outcome),
-            None => return false,
-        };
-        if matches!(
-            status_after,
-            super::artifact_completion_job::ArtifactCompletionStatus::Exhausted { .. }
-        )
-        // Issue #663 (Phase A): with 5 variants the `Exhausted` match
-        // remains the only terminal-failure trigger; new states do not
-        // alter the diagnostic surface.
-        {
-            // CB-002: tag the turn so the actor loop terminates with
-            // `MissingRepoEdits` even on call paths that previously
-            // dropped the return value (artifact-directed policy
-            // WrongTarget). Emit the diagnostic only once per
-            // exhaustion (`maybe_emit_..._diagnostic` is gated by the
-            // same flag).
-            let first_exhaustion = !self.artifact_completion_exhausted_this_turn;
-            self.artifact_completion_exhausted_this_turn = true;
-            if first_exhaustion {
-                super::artifact_recovery_flow::maybe_emit_artifact_completion_failed_diagnostic(
-                    self,
-                );
-            }
-            true
-        } else {
-            false
         }
     }
 
@@ -971,14 +879,19 @@ impl Agent {
                     .and_then(serde_json::Value::as_str)
                     .unwrap_or("")
                     .to_string();
-                let _ = self.record_artifact_completion_bash_violation(vec![command_arg]);
+                let _ =
+                    super::artifact_completion_record::record_artifact_completion_bash_violation(
+                        self,
+                        vec![command_arg],
+                    );
             } else {
                 let actual_path = arguments
                     .get("path")
                     .and_then(serde_json::Value::as_str)
                     .unwrap_or("")
                     .to_string();
-                let _ = self.record_artifact_completion_attempt(
+                let _ = super::artifact_completion_record::record_artifact_completion_attempt(
+                    self,
                     super::artifact_completion_job::ArtifactAttemptOutcomeKind::WrongTarget,
                     vec![format!("{name} on {actual_path}")],
                 );
@@ -992,7 +905,10 @@ impl Agent {
                 .and_then(serde_json::Value::as_str)
                 .unwrap_or("")
                 .to_string();
-            let _ = self.record_artifact_completion_bash_violation(vec![command_arg]);
+            let _ = super::artifact_completion_record::record_artifact_completion_bash_violation(
+                self,
+                vec![command_arg],
+            );
         }
         lifecycle::format_tool_error(err)
     }

--- a/src/agent/loop_run/turn_tests.rs
+++ b/src/agent/loop_run/turn_tests.rs
@@ -2002,10 +2002,12 @@ mod tests {
         let limit = super::super::artifact_completion_job::ARTIFACT_COMPLETION_ATTEMPT_LIMIT;
         // All attempts before the budget edge → still InFlight, flag not set.
         for i in 0..limit.saturating_sub(1) {
-            let exhausted = agent.record_artifact_completion_attempt(
-                super::super::artifact_completion_job::ArtifactAttemptOutcomeKind::WrongTarget,
-                vec![format!("Write on src/x_{i}.py")],
-            );
+            let exhausted =
+                super::super::artifact_completion_record::record_artifact_completion_attempt(
+                    &mut agent,
+                    super::super::artifact_completion_job::ArtifactAttemptOutcomeKind::WrongTarget,
+                    vec![format!("Write on src/x_{i}.py")],
+                );
             assert!(!exhausted, "iteration {i} must not exhaust yet");
             assert!(
                 !agent.artifact_completion_exhausted_this_turn,
@@ -2013,10 +2015,12 @@ mod tests {
             );
         }
         // Final budgeted WrongTarget attempt → transition to Exhausted; flag flips.
-        let exhausted = agent.record_artifact_completion_attempt(
-            super::super::artifact_completion_job::ArtifactAttemptOutcomeKind::WrongTarget,
-            vec![format!("Write on src/x_{limit}.py")],
-        );
+        let exhausted =
+            super::super::artifact_completion_record::record_artifact_completion_attempt(
+                &mut agent,
+                super::super::artifact_completion_job::ArtifactAttemptOutcomeKind::WrongTarget,
+                vec![format!("Write on src/x_{limit}.py")],
+            );
         assert!(exhausted, "final budgeted attempt must exhaust the budget");
         assert!(
             agent.artifact_completion_exhausted_this_turn,
@@ -2055,7 +2059,8 @@ mod tests {
         // residual error is still present in unresolved_errors.
         install_artifact_completion_job_for_test(&mut agent, "tests/test_foo.py");
         for _ in 0..super::super::artifact_completion_job::ARTIFACT_COMPLETION_ATTEMPT_LIMIT {
-            agent.record_artifact_completion_attempt(
+            super::super::artifact_completion_record::record_artifact_completion_attempt(
+                &mut agent,
                 super::super::artifact_completion_job::ArtifactAttemptOutcomeKind::WrongTarget,
                 vec!["Write on src/x.py".to_string()],
             );
@@ -2100,7 +2105,8 @@ mod tests {
 
         // Drive to exhaustion.
         for _ in 0..super::super::artifact_completion_job::ARTIFACT_COMPLETION_ATTEMPT_LIMIT {
-            agent.record_artifact_completion_attempt(
+            super::super::artifact_completion_record::record_artifact_completion_attempt(
+                &mut agent,
                 super::super::artifact_completion_job::ArtifactAttemptOutcomeKind::WrongTarget,
                 vec!["Write on src/x.py".to_string()],
             );
@@ -2122,10 +2128,12 @@ mod tests {
         // A post-exhaustion attempt must NOT re-emit. The
         // record_attempt is a no-op on Exhausted, returns true again,
         // but the dedup gate suppresses the diagnostic.
-        let exhausted_again = agent.record_artifact_completion_attempt(
-            super::super::artifact_completion_job::ArtifactAttemptOutcomeKind::WrongTarget,
-            vec!["Write on src/y.py".to_string()],
-        );
+        let exhausted_again =
+            super::super::artifact_completion_record::record_artifact_completion_attempt(
+                &mut agent,
+                super::super::artifact_completion_job::ArtifactAttemptOutcomeKind::WrongTarget,
+                vec!["Write on src/y.py".to_string()],
+            );
         // The function still returns true (exhausted), but the
         // working memory must not gain a 2nd identical error.
         assert!(exhausted_again);
@@ -2204,7 +2212,8 @@ mod tests {
         std::fs::create_dir_all(agent.work_root.join("tests")).unwrap();
         install_artifact_completion_job_for_test(&mut agent, "tests/keep.py");
         // Consume one attempt.
-        agent.record_artifact_completion_attempt(
+        super::super::artifact_completion_record::record_artifact_completion_attempt(
+            &mut agent,
             super::super::artifact_completion_job::ArtifactAttemptOutcomeKind::WrongTarget,
             vec!["Write on src/x.py".to_string()],
         );
@@ -2472,7 +2481,8 @@ mod tests {
         std::fs::create_dir_all(agent.work_root.join("tests")).unwrap();
         install_artifact_completion_job_for_test(&mut agent, "tests/first.py");
         // Consume an attempt against the first target.
-        agent.record_artifact_completion_attempt(
+        super::super::artifact_completion_record::record_artifact_completion_attempt(
+            &mut agent,
             super::super::artifact_completion_job::ArtifactAttemptOutcomeKind::WrongTarget,
             vec!["Write on src/x.py".to_string()],
         );


### PR DESCRIPTION
## Summary

Continue the meta-issue #680 split: move the Issue #652 / #664
artifact-completion attempt-recording cluster out of \`turn.rs\` into a
focused sibling module so \`turn.rs\` keeps shrinking toward
responsibility-focused units.

Two production helpers + two private helpers were extracted as free
functions taking \`&mut Agent\` (matching \`actor_loop_flow\` /
\`reply_retry\` / earlier vertical-slice precedent):

- \`push_artifact_directed_recovery_note\` (focused-edit gated note push)
- \`record_artifact_completion_attempt\` (appends a regular outcome)
- \`record_artifact_completion_bash_violation\` (private: bash-policy
  violation outcome — raw command bytes never stored verbatim)
- \`record_artifact_completion_outcome\` (private shared core: append +
  trigger turn-local \`artifact_completion_failed\` diagnostic on
  \`Exhausted\` transition with the CB-002 first-exhaustion gate)

Behavior unchanged: same focused-edit gating in
\`push_artifact_directed_recovery_note\`, same
\`ArtifactAttemptOutcome::new\` / \`_bash_policy_violation\` constructors,
same \`Exhausted\` match for terminal-failure trigger (Issue #663 Phase A
5-variant invariant), same first-exhaustion gate.

\`pub(super)\` limited / no facade re-export (DR3-001). Callers updated
in \`turn.rs\` (6 self-callers), \`actor_loop_flow.rs\` (~14 sites), and
\`turn_tests.rs\` (7 sites) to the free-fn form.

### LOC delta

- \`turn.rs\`: 1,923 → 1,839 (-84)
- new module: +121

Cumulative \`turn.rs\` reduction across the parent #680 split:
39,489 → 1,839 (-95.3%).

## Test plan

- [x] \`cargo build --lib\`
- [x] \`cargo fmt\`
- [x] \`cargo clippy --lib --all-targets -- -D warnings\`
- [x] \`cargo test --lib\` (3,114 passed, 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)