### PR TITLE
Extract python_request_helpers.rs from turn.rs (parent #680)

### DIFF
--- a/src/agent/loop_run.rs
+++ b/src/agent/loop_run.rs
@@ -305,6 +305,14 @@ mod quality_gate;
 // `effective_tool_policy_flow`). Free fns over `&Agent`. `pub(super)`
 // limited / no facade re-export (DR3-001).
 mod tool_policy_decisions;
+// Python request inspection helpers extracted from `turn.rs` (parent
+// #680). Hosts the Python-specific signals that drive completion /
+// scaffold gating: `active_python_request_requires_tests`,
+// `python_verifier_available_for_requested_tests`, and
+// `python_test_artifact_exists` (top-level `test_*.py` / `*_test.py` /
+// `tests.py` scan). Free fns over `&Agent`. `pub(super)` limited / no
+// facade re-export (DR3-001).
+mod python_request_helpers;
 // Issue #652: `ArtifactCompletionJob` + role-specific retry budget +
 // `ArtifactAttemptOutcome` 4-variant taxonomy +
 // `ArtifactCompletionFailureSnapshot` for #654. Module is intentionally

--- a/src/agent/loop_run/actor_loop_flow.rs
+++ b/src/agent/loop_run/actor_loop_flow.rs
@@ -605,9 +605,9 @@ pub(super) fn maybe_handle_python_test_artifact_recovery(
     args: &mut PostReplyRecoveryArgs<'_, '_>,
 ) -> Option<PostReplyRecoveryOutcome> {
     if args.repo_edit_calls_made_this_turn == 0
-        || !agent.active_python_request_requires_tests()
-        || agent.python_test_artifact_exists()
-        || agent.python_verifier_available_for_requested_tests()
+        || !super::python_request_helpers::active_python_request_requires_tests(agent)
+        || super::python_request_helpers::python_test_artifact_exists(agent)
+        || super::python_request_helpers::python_verifier_available_for_requested_tests(agent)
     {
         return None;
     }
@@ -3771,7 +3771,8 @@ pub(super) fn run_actor_loop(
         && model_capabilities(&agent.current_assistant_model()).finish_after_edit_format_error
         && stats.total_changed > 0
         && agent.session.mode_state.mode == ExecutionMode::Act
-        && (!agent.active_python_request_requires_tests() || agent.python_test_artifact_exists())
+        && (!super::python_request_helpers::active_python_request_requires_tests(agent)
+            || super::python_request_helpers::python_test_artifact_exists(agent))
     {
         // Issue #634: 旧文言は qwen3.5 を名指ししていたが、capability ベース
         // (`finish_after_edit_format_error`) に統一されたためモデル非依存の文言に変更。

--- a/src/agent/loop_run/python_request_helpers.rs
+++ b/src/agent/loop_run/python_request_helpers.rs
@@ -1,0 +1,56 @@
+//! Python request inspection helpers extracted from `turn.rs` (parent
+//! #680).
+//!
+//! Hosts the Python-specific signals that drive completion / scaffold
+//! gating decisions for `WorkMode::Python`:
+//!
+//! - `active_python_request_requires_tests` — Python work mode +
+//!   request explicitly requires tests.
+//! - `python_verifier_available_for_requested_tests` — `AutoTestRunner`
+//!   can detect a runnable Python test plan in the workspace.
+//! - `python_test_artifact_exists` — top-level `test_*.py` /
+//!   `*_test.py` / `tests.py` exists in `work_root`.
+//!
+//! Originally `impl Agent` methods; converted to free functions taking
+//! `&Agent`, matching the `actor_loop_flow` / `reply_retry` / earlier
+//! vertical-slice precedent. `pub(super)` limited / no facade
+//! re-export (DR3-001).
+
+use super::Agent;
+use super::auto_test::{AutoTestKind, AutoTestRunner};
+use super::quality::request_explicitly_requires_tests;
+use crate::modes::plan_act::WorkMode;
+
+pub(super) fn active_python_request_requires_tests(agent: &Agent) -> bool {
+    agent.session.mode_state.work_mode == WorkMode::Python
+        && agent
+            .active_request_text()
+            .as_deref()
+            .is_some_and(request_explicitly_requires_tests)
+}
+
+pub(super) fn python_verifier_available_for_requested_tests(agent: &Agent) -> bool {
+    AutoTestRunner::detect(
+        &agent.work_root,
+        &agent.session.working_memory.touched_files,
+    )
+    .is_some_and(|plan| plan.auto_test_kind() == AutoTestKind::Test)
+}
+
+pub(super) fn python_test_artifact_exists(agent: &Agent) -> bool {
+    let Ok(entries) = std::fs::read_dir(&agent.work_root) else {
+        return false;
+    };
+    entries.flatten().any(|entry| {
+        let path = entry.path();
+        if !path.is_file() {
+            return false;
+        }
+        let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+            return false;
+        };
+        (name.starts_with("test_") && name.ends_with(".py"))
+            || name.ends_with("_test.py")
+            || name == "tests.py"
+    })
+}

--- a/src/agent/loop_run/reply_retry.rs
+++ b/src/agent/loop_run/reply_retry.rs
@@ -404,7 +404,9 @@ fn maybe_finish_after_edit_format_error(agent: &Agent, err: &str) -> Option<Assi
     {
         return None;
     }
-    if agent.active_python_request_requires_tests() && !agent.python_test_artifact_exists() {
+    if super::python_request_helpers::active_python_request_requires_tests(agent)
+        && !super::python_request_helpers::python_test_artifact_exists(agent)
+    {
         return None;
     }
     let edits = successful_non_plan_repo_edit_count(

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -1,6 +1,5 @@
 use super::active_job_arbiter::RecoveryOwner;
 use super::actor_loop_flow::format_iteration_status;
-use super::auto_test::{AutoTestKind, AutoTestRunner};
 
 use super::file_excerpt::{
     open_excerpt_file_nofollow, truncate_on_char_boundary, utf8_prefix_respecting_cap,
@@ -28,7 +27,7 @@ use crate::session::store::ScaffoldArtifactFileSnapshot;
 use crate::tools::registry::ToolSpec;
 use std::path::{Path, PathBuf};
 
-use super::quality::{repo_change_request_text, request_explicitly_requires_tests};
+use super::quality::repo_change_request_text;
 
 /// Maximum number of characters of tool-call arguments retained in trace logs.
 pub(super) const LOG_ARGS_MAX_CHARS: usize = 200;
@@ -558,36 +557,6 @@ impl Agent {
         )
     }
 
-    pub(super) fn active_python_request_requires_tests(&self) -> bool {
-        self.session.mode_state.work_mode == WorkMode::Python
-            && self
-                .active_request_text()
-                .as_deref()
-                .is_some_and(request_explicitly_requires_tests)
-    }
-
-    pub(super) fn python_verifier_available_for_requested_tests(&self) -> bool {
-        AutoTestRunner::detect(&self.work_root, &self.session.working_memory.touched_files)
-            .is_some_and(|plan| plan.auto_test_kind() == AutoTestKind::Test)
-    }
-
-    pub(super) fn python_test_artifact_exists(&self) -> bool {
-        let Ok(entries) = std::fs::read_dir(&self.work_root) else {
-            return false;
-        };
-        entries.flatten().any(|entry| {
-            let path = entry.path();
-            if !path.is_file() {
-                return false;
-            }
-            let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
-                return false;
-            };
-            (name.starts_with("test_") && name.ends_with(".py"))
-                || name.ends_with("_test.py")
-                || name == "tests.py"
-        })
-    }
     pub(super) fn prepare_tool_call(&self, mut tool_call: ToolCall) -> ToolCall {
         tool_call.arguments = normalize_tool_call_arguments(&tool_call.name, tool_call.arguments);
         if matches!(tool_call.name.as_str(), "Read" | "Write" | "Edit")


### PR DESCRIPTION
## Summary

Continue the meta-issue #680 split: move the Python-specific request
inspection helpers out of \`turn.rs\` into a focused sibling module so
\`turn.rs\` keeps shrinking toward responsibility-focused units.

Three production helpers were extracted as free functions taking
\`&Agent\` (matching \`actor_loop_flow\` / \`reply_retry\` / earlier
vertical-slice precedent):

- \`active_python_request_requires_tests\`
- \`python_verifier_available_for_requested_tests\`
- \`python_test_artifact_exists\`

Behavior unchanged: same \`WorkMode::Python\` gate, same
\`AutoTestKind::Test\` predicate, same top-level test-file pattern set.

\`pub(super)\` limited / no facade re-export (DR3-001). Callers updated
in \`actor_loop_flow.rs\` (4 sites) and \`reply_retry.rs\` (2 sites) to
the free-fn form.

### LOC delta

- \`turn.rs\`: 687 → 656 (-31)
- new module: +56

Cumulative \`turn.rs\` reduction across the parent #680 split:
39,489 → 656 (-98.3%).

## Test plan

- [x] \`cargo build --lib\`
- [x] \`cargo fmt\`
- [x] \`cargo clippy --lib --all-targets -- -D warnings\`
- [x] \`cargo test --lib\` (3,114 passed, 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)