### PR TITLE
Extract read_target_helpers.rs from turn.rs (parent #680)

### DIFF
--- a/src/agent/loop_run.rs
+++ b/src/agent/loop_run.rs
@@ -14,7 +14,6 @@ use crate::repo_graph::{
     BuildOptions as RepoGraphBuildOptions, BuildOutcome, RepoGraph, RepoGraphError,
     build_repo_graph,
 };
-use crate::safety::path_guard::resolve_user_path;
 use crate::session::compact::{
     approximate_token_count, compact_messages, compact_messages_with_strategy,
 };
@@ -362,6 +361,13 @@ mod agent_misc;
 // focused-edit Read directory→target redirect. Free fn over `&Agent`.
 // `pub(super)` limited / no facade re-export (DR3-001).
 mod tool_call_prepare;
+// Read-tool path lookup helpers extracted from `turn.rs` (parent
+// #680). Hosts `last_read_tool_path` (most recent `Read` path across
+// all turns) and `latest_turn_preferred_read_edit_target` (latest user
+// turn's `Read`s, resolved + filtered to existing files, prefers
+// `is_preferred_read_edit_target` matches). Free fns (no Agent
+// dependency). `pub(super)` limited / no facade re-export (DR3-001).
+mod read_target_helpers;
 // Issue #652: `ArtifactCompletionJob` + role-specific retry budget +
 // `ArtifactAttemptOutcome` 4-variant taxonomy +
 // `ArtifactCompletionFailureSnapshot` for #654. Module is intentionally

--- a/src/agent/loop_run/forced_small_edit.rs
+++ b/src/agent/loop_run/forced_small_edit.rs
@@ -19,12 +19,12 @@
 use std::path::PathBuf;
 
 use super::Agent;
+use super::read_target_helpers::{last_read_tool_path, latest_turn_preferred_read_edit_target};
 use super::tool_display::progress_path_display;
 use super::tool_history::{
     has_successful_non_plan_repo_edit_after_latest_truncated_tool_call,
     recent_truncated_tool_call_attempt,
 };
-use super::turn::{last_read_tool_path, latest_turn_preferred_read_edit_target};
 use crate::agent::recovery;
 use crate::modes::plan_act::ExecutionMode;
 use crate::safety::path_guard::resolve_user_path;

--- a/src/agent/loop_run/progress_tests.rs
+++ b/src/agent/loop_run/progress_tests.rs
@@ -117,6 +117,9 @@ mod inner {
         first_existing_impl_target, repo_change_request_text,
         request_needs_playable_ui_quality_gate,
     };
+    use super::super::read_target_helpers::{
+        last_read_tool_path, latest_turn_preferred_read_edit_target,
+    };
     use super::super::repair_job::{
         SNAPSHOT_FIELD_BYTE_CAP, sanitize_repair_job_text, truncate_for_snapshot,
     };
@@ -154,7 +157,6 @@ mod inner {
         focused_edit_policy_violation_feedback_note, focused_edit_tool_batch_action,
         focused_edit_tool_policy_error,
     };
-    use super::super::turn::{last_read_tool_path, latest_turn_preferred_read_edit_target};
     use super::super::verifier_assessment_parser::parse_verifier_repair_assessment_reply;
     use super::super::verifier_diagnostic_attempt::{
         VERIFIER_DIAGNOSTIC_ATTEMPT_LIMIT, VERIFIER_DIAGNOSTIC_MAIN_FALLBACK_TIMEOUT_SECS,

--- a/src/agent/loop_run/read_target_helpers.rs
+++ b/src/agent/loop_run/read_target_helpers.rs
@@ -1,0 +1,76 @@
+//! Read-tool path lookup helpers extracted from `turn.rs` (parent
+//! #680).
+//!
+//! Hosts two small free functions that mine the conversation message
+//! log for previous `Read` tool calls so the recovery / focused-edit
+//! pipelines can pick a continuation target:
+//!
+//! - `last_read_tool_path` — the most recent (across all turns)
+//!   `Read` tool-call `path` argument as a raw string.
+//! - `latest_turn_preferred_read_edit_target` — the latest **user
+//!   turn**'s `Read` calls, resolved against `work_root` and filtered
+//!   to existing files; prefers `is_preferred_read_edit_target`
+//!   matches, otherwise falls back to the most-recent existing read.
+//!
+//! Originally `pub(super) fn` helpers in `turn.rs` (NOT `impl Agent`);
+//! these are pure projections over message slices and don't need
+//! `Agent`. `pub(super)` limited / no facade re-export (DR3-001).
+
+use std::path::{Path, PathBuf};
+
+use super::tool_history::{is_preferred_read_edit_target, latest_user_turn_slice};
+use crate::safety::path_guard::resolve_user_path;
+use crate::session::store::ConversationMessage;
+
+pub(super) fn last_read_tool_path(messages: &[ConversationMessage]) -> Option<String> {
+    messages.iter().rev().find_map(|message| {
+        if message.role != "assistant" {
+            return None;
+        }
+        message.tool_calls.iter().rev().find_map(|tool_call| {
+            if tool_call.name != "Read" {
+                return None;
+            }
+            tool_call
+                .arguments
+                .get("path")
+                .and_then(serde_json::Value::as_str)
+                .map(ToString::to_string)
+        })
+    })
+}
+
+pub(super) fn latest_turn_preferred_read_edit_target(
+    messages: &[ConversationMessage],
+    work_root: &Path,
+) -> Option<PathBuf> {
+    let mut latest_existing = None;
+    for message in latest_user_turn_slice(messages).iter().rev() {
+        if message.role != "assistant" {
+            continue;
+        }
+        for tool_call in message.tool_calls.iter().rev() {
+            if tool_call.name != "Read" {
+                continue;
+            }
+            let Some(path) = tool_call
+                .arguments
+                .get("path")
+                .and_then(serde_json::Value::as_str)
+            else {
+                continue;
+            };
+            let Ok(candidate) = resolve_user_path(work_root, path) else {
+                continue;
+            };
+            if !candidate.is_file() {
+                continue;
+            }
+            latest_existing.get_or_insert_with(|| candidate.clone());
+            if is_preferred_read_edit_target(&candidate) {
+                return Some(candidate);
+            }
+        }
+    }
+    latest_existing
+}

--- a/src/agent/loop_run/recovery_targets.rs
+++ b/src/agent/loop_run/recovery_targets.rs
@@ -28,12 +28,10 @@
 use std::path::PathBuf;
 
 use super::Agent;
+use super::read_target_helpers::{last_read_tool_path, latest_turn_preferred_read_edit_target};
 use super::tool_display::progress_path_display;
 use super::tool_history::{focused_edit_target_already_read, has_successful_non_plan_repo_edit};
-use super::turn::{
-    TASK_CONTRACT_VERIFIER_ATTEMPT_LIMIT, last_read_tool_path,
-    latest_turn_preferred_read_edit_target,
-};
+use super::turn::TASK_CONTRACT_VERIFIER_ATTEMPT_LIMIT;
 use super::verifier_orchestration::{
     task_contract_verifier_targeted_edit_required_note, verifier_repair_diagnostic_pending_note,
     verifier_repair_target_display,

--- a/src/agent/loop_run/scaffold_pipeline.rs
+++ b/src/agent/loop_run/scaffold_pipeline.rs
@@ -56,14 +56,15 @@ use super::quality::{
     first_existing_impl_target, implementation_quality_issue_for_request,
     package_json_with_requested_port, react_dev_wrapper_for_requested_port,
 };
+use super::read_target_helpers::{last_read_tool_path, latest_turn_preferred_read_edit_target};
 use super::task_contract::{ArtifactRole, CompletionDecision};
 use super::tool_display::progress_path_display;
 use super::tool_history::{
     focused_edit_target_already_read, has_successful_non_plan_repo_edit, latest_user_turn_slice,
 };
 use super::turn::{
-    WrittenScaffoldArtifacts, extract_filename_with_suffix, last_read_tool_path,
-    latest_turn_preferred_read_edit_target, tool_result_failed, write_stdout_rendered,
+    WrittenScaffoldArtifacts, extract_filename_with_suffix, tool_result_failed,
+    write_stdout_rendered,
 };
 use super::workspace_walk::{meaningful_workspace_files, workspace_appears_empty};
 use crate::agent::prompting;

--- a/src/agent/loop_run/tool_prep.rs
+++ b/src/agent/loop_run/tool_prep.rs
@@ -21,9 +21,9 @@
 use std::path::PathBuf;
 
 use super::Agent;
+use super::read_target_helpers::latest_turn_preferred_read_edit_target;
 use super::tool_history::{focused_edit_target_already_read, has_successful_non_plan_repo_edit};
 use super::tool_policy::EffectiveToolPolicy;
-use super::turn::latest_turn_preferred_read_edit_target;
 use crate::modes::plan_act::{ExecutionMode, WorkMode};
 use crate::session::store::ConversationMessage;
 use crate::tools::registry::ToolSpec;

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -1,9 +1,8 @@
 use super::small_helpers::raw_mode_safe_text;
-use super::tool_history::{is_preferred_read_edit_target, latest_user_turn_slice};
 use super::workspace_walk::workspace_appears_empty;
 use super::*;
 use crate::session::store::ScaffoldArtifactFileSnapshot;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use super::quality::repo_change_request_text;
 
@@ -173,57 +172,4 @@ impl Agent {
             .messages
             .push(ConversationMessage::user(content));
     }
-}
-
-pub(super) fn last_read_tool_path(messages: &[ConversationMessage]) -> Option<String> {
-    messages.iter().rev().find_map(|message| {
-        if message.role != "assistant" {
-            return None;
-        }
-        message.tool_calls.iter().rev().find_map(|tool_call| {
-            if tool_call.name != "Read" {
-                return None;
-            }
-            tool_call
-                .arguments
-                .get("path")
-                .and_then(serde_json::Value::as_str)
-                .map(ToString::to_string)
-        })
-    })
-}
-
-pub(super) fn latest_turn_preferred_read_edit_target(
-    messages: &[ConversationMessage],
-    work_root: &Path,
-) -> Option<PathBuf> {
-    let mut latest_existing = None;
-    for message in latest_user_turn_slice(messages).iter().rev() {
-        if message.role != "assistant" {
-            continue;
-        }
-        for tool_call in message.tool_calls.iter().rev() {
-            if tool_call.name != "Read" {
-                continue;
-            }
-            let Some(path) = tool_call
-                .arguments
-                .get("path")
-                .and_then(serde_json::Value::as_str)
-            else {
-                continue;
-            };
-            let Ok(candidate) = resolve_user_path(work_root, path) else {
-                continue;
-            };
-            if !candidate.is_file() {
-                continue;
-            }
-            latest_existing.get_or_insert_with(|| candidate.clone());
-            if is_preferred_read_edit_target(&candidate) {
-                return Some(candidate);
-            }
-        }
-    }
-    latest_existing
 }


### PR DESCRIPTION
## Summary

Continue the meta-issue #680 split: move the read-tool path lookup
helpers out of \`turn.rs\` into a focused sibling module so \`turn.rs\`
keeps shrinking toward responsibility-focused units.

Two free fn helpers were extracted (no Agent dependency — pure
projections over message slices):

- \`last_read_tool_path\` — most recent (across all turns) \`Read\`
  tool-call \`path\` argument
- \`latest_turn_preferred_read_edit_target\` — latest user turn's
  \`Read\` calls, resolved + filtered to existing files; prefers
  \`is_preferred_read_edit_target\` matches, otherwise falls back to
  the most-recent existing read

Behavior unchanged: same message iteration order, same
\`resolve_user_path\` workspace confinement, same
\`is_preferred_read_edit_target\` priority.

\`pub(super)\` limited / no facade re-export (DR3-001). Callers updated
in \`recovery_targets.rs\`, \`forced_small_edit.rs\`, \`tool_prep.rs\`,
\`scaffold_pipeline.rs\`, and \`progress_tests.rs\` (5 import paths).

### LOC delta

- \`turn.rs\`: 229 → 175 (-54)
- new module: +76

Cumulative \`turn.rs\` reduction across the parent #680 split:
39,489 → 175 (-99.6%). Crosses under 180 LOC.

## Test plan

- [x] \`cargo build --lib\`
- [x] \`cargo fmt\`
- [x] \`cargo clippy --lib --all-targets -- -D warnings\`
- [x] \`cargo test --lib\` (3,114 passed, 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)