### PR TITLE
Extract tool_policy_decisions.rs from turn.rs (parent #680)

### DIFF
--- a/src/agent/loop_run.rs
+++ b/src/agent/loop_run.rs
@@ -296,6 +296,15 @@ mod recovery_targets;
 // `&mut Agent` / `&Agent`. `pub(super)` limited / no facade re-export
 // (DR3-001).
 mod quality_gate;
+// Per-Agent tool-policy decision helpers extracted from `turn.rs`
+// (parent #680). Hosts `answer_only_mode_active` (Issue #576 / DR3-001
+// SSOT: second-pass work_mode only) + `script_execution_requested` +
+// `answer_only_policy_error` (read-only gate with Read/Glob/Grep
+// allowlist + Bash-script allowlist branch) +
+// `effective_tool_policy_error` (no-explicit-policy fallback via
+// `effective_tool_policy_flow`). Free fns over `&Agent`. `pub(super)`
+// limited / no facade re-export (DR3-001).
+mod tool_policy_decisions;
 // Issue #652: `ArtifactCompletionJob` + role-specific retry budget +
 // `ArtifactAttemptOutcome` 4-variant taxonomy +
 // `ArtifactCompletionFailureSnapshot` for #654. Module is intentionally

--- a/src/agent/loop_run/actor_loop_flow.rs
+++ b/src/agent/loop_run/actor_loop_flow.rs
@@ -446,7 +446,7 @@ pub(super) fn maybe_handle_answer_only_inadequate_recovery(
     args: &mut PostReplyRecoveryArgs<'_, '_>,
 ) -> Option<PostReplyRecoveryOutcome> {
     if !args.requires_action
-        && agent.answer_only_mode_active()
+        && super::tool_policy_decisions::answer_only_mode_active(agent)
         && answer_only_reply_is_inadequate(args.final_reply)
     {
         *args.no_tool_retries += 1;
@@ -2713,7 +2713,7 @@ pub(super) fn maybe_handle_answer_only_future_work_recovery(
     args: &mut PostReplyRecoveryArgs<'_, '_>,
 ) -> Option<PostReplyRecoveryOutcome> {
     if !args.requires_action
-        && agent.answer_only_mode_active()
+        && super::tool_policy_decisions::answer_only_mode_active(agent)
         && reply_looks_like_future_work(args.final_reply)
     {
         *args.no_tool_retries += 1;

--- a/src/agent/loop_run/effective_tool_policy_flow.rs
+++ b/src/agent/loop_run/effective_tool_policy_flow.rs
@@ -42,14 +42,14 @@ pub(super) fn effective_tool_policy(agent: &Agent) -> EffectiveToolPolicy {
     // Issue #660: `AnswerOnlyMode` is a pre-arbitration gate (priority 0
     // in §4 of the design policy). The arbiter never sees it; we early-
     // return before constructing any selectable `JobCandidate`.
-    if agent.answer_only_mode_active() {
+    if super::tool_policy_decisions::answer_only_mode_active(agent) {
         if agent.workspace_appears_empty() {
             return EffectiveToolPolicy::restricted(
                 EffectiveToolPolicyReason::AnswerOnly,
                 Vec::new(),
             );
         }
-        if agent.script_execution_requested() {
+        if super::tool_policy_decisions::script_execution_requested(agent) {
             return EffectiveToolPolicy::restricted(
                 EffectiveToolPolicyReason::AnswerOnly,
                 vec!["Read", "Glob", "Grep", "Bash"],

--- a/src/agent/loop_run/photon_feedback_derive.rs
+++ b/src/agent/loop_run/photon_feedback_derive.rs
@@ -1137,7 +1137,7 @@ pub(super) fn invoke_photon_evaluate(agent: &mut Agent) {
         repo_edit_succeeded_this_turn: agent.session.repo_edit_succeeded_this_turn,
         // DR3-001 SSOT: AnswerOnly check goes through the helper, never
         // a direct `mode_state.work_mode == WorkMode::AnswerOnly` compare.
-        work_mode_is_answer_only: agent.answer_only_mode_active(),
+        work_mode_is_answer_only: super::tool_policy_decisions::answer_only_mode_active(agent),
         verifier_exit_zero_this_turn: photon_verifier_exit_zero_this_turn(agent),
     };
     let PhotonFeedbackOutcome {

--- a/src/agent/loop_run/tool_call_execution.rs
+++ b/src/agent/loop_run/tool_call_execution.rs
@@ -61,7 +61,9 @@ pub(super) fn execute_tool_call(
     effective_tool_policy: Option<&EffectiveToolPolicy>,
     cancel_flag: Option<std::sync::Arc<std::sync::atomic::AtomicBool>>,
 ) -> String {
-    if let Some(err) = agent.answer_only_policy_error(name, arguments) {
+    if let Some(err) =
+        super::tool_policy_decisions::answer_only_policy_error(agent, name, arguments)
+    {
         agent.session.working_memory.note_error(err.clone());
         return lifecycle::format_tool_error(&err);
     }
@@ -112,7 +114,7 @@ fn effective_tool_policy_error_for_execution(
             scope_for_policy.as_ref(),
         )
     } else {
-        agent.effective_tool_policy_error(name, arguments)
+        super::tool_policy_decisions::effective_tool_policy_error(agent, name, arguments)
     }
 }
 

--- a/src/agent/loop_run/tool_policy_decisions.rs
+++ b/src/agent/loop_run/tool_policy_decisions.rs
@@ -1,0 +1,92 @@
+//! Per-Agent tool-policy decision helpers extracted from `turn.rs`
+//! (parent #680).
+//!
+//! Hosts the per-Agent policy decisions that the tool-call pipeline,
+//! the effective-tool-policy flow, and the photon feedback derivation
+//! consult:
+//!
+//! - `answer_only_mode_active` — Issue #576 / DR3-001 SSOT: trust the
+//!   second-pass-corrected `session.mode_state.work_mode` (no OR with
+//!   the lexical pre-classifier).
+//! - `script_execution_requested` — request explicitly requests a
+//!   local script / shell execution.
+//! - `answer_only_policy_error` — answer-only mode read-only gate;
+//!   allows Read / Glob / Grep and (when scripted) `Bash` whose
+//!   command matches the allowlist.
+//! - `effective_tool_policy_error` — fallback when no explicit
+//!   `EffectiveToolPolicy` is supplied: derives the policy via
+//!   `effective_tool_policy_flow::effective_tool_policy` and applies
+//!   it (with workspace scope when a `MissingVerifierJob` is active).
+//!
+//! Originally `impl Agent` methods; converted to free functions taking
+//! `&Agent`, matching the `actor_loop_flow` / `reply_retry` / earlier
+//! vertical-slice precedent. `pub(super)` limited / no facade
+//! re-export (DR3-001).
+
+use super::Agent;
+use super::answer_only_mode::answer_only_script_command_allowed;
+use super::photon_feedback_derive::request_explicitly_requests_script_execution;
+use super::tool_policy::effective_tool_policy_error_for_call_with_scope;
+use crate::modes::plan_act::WorkMode;
+
+pub(super) fn answer_only_policy_error(
+    agent: &Agent,
+    name: &str,
+    arguments: &serde_json::Value,
+) -> Option<String> {
+    if !answer_only_mode_active(agent) {
+        return None;
+    }
+    if matches!(name, "Read" | "Glob" | "Grep") {
+        return None;
+    }
+    if name == "Bash"
+        && script_execution_requested(agent)
+        && arguments
+            .get("command")
+            .and_then(serde_json::Value::as_str)
+            .is_some_and(answer_only_script_command_allowed)
+    {
+        return None;
+    }
+    Some(format!(
+        "Error: answer-only mode is read-only. Use Read, Glob, or Grep if inspection is needed, and only run Bash for an explicitly requested local script or read-only command. Blocked tool: {name}."
+    ))
+}
+
+pub(super) fn answer_only_mode_active(agent: &Agent) -> bool {
+    // Issue #576 / DR3-001: tool policy must honour the second-pass-
+    // corrected `session.mode_state.work_mode` as the single source of
+    // truth. The previous OR with
+    // `infer_work_mode_from_text(active_request_text())` bypassed the
+    // second-pass result whenever the lexical pre-classifier still
+    // inferred `AnswerOnly`, defeating the whole point of this Issue.
+    agent.session.mode_state.work_mode == WorkMode::AnswerOnly
+}
+
+pub(super) fn script_execution_requested(agent: &Agent) -> bool {
+    agent
+        .active_request_text()
+        .as_deref()
+        .is_some_and(request_explicitly_requests_script_execution)
+}
+
+pub(super) fn effective_tool_policy_error(
+    agent: &Agent,
+    name: &str,
+    arguments: &serde_json::Value,
+) -> Option<String> {
+    let effective_tool_policy = super::effective_tool_policy_flow::effective_tool_policy(agent);
+    let scope = if agent.missing_verifier_job.is_some() {
+        Some(agent.current_workspace_scope())
+    } else {
+        None
+    };
+    effective_tool_policy_error_for_call_with_scope(
+        &effective_tool_policy,
+        name,
+        arguments,
+        &agent.work_root,
+        scope.as_ref(),
+    )
+}

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -2,11 +2,9 @@ use super::active_job_arbiter::RecoveryOwner;
 use super::actor_loop_flow::format_iteration_status;
 use super::auto_test::{AutoTestKind, AutoTestRunner};
 
-use super::answer_only_mode::answer_only_script_command_allowed;
 use super::file_excerpt::{
     open_excerpt_file_nofollow, truncate_on_char_boundary, utf8_prefix_respecting_cap,
 };
-use super::photon_feedback_derive::request_explicitly_requests_script_execution;
 use super::plan_mode_helpers::assistant_model_for_mode;
 use super::small_helpers::raw_mode_safe_text;
 use super::summary::ExitReason;
@@ -17,7 +15,9 @@ use super::tool_history::{
     has_successful_non_plan_repo_edit_after_latest_truncated_tool_call,
     is_preferred_read_edit_target, latest_user_turn_slice, recent_truncated_tool_call_attempt,
 };
-use super::tool_policy::{EffectiveToolPolicy, effective_tool_policy_error_for_call_with_scope};
+use super::tool_policy::EffectiveToolPolicy;
+#[cfg(test)]
+use super::tool_policy::effective_tool_policy_error_for_call_with_scope;
 use super::verifier_orchestration::task_contract_no_verifier_note;
 use super::workspace_walk::workspace_appears_empty;
 use super::*;
@@ -536,66 +536,6 @@ impl Agent {
     ) -> super::task_workspace_scope::TaskWorkspaceScope {
         let request = self.active_request_text().unwrap_or_default();
         super::task_workspace_scope::TaskWorkspaceScope::detect(&self.work_root, &request)
-    }
-
-    pub(super) fn answer_only_policy_error(
-        &self,
-        name: &str,
-        arguments: &serde_json::Value,
-    ) -> Option<String> {
-        if !self.answer_only_mode_active() {
-            return None;
-        }
-        if matches!(name, "Read" | "Glob" | "Grep") {
-            return None;
-        }
-        if name == "Bash"
-            && self.script_execution_requested()
-            && arguments
-                .get("command")
-                .and_then(serde_json::Value::as_str)
-                .is_some_and(answer_only_script_command_allowed)
-        {
-            return None;
-        }
-        Some(format!(
-            "Error: answer-only mode is read-only. Use Read, Glob, or Grep if inspection is needed, and only run Bash for an explicitly requested local script or read-only command. Blocked tool: {name}."
-        ))
-    }
-
-    pub(super) fn answer_only_mode_active(&self) -> bool {
-        // Issue #576 / DR3-001: tool policy must honour the second-pass-
-        // corrected `session.mode_state.work_mode` as the single source of
-        // truth. The previous OR with `infer_work_mode_from_text(active_request_text())`
-        // bypassed the second-pass result whenever the lexical pre-classifier
-        // still inferred `AnswerOnly`, defeating the whole point of this Issue.
-        self.session.mode_state.work_mode == WorkMode::AnswerOnly
-    }
-
-    pub(super) fn script_execution_requested(&self) -> bool {
-        self.active_request_text()
-            .as_deref()
-            .is_some_and(request_explicitly_requests_script_execution)
-    }
-
-    pub(super) fn effective_tool_policy_error(
-        &self,
-        name: &str,
-        arguments: &serde_json::Value,
-    ) -> Option<String> {
-        let effective_tool_policy = super::effective_tool_policy_flow::effective_tool_policy(self);
-        let scope = if self.missing_verifier_job.is_some() {
-            Some(self.current_workspace_scope())
-        } else {
-            None
-        };
-        effective_tool_policy_error_for_call_with_scope(
-            &effective_tool_policy,
-            name,
-            arguments,
-            &self.work_root,
-            scope.as_ref(),
-        )
     }
 
     pub(super) fn workspace_appears_empty(&self) -> bool {


### PR DESCRIPTION
## Summary

Continue the meta-issue #680 split: move the per-Agent tool-policy
decision helpers out of \`turn.rs\` into a focused sibling module so
\`turn.rs\` keeps shrinking toward responsibility-focused units.

Four production helpers were extracted as free functions taking
\`&Agent\` (matching \`actor_loop_flow\` / \`reply_retry\` / earlier
vertical-slice precedent):

- \`answer_only_mode_active\` (Issue #576 / DR3-001 SSOT)
- \`script_execution_requested\`
- \`answer_only_policy_error\` (read-only gate)
- \`effective_tool_policy_error\` (no-explicit-policy fallback)

Behavior unchanged: same Issue #576 SSOT (no OR with the lexical
pre-classifier), same Read/Glob/Grep / Bash-script allowlist order,
same workspace-scope override when a \`MissingVerifierJob\` is active.

\`pub(super)\` limited / no facade re-export (DR3-001). Callers updated
in \`photon_feedback_derive.rs\` (1 site),
\`effective_tool_policy_flow.rs\` (2 sites), \`tool_call_execution.rs\`
(2 sites), and \`actor_loop_flow.rs\` (2 sites) to the free-fn form.
Also gated the \`effective_tool_policy_error_for_call_with_scope\`
import in \`turn.rs\` under \`#[cfg(test)]\` (the last non-test caller
was the just-extracted method; the test seam
\`drive_policy_error_for_test\` still uses it directly).

### LOC delta

- \`turn.rs\`: 747 → 687 (-60)
- new module: +92

Cumulative \`turn.rs\` reduction across the parent #680 split:
39,489 → 687 (-98.3%).

## Test plan

- [x] \`cargo build --lib\`
- [x] \`cargo fmt\`
- [x] \`cargo clippy --lib --all-targets -- -D warnings\`
- [x] \`cargo test --lib\` (3,114 passed, 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)