### PR TITLE
Extract tool_prep.rs from turn.rs (parent #680)

### DIFF
--- a/src/agent/loop_run.rs
+++ b/src/agent/loop_run.rs
@@ -340,6 +340,13 @@ mod forced_small_edit;
 // a behavior-coverage snippet for `plan_artifact_recovery`. Free fn
 // over `&Agent`. `pub(super)` limited / no facade re-export (DR3-001).
 mod post_edit_excerpt;
+// Tool-prep helpers extracted from `turn.rs` (parent #680). Hosts
+// `tool_specs_for_policy` (filter registered tool specs by policy
+// allowlist), `local_llm_small_edit_target` (small-edit Edit target
+// for local LLMs), and `mode_policy_message` (per-`WorkMode`
+// `[Mode Policy]` system note; Auto returns None). Free fns over
+// `&Agent`. `pub(super)` limited / no facade re-export (DR3-001).
+mod tool_prep;
 // Issue #652: `ArtifactCompletionJob` + role-specific retry budget +
 // `ArtifactAttemptOutcome` 4-variant taxonomy +
 // `ArtifactCompletionFailureSnapshot` for #654. Module is intentionally

--- a/src/agent/loop_run/build_request_messages.rs
+++ b/src/agent/loop_run/build_request_messages.rs
@@ -90,7 +90,7 @@ pub(super) fn build_request_messages(
         &next_sections,
         effective_tool_policy.allowed_tool_names_for_prompt(),
     )));
-    if let Some(message) = agent.mode_policy_message() {
+    if let Some(message) = super::tool_prep::mode_policy_message(agent) {
         messages.push(message);
     }
     if focused_edit_target.is_none() {

--- a/src/agent/loop_run/effective_tool_policy_flow.rs
+++ b/src/agent/loop_run/effective_tool_policy_flow.rs
@@ -148,7 +148,7 @@ pub(super) fn build_arbiter_candidates(agent: &Agent) -> Vec<JobCandidate> {
     }
 
     // Priority 6: LocalLlmSmallEditAfterRead.
-    if let Some(target) = agent.local_llm_small_edit_target() {
+    if let Some(target) = super::tool_prep::local_llm_small_edit_target(agent) {
         push_focused_edit_candidate(
             agent,
             &mut candidates,

--- a/src/agent/loop_run/reply_retry.rs
+++ b/src/agent/loop_run/reply_retry.rs
@@ -339,7 +339,7 @@ fn request_assistant_reply(
         focused_edit_target,
         &agent.work_root,
     );
-    let tool_specs = agent.tool_specs_for_policy(&effective_tool_policy);
+    let tool_specs = super::tool_prep::tool_specs_for_policy(agent, &effective_tool_policy);
 
     if request_plan.use_streaming_transport {
         request_streaming_assistant_reply(

--- a/src/agent/loop_run/tool_prep.rs
+++ b/src/agent/loop_run/tool_prep.rs
@@ -1,0 +1,92 @@
+//! Tool-prep helpers extracted from `turn.rs` (parent #680).
+//!
+//! Hosts three small Agent-level "prep before tool call" helpers that
+//! the request-builder, the reply-retry loop, and the policy flow
+//! consult before / during a tool dispatch:
+//!
+//! - `tool_specs_for_policy` — filters the registered tool specs to
+//!   the `EffectiveToolPolicy`'s allowed-name list (when set).
+//! - `local_llm_small_edit_target` — picks an Edit target for the
+//!   small-edit protocol that local LLMs prefer (Act mode +
+//!   repo_edit_required + task expects repo change + no successful
+//!   non-plan repo edit yet + target already read).
+//! - `mode_policy_message` — renders the per-`WorkMode` `[Mode Policy]`
+//!   system note (Auto returns None).
+//!
+//! Originally `impl Agent` methods; converted to free functions taking
+//! `&Agent`, matching the `actor_loop_flow` / `reply_retry` / earlier
+//! vertical-slice precedent. `pub(super)` limited / no facade
+//! re-export (DR3-001).
+
+use std::path::PathBuf;
+
+use super::Agent;
+use super::tool_history::{focused_edit_target_already_read, has_successful_non_plan_repo_edit};
+use super::tool_policy::EffectiveToolPolicy;
+use super::turn::latest_turn_preferred_read_edit_target;
+use crate::modes::plan_act::{ExecutionMode, WorkMode};
+use crate::session::store::ConversationMessage;
+use crate::tools::registry::ToolSpec;
+
+pub(super) fn tool_specs_for_policy(agent: &Agent, policy: &EffectiveToolPolicy) -> Vec<ToolSpec> {
+    let mut specs = agent.tool_registry.specs().to_vec();
+    if let Some(allowed_tools) = policy.allowed_tool_names_for_prompt() {
+        specs.retain(|spec| allowed_tools.contains(&spec.function.name.as_str()));
+    }
+    specs
+}
+
+pub(super) fn local_llm_small_edit_target(agent: &Agent) -> Option<PathBuf> {
+    if !crate::model_capabilities::model_capabilities(&agent.current_assistant_model())
+        .read_after_small_edit_protocol
+    {
+        return None;
+    }
+    if agent.session.mode_state.mode != ExecutionMode::Act
+        || !agent.session.mode_state.policy().repo_edit_required
+        || !agent.active_task_expects_repo_change()
+    {
+        return None;
+    }
+    if has_successful_non_plan_repo_edit(
+        &agent.session.messages,
+        &agent.work_root,
+        agent.session.mode_state.active_plan_path.as_deref(),
+    ) {
+        return None;
+    }
+    if let Some(target) = super::artifact_recovery_flow::artifact_recovery_target_path(agent) {
+        return focused_edit_target_already_read(
+            &agent.session.messages,
+            &target,
+            &agent.work_root,
+        )
+        .then_some(target);
+    }
+    let target = latest_turn_preferred_read_edit_target(&agent.session.messages, &agent.work_root)?;
+    focused_edit_target_already_read(&agent.session.messages, &target, &agent.work_root)
+        .then_some(target)
+}
+
+pub(super) fn mode_policy_message(agent: &Agent) -> Option<ConversationMessage> {
+    let work_mode = agent.session.mode_state.work_mode;
+    let text = match work_mode {
+        WorkMode::Auto => return None,
+        WorkMode::TypeScriptUi => {
+            "[Mode Policy] Work mode is TypeScript UI. Prefer the existing JavaScript or TypeScript framework when present. Do not switch to Python or documentation-only output unless the user asks."
+        }
+        WorkMode::Python => {
+            "[Mode Policy] Work mode is Python. Use Python-oriented files and verification. Do not create TypeScript, React, Next.js, Nuxt, or browser UI scaffolds unless the user asks."
+        }
+        WorkMode::Docs => {
+            "[Mode Policy] Work mode is documentation. Edit or create documentation files only unless code changes are explicitly requested."
+        }
+        WorkMode::AnswerOnly => {
+            "[Mode Policy] Work mode is answer-only/read-only. You may inspect files if needed, and may run an explicitly requested local script or read-only command, but do not require or perform repository edits."
+        }
+        WorkMode::GenericCode | WorkMode::Unknown => {
+            "[Mode Policy] Work mode is generic code. Follow the repository stack and avoid TypeScript UI deterministic fallback unless the request explicitly asks for a browser UI."
+        }
+    };
+    Some(ConversationMessage::system(text.to_string()))
+}

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -5,18 +5,13 @@ use super::plan_mode_helpers::assistant_model_for_mode;
 use super::small_helpers::raw_mode_safe_text;
 use super::summary::ExitReason;
 use super::tool_history::{
-    focused_edit_target_already_read, focused_read_target_for_directory,
-    has_successful_non_plan_repo_edit, is_preferred_read_edit_target, latest_user_turn_slice,
+    focused_read_target_for_directory, is_preferred_read_edit_target, latest_user_turn_slice,
 };
-use super::tool_policy::EffectiveToolPolicy;
 use super::verifier_orchestration::task_contract_no_verifier_note;
 use super::workspace_walk::workspace_appears_empty;
 use super::*;
-use crate::model_capabilities::model_capabilities;
-use crate::modes::plan_act::WorkMode;
 use crate::ollama::xml_fallback::normalize_tool_call_arguments;
 use crate::session::store::ScaffoldArtifactFileSnapshot;
-use crate::tools::registry::ToolSpec;
 use std::path::{Path, PathBuf};
 
 use super::quality::repo_change_request_text;
@@ -213,68 +208,6 @@ impl Agent {
             &self.models.main,
             self.plan_model_override.as_deref(),
         )
-    }
-
-    pub(super) fn tool_specs_for_policy(&self, policy: &EffectiveToolPolicy) -> Vec<ToolSpec> {
-        let mut specs = self.tool_registry.specs().to_vec();
-        if let Some(allowed_tools) = policy.allowed_tool_names_for_prompt() {
-            specs.retain(|spec| allowed_tools.contains(&spec.function.name.as_str()));
-        }
-        specs
-    }
-
-    pub(super) fn local_llm_small_edit_target(&self) -> Option<PathBuf> {
-        if !model_capabilities(&self.current_assistant_model()).read_after_small_edit_protocol {
-            return None;
-        }
-        if self.session.mode_state.mode != ExecutionMode::Act
-            || !self.session.mode_state.policy().repo_edit_required
-            || !self.active_task_expects_repo_change()
-        {
-            return None;
-        }
-        if has_successful_non_plan_repo_edit(
-            &self.session.messages,
-            &self.work_root,
-            self.session.mode_state.active_plan_path.as_deref(),
-        ) {
-            return None;
-        }
-        if let Some(target) = super::artifact_recovery_flow::artifact_recovery_target_path(self) {
-            return focused_edit_target_already_read(
-                &self.session.messages,
-                &target,
-                &self.work_root,
-            )
-            .then_some(target);
-        }
-        let target =
-            latest_turn_preferred_read_edit_target(&self.session.messages, &self.work_root)?;
-        focused_edit_target_already_read(&self.session.messages, &target, &self.work_root)
-            .then_some(target)
-    }
-
-    pub(super) fn mode_policy_message(&self) -> Option<ConversationMessage> {
-        let work_mode = self.session.mode_state.work_mode;
-        let text = match work_mode {
-            WorkMode::Auto => return None,
-            WorkMode::TypeScriptUi => {
-                "[Mode Policy] Work mode is TypeScript UI. Prefer the existing JavaScript or TypeScript framework when present. Do not switch to Python or documentation-only output unless the user asks."
-            }
-            WorkMode::Python => {
-                "[Mode Policy] Work mode is Python. Use Python-oriented files and verification. Do not create TypeScript, React, Next.js, Nuxt, or browser UI scaffolds unless the user asks."
-            }
-            WorkMode::Docs => {
-                "[Mode Policy] Work mode is documentation. Edit or create documentation files only unless code changes are explicitly requested."
-            }
-            WorkMode::AnswerOnly => {
-                "[Mode Policy] Work mode is answer-only/read-only. You may inspect files if needed, and may run an explicitly requested local script or read-only command, but do not require or perform repository edits."
-            }
-            WorkMode::GenericCode | WorkMode::Unknown => {
-                "[Mode Policy] Work mode is generic code. Follow the repository stack and avoid TypeScript UI deterministic fallback unless the request explicitly asks for a browser UI."
-            }
-        };
-        Some(ConversationMessage::system(text.to_string()))
     }
 
     /// Issue #646: build the active `TaskWorkspaceScope` for the current


### PR DESCRIPTION
## Summary

Continue the meta-issue #680 split: move three small Agent-level "prep
before tool call" helpers out of \`turn.rs\` into a focused sibling
module so \`turn.rs\` keeps shrinking toward responsibility-focused
units.

Three production helpers were extracted as free functions taking
\`&Agent\` (matching \`actor_loop_flow\` / \`reply_retry\` / earlier
vertical-slice precedent):

- \`tool_specs_for_policy\`
- \`local_llm_small_edit_target\`
- \`mode_policy_message\`

Behavior unchanged: same \`allowed_tool_names_for_prompt\` filter
semantics, same gate chain for the small-edit target, byte-for-byte
identical mode-policy text.

\`pub(super)\` limited / no facade re-export (DR3-001). Callers updated
in \`effective_tool_policy_flow.rs\` (1 site),
\`build_request_messages.rs\` (1 site), and \`reply_retry.rs\` (1 site)
to the free-fn form.

### LOC delta

- \`turn.rs\`: 409 → 342 (-67)
- new module: +92

Cumulative \`turn.rs\` reduction across the parent #680 split:
39,489 → 342 (-99.1%).

## Test plan

- [x] \`cargo build --lib\`
- [x] \`cargo fmt\`
- [x] \`cargo clippy --lib --all-targets -- -D warnings\`
- [x] \`cargo test --lib\` (3,114 passed, 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)