### PR TITLE
Extract quality_gate.rs from turn.rs (parent #680)

### DIFF
--- a/src/agent/loop_run.rs
+++ b/src/agent/loop_run.rs
@@ -287,6 +287,15 @@ mod repo_edit_observation;
 // RequestPatch branches). Free fns over `&mut Agent` / `&Agent`.
 // `pub(super)` limited / no facade re-export (DR3-001).
 mod recovery_targets;
+// Playable-UI quality gate decision helpers extracted from `turn.rs`
+// (parent #680). Hosts `current_request_needs_playable_ui_quality_gate`
+// (Act + policy + request gate), `accepted_repo_change_quality_issue`
+// (Issue #580 second-pass classifier), `accepted_repo_change_polish_target`
+// (deterministic polish target with quality-suppression), and the
+// private `unsupported_ui_framework_context` predicate. Free fns over
+// `&mut Agent` / `&Agent`. `pub(super)` limited / no facade re-export
+// (DR3-001).
+mod quality_gate;
 // Issue #652: `ArtifactCompletionJob` + role-specific retry budget +
 // `ArtifactAttemptOutcome` 4-variant taxonomy +
 // `ArtifactCompletionFailureSnapshot` for #654. Module is intentionally

--- a/src/agent/loop_run/actor_loop_flow.rs
+++ b/src/agent/loop_run/actor_loop_flow.rs
@@ -490,12 +490,13 @@ pub(super) fn maybe_handle_repo_change_quality_gate_recovery(
         args.action_expectation,
         agent.active_task_expects_repo_change(),
         agent.session.mode_state.mode,
-    ) || agent.current_request_needs_playable_ui_quality_gate())
+    ) || super::quality_gate::current_request_needs_playable_ui_quality_gate(agent))
         || !args.recovery_dispatch_gate.allows_deterministic_fallback()
     {
         return None;
     }
-    let (request, target_path, issue) = agent.accepted_repo_change_quality_issue()?;
+    let (request, target_path, issue) =
+        super::quality_gate::accepted_repo_change_quality_issue(agent)?;
     match super::scaffold_pipeline::maybe_apply_deterministic_quality_fallback(
         agent,
         &request,
@@ -1456,11 +1457,13 @@ fn handle_actor_loop_post_tool_no_edit_fallbacks(
     if repo_edit_calls_made_this_turn != 0
         || tool_calls_made_this_turn == 0
         || !recovery_dispatch_gate.allows_deterministic_fallback()
-        || !agent.current_request_needs_playable_ui_quality_gate()
+        || !super::quality_gate::current_request_needs_playable_ui_quality_gate(agent)
     {
         return ActorLoopPostToolFallbackOutcome::Proceed;
     }
-    if let Some((request, target_path)) = agent.accepted_repo_change_polish_target() {
+    if let Some((request, target_path)) =
+        super::quality_gate::accepted_repo_change_polish_target(agent)
+    {
         return handle_actor_loop_post_tool_polish_fallback(
             agent,
             last_iter,
@@ -1469,7 +1472,9 @@ fn handle_actor_loop_post_tool_no_edit_fallbacks(
             repo_change_retries,
         );
     }
-    if let Some((request, target_path, _issue)) = agent.accepted_repo_change_quality_issue() {
+    if let Some((request, target_path, _issue)) =
+        super::quality_gate::accepted_repo_change_quality_issue(agent)
+    {
         return handle_actor_loop_post_tool_quality_fallback(
             agent,
             last_iter,
@@ -1577,11 +1582,13 @@ fn handle_actor_loop_post_tool_repo_edit_quality_gate(
             action_expectation,
             agent.active_task_expects_repo_change(),
             agent.session.mode_state.mode,
-        ) || agent.current_request_needs_playable_ui_quality_gate())
+        ) || super::quality_gate::current_request_needs_playable_ui_quality_gate(agent))
     {
         return ActorLoopPostToolFallbackOutcome::Proceed;
     }
-    let Some((request, target_path, issue)) = agent.accepted_repo_change_quality_issue() else {
+    let Some((request, target_path, issue)) =
+        super::quality_gate::accepted_repo_change_quality_issue(agent)
+    else {
         return ActorLoopPostToolFallbackOutcome::Proceed;
     };
     match super::scaffold_pipeline::maybe_apply_deterministic_quality_fallback(
@@ -2046,11 +2053,11 @@ pub(super) fn maybe_handle_actor_loop_playable_ui_fallback(
     if !actor_loop_pre_reply_deterministic_fallback_allowed(
         *args.repo_edit_calls_made_this_turn,
         recovery_dispatch_gate,
-    ) || !agent.current_request_needs_playable_ui_quality_gate()
+    ) || !super::quality_gate::current_request_needs_playable_ui_quality_gate(agent)
     {
         return None;
     }
-    let (request, target_path) = agent.accepted_repo_change_polish_target()?;
+    let (request, target_path) = super::quality_gate::accepted_repo_change_polish_target(agent)?;
     match handle_actor_loop_post_tool_polish_fallback(
         agent,
         args.last_iter,

--- a/src/agent/loop_run/quality_gate.rs
+++ b/src/agent/loop_run/quality_gate.rs
@@ -1,0 +1,118 @@
+//! Playable-UI quality gate decision helpers extracted from `turn.rs`
+//! (parent #680).
+//!
+//! Hosts the per-turn quality-gate decisions that the actor loop and
+//! the scaffold pipeline consult before running the
+//! `implementation_quality_issue_with_confirm` sidecar:
+//!
+//! - `current_request_needs_playable_ui_quality_gate` — Act mode +
+//!   `quality_gate_enabled` policy + not in an unsupported UI
+//!   framework context + active request mentions playable UI.
+//! - `accepted_repo_change_quality_issue` — runs the quality issue
+//!   classifier (with second-pass sidecar confirmation per Issue
+//!   #580) against the first existing impl target and returns
+//!   `(request, relative_path, issue_text)` when a quality issue is
+//!   accepted.
+//! - `accepted_repo_change_polish_target` — runs the deterministic
+//!   `playable_ui_polish` pre-checker against the first existing impl
+//!   target and returns `(request, relative_path)` when a polish
+//!   action should run. A `Some(...)` quality verdict from the
+//!   second-pass adapter suppresses polishing (treats it as a quality
+//!   issue instead).
+//! - `unsupported_ui_framework_context` (private) — request mentions
+//!   unsupported framework OR workspace already contains one.
+//!
+//! Originally `impl Agent` methods; converted to free functions taking
+//! `&mut Agent` / `&Agent`, matching the `actor_loop_flow` /
+//! `reply_retry` / earlier vertical-slice precedent. `pub(super)`
+//! limited / no facade re-export (DR3-001).
+
+use super::Agent;
+use super::deterministic;
+use super::quality::{
+    first_existing_impl_target, request_allows_fast_polish_fallback,
+    request_mentions_unsupported_ui_framework, request_needs_playable_ui_quality_gate,
+    workspace_has_unsupported_ui_framework,
+};
+use crate::modes::plan_act::ExecutionMode;
+
+pub(super) fn current_request_needs_playable_ui_quality_gate(agent: &Agent) -> bool {
+    agent.session.mode_state.mode == ExecutionMode::Act
+        && agent.session.mode_state.policy().quality_gate_enabled
+        && !unsupported_ui_framework_context(agent)
+        && agent
+            .active_request_text()
+            .as_deref()
+            .is_some_and(request_needs_playable_ui_quality_gate)
+}
+
+pub(super) fn accepted_repo_change_quality_issue(
+    agent: &mut Agent,
+) -> Option<(String, String, String)> {
+    if !agent.session.mode_state.policy().quality_gate_enabled {
+        return None;
+    }
+    if unsupported_ui_framework_context(agent) {
+        return None;
+    }
+    let request = agent.active_request_text()?;
+    let request = request.trim().to_string();
+    if !request_needs_playable_ui_quality_gate(&request) {
+        return None;
+    }
+    let target = first_existing_impl_target(&agent.work_root)?;
+    let content = std::fs::read_to_string(&target).ok()?;
+    // Issue #580: route through the second-pass adapter so borderline
+    // UI verdicts can be confirmed/overridden by the sidecar LLM.
+    let issue = super::classify_confirm_flow::implementation_quality_issue_with_confirm(
+        agent, &request, &content,
+    )?;
+    let relative = target
+        .strip_prefix(&agent.work_root)
+        .unwrap_or(&target)
+        .to_string_lossy()
+        .replace('\\', "/");
+    Some((request, relative, issue))
+}
+
+pub(super) fn accepted_repo_change_polish_target(agent: &mut Agent) -> Option<(String, String)> {
+    if !agent.session.mode_state.policy().allow_polish_fallback {
+        return None;
+    }
+    if unsupported_ui_framework_context(agent) {
+        return None;
+    }
+    let request = agent.active_request_text()?;
+    let request = request.trim().to_string();
+    if !request_allows_fast_polish_fallback(&request) {
+        return None;
+    }
+    let target = first_existing_impl_target(&agent.work_root)?;
+    let content = std::fs::read_to_string(&target).ok()?;
+    // Issue #580: a second-pass `interactive=false` verdict surfaces
+    // here as `Some(...)` which correctly suppresses the polish action
+    // (treating the file as a quality issue rather than polishing
+    // static code).
+    if super::classify_confirm_flow::implementation_quality_issue_with_confirm(
+        agent, &request, &content,
+    )
+    .is_some()
+    {
+        return None;
+    }
+    deterministic::playable_ui_polish(&request, &target, &content)?;
+    let relative = target
+        .strip_prefix(&agent.work_root)
+        .unwrap_or(&target)
+        .to_string_lossy()
+        .replace('\\', "/");
+    Some((request, relative))
+}
+
+fn unsupported_ui_framework_context(agent: &Agent) -> bool {
+    agent
+        .active_request_text()
+        .as_deref()
+        .is_some_and(request_mentions_unsupported_ui_framework)
+        || workspace_has_unsupported_ui_framework(&agent.work_root)
+}

--- a/src/agent/loop_run/scaffold_pipeline.rs
+++ b/src/agent/loop_run/scaffold_pipeline.rs
@@ -1599,7 +1599,7 @@ pub(super) fn maybe_apply_deterministic_quality_fallback_after_timeout(
     err: &str,
 ) -> Option<AssistantReply> {
     if !err.to_ascii_lowercase().contains("timed out")
-        || !agent.current_request_needs_playable_ui_quality_gate()
+        || !super::quality_gate::current_request_needs_playable_ui_quality_gate(agent)
     {
         return None;
     }
@@ -1611,7 +1611,7 @@ pub(super) fn maybe_apply_deterministic_polish_fallback_after_timeout(
     err: &str,
 ) -> Option<AssistantReply> {
     if !err.to_ascii_lowercase().contains("timed out")
-        || !agent.current_request_needs_playable_ui_quality_gate()
+        || !super::quality_gate::current_request_needs_playable_ui_quality_gate(agent)
     {
         return None;
     }

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -28,12 +28,7 @@ use crate::session::store::ScaffoldArtifactFileSnapshot;
 use crate::tools::registry::ToolSpec;
 use std::path::{Path, PathBuf};
 
-use super::deterministic;
-use super::quality::{
-    first_existing_impl_target, repo_change_request_text, request_allows_fast_polish_fallback,
-    request_explicitly_requires_tests, request_mentions_unsupported_ui_framework,
-    request_needs_playable_ui_quality_gate, workspace_has_unsupported_ui_framework,
-};
+use super::quality::{repo_change_request_text, request_explicitly_requires_tests};
 
 /// Maximum number of characters of tool-call arguments retained in trace logs.
 pub(super) const LOG_ARGS_MAX_CHARS: usize = 200;
@@ -621,86 +616,6 @@ impl Agent {
             self.session.working_memory.active_task.as_deref(),
             &self.session.messages,
         )
-    }
-
-    pub(super) fn current_request_needs_playable_ui_quality_gate(&self) -> bool {
-        self.session.mode_state.mode == ExecutionMode::Act
-            && self.session.mode_state.policy().quality_gate_enabled
-            && !self.unsupported_ui_framework_context()
-            && self
-                .active_request_text()
-                .as_deref()
-                .is_some_and(request_needs_playable_ui_quality_gate)
-    }
-
-    pub(super) fn accepted_repo_change_quality_issue(
-        &mut self,
-    ) -> Option<(String, String, String)> {
-        if !self.session.mode_state.policy().quality_gate_enabled {
-            return None;
-        }
-        if self.unsupported_ui_framework_context() {
-            return None;
-        }
-        let request = self.active_request_text()?;
-        let request = request.trim().to_string();
-        if !request_needs_playable_ui_quality_gate(&request) {
-            return None;
-        }
-        let target = first_existing_impl_target(&self.work_root)?;
-        let content = std::fs::read_to_string(&target).ok()?;
-        // Issue #580: route through the second-pass adapter so borderline UI
-        // verdicts can be confirmed/overridden by the sidecar LLM.
-        let issue = super::classify_confirm_flow::implementation_quality_issue_with_confirm(
-            self, &request, &content,
-        )?;
-        let relative = target
-            .strip_prefix(&self.work_root)
-            .unwrap_or(&target)
-            .to_string_lossy()
-            .replace('\\', "/");
-        Some((request, relative, issue))
-    }
-
-    pub(super) fn accepted_repo_change_polish_target(&mut self) -> Option<(String, String)> {
-        if !self.session.mode_state.policy().allow_polish_fallback {
-            return None;
-        }
-        if self.unsupported_ui_framework_context() {
-            return None;
-        }
-        let request = self.active_request_text()?;
-        let request = request.trim().to_string();
-        if !request_allows_fast_polish_fallback(&request) {
-            return None;
-        }
-        let target = first_existing_impl_target(&self.work_root)?;
-        let content = std::fs::read_to_string(&target).ok()?;
-        // Issue #580: a second-pass `interactive=false` verdict surfaces here
-        // as `Some(...)` which correctly suppresses the polish action
-        // (treating the file as a quality issue rather than polishing static
-        // code).
-        if super::classify_confirm_flow::implementation_quality_issue_with_confirm(
-            self, &request, &content,
-        )
-        .is_some()
-        {
-            return None;
-        }
-        deterministic::playable_ui_polish(&request, &target, &content)?;
-        let relative = target
-            .strip_prefix(&self.work_root)
-            .unwrap_or(&target)
-            .to_string_lossy()
-            .replace('\\', "/");
-        Some((request, relative))
-    }
-
-    fn unsupported_ui_framework_context(&self) -> bool {
-        self.active_request_text()
-            .as_deref()
-            .is_some_and(request_mentions_unsupported_ui_framework)
-            || workspace_has_unsupported_ui_framework(&self.work_root)
     }
 
     pub(super) fn active_python_request_requires_tests(&self) -> bool {


### PR DESCRIPTION
## Summary

Continue the meta-issue #680 split: move the playable-UI quality gate
decision helpers out of \`turn.rs\` into a focused sibling module so
\`turn.rs\` keeps shrinking toward responsibility-focused units.

Three production helpers + one private predicate were extracted as
free functions taking \`&mut Agent\` / \`&Agent\` (matching
\`actor_loop_flow\` / \`reply_retry\` / earlier vertical-slice precedent):

- \`current_request_needs_playable_ui_quality_gate\`
- \`accepted_repo_change_quality_issue\` (Issue #580 second-pass
  classifier)
- \`accepted_repo_change_polish_target\` (deterministic polish target
  with quality-suppression)
- \`unsupported_ui_framework_context\` (private)

Behavior unchanged: same Act-mode + \`quality_gate_enabled\` gate, same
unsupported-UI-framework guard order, same Issue #580 second-pass
classifier flow, same \`first_existing_impl_target\` selection, same
quality-suppresses-polish invariant.

\`pub(super)\` limited / no facade re-export (DR3-001). Callers updated
in \`scaffold_pipeline.rs\` (2 sites) and \`actor_loop_flow.rs\` (7
sites) to the free-fn form.

### LOC delta

- \`turn.rs\`: 832 → 747 (-85)
- new module: +118

Cumulative \`turn.rs\` reduction across the parent #680 split:
39,489 → 747 (-98.1%). Crosses below the -98% milestone.

## Test plan

- [x] \`cargo build --lib\`
- [x] \`cargo fmt\`
- [x] \`cargo clippy --lib --all-targets -- -D warnings\`
- [x] \`cargo test --lib\` (3,114 passed, 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)