### PR TITLE
Extract tool_call_execution.rs from turn.rs (parent #680)

### DIFF
--- a/src/agent/loop_run.rs
+++ b/src/agent/loop_run.rs
@@ -21,7 +21,7 @@ use crate::session::compact::{
 };
 use crate::session::store::{ConversationMessage, SessionSnapshot, SessionStore};
 use crate::stdin_prompt;
-use crate::tools::registry::{ToolContext, ToolRegistry};
+use crate::tools::registry::ToolRegistry;
 
 // Issue #646: artifact ownership classification. Module is intentionally
 // *not* re-exported (DR3-001) — `turn.rs` and `task_contract.rs` are the
@@ -259,6 +259,16 @@ mod task_contract_recovery;
 // production authority. Free fns over `&mut Agent` / `&Agent`.
 // `pub(super)` limited / no facade re-export (DR3-001).
 mod owned_test_projection;
+// Tool-call execution dispatch extracted from `turn.rs` (parent #680).
+// Hosts the per-tool-call execution lifecycle: production chokepoint
+// `execute_tool_call` (policy gates → Bash vs. non-Bash dispatch) +
+// `tool_context` builder + 4 dispatch helpers
+// (`{handle_tool_execution_rejection,execute_bash_tool_call,capture_pre_tool_hash_if_needed,execute_non_bash_tool_call}`)
+// + Issue #606 T-1.6 `observe_evidence_from_bash_outcome` (Bash exit-0
+// → VerifierExitZero evidence + last_verifier_invocation record). Free
+// fns over `&mut Agent` / `&Agent`. `pub(super)` limited / no facade
+// re-export (DR3-001).
+mod tool_call_execution;
 // Issue #652: `ArtifactCompletionJob` + role-specific retry budget +
 // `ArtifactAttemptOutcome` 4-variant taxonomy +
 // `ArtifactCompletionFailureSnapshot` for #654. Module is intentionally

--- a/src/agent/loop_run/actor_loop_flow.rs
+++ b/src/agent/loop_run/actor_loop_flow.rs
@@ -3376,14 +3376,16 @@ pub(super) fn run_actor_loop(
                         recovery::repeated_bash_error(&bash_command)
                     } else if start_spinner_for_exec {
                         let _sp = Spinner::start(format!("running {tool_name}..."));
-                        agent.execute_tool_call(
+                        super::tool_call_execution::execute_tool_call(
+                            agent,
                             &tool_name,
                             &tool_call.arguments,
                             Some(&effective_tool_policy),
                             Some(interrupt_flag.flag.clone()),
                         )
                     } else {
-                        agent.execute_tool_call(
+                        super::tool_call_execution::execute_tool_call(
+                            agent,
                             &tool_name,
                             &tool_call.arguments,
                             Some(&effective_tool_policy),
@@ -3392,14 +3394,16 @@ pub(super) fn run_actor_loop(
                     }
                 } else if start_spinner_for_exec {
                     let _sp = Spinner::start(format!("running {tool_name}..."));
-                    agent.execute_tool_call(
+                    super::tool_call_execution::execute_tool_call(
+                        agent,
                         &tool_name,
                         &tool_call.arguments,
                         Some(&effective_tool_policy),
                         Some(interrupt_flag.flag.clone()),
                     )
                 } else {
-                    agent.execute_tool_call(
+                    super::tool_call_execution::execute_tool_call(
+                        agent,
                         &tool_name,
                         &tool_call.arguments,
                         Some(&effective_tool_policy),

--- a/src/agent/loop_run/scaffold_pipeline.rs
+++ b/src/agent/loop_run/scaffold_pipeline.rs
@@ -949,7 +949,8 @@ pub(super) fn maybe_apply_deterministic_nextjs_scaffold(
 
     let mut fallback_failed = false;
     for tool_call in fallback_tool_calls {
-        let raw_result = agent.execute_tool_call(
+        let raw_result = super::tool_call_execution::execute_tool_call(
+            agent,
             &tool_call.name,
             &tool_call.arguments,
             None,

--- a/src/agent/loop_run/tool_call_execution.rs
+++ b/src/agent/loop_run/tool_call_execution.rs
@@ -1,0 +1,360 @@
+//! Tool-call execution dispatch extracted from `turn.rs` (parent #680).
+//!
+//! Hosts the per-tool-call execution lifecycle:
+//!
+//! - `execute_tool_call` — production chokepoint. Order: answer-only
+//!   policy gate → empty-workspace scaffold policy gate →
+//!   effective-tool-policy gate → cancel-flag check → Bash vs.
+//!   non-Bash dispatch.
+//! - `effective_tool_policy_error_for_execution` (private) —
+//!   per-execution policy error: routes through the explicit
+//!   `EffectiveToolPolicy` (with the active workspace scope when a
+//!   `MissingVerifierJob` is selected) or falls back to the per-Agent
+//!   `effective_tool_policy_error`.
+//! - `handle_tool_execution_rejection` (private) — records the
+//!   rejection into working memory + appends an artifact-completion
+//!   attempt (WrongTarget for non-Bash, Bash policy violation for Bash)
+//!   when relevant, then renders the masked tool error string.
+//! - `tool_context` (private) — builds `ToolContext` snapshot.
+//! - `execute_bash_tool_call` (private) — Bash execution + feedback
+//!   recording + bash-outcome evidence observation + DangerousBlock
+//!   unsafe-feedback path.
+//! - `capture_pre_tool_hash_if_needed` (private) — `Write` / `Edit`
+//!   pre-tool hash capture for the per-turn baseline cache.
+//! - `execute_non_bash_tool_call` (private) — non-Bash execution +
+//!   working-memory touched-file + repo-edit evidence observation +
+//!   Edit-failure feedback.
+//! - `observe_evidence_from_bash_outcome` (private) — Issue #606 T-1.6
+//!   post-hoc Bash → VerifierExitZero evidence observation +
+//!   `last_verifier_invocation` recording.
+//!
+//! Originally `impl Agent` methods; converted to free functions taking
+//! `&mut Agent` / `&Agent`, matching the `actor_loop_flow` /
+//! `reply_retry` / earlier vertical-slice precedent. `pub(super)`
+//! limited / no facade re-export (DR3-001).
+
+use std::io::{self, IsTerminal};
+
+use super::Agent;
+use super::feedback_builders::{
+    build_feedback_for_bash, build_feedback_for_edit_failure,
+    build_feedback_for_unsafe_block_reason,
+};
+use super::file_excerpt::current_file_hash_for_relative_path;
+use super::lifecycle;
+use super::path_helpers::normalize_memory_path;
+use super::small_helpers::{rfc3339_now_utc, user_interrupt_result};
+use super::tool_execution::{
+    failed_outcome_for_call, rejected_outcome_for_call, success_outcome_for_call,
+};
+use super::tool_policy::{
+    EffectiveToolPolicy, effective_tool_policy_error_for_call_with_scope,
+    workspace_relative_path_for_tool_arg,
+};
+use super::verifier_orchestration::build_verifier_exit_zero_evidence;
+use crate::tools::registry::{BashErrorClass, ToolContext};
+
+pub(super) fn execute_tool_call(
+    agent: &mut Agent,
+    name: &str,
+    arguments: &serde_json::Value,
+    effective_tool_policy: Option<&EffectiveToolPolicy>,
+    cancel_flag: Option<std::sync::Arc<std::sync::atomic::AtomicBool>>,
+) -> String {
+    if let Some(err) = agent.answer_only_policy_error(name, arguments) {
+        agent.session.working_memory.note_error(err.clone());
+        return lifecycle::format_tool_error(&err);
+    }
+    if let Some(err) =
+        super::scaffold_pipeline::empty_workspace_scaffold_policy_error(agent, name, arguments)
+    {
+        agent.session.working_memory.note_error(err.clone());
+        return lifecycle::format_tool_error(&err);
+    }
+    // Issue #646 (A1/A3): when a first-class MissingVerifierJob is
+    // active, hand the active workspace scope to the policy gate so
+    // out-of-scope `Write`/`Edit` paths are rejected even when the
+    // restricted whitelist would otherwise admit them.
+    if let Some(err) =
+        effective_tool_policy_error_for_execution(agent, name, arguments, effective_tool_policy)
+    {
+        return handle_tool_execution_rejection(agent, name, arguments, &err);
+    }
+    if cancel_flag
+        .as_ref()
+        .is_some_and(|flag| flag.load(std::sync::atomic::Ordering::SeqCst))
+    {
+        return user_interrupt_result();
+    }
+    let context = tool_context(agent, cancel_flag);
+    if name == "Bash" {
+        return execute_bash_tool_call(agent, name, arguments, &context);
+    }
+    execute_non_bash_tool_call(agent, name, arguments, &context)
+}
+
+fn effective_tool_policy_error_for_execution(
+    agent: &Agent,
+    name: &str,
+    arguments: &serde_json::Value,
+    effective_tool_policy: Option<&EffectiveToolPolicy>,
+) -> Option<String> {
+    let scope_for_policy = agent
+        .missing_verifier_job
+        .as_ref()
+        .map(|_| agent.current_workspace_scope());
+    if let Some(policy) = effective_tool_policy {
+        effective_tool_policy_error_for_call_with_scope(
+            policy,
+            name,
+            arguments,
+            &agent.work_root,
+            scope_for_policy.as_ref(),
+        )
+    } else {
+        agent.effective_tool_policy_error(name, arguments)
+    }
+}
+
+fn handle_tool_execution_rejection(
+    agent: &mut Agent,
+    name: &str,
+    arguments: &serde_json::Value,
+    err: &str,
+) -> String {
+    let _tool_outcome = rejected_outcome_for_call(name, err);
+    agent.session.working_memory.note_error(err.to_string());
+    if err.contains("artifact-directed recovery rejected") {
+        if name == "Bash" {
+            let command_arg = arguments
+                .get("command")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("")
+                .to_string();
+            let _ = super::artifact_completion_record::record_artifact_completion_bash_violation(
+                agent,
+                vec![command_arg],
+            );
+        } else {
+            let actual_path = arguments
+                .get("path")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("")
+                .to_string();
+            let _ = super::artifact_completion_record::record_artifact_completion_attempt(
+                agent,
+                super::artifact_completion_job::ArtifactAttemptOutcomeKind::WrongTarget,
+                vec![format!("{name} on {actual_path}")],
+            );
+        }
+    } else if err.starts_with("setup bootstrap")
+        && name == "Bash"
+        && agent.artifact_completion_job.is_some()
+    {
+        let command_arg = arguments
+            .get("command")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("")
+            .to_string();
+        let _ = super::artifact_completion_record::record_artifact_completion_bash_violation(
+            agent,
+            vec![command_arg],
+        );
+    }
+    lifecycle::format_tool_error(err)
+}
+
+fn tool_context(
+    agent: &Agent,
+    cancel_flag: Option<std::sync::Arc<std::sync::atomic::AtomicBool>>,
+) -> ToolContext {
+    let tmp_tests_root = Some(
+        agent
+            .session_store
+            .state_root()
+            .join("sessions")
+            .join(agent.session_store.session_id())
+            .join("tmp-tests"),
+    );
+    ToolContext {
+        root: agent.work_root.clone(),
+        mode: agent.session.mode_state.mode,
+        plan_path: agent.session.mode_state.active_plan_path.clone(),
+        plan_stage: agent.session.mode_state.plan_stage,
+        auto_approve: agent.config.yes_mode,
+        interactive_approval: io::stdin().is_terminal(),
+        offline: agent.config.offline,
+        cancel_flag,
+        tmp_tests_root,
+        tester_active: agent.tester_called_this_turn,
+    }
+}
+
+fn execute_bash_tool_call(
+    agent: &mut Agent,
+    name: &str,
+    arguments: &serde_json::Value,
+    context: &ToolContext,
+) -> String {
+    let (result, outcome) = agent
+        .tool_registry
+        .execute_bash_with_outcome(arguments, context);
+    if let Some(outcome) = outcome.as_ref()
+        && let Some(frame) = build_feedback_for_bash(outcome, &agent.work_root)
+    {
+        agent.session.record_feedback(frame);
+    }
+    if let Some(outcome) = outcome.as_ref() {
+        observe_evidence_from_bash_outcome(agent, outcome);
+    }
+    match result {
+        Ok(text) => {
+            agent.maybe_update_work_root(name, arguments, &text);
+            text
+        }
+        Err((err, class)) => {
+            agent
+                .session
+                .working_memory
+                .note_error(format!("{name}: {err}"));
+            if class == BashErrorClass::DangerousBlock {
+                let cmd = arguments
+                    .get("command")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or("");
+                let frame = build_feedback_for_unsafe_block_reason(cmd, &err, &agent.work_root);
+                agent.session.record_feedback(frame);
+                agent.session.unsafe_blocks_this_turn =
+                    agent.session.unsafe_blocks_this_turn.saturating_add(1);
+            }
+            lifecycle::format_tool_error(&err)
+        }
+    }
+}
+
+fn capture_pre_tool_hash_if_needed(agent: &mut Agent, arguments: &serde_json::Value, name: &str) {
+    if matches!(name, "Write" | "Edit")
+        && let Some(raw_path) = arguments.get("path").and_then(serde_json::Value::as_str)
+        && let Some(rel) = workspace_relative_path_for_tool_arg(&agent.work_root, raw_path)
+    {
+        let pre_hash = current_file_hash_for_relative_path(&agent.work_root, &rel);
+        agent.turn_pre_tool_file_hashes.insert(rel, pre_hash);
+    }
+}
+
+fn execute_non_bash_tool_call(
+    agent: &mut Agent,
+    name: &str,
+    arguments: &serde_json::Value,
+    context: &ToolContext,
+) -> String {
+    capture_pre_tool_hash_if_needed(agent, arguments, name);
+    match agent.tool_registry.execute(name, arguments, context) {
+        Ok(result) => {
+            let tool_outcome = success_outcome_for_call(name, arguments, &agent.work_root);
+            if let Some(edit) = tool_outcome.repo_edit_evidence() {
+                agent
+                    .session
+                    .working_memory
+                    .note_touched_file(normalize_memory_path(edit.raw_path(), &agent.work_root));
+                agent.session.repo_edit_succeeded_this_turn = true;
+                agent.observe_evidence_from_repo_edit(edit.raw_path());
+            }
+            agent.maybe_update_work_root(name, arguments, &result);
+            result
+        }
+        Err(err) => {
+            let _tool_outcome = failed_outcome_for_call(name, &err);
+            agent
+                .session
+                .working_memory
+                .note_error(format!("{name}: {err}"));
+            if name == "Edit" {
+                let path = arguments.get("path").and_then(serde_json::Value::as_str);
+                let frame = build_feedback_for_edit_failure(path, &err, &agent.work_root);
+                agent.session.record_feedback(frame);
+            }
+            lifecycle::format_tool_error(&err)
+        }
+    }
+}
+
+/// Issue #606 (T-1.6): post-hoc observation of a Bash invocation as
+/// `VerifierExitZero` completion evidence. A signal is recorded **only**
+/// when:
+///
+/// 1. `outcome.exit_code == Some(0)` — non-zero / timeout / interrupted
+///    invocations are explicit failures, not silent passes.
+/// 2. `outcome.class == BuildTest` — read-only / network / mutating
+///    classes don't represent verification work even when they happen
+///    to exit 0.
+/// 3. `is_completion_verifier_command(&outcome.command) == true` —
+///    rejects commands containing shell control operators that can
+///    mask the real exit code (DR4-002, e.g. `cargo test || true`).
+///
+/// The evidence is consumed by `ProtocolKind::evidence_set_satisfies`
+/// in `success.rs`.
+fn observe_evidence_from_bash_outcome(
+    agent: &mut Agent,
+    outcome: &crate::tools::bash::BashExecutionOutcome,
+) {
+    use crate::tools::bash::BashCommandClass;
+    // Issue #608 Phase α-2 (AP-09): record `last_verifier_command` /
+    // `last_verifier_invocation` for any BuildTest invocation
+    // (regardless of exit code) so the rerun-trigger handler can
+    // surface the most recent verifier attempt — even failed ones (the
+    // user often types `再実行` precisely because the last run failed).
+    if matches!(outcome.class, BashCommandClass::BuildTest)
+        && super::completion_evidence::is_completion_verifier_command(&outcome.command)
+    {
+        let redacted =
+            crate::session::feedback::redact_verifier_command_for_storage(&outcome.command);
+        // Drop empty redacted commands (e.g. all-control-char input).
+        if !redacted.trim().is_empty() {
+            agent.session.last_verifier_command = Some(redacted.clone());
+            agent.session.last_verifier_invocation =
+                Some(crate::session::store::VerifierInvocationRecord {
+                    command: redacted,
+                    exit_code: outcome.exit_code.unwrap_or(-1),
+                    recorded_at: rfc3339_now_utc(),
+                });
+        }
+    }
+
+    // Issue #607 (β): build VerifierExitZero evidence for BuildTest |
+    // EnvSetup exit-zero outcomes (per `build_verifier_exit_zero_evidence`).
+    let Some(evidence) = build_verifier_exit_zero_evidence(outcome) else {
+        return;
+    };
+    let crate::agent::loop_run::completion_evidence::CompletionEvidence::VerifierExitZero {
+        class,
+        ..
+    } = evidence
+    else {
+        // `build_verifier_exit_zero_evidence` only ever constructs
+        // VerifierExitZero today; the match keeps us honest if a
+        // future helper returns a different variant.
+        agent.evidence_set_this_turn.push(evidence.clone());
+        if agent.current_artifact_recovery_target.is_none() {
+            agent.task_contract_evidence_set_this_turn.push(evidence);
+        }
+        return;
+    };
+    agent.evidence_set_this_turn.push(evidence.clone());
+    if agent.current_artifact_recovery_target.is_none() {
+        agent
+            .task_contract_evidence_set_this_turn
+            .push(evidence.clone());
+    }
+    crate::logging::log_completion_evidence_observed(
+        agent.current_turn_index,
+        0, // α-1: iter_index plumbing is α-2 work; emit 0 for now.
+        "verifier_exit_zero",
+        serde_json::json!({
+            // Issue #607 BP-07 / S3-002: snake_case label matches
+            // serde rename_all so `command_class` reads `"env_setup"` /
+            // `"build_test"` instead of `"EnvSetup"` / `"BuildTest"`.
+            "command_class": class.as_str(),
+        }),
+    );
+}

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -4,23 +4,15 @@ use super::auto_test::{AutoTestKind, AutoTestRunner};
 use super::completion_evidence::is_repo_edit_no_op;
 
 use super::answer_only_mode::answer_only_script_command_allowed;
-use super::feedback_builders::{
-    build_feedback_for_bash, build_feedback_for_edit_failure,
-    build_feedback_for_unsafe_block_reason,
-};
 use super::file_excerpt::{
     current_file_hash_for_relative_path, open_excerpt_file_nofollow, truncate_on_char_boundary,
     utf8_prefix_respecting_cap,
 };
-use super::path_helpers::normalize_memory_path;
 use super::photon_feedback_derive::request_explicitly_requests_script_execution;
 use super::plan_mode_helpers::assistant_model_for_mode;
-use super::small_helpers::{raw_mode_safe_text, rfc3339_now_utc, user_interrupt_result};
+use super::small_helpers::raw_mode_safe_text;
 use super::summary::ExitReason;
 use super::tool_display::progress_path_display;
-use super::tool_execution::{
-    failed_outcome_for_call, rejected_outcome_for_call, success_outcome_for_call,
-};
 use super::tool_history::{
     focused_edit_target_already_read, focused_read_target_for_directory,
     has_successful_non_plan_repo_edit,
@@ -32,9 +24,8 @@ use super::tool_policy::{
     workspace_relative_path_for_tool_arg,
 };
 use super::verifier_orchestration::{
-    build_verifier_exit_zero_evidence, task_contract_no_verifier_note,
-    task_contract_verifier_targeted_edit_required_note, verifier_repair_diagnostic_pending_note,
-    verifier_repair_target_display,
+    task_contract_no_verifier_note, task_contract_verifier_targeted_edit_required_note,
+    verifier_repair_diagnostic_pending_note, verifier_repair_target_display,
 };
 use super::workspace_walk::workspace_appears_empty;
 use super::*;
@@ -43,7 +34,7 @@ use crate::model_capabilities::model_capabilities;
 use crate::modes::plan_act::WorkMode;
 use crate::ollama::xml_fallback::normalize_tool_call_arguments;
 use crate::session::store::ScaffoldArtifactFileSnapshot;
-use crate::tools::registry::{BashErrorClass, ToolSpec};
+use crate::tools::registry::ToolSpec;
 use crate::util::workspace_paths::is_ignored_workspace_display_path;
 use std::path::{Path, PathBuf};
 
@@ -607,308 +598,6 @@ impl Agent {
         }
     }
 
-    pub(super) fn execute_tool_call(
-        &mut self,
-        name: &str,
-        arguments: &serde_json::Value,
-        effective_tool_policy: Option<&EffectiveToolPolicy>,
-        cancel_flag: Option<std::sync::Arc<std::sync::atomic::AtomicBool>>,
-    ) -> String {
-        if let Some(err) = self.answer_only_policy_error(name, arguments) {
-            self.session.working_memory.note_error(err.clone());
-            return lifecycle::format_tool_error(&err);
-        }
-        if let Some(err) =
-            super::scaffold_pipeline::empty_workspace_scaffold_policy_error(self, name, arguments)
-        {
-            self.session.working_memory.note_error(err.clone());
-            return lifecycle::format_tool_error(&err);
-        }
-        // Issue #646 (A1/A3): when a first-class MissingVerifierJob is
-        // active, hand the active workspace scope to the policy gate so
-        // out-of-scope `Write`/`Edit` paths are rejected even when the
-        // restricted whitelist would otherwise admit them.
-        if let Some(err) =
-            self.effective_tool_policy_error_for_execution(name, arguments, effective_tool_policy)
-        {
-            return self.handle_tool_execution_rejection(name, arguments, &err);
-        }
-        if cancel_flag
-            .as_ref()
-            .is_some_and(|flag| flag.load(std::sync::atomic::Ordering::SeqCst))
-        {
-            return user_interrupt_result();
-        }
-        let context = self.tool_context(cancel_flag);
-        if name == "Bash" {
-            return self.execute_bash_tool_call(name, arguments, &context);
-        }
-
-        self.execute_non_bash_tool_call(name, arguments, &context)
-    }
-
-    fn effective_tool_policy_error_for_execution(
-        &self,
-        name: &str,
-        arguments: &serde_json::Value,
-        effective_tool_policy: Option<&EffectiveToolPolicy>,
-    ) -> Option<String> {
-        let scope_for_policy = self
-            .missing_verifier_job
-            .as_ref()
-            .map(|_| self.current_workspace_scope());
-        if let Some(policy) = effective_tool_policy {
-            effective_tool_policy_error_for_call_with_scope(
-                policy,
-                name,
-                arguments,
-                &self.work_root,
-                scope_for_policy.as_ref(),
-            )
-        } else {
-            self.effective_tool_policy_error(name, arguments)
-        }
-    }
-
-    fn handle_tool_execution_rejection(
-        &mut self,
-        name: &str,
-        arguments: &serde_json::Value,
-        err: &str,
-    ) -> String {
-        let _tool_outcome = rejected_outcome_for_call(name, err);
-        self.session.working_memory.note_error(err.to_string());
-        if err.contains("artifact-directed recovery rejected") {
-            if name == "Bash" {
-                let command_arg = arguments
-                    .get("command")
-                    .and_then(serde_json::Value::as_str)
-                    .unwrap_or("")
-                    .to_string();
-                let _ =
-                    super::artifact_completion_record::record_artifact_completion_bash_violation(
-                        self,
-                        vec![command_arg],
-                    );
-            } else {
-                let actual_path = arguments
-                    .get("path")
-                    .and_then(serde_json::Value::as_str)
-                    .unwrap_or("")
-                    .to_string();
-                let _ = super::artifact_completion_record::record_artifact_completion_attempt(
-                    self,
-                    super::artifact_completion_job::ArtifactAttemptOutcomeKind::WrongTarget,
-                    vec![format!("{name} on {actual_path}")],
-                );
-            }
-        } else if err.starts_with("setup bootstrap")
-            && name == "Bash"
-            && self.artifact_completion_job.is_some()
-        {
-            let command_arg = arguments
-                .get("command")
-                .and_then(serde_json::Value::as_str)
-                .unwrap_or("")
-                .to_string();
-            let _ = super::artifact_completion_record::record_artifact_completion_bash_violation(
-                self,
-                vec![command_arg],
-            );
-        }
-        lifecycle::format_tool_error(err)
-    }
-
-    fn tool_context(
-        &self,
-        cancel_flag: Option<std::sync::Arc<std::sync::atomic::AtomicBool>>,
-    ) -> ToolContext {
-        let tmp_tests_root = Some(
-            self.session_store
-                .state_root()
-                .join("sessions")
-                .join(self.session_store.session_id())
-                .join("tmp-tests"),
-        );
-        ToolContext {
-            root: self.work_root.clone(),
-            mode: self.session.mode_state.mode,
-            plan_path: self.session.mode_state.active_plan_path.clone(),
-            plan_stage: self.session.mode_state.plan_stage,
-            auto_approve: self.config.yes_mode,
-            interactive_approval: io::stdin().is_terminal(),
-            offline: self.config.offline,
-            cancel_flag,
-            tmp_tests_root,
-            tester_active: self.tester_called_this_turn,
-        }
-    }
-
-    fn execute_bash_tool_call(
-        &mut self,
-        name: &str,
-        arguments: &serde_json::Value,
-        context: &ToolContext,
-    ) -> String {
-        let (result, outcome) = self
-            .tool_registry
-            .execute_bash_with_outcome(arguments, context);
-        if let Some(outcome) = outcome.as_ref()
-            && let Some(frame) = build_feedback_for_bash(outcome, &self.work_root)
-        {
-            self.session.record_feedback(frame);
-        }
-        if let Some(outcome) = outcome.as_ref() {
-            self.observe_evidence_from_bash_outcome(outcome);
-        }
-        match result {
-            Ok(text) => {
-                self.maybe_update_work_root(name, arguments, &text);
-                text
-            }
-            Err((err, class)) => {
-                self.session
-                    .working_memory
-                    .note_error(format!("{name}: {err}"));
-                if class == BashErrorClass::DangerousBlock {
-                    let cmd = arguments
-                        .get("command")
-                        .and_then(serde_json::Value::as_str)
-                        .unwrap_or("");
-                    let frame = build_feedback_for_unsafe_block_reason(cmd, &err, &self.work_root);
-                    self.session.record_feedback(frame);
-                    self.session.unsafe_blocks_this_turn =
-                        self.session.unsafe_blocks_this_turn.saturating_add(1);
-                }
-                lifecycle::format_tool_error(&err)
-            }
-        }
-    }
-
-    fn capture_pre_tool_hash_if_needed(&mut self, arguments: &serde_json::Value, name: &str) {
-        if matches!(name, "Write" | "Edit")
-            && let Some(raw_path) = arguments.get("path").and_then(serde_json::Value::as_str)
-            && let Some(rel) = workspace_relative_path_for_tool_arg(&self.work_root, raw_path)
-        {
-            let pre_hash = current_file_hash_for_relative_path(&self.work_root, &rel);
-            self.turn_pre_tool_file_hashes.insert(rel, pre_hash);
-        }
-    }
-
-    fn execute_non_bash_tool_call(
-        &mut self,
-        name: &str,
-        arguments: &serde_json::Value,
-        context: &ToolContext,
-    ) -> String {
-        self.capture_pre_tool_hash_if_needed(arguments, name);
-        match self.tool_registry.execute(name, arguments, context) {
-            Ok(result) => {
-                let tool_outcome = success_outcome_for_call(name, arguments, &self.work_root);
-                if let Some(edit) = tool_outcome.repo_edit_evidence() {
-                    self.session
-                        .working_memory
-                        .note_touched_file(normalize_memory_path(edit.raw_path(), &self.work_root));
-                    self.session.repo_edit_succeeded_this_turn = true;
-                    self.observe_evidence_from_repo_edit(edit.raw_path());
-                }
-                self.maybe_update_work_root(name, arguments, &result);
-                result
-            }
-            Err(err) => {
-                let _tool_outcome = failed_outcome_for_call(name, &err);
-                self.session
-                    .working_memory
-                    .note_error(format!("{name}: {err}"));
-                if name == "Edit" {
-                    let path = arguments.get("path").and_then(serde_json::Value::as_str);
-                    let frame = build_feedback_for_edit_failure(path, &err, &self.work_root);
-                    self.session.record_feedback(frame);
-                }
-                lifecycle::format_tool_error(&err)
-            }
-        }
-    }
-
-    /// Issue #606 (T-1.6): post-hoc observation of a Bash invocation as
-    /// `VerifierExitZero` completion evidence. A signal is recorded **only**
-    /// when:
-    ///
-    /// 1. `outcome.exit_code == Some(0)` — non-zero / timeout / interrupted
-    ///    invocations are explicit failures, not silent passes.
-    /// 2. `outcome.class == BuildTest` — read-only / network / mutating
-    ///    classes don't represent verification work even when they
-    ///    happen to exit 0.
-    /// 3. `is_completion_verifier_command(&outcome.command) == true` —
-    ///    rejects commands containing shell control operators that can
-    ///    mask the real exit code (DR4-002, e.g. `cargo test || true`).
-    ///
-    /// The evidence is consumed by
-    /// `ProtocolKind::evidence_set_satisfies` in `success.rs`.
-    fn observe_evidence_from_bash_outcome(
-        &mut self,
-        outcome: &crate::tools::bash::BashExecutionOutcome,
-    ) {
-        use crate::tools::bash::BashCommandClass;
-        // Issue #608 Phase α-2 (AP-09): record `last_verifier_command` /
-        // `last_verifier_invocation` for any BuildTest invocation (regardless
-        // of exit code) so the rerun-trigger handler can surface the most
-        // recent verifier attempt — even failed ones (the user often types
-        // `再実行` precisely because the last run failed).
-        if matches!(outcome.class, BashCommandClass::BuildTest)
-            && super::completion_evidence::is_completion_verifier_command(&outcome.command)
-        {
-            let redacted =
-                crate::session::feedback::redact_verifier_command_for_storage(&outcome.command);
-            // Drop empty redacted commands (e.g. all-control-char input).
-            if !redacted.trim().is_empty() {
-                self.session.last_verifier_command = Some(redacted.clone());
-                self.session.last_verifier_invocation =
-                    Some(crate::session::store::VerifierInvocationRecord {
-                        command: redacted,
-                        exit_code: outcome.exit_code.unwrap_or(-1),
-                        recorded_at: rfc3339_now_utc(),
-                    });
-            }
-        }
-
-        // Issue #607 (β): build VerifierExitZero evidence for BuildTest |
-        // EnvSetup exit-zero outcomes (per `build_verifier_exit_zero_evidence`).
-        let Some(evidence) = build_verifier_exit_zero_evidence(outcome) else {
-            return;
-        };
-        let crate::agent::loop_run::completion_evidence::CompletionEvidence::VerifierExitZero {
-            class,
-            ..
-        } = evidence
-        else {
-            // build_verifier_exit_zero_evidence only ever constructs
-            // VerifierExitZero today; the match keeps us honest if a future
-            // helper returns a different variant.
-            self.evidence_set_this_turn.push(evidence.clone());
-            if self.current_artifact_recovery_target.is_none() {
-                self.task_contract_evidence_set_this_turn.push(evidence);
-            }
-            return;
-        };
-        self.evidence_set_this_turn.push(evidence.clone());
-        if self.current_artifact_recovery_target.is_none() {
-            self.task_contract_evidence_set_this_turn
-                .push(evidence.clone());
-        }
-        crate::logging::log_completion_evidence_observed(
-            self.current_turn_index,
-            0, // α-1: iter_index plumbing is α-2 work; emit 0 for now.
-            "verifier_exit_zero",
-            serde_json::json!({
-                // Issue #607 BP-07 / S3-002: snake_case label matches serde
-                // rename_all so `command_class` reads `"env_setup"` /
-                // `"build_test"` instead of `"EnvSetup"` / `"BuildTest"`.
-                "command_class": class.as_str(),
-            }),
-        );
-    }
-
     /// Issue #606 (T-1.7): post-hoc observation of an Edit/Write success
     /// as `RepoEdit` completion evidence. The path is run through
     /// `classify_repo_edit_path` which uses the SSOT in `util::file_classify`
@@ -1098,7 +787,7 @@ impl Agent {
         super::task_workspace_scope::TaskWorkspaceScope::detect(&self.work_root, &request)
     }
 
-    fn answer_only_policy_error(
+    pub(super) fn answer_only_policy_error(
         &self,
         name: &str,
         arguments: &serde_json::Value,
@@ -1138,7 +827,7 @@ impl Agent {
             .is_some_and(request_explicitly_requests_script_execution)
     }
 
-    fn effective_tool_policy_error(
+    pub(super) fn effective_tool_policy_error(
         &self,
         name: &str,
         arguments: &serde_json::Value,


### PR DESCRIPTION
## Summary

Continue the meta-issue #680 split: move the per-tool-call execution
dispatch out of \`turn.rs\` into a focused sibling module so \`turn.rs\`
keeps shrinking toward responsibility-focused units.

One production helper + 7 private helpers were extracted as free
functions taking \`&mut Agent\` / \`&Agent\` (matching \`actor_loop_flow\` /
\`reply_retry\` / earlier vertical-slice precedent):

- \`execute_tool_call\` (production chokepoint)
- \`effective_tool_policy_error_for_execution\` (private)
- \`handle_tool_execution_rejection\` (private)
- \`tool_context\` (private)
- \`execute_bash_tool_call\` (private)
- \`capture_pre_tool_hash_if_needed\` (private)
- \`execute_non_bash_tool_call\` (private)
- \`observe_evidence_from_bash_outcome\` (private; Issue #606 T-1.6 +
  Issue #608 α-2 \`last_verifier_invocation\` record)

Behavior unchanged: same policy gate order, same \`ToolContext\` shape
(including \`interactive_approval = io::stdin().is_terminal()\`), same
Bash / non-Bash dispatch split, same feedback frame recording, same
Issue #606 T-1.6 BuildTest exit-0 evidence path + Issue #608 α-2
\`last_verifier_invocation\` recording invariants.

\`answer_only_policy_error\` and \`effective_tool_policy_error\` were
promoted from private to \`pub(super)\` so the sibling module can call
them as methods. Both stay in \`turn.rs\` for now; they're candidates
for a future policy-evaluation extraction.

\`pub(super)\` limited / no facade re-export (DR3-001). Callers updated in
\`scaffold_pipeline.rs\` (1 site) and \`actor_loop_flow.rs\` (4 sites) to
the free-fn form.

### LOC delta

- \`turn.rs\`: 1,387 → 1,076 (-311)
- new module: +360

Cumulative \`turn.rs\` reduction across the parent #680 split:
39,489 → 1,076 (-97.3%). Crosses under 1,100 LOC.

## Test plan

- [x] \`cargo build --lib\`
- [x] \`cargo fmt\`
- [x] \`cargo clippy --lib --all-targets -- -D warnings\`
- [x] \`cargo test --lib\` (3,114 passed, 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)