### PR TITLE
Extract forced_small_edit.rs from turn.rs (parent #680)

### DIFF
--- a/src/agent/loop_run.rs
+++ b/src/agent/loop_run.rs
@@ -324,6 +324,14 @@ mod python_request_helpers;
 // re-export (DR3-001).
 #[cfg(test)]
 mod test_seams;
+// Forced-small-edit recovery target / note builders extracted from
+// `turn.rs` (parent #680). Hosts the focused-edit policy's
+// "previous tool call truncated → force a small follow-up edit"
+// branch: `forced_small_edit_recovery_target` (Act mode + truncated +
+// no successful non-plan edit since) + `forced_small_edit_recovery_message`
+// (renders the recovery note). Free fns over `&Agent`. `pub(super)`
+// limited / no facade re-export (DR3-001).
+mod forced_small_edit;
 // Issue #652: `ArtifactCompletionJob` + role-specific retry budget +
 // `ArtifactAttemptOutcome` 4-variant taxonomy +
 // `ArtifactCompletionFailureSnapshot` for #654. Module is intentionally

--- a/src/agent/loop_run/build_request_messages.rs
+++ b/src/agent/loop_run/build_request_messages.rs
@@ -244,7 +244,7 @@ fn append_common_request_messages(
             plan_file_alias(plan_path)
         )));
     }
-    if let Some(note) = agent.forced_small_edit_recovery_message() {
+    if let Some(note) = super::forced_small_edit::forced_small_edit_recovery_message(agent) {
         messages.push(ConversationMessage::system(note));
     }
     if let Some(note) = super::scaffold_pipeline::post_scaffold_edit_recovery_message(agent) {

--- a/src/agent/loop_run/effective_tool_policy_flow.rs
+++ b/src/agent/loop_run/effective_tool_policy_flow.rs
@@ -93,7 +93,7 @@ pub(super) fn build_arbiter_candidates(agent: &Agent) -> Vec<JobCandidate> {
     let mut candidates: Vec<JobCandidate> = Vec::new();
 
     // Priority 2: ForcedSmallEditRecovery.
-    if let Some(target) = agent.forced_small_edit_recovery_target() {
+    if let Some(target) = super::forced_small_edit::forced_small_edit_recovery_target(agent) {
         push_focused_edit_candidate(
             agent,
             &mut candidates,

--- a/src/agent/loop_run/forced_small_edit.rs
+++ b/src/agent/loop_run/forced_small_edit.rs
@@ -1,0 +1,67 @@
+//! Forced-small-edit recovery target / note builders extracted from
+//! `turn.rs` (parent #680).
+//!
+//! Hosts the focused-edit policy's "the previous tool call truncated;
+//! force a small follow-up edit on the file we just read" branch:
+//!
+//! - `forced_small_edit_recovery_target` — Act mode + last tool call
+//!   truncated + no successful non-plan repo edit since → pick the
+//!   `latest_turn_preferred_read_edit_target`, falling back to the
+//!   last `Read` tool path.
+//! - `forced_small_edit_recovery_message` — renders the
+//!   `forced_small_edit_recovery_note` prompt for the chosen target.
+//!
+//! Originally `impl Agent` methods; converted to free functions taking
+//! `&Agent`, matching the `actor_loop_flow` / `reply_retry` / earlier
+//! vertical-slice precedent. `pub(super)` limited / no facade
+//! re-export (DR3-001).
+
+use std::path::PathBuf;
+
+use super::Agent;
+use super::tool_display::progress_path_display;
+use super::tool_history::{
+    has_successful_non_plan_repo_edit_after_latest_truncated_tool_call,
+    recent_truncated_tool_call_attempt,
+};
+use super::turn::{last_read_tool_path, latest_turn_preferred_read_edit_target};
+use crate::agent::recovery;
+use crate::modes::plan_act::ExecutionMode;
+use crate::safety::path_guard::resolve_user_path;
+
+pub(super) fn forced_small_edit_recovery_message(agent: &Agent) -> Option<String> {
+    let path = forced_small_edit_recovery_target(agent)?;
+    let attempt = recent_truncated_tool_call_attempt(&agent.session.messages).max(1);
+    Some(recovery::forced_small_edit_recovery_note(
+        &progress_path_display(
+            &path.display().to_string(),
+            &agent.work_root,
+            agent.session.mode_state.active_plan_path.as_deref(),
+            120,
+        ),
+        attempt,
+    ))
+}
+
+pub(super) fn forced_small_edit_recovery_target(agent: &Agent) -> Option<PathBuf> {
+    if agent.session.mode_state.mode != ExecutionMode::Act {
+        return None;
+    }
+    if recent_truncated_tool_call_attempt(&agent.session.messages) == 0 {
+        return None;
+    }
+    if has_successful_non_plan_repo_edit_after_latest_truncated_tool_call(
+        &agent.session.messages,
+        &agent.work_root,
+        agent.session.mode_state.active_plan_path.as_deref(),
+    ) {
+        return None;
+    }
+    latest_turn_preferred_read_edit_target(&agent.session.messages, &agent.work_root).or_else(
+        || {
+            let path = last_read_tool_path(&agent.session.messages)?;
+            let candidate = resolve_user_path(&agent.work_root, &path).ok()?;
+            candidate.is_file().then_some(candidate)
+        },
+    )
+}

--- a/src/agent/loop_run/recovery_targets.rs
+++ b/src/agent/loop_run/recovery_targets.rs
@@ -43,8 +43,7 @@ use crate::modes::plan_act::ExecutionMode;
 use crate::safety::path_guard::resolve_user_path;
 
 pub(super) fn focused_edit_recovery_target(agent: &Agent) -> Option<PathBuf> {
-    agent
-        .forced_small_edit_recovery_target()
+    super::forced_small_edit::forced_small_edit_recovery_target(agent)
         .or_else(|| super::scaffold_pipeline::post_scaffold_edit_recovery_target(agent))
         .or_else(|| super::scaffold_pipeline::post_scaffold_continuation_recovery_target(agent))
 }

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -7,12 +7,9 @@ use super::file_excerpt::{
 use super::plan_mode_helpers::assistant_model_for_mode;
 use super::small_helpers::raw_mode_safe_text;
 use super::summary::ExitReason;
-use super::tool_display::progress_path_display;
 use super::tool_history::{
     focused_edit_target_already_read, focused_read_target_for_directory,
-    has_successful_non_plan_repo_edit,
-    has_successful_non_plan_repo_edit_after_latest_truncated_tool_call,
-    is_preferred_read_edit_target, latest_user_turn_slice, recent_truncated_tool_call_attempt,
+    has_successful_non_plan_repo_edit, is_preferred_read_edit_target, latest_user_turn_slice,
 };
 use super::tool_policy::EffectiveToolPolicy;
 use super::verifier_orchestration::task_contract_no_verifier_note;
@@ -281,43 +278,6 @@ impl Agent {
             }
         };
         Some(ConversationMessage::system(text.to_string()))
-    }
-
-    pub(super) fn forced_small_edit_recovery_message(&self) -> Option<String> {
-        let path = self.forced_small_edit_recovery_target()?;
-        let attempt = recent_truncated_tool_call_attempt(&self.session.messages).max(1);
-        Some(recovery::forced_small_edit_recovery_note(
-            &progress_path_display(
-                &path.display().to_string(),
-                &self.work_root,
-                self.session.mode_state.active_plan_path.as_deref(),
-                120,
-            ),
-            attempt,
-        ))
-    }
-
-    pub(super) fn forced_small_edit_recovery_target(&self) -> Option<PathBuf> {
-        if self.session.mode_state.mode != ExecutionMode::Act {
-            return None;
-        }
-        if recent_truncated_tool_call_attempt(&self.session.messages) == 0 {
-            return None;
-        }
-        if has_successful_non_plan_repo_edit_after_latest_truncated_tool_call(
-            &self.session.messages,
-            &self.work_root,
-            self.session.mode_state.active_plan_path.as_deref(),
-        ) {
-            return None;
-        }
-        latest_turn_preferred_read_edit_target(&self.session.messages, &self.work_root).or_else(
-            || {
-                let path = last_read_tool_path(&self.session.messages)?;
-                let candidate = resolve_user_path(&self.work_root, &path).ok()?;
-                candidate.is_file().then_some(candidate)
-            },
-        )
     }
 
     /// Issue #636: read a workspace-confined, cap-bounded excerpt of

--- a/src/agent/loop_run/turn_tests.rs
+++ b/src/agent/loop_run/turn_tests.rs
@@ -3737,7 +3737,7 @@ mod tests {
         // Sanity: forced_small_edit_recovery_target must resolve under
         // this fixture (otherwise the arbiter would not select ForcedSmallEdit).
         assert!(
-            agent.forced_small_edit_recovery_target().is_some(),
+            super::super::forced_small_edit::forced_small_edit_recovery_target(&agent).is_some(),
             "fixture invariant: forced_small_edit_recovery_target must be Some"
         );
 


### PR DESCRIPTION
## Summary

Continue the meta-issue #680 split: move the focused-edit policy's
forced-small-edit recovery target + note builders out of \`turn.rs\`
into a focused sibling module so \`turn.rs\` keeps shrinking toward
responsibility-focused units.

Two production helpers were extracted as free functions taking
\`&Agent\` (matching \`actor_loop_flow\` / \`reply_retry\` / earlier
vertical-slice precedent):

- \`forced_small_edit_recovery_target\`
- \`forced_small_edit_recovery_message\`

Behavior unchanged: same Act-mode + recent-truncated-tool-call gate,
same \`has_successful_non_plan_repo_edit_after_latest_truncated_tool_call\`
short-circuit, same target priority chain.

\`pub(super)\` limited / no facade re-export (DR3-001). Callers updated
in \`recovery_targets.rs\` (1 site), \`effective_tool_policy_flow.rs\`
(1 site), \`build_request_messages.rs\` (1 site), and \`turn_tests.rs\`
(1 site) to the free-fn form.

### LOC delta

- \`turn.rs\`: 504 → 464 (-40)
- new module: +67

Cumulative \`turn.rs\` reduction across the parent #680 split:
39,489 → 464 (-98.8%).

## Test plan

- [x] \`cargo build --lib\`
- [x] \`cargo fmt\`
- [x] \`cargo clippy --lib --all-targets -- -D warnings\`
- [x] \`cargo test --lib\` (3,114 passed, 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)