### PR TITLE
Extract agent_misc.rs from turn.rs (parent #680)

### DIFF
--- a/src/agent/loop_run.rs
+++ b/src/agent/loop_run.rs
@@ -347,6 +347,16 @@ mod post_edit_excerpt;
 // `[Mode Policy]` system note; Auto returns None). Free fns over
 // `&Agent`. `pub(super)` limited / no facade re-export (DR3-001).
 mod tool_prep;
+// Per-Agent misc lifecycle helpers extracted from `turn.rs` (parent
+// #680). Hosts `refresh_artifact_completion_satisfied` (Issue #663
+// SSOT for ledger-driven Satisfied transition),
+// `tool_policy_violation_exit_reason` (RecoveryOwner → ExitReason
+// mapping), `record_missing_verifier_setup_failure` (invalid setup
+// attempt → SafeStop or task_contract_no_verifier_note push), and
+// `current_assistant_model` (mode + plan-model override picker). Free
+// fns over `&mut Agent` / `&Agent`. `pub(super)` limited / no facade
+// re-export (DR3-001).
+mod agent_misc;
 // Issue #652: `ArtifactCompletionJob` + role-specific retry budget +
 // `ArtifactAttemptOutcome` 4-variant taxonomy +
 // `ArtifactCompletionFailureSnapshot` for #654. Module is intentionally

--- a/src/agent/loop_run/actor_loop_flow.rs
+++ b/src/agent/loop_run/actor_loop_flow.rs
@@ -2552,7 +2552,11 @@ pub(super) fn maybe_handle_rejected_tool_batch_missing_verifier(
     if !missing_verifier_setup_turn {
         return None;
     }
-    if agent.record_missing_verifier_setup_failure(last_iter, "tool policy violation") {
+    if super::agent_misc::record_missing_verifier_setup_failure(
+        agent,
+        last_iter,
+        "tool policy violation",
+    ) {
         return Some(ActorLoopToolPreparationOutcome::Exit {
             reason: ExitReason::MissingVerification,
             error_text:
@@ -2649,7 +2653,7 @@ pub(super) fn maybe_handle_rejected_tool_batch_focused_retry_exhausted(
     }
     if !recovery_dispatch_gate.allows_focused_edit_recovery() {
         return Some(ActorLoopToolPreparationOutcome::Exit {
-            reason: Agent::tool_policy_violation_exit_reason(recovery_owner),
+            reason: super::agent_misc::tool_policy_violation_exit_reason(recovery_owner),
             error_text:
                 "verifier-owned recovery rejected invalid tool calls repeatedly before an allowed repair edit"
                     .to_string(),
@@ -3552,7 +3556,11 @@ pub(super) fn run_actor_loop(
 
         let final_reply = reply_content.trim().to_string();
         if missing_verifier_setup_turn {
-            if agent.record_missing_verifier_setup_failure(last_iter, "no setup edit emitted") {
+            if super::agent_misc::record_missing_verifier_setup_failure(
+                agent,
+                last_iter,
+                "no setup edit emitted",
+            ) {
                 exit_reason = ExitReason::MissingVerification;
                 error_text =
                     "task contract requires verification, but the MissingVerifierJob setup budget is exhausted"
@@ -3768,7 +3776,8 @@ pub(super) fn run_actor_loop(
         duration_secs,
     );
     if exit_reason == ExitReason::ToolCallFormatError
-        && model_capabilities(&agent.current_assistant_model()).finish_after_edit_format_error
+        && model_capabilities(&super::agent_misc::current_assistant_model(agent))
+            .finish_after_edit_format_error
         && stats.total_changed > 0
         && agent.session.mode_state.mode == ExecutionMode::Act
         && (!super::python_request_helpers::active_python_request_requires_tests(agent)

--- a/src/agent/loop_run/agent_misc.rs
+++ b/src/agent/loop_run/agent_misc.rs
@@ -1,0 +1,100 @@
+//! Per-Agent misc lifecycle helpers extracted from `turn.rs` (parent
+//! #680).
+//!
+//! Hosts four small Agent-level helpers that live at distinct points
+//! in the actor-loop lifecycle:
+//!
+//! - `refresh_artifact_completion_satisfied` — Issue #663 (AD2 / AD9
+//!   / DR1-001) SSOT chokepoint for the ledger-driven Satisfied
+//!   transition. Status guard lives inside
+//!   `ArtifactCompletionJob::record_satisfied_from_ledger`; the
+//!   helper computes the projection once and delegates.
+//! - `tool_policy_violation_exit_reason` — static mapping from
+//!   `RecoveryOwner` to `ExitReason`.
+//! - `record_missing_verifier_setup_failure` — records an invalid
+//!   `MissingVerifierJob` setup attempt; emits a
+//!   `verifier_missing` SafeStop report when exhausted; otherwise
+//!   prints an iteration status + pushes the
+//!   `task_contract_no_verifier_note` system note.
+//! - `current_assistant_model` — picks the assistant model name from
+//!   the active mode + plan-model override.
+//!
+//! Originally `impl Agent` methods; converted to free functions taking
+//! `&mut Agent` / `&Agent`, matching the `actor_loop_flow` /
+//! `reply_retry` / earlier vertical-slice precedent. `pub(super)`
+//! limited / no facade re-export (DR3-001).
+
+use super::Agent;
+use super::active_job_arbiter::RecoveryOwner;
+use super::actor_loop_flow::format_iteration_status;
+use super::plan_mode_helpers::assistant_model_for_mode;
+use super::summary::ExitReason;
+use super::turn::write_stdout_rendered;
+use super::verifier_orchestration::task_contract_no_verifier_note;
+
+pub(super) fn refresh_artifact_completion_satisfied(agent: &mut Agent) {
+    if agent.artifact_completion_job.is_none() {
+        return;
+    }
+    let task_contract = match agent.active_request_text() {
+        Some(req) => super::task_contract::TaskContract::from_request(&req),
+        None => return,
+    };
+    let projection = agent
+        .artifact_ledger
+        .required_artifacts_completed_projection(&task_contract);
+    if let Some(job) = agent.artifact_completion_job.as_mut() {
+        job.record_satisfied_from_ledger(&projection);
+    }
+}
+
+pub(super) fn tool_policy_violation_exit_reason(recovery_owner: RecoveryOwner) -> ExitReason {
+    if recovery_owner == RecoveryOwner::MissingVerifierJob {
+        ExitReason::MissingVerification
+    } else if recovery_owner.is_verifier_owned() {
+        ExitReason::VerifierFailed
+    } else {
+        ExitReason::ToolCallFormatError
+    }
+}
+
+pub(super) fn record_missing_verifier_setup_failure(
+    agent: &mut Agent,
+    last_iter: usize,
+    reason: &str,
+) -> bool {
+    let Some(job) = agent.missing_verifier_job.as_mut() else {
+        return false;
+    };
+    let exhausted = job.record_invalid_setup_attempt();
+    let attempt = job.setup_attempts_used as usize;
+    let attempt_limit = job.retry_budget as usize;
+    if exhausted {
+        super::safe_stop_emit::emit_safe_stop_report_for_verifier_missing(agent);
+        return true;
+    }
+    write_stdout_rendered(
+        &format_iteration_status(
+            last_iter,
+            agent.config.max_iterations,
+            "Verification missing",
+            &format!("Verifier setup still needs an in-scope repository edit ({reason})."),
+            agent.footer.current_cols(),
+        ),
+        true,
+    );
+    agent.push_system_note(task_contract_no_verifier_note(
+        attempt,
+        attempt_limit,
+        agent.active_request_text().unwrap_or_default().as_str(),
+    ));
+    false
+}
+
+pub(super) fn current_assistant_model(agent: &Agent) -> String {
+    assistant_model_for_mode(
+        agent.session.mode_state.mode,
+        &agent.models.main,
+        agent.plan_model_override.as_deref(),
+    )
+}

--- a/src/agent/loop_run/handle_user_message.rs
+++ b/src/agent/loop_run/handle_user_message.rs
@@ -178,7 +178,7 @@ pub(super) fn handle_user_message(
     // (DR1-001 SSOT集約). Runs BEFORE `maybe_emit_job_reports` so
     // the job state emitted in `ArtifactCompletionReport` reflects
     // ledger-driven Satisfied transitions for the turn.
-    agent.refresh_artifact_completion_satisfied();
+    super::agent_misc::refresh_artifact_completion_satisfied(agent);
     // Issue #666: emit per-turn structured job reports just before
     // returning. Wrapping the result guarantees emit fires once per
     // turn regardless of how `run_turn` exited (Ok / Err / early

--- a/src/agent/loop_run/reply_retry.rs
+++ b/src/agent/loop_run/reply_retry.rs
@@ -29,7 +29,7 @@
 //! `&mut Agent` / `&Agent`, matching `actor_loop_flow` /
 //! `anti_pattern_flow` / `case_record_flow` pattern. `current_assistant_model`
 //! stays on `Agent` because it has 5+ external call sites; this module
-//! reaches it via `agent.current_assistant_model()`.
+//! reaches it via `super::agent_misc::current_assistant_model(agent)`.
 //!
 //! `pub(super)` limited / no facade re-export (DR3-001).
 
@@ -69,7 +69,10 @@ pub(super) fn request_assistant_reply_with_retry(
     // Start spinner once at function entry; retries share the same
     // animation (no flicker between attempts). Dropped automatically on
     // function exit (Ok / Err / early-return), clearing the line.
-    let sp = Spinner::start(format!("thinking... ({})", agent.current_assistant_model()));
+    let sp = Spinner::start(format!(
+        "thinking... ({})",
+        super::agent_misc::current_assistant_model(agent)
+    ));
     let mut retry_state =
         AssistantReplyRetryState::new(agent.config.chat_retries, agent.session.messages.len());
     loop {
@@ -329,7 +332,7 @@ fn request_assistant_reply(
         protocol,
         &effective_tool_policy,
     );
-    let assistant_model = agent.current_assistant_model();
+    let assistant_model = super::agent_misc::current_assistant_model(agent);
     let request_plan = build_assistant_request_plan(
         assistant_model.as_str(),
         native_tools_enabled,
@@ -373,7 +376,7 @@ fn request_streaming_assistant_reply(
     stop_signal: Option<SpinnerStopSignal>,
     interrupt_flag: &InterruptFlag,
 ) -> Result<AssistantReply, String> {
-    let assistant_model = agent.current_assistant_model();
+    let assistant_model = super::agent_misc::current_assistant_model(agent);
     let mut render_state = super::streaming_reply::StreamingReplyRenderState::new();
     let reply = agent.client.chat_streaming_with_mode(
         assistant_model.as_str(),
@@ -399,7 +402,8 @@ fn request_streaming_assistant_reply(
 /// (experimental flag 非依存)。
 fn maybe_finish_after_edit_format_error(agent: &Agent, err: &str) -> Option<AssistantReply> {
     if !lifecycle::is_tool_call_format_error(err)
-        || !model_capabilities(&agent.current_assistant_model()).finish_after_edit_format_error
+        || !model_capabilities(&super::agent_misc::current_assistant_model(agent))
+            .finish_after_edit_format_error
         || agent.session.mode_state.mode != ExecutionMode::Act
     {
         return None;

--- a/src/agent/loop_run/scaffold_pipeline.rs
+++ b/src/agent/loop_run/scaffold_pipeline.rs
@@ -1419,7 +1419,9 @@ pub(super) fn maybe_apply_local_llm_small_edit_fallback(
     {
         return Ok(None);
     }
-    if !model_capabilities(&agent.current_assistant_model()).read_after_small_edit_protocol {
+    if !model_capabilities(&super::agent_misc::current_assistant_model(agent))
+        .read_after_small_edit_protocol
+    {
         return Ok(None);
     }
     let Some(target) = local_llm_small_edit_fallback_target(agent) else {
@@ -1626,7 +1628,7 @@ pub(super) fn maybe_apply_deterministic_edit_after_format_error(
         return Ok(None);
     }
     if !lifecycle::is_tool_call_format_error(err)
-        || !model_capabilities(&agent.current_assistant_model())
+        || !model_capabilities(&super::agent_misc::current_assistant_model(agent))
             .deterministic_edit_after_format_error
         || has_successful_non_plan_repo_edit(
             &agent.session.messages,

--- a/src/agent/loop_run/tool_prep.rs
+++ b/src/agent/loop_run/tool_prep.rs
@@ -37,8 +37,10 @@ pub(super) fn tool_specs_for_policy(agent: &Agent, policy: &EffectiveToolPolicy)
 }
 
 pub(super) fn local_llm_small_edit_target(agent: &Agent) -> Option<PathBuf> {
-    if !crate::model_capabilities::model_capabilities(&agent.current_assistant_model())
-        .read_after_small_edit_protocol
+    if !crate::model_capabilities::model_capabilities(&super::agent_misc::current_assistant_model(
+        agent,
+    ))
+    .read_after_small_edit_protocol
     {
         return None;
     }

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -1,13 +1,7 @@
-use super::active_job_arbiter::RecoveryOwner;
-use super::actor_loop_flow::format_iteration_status;
-
-use super::plan_mode_helpers::assistant_model_for_mode;
 use super::small_helpers::raw_mode_safe_text;
-use super::summary::ExitReason;
 use super::tool_history::{
     focused_read_target_for_directory, is_preferred_read_edit_target, latest_user_turn_slice,
 };
-use super::verifier_orchestration::task_contract_no_verifier_note;
 use super::workspace_walk::workspace_appears_empty;
 use super::*;
 use crate::ollama::xml_fallback::normalize_tool_call_arguments;
@@ -132,84 +126,6 @@ pub(super) fn quality_confirm_cache_key(request: &str, content: &str) -> u64 {
 }
 
 impl Agent {
-    /// Issue #663 (AD2 / AD9 / DR1-001): SSOT chokepoint for the
-    /// ledger-driven Satisfied transition. Status guard is intentionally
-    /// absent here — it lives inside
-    /// `ArtifactCompletionJob::record_satisfied_from_ledger`. The function
-    /// computes the projection once and delegates to every active job.
-    ///
-    /// Today the Agent still holds a single `Option<ArtifactCompletionJob>`
-    /// (the BTreeMap migration tracked in AD9 is staged for the legacy
-    /// counter cleanup follow-up PR); the function therefore iterates the
-    /// single-entry option but is shaped so the future BTreeMap
-    /// substitution is a single-line replacement.
-    pub(super) fn refresh_artifact_completion_satisfied(&mut self) {
-        if self.artifact_completion_job.is_none() {
-            return;
-        }
-        let task_contract = match self.active_request_text() {
-            Some(req) => super::task_contract::TaskContract::from_request(&req),
-            None => return,
-        };
-        let projection = self
-            .artifact_ledger
-            .required_artifacts_completed_projection(&task_contract);
-        if let Some(job) = self.artifact_completion_job.as_mut() {
-            job.record_satisfied_from_ledger(&projection);
-        }
-    }
-
-    pub(super) fn tool_policy_violation_exit_reason(recovery_owner: RecoveryOwner) -> ExitReason {
-        if recovery_owner == RecoveryOwner::MissingVerifierJob {
-            ExitReason::MissingVerification
-        } else if recovery_owner.is_verifier_owned() {
-            ExitReason::VerifierFailed
-        } else {
-            ExitReason::ToolCallFormatError
-        }
-    }
-
-    pub(super) fn record_missing_verifier_setup_failure(
-        &mut self,
-        last_iter: usize,
-        reason: &str,
-    ) -> bool {
-        let Some(job) = self.missing_verifier_job.as_mut() else {
-            return false;
-        };
-        let exhausted = job.record_invalid_setup_attempt();
-        let attempt = job.setup_attempts_used as usize;
-        let attempt_limit = job.retry_budget as usize;
-        if exhausted {
-            super::safe_stop_emit::emit_safe_stop_report_for_verifier_missing(self);
-            return true;
-        }
-        write_stdout_rendered(
-            &format_iteration_status(
-                last_iter,
-                self.config.max_iterations,
-                "Verification missing",
-                &format!("Verifier setup still needs an in-scope repository edit ({reason})."),
-                self.footer.current_cols(),
-            ),
-            true,
-        );
-        self.push_system_note(task_contract_no_verifier_note(
-            attempt,
-            attempt_limit,
-            self.active_request_text().unwrap_or_default().as_str(),
-        ));
-        false
-    }
-
-    pub(super) fn current_assistant_model(&self) -> String {
-        assistant_model_for_mode(
-            self.session.mode_state.mode,
-            &self.models.main,
-            self.plan_model_override.as_deref(),
-        )
-    }
-
     /// Issue #646: build the active `TaskWorkspaceScope` for the current
     /// task. Pure projection of `work_root` + the active user request; no
     /// filesystem mutation. Called from `task_contract_artifact_states` and

--- a/src/agent/loop_run/turn_tests.rs
+++ b/src/agent/loop_run/turn_tests.rs
@@ -1500,17 +1500,19 @@ mod tests {
     #[test]
     fn tool_policy_violation_exit_reason_tracks_recovery_owner() {
         assert_eq!(
-            super::Agent::tool_policy_violation_exit_reason(
+            super::super::agent_misc::tool_policy_violation_exit_reason(
                 super::RecoveryOwner::MissingVerifierJob
             ),
             super::ExitReason::MissingVerification
         );
         assert_eq!(
-            super::Agent::tool_policy_violation_exit_reason(super::RecoveryOwner::RepairJob),
+            super::super::agent_misc::tool_policy_violation_exit_reason(
+                super::RecoveryOwner::RepairJob
+            ),
             super::ExitReason::VerifierFailed
         );
         assert_eq!(
-            super::Agent::tool_policy_violation_exit_reason(super::RecoveryOwner::None),
+            super::super::agent_misc::tool_policy_violation_exit_reason(super::RecoveryOwner::None),
             super::ExitReason::ToolCallFormatError
         );
     }


### PR DESCRIPTION
## Summary

Continue the meta-issue #680 split: move four per-Agent misc
lifecycle helpers out of \`turn.rs\` into a focused sibling module so
\`turn.rs\` keeps shrinking toward responsibility-focused units.

Four production helpers were extracted as free functions taking
\`&mut Agent\` / \`&Agent\` (matching \`actor_loop_flow\` / \`reply_retry\` /
earlier vertical-slice precedent):

- \`refresh_artifact_completion_satisfied\` (Issue #663 SSOT)
- \`tool_policy_violation_exit_reason\` (\`RecoveryOwner → ExitReason\`)
- \`record_missing_verifier_setup_failure\` (invalid setup attempt →
  SafeStop or \`task_contract_no_verifier_note\` push)
- \`current_assistant_model\` (mode + plan-model override picker)

Behavior unchanged: same Issue #663 status-guard placement, same
\`RecoveryOwner\` mapping, same exhausted-vs-progress branching, same
plan-model-override priority.

\`pub(super)\` limited / no facade re-export (DR3-001). Callers updated
in \`handle_user_message.rs\` (1 site), \`actor_loop_flow.rs\` (5 sites),
\`reply_retry.rs\` (4 sites), \`scaffold_pipeline.rs\` (2 sites),
\`tool_prep.rs\` (1 site), and \`turn_tests.rs\` (3 sites) to the free-fn
form.

### LOC delta

- \`turn.rs\`: 342 → 258 (-84)
- new module: +100

Cumulative \`turn.rs\` reduction across the parent #680 split:
39,489 → 258 (-99.3%).

## Test plan

- [x] \`cargo build --lib\`
- [x] \`cargo fmt\`
- [x] \`cargo clippy --lib --all-targets -- -D warnings\`
- [x] \`cargo test --lib\` (3,114 passed, 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)