### PR TITLE
Extract recovery_targets.rs from turn.rs (parent #680)

### DIFF
--- a/src/agent/loop_run.rs
+++ b/src/agent/loop_run.rs
@@ -278,6 +278,15 @@ mod tool_call_execution;
 // Task 2.5 ArtifactLedger seed. Free fn over `&mut Agent`.
 // `pub(super)` limited / no facade re-export (DR3-001).
 mod repo_edit_observation;
+// Focused-edit / repo-change / verifier-repair recovery target +
+// note builders extracted from `turn.rs` (parent #680). Hosts
+// `focused_edit_recovery_target` (focused-edit chain),
+// `repo_change_no_edit_recovery_target` (private repo-change chain),
+// `push_repo_change_no_edit_recovery_note`, and
+// `push_verifier_repair_recovery_note` (RequestDiagnostic /
+// RequestPatch branches). Free fns over `&mut Agent` / `&Agent`.
+// `pub(super)` limited / no facade re-export (DR3-001).
+mod recovery_targets;
 // Issue #652: `ArtifactCompletionJob` + role-specific retry budget +
 // `ArtifactAttemptOutcome` 4-variant taxonomy +
 // `ArtifactCompletionFailureSnapshot` for #654. Module is intentionally

--- a/src/agent/loop_run/actor_loop_flow.rs
+++ b/src/agent/loop_run/actor_loop_flow.rs
@@ -728,7 +728,7 @@ pub(super) fn maybe_continue_missing_repo_scaffold_fallback(
 }
 
 pub(super) fn push_missing_repo_edit_retry_note(agent: &mut Agent, attempt: usize) {
-    if let Some(target) = agent.focused_edit_recovery_target() {
+    if let Some(target) = super::recovery_targets::focused_edit_recovery_target(agent) {
         let target_already_read =
             focused_edit_target_already_read(&agent.session.messages, &target, &agent.work_root);
         let note = super::recovery_messages::focused_edit_no_tool_note_for_target(
@@ -1115,8 +1115,10 @@ fn handle_empty_missing_repo_change_retry(
     if !super::artifact_completion_record::push_artifact_directed_recovery_note(
         agent,
         repo_change_retries,
-    ) && !agent.push_repo_change_no_edit_recovery_note(repo_change_retries)
-    {
+    ) && !super::recovery_targets::push_repo_change_no_edit_recovery_note(
+        agent,
+        repo_change_retries,
+    ) {
         agent.push_system_note(recovery::repo_change_recovery_note(repo_change_retries));
     }
     if super::artifact_completion_record::record_artifact_completion_attempt(
@@ -1133,7 +1135,7 @@ fn handle_prose_only_missing_repo_change_retry(
     agent: &mut Agent,
     repo_change_retries: usize,
 ) -> ActorLoopNoToolReplyOutcome {
-    if let Some(target) = agent.focused_edit_recovery_target() {
+    if let Some(target) = super::recovery_targets::focused_edit_recovery_target(agent) {
         let target_already_read =
             focused_edit_target_already_read(&agent.session.messages, &target, &agent.work_root);
         let note = super::recovery_messages::focused_edit_no_tool_note_for_target(
@@ -1146,8 +1148,10 @@ fn handle_prose_only_missing_repo_change_retry(
     } else if !super::artifact_completion_record::push_artifact_directed_recovery_note(
         agent,
         repo_change_retries,
-    ) && !agent.push_repo_change_no_edit_recovery_note(repo_change_retries)
-    {
+    ) && !super::recovery_targets::push_repo_change_no_edit_recovery_note(
+        agent,
+        repo_change_retries,
+    ) {
         agent.push_system_note(recovery::repo_change_no_tool_recovery_note(
             repo_change_retries,
         ));
@@ -1170,7 +1174,10 @@ fn handle_actor_loop_missing_repo_change_retry_exhausted(
         && (super::artifact_completion_record::push_artifact_directed_recovery_note(
             agent,
             args.repo_change_retries,
-        ) || agent.push_repo_change_no_edit_recovery_note(args.repo_change_retries))
+        ) || super::recovery_targets::push_repo_change_no_edit_recovery_note(
+            agent,
+            args.repo_change_retries,
+        ))
     {
         super::turn::write_stdout_rendered(
             &format_iteration_status(
@@ -2391,7 +2398,7 @@ pub(super) fn handle_actor_loop_task_contract_repair_artifact(
         ),
         true,
     );
-    if !agent.push_verifier_repair_recovery_note(*verifier_repair_retries)
+    if !super::recovery_targets::push_verifier_repair_recovery_note(agent, *verifier_repair_retries)
         && !super::artifact_completion_record::push_artifact_directed_recovery_note(
             agent,
             *verifier_repair_retries,

--- a/src/agent/loop_run/artifact_completion_record.rs
+++ b/src/agent/loop_run/artifact_completion_record.rs
@@ -26,7 +26,7 @@ use super::Agent;
 use crate::agent::recovery;
 
 pub(super) fn push_artifact_directed_recovery_note(agent: &mut Agent, attempt: usize) -> bool {
-    if agent.focused_edit_recovery_target().is_some() {
+    if super::recovery_targets::focused_edit_recovery_target(agent).is_some() {
         return false;
     }
     let Some(target) = agent.current_artifact_recovery_target.as_ref() else {

--- a/src/agent/loop_run/effective_tool_policy_flow.rs
+++ b/src/agent/loop_run/effective_tool_policy_flow.rs
@@ -137,7 +137,7 @@ pub(super) fn build_arbiter_candidates(agent: &Agent) -> Vec<JobCandidate> {
     }
 
     // Priority 5: FocusedEditRecovery.
-    if let Some(target) = agent.focused_edit_recovery_target() {
+    if let Some(target) = super::recovery_targets::focused_edit_recovery_target(agent) {
         push_focused_edit_candidate(
             agent,
             &mut candidates,

--- a/src/agent/loop_run/feedback_builders.rs
+++ b/src/agent/loop_run/feedback_builders.rs
@@ -223,7 +223,7 @@ pub(super) fn extract_current_request_paths(agent: &Agent, work_root: &Path) -> 
             }
         }
     }
-    if let Some(target) = agent.focused_edit_recovery_target() {
+    if let Some(target) = super::recovery_targets::focused_edit_recovery_target(agent) {
         let canonical_root = work_root.canonicalize().ok();
         let rel = if let Some(root) = &canonical_root {
             target

--- a/src/agent/loop_run/recovery_targets.rs
+++ b/src/agent/loop_run/recovery_targets.rs
@@ -1,0 +1,151 @@
+//! Focused-edit / repo-change / verifier-repair recovery target +
+//! note builders extracted from `turn.rs` (parent #680).
+//!
+//! Hosts the recovery-target-selection helpers that decide which file
+//! to push the assistant back toward when its previous reply did not
+//! produce useful repo state:
+//!
+//! - `focused_edit_recovery_target` — the focused-edit policy's
+//!   target chain (forced-small-edit → post-scaffold edit recovery →
+//!   post-scaffold continuation recovery).
+//! - `repo_change_no_edit_recovery_target` (private) — repo-change
+//!   policy's target chain (Act mode + repo-edit required + active
+//!   task expects a repo change + no successful non-plan edit yet →
+//!   artifact-recovery path / first-existing-impl-target /
+//!   latest-turn-preferred-read-edit target / last-read-tool fallback).
+//! - `push_repo_change_no_edit_recovery_note` — pushes a system note
+//!   for the repo-change recovery target (missing target vs.
+//!   read-then-no-edit form).
+//! - `push_verifier_repair_recovery_note` — pushes a system note for
+//!   the verifier-repair policy (RequestDiagnostic / RequestPatch
+//!   branches). RerunVerifier / SafeStop / VerifiedDone return false.
+//!
+//! Originally `impl Agent` methods; converted to free functions taking
+//! `&mut Agent` / `&Agent`, matching the `actor_loop_flow` /
+//! `reply_retry` / earlier vertical-slice precedent. `pub(super)`
+//! limited / no facade re-export (DR3-001).
+
+use std::path::PathBuf;
+
+use super::Agent;
+use super::tool_display::progress_path_display;
+use super::tool_history::{focused_edit_target_already_read, has_successful_non_plan_repo_edit};
+use super::turn::{
+    TASK_CONTRACT_VERIFIER_ATTEMPT_LIMIT, last_read_tool_path,
+    latest_turn_preferred_read_edit_target,
+};
+use super::verifier_orchestration::{
+    task_contract_verifier_targeted_edit_required_note, verifier_repair_diagnostic_pending_note,
+    verifier_repair_target_display,
+};
+use crate::agent::recovery;
+use crate::modes::plan_act::ExecutionMode;
+use crate::safety::path_guard::resolve_user_path;
+
+pub(super) fn focused_edit_recovery_target(agent: &Agent) -> Option<PathBuf> {
+    agent
+        .forced_small_edit_recovery_target()
+        .or_else(|| super::scaffold_pipeline::post_scaffold_edit_recovery_target(agent))
+        .or_else(|| super::scaffold_pipeline::post_scaffold_continuation_recovery_target(agent))
+}
+
+fn repo_change_no_edit_recovery_target(agent: &Agent) -> Option<PathBuf> {
+    if agent.session.mode_state.mode != ExecutionMode::Act
+        || !agent.session.mode_state.policy().repo_edit_required
+        || !agent.active_task_expects_repo_change()
+        || has_successful_non_plan_repo_edit(
+            &agent.session.messages,
+            &agent.work_root,
+            agent.session.mode_state.active_plan_path.as_deref(),
+        )
+    {
+        return None;
+    }
+    if let Some(candidate) = super::artifact_recovery_flow::artifact_recovery_target_path(agent) {
+        return Some(candidate);
+    }
+    if let Some(candidate) = super::quality::first_existing_impl_target(&agent.work_root)
+        && focused_edit_target_already_read(&agent.session.messages, &candidate, &agent.work_root)
+    {
+        return Some(candidate);
+    }
+    latest_turn_preferred_read_edit_target(&agent.session.messages, &agent.work_root).or_else(
+        || {
+            let path = last_read_tool_path(&agent.session.messages)?;
+            let candidate = resolve_user_path(&agent.work_root, &path).ok()?;
+            candidate.is_file().then_some(candidate)
+        },
+    )
+}
+
+pub(super) fn push_repo_change_no_edit_recovery_note(agent: &mut Agent, attempt: usize) -> bool {
+    let Some(target) = repo_change_no_edit_recovery_target(agent) else {
+        return false;
+    };
+    let target_display = progress_path_display(
+        &target.display().to_string(),
+        &agent.work_root,
+        agent.session.mode_state.active_plan_path.as_deref(),
+        120,
+    );
+    let note = if !target.is_file() {
+        recovery::focused_edit_missing_target_recovery_note(&target_display, attempt)
+    } else {
+        recovery::repo_change_after_read_no_edit_note(&target_display, attempt)
+    };
+    agent.push_system_note(note);
+    true
+}
+
+pub(super) fn push_verifier_repair_recovery_note(agent: &mut Agent, attempt: usize) -> bool {
+    let Some(context) = agent.repair_job.as_ref() else {
+        return false;
+    };
+    match context.next_action() {
+        super::repair_job::RepairNextAction::RequestDiagnostic
+        | super::repair_job::RepairNextAction::Replan => {
+            // Issue #665 Phase 5: caller-side projection (S5-005 では
+            // raw label/excerpt は system note に出さないため helper
+            // 内部で metadata のみに縮退する)。
+            let active_request = agent.active_request_text().unwrap_or_default();
+            let task_contract = super::task_contract::TaskContract::from_request(&active_request);
+            let behavior_projection =
+                super::required_behavior::project_behavior_contract(&task_contract);
+            let note =
+                verifier_repair_diagnostic_pending_note(context, behavior_projection.as_ref());
+            agent.push_system_note(note);
+            true
+        }
+        super::repair_job::RepairNextAction::RequestPatch { target_hint } => {
+            let Some(relative) = super::repair_job::safe_relative_path_string(&target_hint.path)
+            else {
+                return false;
+            };
+            let target = agent.work_root.join(relative);
+            let target = std::fs::canonicalize(&target).unwrap_or(target);
+            if !target.is_file() {
+                let target_display = verifier_repair_target_display(&target, &agent.work_root);
+                agent.push_system_note(recovery::focused_edit_missing_target_recovery_note(
+                    &target_display,
+                    attempt,
+                ));
+                return true;
+            }
+            agent.push_system_note(task_contract_verifier_targeted_edit_required_note(
+                context,
+                &agent.work_root,
+                focused_edit_target_already_read(
+                    &agent.session.messages,
+                    &target,
+                    &agent.work_root,
+                ),
+                attempt,
+                TASK_CONTRACT_VERIFIER_ATTEMPT_LIMIT,
+            ));
+            true
+        }
+        super::repair_job::RepairNextAction::RerunVerifier
+        | super::repair_job::RepairNextAction::SafeStop { .. }
+        | super::repair_job::RepairNextAction::VerifiedDone => false,
+    }
+}

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -18,10 +18,7 @@ use super::tool_history::{
     is_preferred_read_edit_target, latest_user_turn_slice, recent_truncated_tool_call_attempt,
 };
 use super::tool_policy::{EffectiveToolPolicy, effective_tool_policy_error_for_call_with_scope};
-use super::verifier_orchestration::{
-    task_contract_no_verifier_note, task_contract_verifier_targeted_edit_required_note,
-    verifier_repair_diagnostic_pending_note, verifier_repair_target_display,
-};
+use super::verifier_orchestration::task_contract_no_verifier_note;
 use super::workspace_walk::workspace_appears_empty;
 use super::*;
 use crate::model_capabilities::model_capabilities;
@@ -479,116 +476,6 @@ impl Agent {
                 candidate.is_file().then_some(candidate)
             },
         )
-    }
-
-    pub(super) fn focused_edit_recovery_target(&self) -> Option<PathBuf> {
-        self.forced_small_edit_recovery_target()
-            .or_else(|| super::scaffold_pipeline::post_scaffold_edit_recovery_target(self))
-            .or_else(|| super::scaffold_pipeline::post_scaffold_continuation_recovery_target(self))
-    }
-
-    fn repo_change_no_edit_recovery_target(&self) -> Option<PathBuf> {
-        if self.session.mode_state.mode != ExecutionMode::Act
-            || !self.session.mode_state.policy().repo_edit_required
-            || !self.active_task_expects_repo_change()
-            || has_successful_non_plan_repo_edit(
-                &self.session.messages,
-                &self.work_root,
-                self.session.mode_state.active_plan_path.as_deref(),
-            )
-        {
-            return None;
-        }
-        if let Some(candidate) = super::artifact_recovery_flow::artifact_recovery_target_path(self)
-        {
-            return Some(candidate);
-        }
-        if let Some(candidate) = first_existing_impl_target(&self.work_root)
-            && focused_edit_target_already_read(&self.session.messages, &candidate, &self.work_root)
-        {
-            return Some(candidate);
-        }
-        latest_turn_preferred_read_edit_target(&self.session.messages, &self.work_root).or_else(
-            || {
-                let path = last_read_tool_path(&self.session.messages)?;
-                let candidate = resolve_user_path(&self.work_root, &path).ok()?;
-                candidate.is_file().then_some(candidate)
-            },
-        )
-    }
-
-    pub(super) fn push_repo_change_no_edit_recovery_note(&mut self, attempt: usize) -> bool {
-        let Some(target) = self.repo_change_no_edit_recovery_target() else {
-            return false;
-        };
-        let target_display = progress_path_display(
-            &target.display().to_string(),
-            &self.work_root,
-            self.session.mode_state.active_plan_path.as_deref(),
-            120,
-        );
-        let note = if !target.is_file() {
-            recovery::focused_edit_missing_target_recovery_note(&target_display, attempt)
-        } else {
-            recovery::repo_change_after_read_no_edit_note(&target_display, attempt)
-        };
-        self.push_system_note(note);
-        true
-    }
-
-    pub(super) fn push_verifier_repair_recovery_note(&mut self, attempt: usize) -> bool {
-        let Some(context) = self.repair_job.as_ref() else {
-            return false;
-        };
-        match context.next_action() {
-            super::repair_job::RepairNextAction::RequestDiagnostic
-            | super::repair_job::RepairNextAction::Replan => {
-                // Issue #665 Phase 5: caller-side projection (S5-005 では
-                // raw label/excerpt は system note に出さないため helper
-                // 内部で metadata のみに縮退する)。
-                let active_request = self.active_request_text().unwrap_or_default();
-                let task_contract =
-                    super::task_contract::TaskContract::from_request(&active_request);
-                let behavior_projection =
-                    super::required_behavior::project_behavior_contract(&task_contract);
-                let note =
-                    verifier_repair_diagnostic_pending_note(context, behavior_projection.as_ref());
-                self.push_system_note(note);
-                true
-            }
-            super::repair_job::RepairNextAction::RequestPatch { target_hint } => {
-                let Some(relative) =
-                    super::repair_job::safe_relative_path_string(&target_hint.path)
-                else {
-                    return false;
-                };
-                let target = self.work_root.join(relative);
-                let target = std::fs::canonicalize(&target).unwrap_or(target);
-                if !target.is_file() {
-                    let target_display = verifier_repair_target_display(&target, &self.work_root);
-                    self.push_system_note(recovery::focused_edit_missing_target_recovery_note(
-                        &target_display,
-                        attempt,
-                    ));
-                    return true;
-                }
-                self.push_system_note(task_contract_verifier_targeted_edit_required_note(
-                    context,
-                    &self.work_root,
-                    focused_edit_target_already_read(
-                        &self.session.messages,
-                        &target,
-                        &self.work_root,
-                    ),
-                    attempt,
-                    TASK_CONTRACT_VERIFIER_ATTEMPT_LIMIT,
-                ));
-                true
-            }
-            super::repair_job::RepairNextAction::RerunVerifier
-            | super::repair_job::RepairNextAction::SafeStop { .. }
-            | super::repair_job::RepairNextAction::VerifiedDone => false,
-        }
     }
 
     /// Issue #636: read a workspace-confined, cap-bounded excerpt of


### PR DESCRIPTION
## Summary

Continue the meta-issue #680 split: move the focused-edit /
repo-change / verifier-repair recovery target + note builders out of
\`turn.rs\` into a focused sibling module so \`turn.rs\` keeps shrinking
toward responsibility-focused units.

Three production helpers + one private chain were extracted as free
functions taking \`&mut Agent\` / \`&Agent\` (matching \`actor_loop_flow\` /
\`reply_retry\` / earlier vertical-slice precedent):

- \`focused_edit_recovery_target\` (target chain)
- \`repo_change_no_edit_recovery_target\` (private)
- \`push_repo_change_no_edit_recovery_note\`
- \`push_verifier_repair_recovery_note\` (RepairNextAction dispatcher)

Behavior unchanged: same Act-mode + \`repo_edit_required\` gate, same
target chain priority, same Issue #665 Phase 5 caller-side projection
for the diagnostic-pending note, same \`RepairNextAction\` dispatcher
shape.

\`pub(super)\` limited / no facade re-export (DR3-001). Callers updated
in \`artifact_completion_record.rs\` (1 site),
\`effective_tool_policy_flow.rs\` (1 site), \`feedback_builders.rs\`
(1 site), and \`actor_loop_flow.rs\` (5 sites) to the free-fn form.

### LOC delta

- \`turn.rs\`: 945 → 832 (-113)
- new module: +151

Cumulative \`turn.rs\` reduction across the parent #680 split:
39,489 → 832 (-97.9%).

## Test plan

- [x] \`cargo build --lib\`
- [x] \`cargo fmt\`
- [x] \`cargo clippy --lib --all-targets -- -D warnings\`
- [x] \`cargo test --lib\` (3,114 passed, 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)