### PR TITLE
Extract tool_call_prepare.rs from turn.rs (parent #680)

### DIFF
--- a/src/agent/loop_run.rs
+++ b/src/agent/loop_run.rs
@@ -10,7 +10,6 @@ use crate::logging::log_llm_event;
 use crate::model_registry::RuntimeModels;
 use crate::modes::plan_act::{ExecutionMode, ModePolicy};
 use crate::ollama::client::{AssistantReply, OllamaClient, should_use_native_tool_calls};
-use crate::ollama::xml_fallback::ToolCall;
 use crate::repo_graph::{
     BuildOptions as RepoGraphBuildOptions, BuildOutcome, RepoGraph, RepoGraphError,
     build_repo_graph,
@@ -357,6 +356,12 @@ mod tool_prep;
 // fns over `&mut Agent` / `&Agent`. `pub(super)` limited / no facade
 // re-export (DR3-001).
 mod agent_misc;
+// Per-tool-call argument normalization extracted from `turn.rs`
+// (parent #680). Hosts `prepare_tool_call`: per-tool argument sanitise
+// + Read/Write/Edit workspace-confined path resolution +
+// focused-edit Read directory→target redirect. Free fn over `&Agent`.
+// `pub(super)` limited / no facade re-export (DR3-001).
+mod tool_call_prepare;
 // Issue #652: `ArtifactCompletionJob` + role-specific retry budget +
 // `ArtifactAttemptOutcome` 4-variant taxonomy +
 // `ArtifactCompletionFailureSnapshot` for #654. Module is intentionally

--- a/src/agent/loop_run/actor_loop_flow.rs
+++ b/src/agent/loop_run/actor_loop_flow.rs
@@ -1786,7 +1786,7 @@ pub(super) fn drive_actor_loop_tool_preparation_phase(
     let mut prepared_tool_calls = args
         .reply_tool_calls
         .into_iter()
-        .map(|tool_call| agent.prepare_tool_call(tool_call))
+        .map(|tool_call| super::tool_call_prepare::prepare_tool_call(agent, tool_call))
         .collect::<Vec<_>>();
     record_actor_loop_tool_call_summaries(&prepared_tool_calls, args.tool_call_summaries);
 

--- a/src/agent/loop_run/scaffold_pipeline.rs
+++ b/src/agent/loop_run/scaffold_pipeline.rs
@@ -930,7 +930,7 @@ pub(super) fn maybe_apply_deterministic_nextjs_scaffold(
         .tool_calls
         .iter()
         .cloned()
-        .map(|tool_call| agent.prepare_tool_call(tool_call))
+        .map(|tool_call| super::tool_call_prepare::prepare_tool_call(agent, tool_call))
         .collect::<Vec<_>>();
     agent.session.messages.push(ConversationMessage::assistant(
         fallback_reply.content,

--- a/src/agent/loop_run/tool_call_prepare.rs
+++ b/src/agent/loop_run/tool_call_prepare.rs
@@ -1,0 +1,56 @@
+//! Per-tool-call argument normalization extracted from `turn.rs`
+//! (parent #680).
+//!
+//! Hosts `prepare_tool_call`, the pre-dispatch hook invoked on every
+//! assistant-produced `ToolCall` before it reaches
+//! `tool_call_execution::execute_tool_call`:
+//!
+//! 1. `normalize_tool_call_arguments` runs the per-tool argument
+//!    sanitiser (e.g. XML-fallback recovery for tool calls emitted as
+//!    free-text).
+//! 2. For `Read` / `Write` / `Edit`, the `path` argument is resolved
+//!    against `work_root` via `resolve_user_path`; the resolved path
+//!    is written back to the arguments object so downstream tools see
+//!    a workspace-confined absolute path.
+//! 3. For `Read` specifically: when the active
+//!    `EffectiveToolPolicy::focused_edit_policy()` declares a focused
+//!    target and the resolved path is a directory that contains it,
+//!    the focused target replaces the directory path so the read
+//!    lands on the file the policy is actually waiting for.
+//!
+//! Originally an `impl Agent` method; converted to a free function
+//! taking `&Agent`, matching the `actor_loop_flow` / `reply_retry` /
+//! earlier vertical-slice precedent. `pub(super)` limited / no facade
+//! re-export (DR3-001).
+
+use super::Agent;
+use super::tool_history::focused_read_target_for_directory;
+use crate::ollama::xml_fallback::ToolCall;
+use crate::ollama::xml_fallback::normalize_tool_call_arguments;
+use crate::safety::path_guard::resolve_user_path;
+
+pub(super) fn prepare_tool_call(agent: &Agent, mut tool_call: ToolCall) -> ToolCall {
+    tool_call.arguments = normalize_tool_call_arguments(&tool_call.name, tool_call.arguments);
+    if matches!(tool_call.name.as_str(), "Read" | "Write" | "Edit")
+        && let Some(arguments) = tool_call.arguments.as_object_mut()
+        && let Some(raw_path) = arguments.get("path").and_then(serde_json::Value::as_str)
+        && let Ok(resolved) = resolve_user_path(&agent.work_root, raw_path)
+    {
+        let resolved = if tool_call.name == "Read" {
+            super::effective_tool_policy_flow::effective_tool_policy(agent)
+                .focused_edit_policy()
+                .and_then(|policy| {
+                    focused_read_target_for_directory(&resolved, &policy.target)
+                        .then_some(policy.target.clone())
+                })
+                .unwrap_or(resolved)
+        } else {
+            resolved
+        };
+        arguments.insert(
+            "path".to_string(),
+            serde_json::Value::String(resolved.display().to_string()),
+        );
+    }
+    tool_call
+}

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -1,10 +1,7 @@
 use super::small_helpers::raw_mode_safe_text;
-use super::tool_history::{
-    focused_read_target_for_directory, is_preferred_read_edit_target, latest_user_turn_slice,
-};
+use super::tool_history::{is_preferred_read_edit_target, latest_user_turn_slice};
 use super::workspace_walk::workspace_appears_empty;
 use super::*;
-use crate::ollama::xml_fallback::normalize_tool_call_arguments;
 use crate::session::store::ScaffoldArtifactFileSnapshot;
 use std::path::{Path, PathBuf};
 
@@ -157,32 +154,6 @@ impl Agent {
             self.session.working_memory.active_task.as_deref(),
             &self.session.messages,
         )
-    }
-
-    pub(super) fn prepare_tool_call(&self, mut tool_call: ToolCall) -> ToolCall {
-        tool_call.arguments = normalize_tool_call_arguments(&tool_call.name, tool_call.arguments);
-        if matches!(tool_call.name.as_str(), "Read" | "Write" | "Edit")
-            && let Some(arguments) = tool_call.arguments.as_object_mut()
-            && let Some(raw_path) = arguments.get("path").and_then(serde_json::Value::as_str)
-            && let Ok(resolved) = resolve_user_path(&self.work_root, raw_path)
-        {
-            let resolved = if tool_call.name == "Read" {
-                super::effective_tool_policy_flow::effective_tool_policy(self)
-                    .focused_edit_policy()
-                    .and_then(|policy| {
-                        focused_read_target_for_directory(&resolved, &policy.target)
-                            .then_some(policy.target.clone())
-                    })
-                    .unwrap_or(resolved)
-            } else {
-                resolved
-            };
-            arguments.insert(
-                "path".to_string(),
-                serde_json::Value::String(resolved.display().to_string()),
-            );
-        }
-        tool_call
     }
 
     pub(super) fn push_system_note(&mut self, note: String) {


### PR DESCRIPTION
## Summary

Continue the meta-issue #680 split: move the pre-dispatch tool-call
argument normalization out of \`turn.rs\` into a focused sibling module
so \`turn.rs\` keeps shrinking toward responsibility-focused units.

One production helper was extracted as a free function taking
\`&Agent\` (matching \`actor_loop_flow\` / \`reply_retry\` / earlier
vertical-slice precedent):

- \`prepare_tool_call\`: runs \`normalize_tool_call_arguments\`,
  resolves \`Read\`/\`Write\`/\`Edit\` \`path\` arguments against
  \`work_root\` via \`resolve_user_path\`, and redirects \`Read\` calls
  from a focused-edit directory to the policy's focused target file
  when applicable.

Behavior unchanged: same per-tool sanitiser invocation, same
\`resolve_user_path\` workspace confinement, same focused-edit
directory→target redirect for \`Read\`.

\`pub(super)\` limited / no facade re-export (DR3-001). Callers updated
in \`scaffold_pipeline.rs\` (1 site) and \`actor_loop_flow.rs\` (1 site)
to the free-fn form.

### LOC delta

- \`turn.rs\`: 258 → 229 (-29)
- new module: +56

Cumulative \`turn.rs\` reduction across the parent #680 split:
39,489 → 229 (-99.4%).

## Test plan

- [x] \`cargo build --lib\`
- [x] \`cargo fmt\`
- [x] \`cargo clippy --lib --all-targets -- -D warnings\`
- [x] \`cargo test --lib\` (3,114 passed, 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)