### PR TITLE
Extract owned_test_projection.rs from turn.rs (parent #680)

### DIFF
--- a/src/agent/loop_run.rs
+++ b/src/agent/loop_run.rs
@@ -251,6 +251,14 @@ mod recovery_messages;
 // Free fns over `&mut Agent` / `&Agent`. `pub(super)` limited / no
 // facade re-export (DR3-001).
 mod task_contract_recovery;
+// `owned_test_artifacts_for_verifier` projection extracted from
+// `turn.rs` (parent #680). Hosts the Phase-3 (Issue #659 Task 3.3)
+// verifier-binding Owned-test-artifacts projection: legacy + ledger
+// derivations with masked `agent.artifact_ledger.divergence_detected`
+// emit when they disagree; returns the ledger projection as the v0.4.8
+// production authority. Free fns over `&mut Agent` / `&Agent`.
+// `pub(super)` limited / no facade re-export (DR3-001).
+mod owned_test_projection;
 // Issue #652: `ArtifactCompletionJob` + role-specific retry budget +
 // `ArtifactAttemptOutcome` 4-variant taxonomy +
 // `ArtifactCompletionFailureSnapshot` for #654. Module is intentionally

--- a/src/agent/loop_run/artifact_ledger_phase3_tests.rs
+++ b/src/agent/loop_run/artifact_ledger_phase3_tests.rs
@@ -317,7 +317,8 @@ fn owned_test_artifacts_for_verifier_matches_issue651_behavior() {
 
     let contract =
         TaskContract::from_request("FastAPIでCRUD APIを作成してREADMEとテストも追加してください");
-    let owned = agent.owned_test_artifacts_for_verifier(&contract);
+    let owned =
+        super::owned_test_projection::owned_test_artifacts_for_verifier(&mut agent, &contract);
     assert!(
         owned.iter().any(|p| p == "tests/test_match.py"),
         "Issue #651 contract: seeded Test edit must surface in owned slice; got {owned:?}"
@@ -349,9 +350,11 @@ fn owned_test_artifacts_for_verifier_signature_unchanged() {
     // Compile-time witness via a function-pointer cast: the type ascribed
     // here is the Phase-2 signature. If `owned_test_artifacts_for_verifier`
     // changes to a different shape (different receiver mut-ness, different
-    // arg/return types), this assignment fails to compile.
+    // arg/return types), this assignment fails to compile. (Parent #680:
+    // the method was promoted to a free fn in `owned_test_projection`; the
+    // signature itself is unchanged.)
     let signature_witness: fn(&mut Agent, &TaskContract) -> Vec<String> =
-        Agent::owned_test_artifacts_for_verifier;
+        super::owned_test_projection::owned_test_artifacts_for_verifier;
     let result = signature_witness(&mut agent, &contract);
     // The fixture has no edits or workspace files, so the slice is empty.
     assert!(

--- a/src/agent/loop_run/owned_test_projection.rs
+++ b/src/agent/loop_run/owned_test_projection.rs
@@ -1,0 +1,94 @@
+//! `owned_test_artifacts_for_verifier` projection extracted from
+//! `turn.rs` (parent #680).
+//!
+//! Hosts the Phase-3 (Issue #659 Task 3.3) Owned-test-artifacts
+//! projection that the verifier binding consumes:
+//!
+//! - `owned_test_artifacts_for_verifier` — production chokepoint.
+//!   Side-effect-seeds the ledger by calling
+//!   `artifact_state_projection::task_contract_artifact_states`,
+//!   computes both the legacy + ledger derivations, emits a masked
+//!   `agent.artifact_ledger.divergence_detected` event when they
+//!   disagree, and returns the **ledger** projection as the v0.4.8
+//!   production authority.
+//! - `emit_owned_test_artifacts_projection_divergence` (private) —
+//!   masked observability emit (authority=ledger, projection name,
+//!   bounded path-hash lists; no raw paths).
+//!
+//! Originally `impl Agent` methods; converted to free functions taking
+//! `&mut Agent` / `&Agent`, matching the `actor_loop_flow` /
+//! `reply_retry` / earlier vertical-slice precedent. `pub(super)`
+//! limited / no facade re-export (DR3-001).
+
+use super::Agent;
+use crate::logging::log_llm_event;
+
+/// Issue #659 (Task 3.3) — verifier-binding Owned-test-artifact slice.
+/// Reads through the production-authoritative ledger projection. When
+/// legacy and ledger disagree, emit a masked
+/// `agent.artifact_ledger.divergence_detected` event and return the
+/// ledger slice. The caller signature (`&mut Agent`, `&TaskContract`,
+/// `Vec<String>`) is preserved so every existing consumer
+/// (`success.rs`, `verifier_orchestration.rs`,
+/// `task_contract_recovery.rs`) remains source-compatible.
+pub(super) fn owned_test_artifacts_for_verifier(
+    agent: &mut Agent,
+    contract: &super::task_contract::TaskContract,
+) -> Vec<String> {
+    let scope = agent.current_workspace_scope();
+    // `task_contract_artifact_states` has the side effect of seeding the
+    // ledger with Existing / Scaffold baseline events. We MUST call it
+    // before reading the ledger projection so the Phase 3 path sees the
+    // same baseline the legacy derivation sees.
+    let states = super::artifact_state_projection::task_contract_artifact_states(agent, contract);
+    let legacy = super::artifact_ownership::owned_test_artifacts(
+        &states,
+        &agent.work_root,
+        &scope,
+        &|path| agent.turn_edited_relative_paths.contains(path),
+        &|path| super::scaffold_pipeline::repo_edit_has_post_scaffold_delta(agent, path),
+    );
+    let ledger = agent
+        .artifact_ledger
+        .owned_test_artifacts(super::task_contract::ArtifactRole::Test);
+    if legacy != ledger {
+        emit_owned_test_artifacts_projection_divergence(agent, &legacy, &ledger);
+    }
+    ledger
+}
+
+/// Issue #659 (Task 3.3): masked observability emit when the legacy
+/// and ledger-projection derivations of `owned_test_artifacts_for_verifier`
+/// disagree. v0.4.8 makes the ledger projection the production
+/// authority, so `authority="ledger"` is emitted for these
+/// projection-level rows. No raw paths are emitted; only role / count
+/// metadata.
+///
+/// Issue #659 PR-001: also emit bounded masked path-hash lists (max
+/// 16 entries each, deterministic order via BTreeSet) so dataset
+/// consumers can join divergence rows back to per-event rows.
+fn emit_owned_test_artifacts_projection_divergence(
+    agent: &Agent,
+    legacy: &[String],
+    ledger: &[String],
+) {
+    let legacy_set: std::collections::BTreeSet<&str> = legacy.iter().map(String::as_str).collect();
+    let ledger_set: std::collections::BTreeSet<&str> = ledger.iter().map(String::as_str).collect();
+    let legacy_path_hashes =
+        super::artifact_ledger::bounded_masked_path_hashes(legacy_set.iter().copied());
+    let ledger_path_hashes =
+        super::artifact_ledger::bounded_masked_path_hashes(ledger_set.iter().copied());
+    log_llm_event(
+        "agent.artifact_ledger.divergence_detected",
+        serde_json::json!({
+            "session_id": agent.session_store.session_id(),
+            "turn_index": agent.current_turn_index,
+            "authority": "ledger",
+            "projection": "owned_test_artifacts_for_verifier",
+            "legacy_count": legacy.len() as u32,
+            "ledger_count": ledger.len() as u32,
+            "legacy_path_hashes": legacy_path_hashes,
+            "ledger_path_hashes": ledger_path_hashes,
+        }),
+    );
+}

--- a/src/agent/loop_run/success.rs
+++ b/src/agent/loop_run/success.rs
@@ -201,7 +201,8 @@ impl Agent {
         };
         let contract = TaskContract::from_request(&request);
         let test_execution_required = contract.required_behavior.test_execution_required;
-        let owned_test_artifacts = self.owned_test_artifacts_for_verifier(&contract);
+        let owned_test_artifacts =
+            super::owned_test_projection::owned_test_artifacts_for_verifier(self, &contract);
         (owned_test_artifacts, test_execution_required)
     }
 

--- a/src/agent/loop_run/task_contract_recovery.rs
+++ b/src/agent/loop_run/task_contract_recovery.rs
@@ -74,7 +74,8 @@ pub(super) fn task_contract_recovery_action(
     // Issue #651 Phase 5: feed the SSOT `owned_test_artifacts` slice
     // into the planner so the SafeStop gate (test_execution_required
     // && owned_test_artifacts.is_empty()) can fire.
-    let owned_test_artifacts = agent.owned_test_artifacts_for_verifier(contract);
+    let owned_test_artifacts =
+        super::owned_test_projection::owned_test_artifacts_for_verifier(agent, contract);
     let action = super::task_contract::plan_artifact_recovery(
         super::task_contract::ArtifactRecoveryInputs {
             contract,

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -38,7 +38,7 @@ use super::verifier_orchestration::{
 };
 use super::workspace_walk::workspace_appears_empty;
 use super::*;
-use crate::logging::{log_llm_event, stable_path_hash};
+use crate::logging::stable_path_hash;
 use crate::model_capabilities::model_capabilities;
 use crate::modes::plan_act::WorkMode;
 use crate::ollama::xml_fallback::normalize_tool_call_arguments;
@@ -1096,90 +1096,6 @@ impl Agent {
     ) -> super::task_workspace_scope::TaskWorkspaceScope {
         let request = self.active_request_text().unwrap_or_default();
         super::task_workspace_scope::TaskWorkspaceScope::detect(&self.work_root, &request)
-    }
-
-    /// Issue #651 Phase 5: produce the SSOT `owned_test_artifacts` slice
-    /// for the given `TaskContract`. Always classifies via
-    /// `artifact_ownership::owned_test_artifacts`, with the closure
-    /// predicates pointing back at `turn_edited_relative_paths` /
-    /// `repo_edit_has_post_scaffold_delta` so the planner-side ownership
-    /// signals stay consistent across all call sites (DR1-008).
-    ///
-    /// Issue #659 (Task 3.3): internal implementation now reads the
-    /// `ArtifactLedger` projection
-    /// (`artifact_ledger::owned_test_artifacts(ArtifactRole::Test)`) in
-    /// parallel with the legacy `artifact_ownership::owned_test_artifacts`
-    /// derivation. The two should agree by construction (write-through
-    /// adapter from Task 2.5 keeps both sources in lockstep); when they
-    /// diverge the adapter-period contract (Phase 6.1) preserves legacy
-    /// authority — we emit a masked
-    /// `agent.artifact_ledger.divergence_detected` event and return the
-    /// legacy slice. The caller signature (`&mut self`,
-    /// `&TaskContract`, `Vec<String>`) is unchanged so every existing
-    /// consumer (`success.rs`, `turn.rs::run_task_contract_verifier_once`,
-    /// `task_contract_recovery_action`) remains source-compatible.
-    pub(super) fn owned_test_artifacts_for_verifier(
-        &mut self,
-        contract: &super::task_contract::TaskContract,
-    ) -> Vec<String> {
-        let scope = self.current_workspace_scope();
-        // task_contract_artifact_states has the side effect of seeding the
-        // ledger with Existing / Scaffold baseline events. We MUST call it
-        // before reading the ledger projection so the Phase 3 path sees the
-        // same baseline the legacy derivation sees.
-        let states =
-            super::artifact_state_projection::task_contract_artifact_states(self, contract);
-        let legacy = super::artifact_ownership::owned_test_artifacts(
-            &states,
-            &self.work_root,
-            &scope,
-            &|path| self.turn_edited_relative_paths.contains(path),
-            &|path| super::scaffold_pipeline::repo_edit_has_post_scaffold_delta(self, path),
-        );
-        let ledger = self
-            .artifact_ledger
-            .owned_test_artifacts(super::task_contract::ArtifactRole::Test);
-        if legacy != ledger {
-            self.emit_owned_test_artifacts_projection_divergence(&legacy, &ledger);
-        }
-        ledger
-    }
-
-    /// Issue #659 (Task 3.3): masked observability emit when the legacy and
-    /// ledger-projection derivations of `owned_test_artifacts_for_verifier`
-    /// disagree. v0.4.8 makes the ledger projection the production authority,
-    /// so `authority="ledger"` is emitted for these projection-level rows.
-    /// No raw paths are emitted; only role / count metadata.
-    ///
-    /// Issue #659 PR-001: also emit bounded masked path-hash lists (max
-    /// 16 entries each, deterministic order via BTreeSet) so dataset
-    /// consumers can join divergence rows back to per-event rows.
-    fn emit_owned_test_artifacts_projection_divergence(
-        &self,
-        legacy: &[String],
-        ledger: &[String],
-    ) {
-        let legacy_set: std::collections::BTreeSet<&str> =
-            legacy.iter().map(String::as_str).collect();
-        let ledger_set: std::collections::BTreeSet<&str> =
-            ledger.iter().map(String::as_str).collect();
-        let legacy_path_hashes =
-            super::artifact_ledger::bounded_masked_path_hashes(legacy_set.iter().copied());
-        let ledger_path_hashes =
-            super::artifact_ledger::bounded_masked_path_hashes(ledger_set.iter().copied());
-        log_llm_event(
-            "agent.artifact_ledger.divergence_detected",
-            serde_json::json!({
-                "session_id": self.session_store.session_id(),
-                "turn_index": self.current_turn_index,
-                "authority": "ledger",
-                "projection": "owned_test_artifacts_for_verifier",
-                "legacy_count": legacy.len() as u32,
-                "ledger_count": ledger.len() as u32,
-                "legacy_path_hashes": legacy_path_hashes,
-                "ledger_path_hashes": ledger_path_hashes,
-            }),
-        );
     }
 
     fn answer_only_policy_error(

--- a/src/agent/loop_run/verifier_orchestration.rs
+++ b/src/agent/loop_run/verifier_orchestration.rs
@@ -2164,7 +2164,8 @@ pub(super) fn task_contract_verifier_test_binding(
     };
     let contract = TaskContract::from_request(&request);
     let test_execution_required = contract.required_behavior.test_execution_required;
-    let owned_test_artifacts = agent.owned_test_artifacts_for_verifier(&contract);
+    let owned_test_artifacts =
+        super::owned_test_projection::owned_test_artifacts_for_verifier(agent, &contract);
     let scope = agent.current_workspace_scope();
     (owned_test_artifacts, test_execution_required, Some(scope))
 }


### PR DESCRIPTION
## Summary

Continue the meta-issue #680 split: move the Phase-3 (Issue #659 Task
3.3) \`owned_test_artifacts_for_verifier\` projection out of \`turn.rs\`
into a focused sibling module so \`turn.rs\` keeps shrinking toward
responsibility-focused units.

One production helper + one private helper were extracted as free
functions taking \`&mut Agent\` / \`&Agent\` (matching \`actor_loop_flow\` /
\`reply_retry\` / earlier vertical-slice precedent):

- \`owned_test_artifacts_for_verifier\` (production chokepoint)
- \`emit_owned_test_artifacts_projection_divergence\` (private masked
  observability emit)

Behavior unchanged: same baseline-seeding side effect via
\`task_contract_artifact_states\` before reading the ledger projection,
same legacy + ledger compare, same masked event shape
(\`authority="ledger"\`, projection name, bounded path-hash lists).

The Phase-3 signature contract test in
\`owned_test_artifacts_for_verifier_signature_unchanged\` was updated to
point at the free fn instead of \`Agent::...\`. The function-pointer
cast still pins the canonical
\`fn(&mut Agent, &TaskContract) -> Vec<String>\` shape (the signature
itself is unchanged), so a future incompatible refactor still fails
compilation.

\`pub(super)\` limited / no facade re-export (DR3-001). Callers updated
in \`success.rs\` (1 site), \`verifier_orchestration.rs\` (1 site),
\`task_contract_recovery.rs\` (1 site), and
\`artifact_ledger_phase3_tests.rs\` (2 sites) to the free-fn form.

### LOC delta

- \`turn.rs\`: 1,471 → 1,387 (-84)
- new module: +94

Cumulative \`turn.rs\` reduction across the parent #680 split:
39,489 → 1,387 (-96.5%).

## Test plan

- [x] \`cargo build --lib\`
- [x] \`cargo fmt\`
- [x] \`cargo clippy --lib --all-targets -- -D warnings\`
- [x] \`cargo test --lib\` (3,114 passed, 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)