### PR TITLE
Extract turn_helpers.rs from turn.rs (parent #680)

### DIFF
--- a/src/agent/loop_run.rs
+++ b/src/agent/loop_run.rs
@@ -368,6 +368,12 @@ mod tool_call_prepare;
 // `is_preferred_read_edit_target` matches). Free fns (no Agent
 // dependency). `pub(super)` limited / no facade re-export (DR3-001).
 mod read_target_helpers;
+// Small helpers + shared types extracted from `turn.rs` (parent #680).
+// Hosts `extract_filename_with_suffix`, `write_stdout_rendered`,
+// `tool_result_failed`, `quality_confirm_cache_key` free fns +
+// `RetrievalInjection` struct + `WrittenScaffoldArtifacts` type alias.
+// `pub(super)` limited / no facade re-export (DR3-001).
+mod turn_helpers;
 // Issue #652: `ArtifactCompletionJob` + role-specific retry budget +
 // `ArtifactAttemptOutcome` 4-variant taxonomy +
 // `ArtifactCompletionFailureSnapshot` for #654. Module is intentionally

--- a/src/agent/loop_run/actor_loop_flow.rs
+++ b/src/agent/loop_run/actor_loop_flow.rs
@@ -73,9 +73,8 @@ use super::tool_display::tool_display;
 use super::tool_history::focused_edit_target_already_read;
 use super::tool_history::is_plan_file_tool_call;
 use super::tool_policy::EffectiveToolPolicy;
-use super::turn::{
-    LOG_ARGS_MAX_CHARS, PLAN_REPEATED_EXPLORATION_BLOCK_THRESHOLD, write_stdout_rendered,
-};
+use super::turn::{LOG_ARGS_MAX_CHARS, PLAN_REPEATED_EXPLORATION_BLOCK_THRESHOLD};
+use super::turn_helpers::write_stdout_rendered;
 use crate::agent::prompting;
 use crate::session::compact::approximate_token_count;
 use crate::util::workspace_paths::is_ignored_workspace_display_path;
@@ -463,7 +462,7 @@ pub(super) fn maybe_handle_answer_only_inadequate_recovery(
                 error_text: String::new(),
             });
         }
-        super::turn::write_stdout_rendered(
+        super::turn_helpers::write_stdout_rendered(
             &format_iteration_status(
                 args.last_iter,
                 agent.config.max_iterations,
@@ -503,7 +502,7 @@ pub(super) fn maybe_handle_repo_change_quality_gate_recovery(
         &target_path,
     ) {
         Ok(true) => {
-            super::turn::write_stdout_rendered(
+            super::turn_helpers::write_stdout_rendered(
                 &format_iteration_status(
                     args.last_iter,
                     agent.config.max_iterations,
@@ -540,7 +539,7 @@ pub(super) fn maybe_handle_repo_change_quality_gate_recovery(
             error_text: issue,
         });
     }
-    super::turn::write_stdout_rendered(
+    super::turn_helpers::write_stdout_rendered(
         &format_iteration_status(
             args.last_iter,
             agent.config.max_iterations,
@@ -584,7 +583,7 @@ pub(super) fn maybe_handle_repo_change_partial_progress_recovery(
                 .to_string(),
         });
     }
-    super::turn::write_stdout_rendered(
+    super::turn_helpers::write_stdout_rendered(
         &format_iteration_status(
             args.last_iter,
             agent.config.max_iterations,
@@ -635,7 +634,7 @@ pub(super) fn maybe_handle_python_test_artifact_recovery(
             error_text,
         });
     }
-    super::turn::write_stdout_rendered(
+    super::turn_helpers::write_stdout_rendered(
         &format_iteration_status(
             args.last_iter,
             agent.config.max_iterations,
@@ -669,7 +668,7 @@ pub(super) fn maybe_handle_missing_repo_edit_recovery(
     if *args.repo_change_retries >= 3 {
         return Some(finalize_missing_repo_edit_retry_exhausted(agent));
     }
-    super::turn::write_stdout_rendered(
+    super::turn_helpers::write_stdout_rendered(
         &format_iteration_status(
             args.last_iter,
             agent.config.max_iterations,
@@ -892,7 +891,7 @@ pub(super) fn handle_actor_loop_empty_reply(
                 },
             };
         }
-        super::turn::write_stdout_rendered(
+        super::turn_helpers::write_stdout_rendered(
             &format_iteration_status(
                 args.last_iter,
                 agent.config.max_iterations,
@@ -931,7 +930,7 @@ pub(super) fn handle_actor_loop_empty_reply(
             error_text: ExitReason::EmptyResponses.default_error_text().to_string(),
         };
     }
-    super::turn::write_stdout_rendered(
+    super::turn_helpers::write_stdout_rendered(
         &format_iteration_status(
             args.last_iter,
             agent.config.max_iterations,
@@ -996,7 +995,7 @@ fn handle_plan_progress_prose_only_reply(
     if *args.plan_progress_retries >= 2 {
         return handle_plan_progress_prose_only_fallback(agent);
     }
-    super::turn::write_stdout_rendered(
+    super::turn_helpers::write_stdout_rendered(
         &format_iteration_status(
             args.last_iter,
             agent.config.max_iterations,
@@ -1045,7 +1044,7 @@ fn handle_generic_prose_only_retry(
             error_text: ExitReason::NoToolCalls.default_error_text().to_string(),
         };
     }
-    super::turn::write_stdout_rendered(
+    super::turn_helpers::write_stdout_rendered(
         &format_iteration_status(
             last_iter,
             agent.config.max_iterations,
@@ -1088,7 +1087,7 @@ fn handle_actor_loop_missing_repo_change_retry_prompt(
     agent: &mut Agent,
     args: ActorLoopMissingRepoChangeRetryPromptArgs,
 ) -> ActorLoopNoToolReplyOutcome {
-    super::turn::write_stdout_rendered(
+    super::turn_helpers::write_stdout_rendered(
         &format_iteration_status(
             args.last_iter,
             agent.config.max_iterations,
@@ -1180,7 +1179,7 @@ fn handle_actor_loop_missing_repo_change_retry_exhausted(
             args.repo_change_retries,
         ))
     {
-        super::turn::write_stdout_rendered(
+        super::turn_helpers::write_stdout_rendered(
             &format_iteration_status(
                 args.last_iter,
                 agent.config.max_iterations,
@@ -1353,7 +1352,7 @@ pub(super) fn handle_actor_loop_completion(
                     },
                 };
             }
-            super::turn::write_stdout_rendered(
+            super::turn_helpers::write_stdout_rendered(
                 &format_iteration_status(
                     args.last_iter,
                     agent.config.max_iterations,
@@ -1499,7 +1498,7 @@ pub(super) fn handle_actor_loop_post_tool_polish_fallback(
         target_path,
     ) {
         Ok(true) => {
-            super::turn::write_stdout_rendered(
+            super::turn_helpers::write_stdout_rendered(
                 &format_iteration_status(
                     last_iter,
                     agent.config.max_iterations,
@@ -1540,7 +1539,7 @@ fn handle_actor_loop_post_tool_quality_fallback(
         target_path,
     ) {
         Ok(true) => {
-            super::turn::write_stdout_rendered(
+            super::turn_helpers::write_stdout_rendered(
                 &format_iteration_status(
                     last_iter,
                     agent.config.max_iterations,
@@ -1597,7 +1596,7 @@ fn handle_actor_loop_post_tool_repo_edit_quality_gate(
         &target_path,
     ) {
         Ok(true) => {
-            super::turn::write_stdout_rendered(
+            super::turn_helpers::write_stdout_rendered(
                 &format_iteration_status(
                     last_iter,
                     agent.config.max_iterations,
@@ -1625,7 +1624,7 @@ fn handle_actor_loop_post_tool_repo_edit_quality_gate(
                     error_text: issue,
                 }
             } else {
-                super::turn::write_stdout_rendered(
+                super::turn_helpers::write_stdout_rendered(
                     &format_iteration_status(
                         last_iter,
                         agent.config.max_iterations,
@@ -1809,7 +1808,7 @@ pub(super) fn drive_actor_loop_tool_preparation_phase(
             super::tool_policy::FocusedEditBatchAction::Accept => {}
             super::tool_policy::FocusedEditBatchAction::TruncateToFirst => {
                 prepared_tool_calls.truncate(1);
-                super::turn::write_stdout_rendered(
+                super::turn_helpers::write_stdout_rendered(
                     &format_iteration_status(
                         args.last_iter,
                         agent.config.max_iterations,
@@ -2260,7 +2259,7 @@ pub(super) fn handle_actor_loop_task_contract_tool_recovery(
             ),
         };
     }
-    super::turn::write_stdout_rendered(
+    super::turn_helpers::write_stdout_rendered(
         &format_iteration_status(
             args.last_iter,
             agent.config.max_iterations,
@@ -2328,7 +2327,7 @@ pub(super) fn handle_actor_loop_task_contract_incomplete_artifacts(
             ),
         };
     }
-    super::turn::write_stdout_rendered(
+    super::turn_helpers::write_stdout_rendered(
         &format_iteration_status(
             args.last_iter,
             agent.config.max_iterations,
@@ -2395,7 +2394,7 @@ pub(super) fn handle_actor_loop_task_contract_repair_artifact(
             error_text: "assistant stopped before repairing the verifier failure".to_string(),
         };
     }
-    super::turn::write_stdout_rendered(
+    super::turn_helpers::write_stdout_rendered(
         &format_iteration_status(
             last_iter,
             agent.config.max_iterations,
@@ -2517,7 +2516,7 @@ pub(super) fn handle_actor_loop_rejected_tool_batch(
         };
     }
     let retry_status_note = rejected_tool_batch_retry_status_note(focused_retry.is_some());
-    super::turn::write_stdout_rendered(
+    super::turn_helpers::write_stdout_rendered(
         &format_iteration_status(
             args.last_iter,
             agent.config.max_iterations,
@@ -2619,7 +2618,7 @@ pub(super) fn maybe_handle_rejected_tool_batch_artifact(
             ),
         });
     }
-    super::turn::write_stdout_rendered(
+    super::turn_helpers::write_stdout_rendered(
         &format_iteration_status(
             last_iter,
             agent.config.max_iterations,
@@ -2728,7 +2727,7 @@ pub(super) fn maybe_handle_answer_only_future_work_recovery(
                 error_text: String::new(),
             });
         }
-        super::turn::write_stdout_rendered(
+        super::turn_helpers::write_stdout_rendered(
             &format_iteration_status(
                 args.last_iter,
                 agent.config.max_iterations,

--- a/src/agent/loop_run/agent_misc.rs
+++ b/src/agent/loop_run/agent_misc.rs
@@ -29,7 +29,7 @@ use super::active_job_arbiter::RecoveryOwner;
 use super::actor_loop_flow::format_iteration_status;
 use super::plan_mode_helpers::assistant_model_for_mode;
 use super::summary::ExitReason;
-use super::turn::write_stdout_rendered;
+use super::turn_helpers::write_stdout_rendered;
 use super::verifier_orchestration::task_contract_no_verifier_note;
 
 pub(super) fn refresh_artifact_completion_satisfied(agent: &mut Agent) {

--- a/src/agent/loop_run/anti_pattern_flow.rs
+++ b/src/agent/loop_run/anti_pattern_flow.rs
@@ -16,7 +16,7 @@
 //! facade re-export (DR3-001).
 
 use super::Agent;
-use super::turn::RetrievalInjection;
+use super::turn_helpers::RetrievalInjection;
 use crate::logging::log_llm_event;
 use crate::modes::plan_act::ExecutionMode;
 use crate::session::feedback::{FeedbackFrame, FeedbackKind};

--- a/src/agent/loop_run/build_request_messages.rs
+++ b/src/agent/loop_run/build_request_messages.rs
@@ -39,7 +39,7 @@ use super::tool_history::{
     successful_non_plan_repo_edit_count,
 };
 use super::tool_policy::{EffectiveToolPolicy, focused_edit_policy_violation_feedback_note};
-use super::turn::RetrievalInjection;
+use super::turn_helpers::RetrievalInjection;
 use crate::agent::prompting;
 use crate::agent::recovery;
 use crate::modes::plan_act::ExecutionMode;

--- a/src/agent/loop_run/case_record_flow.rs
+++ b/src/agent/loop_run/case_record_flow.rs
@@ -21,7 +21,7 @@ use super::case_record_extract::{
     case_record_auto_test_active, case_record_extraction_succeeded, case_record_initial_feedback,
     derive_language_stack,
 };
-use super::turn::RetrievalInjection;
+use super::turn_helpers::RetrievalInjection;
 use crate::logging::log_llm_event;
 use crate::modes::plan_act::ExecutionMode;
 use crate::session::precaution::PrecautionStatus;

--- a/src/agent/loop_run/classify_confirm_flow.rs
+++ b/src/agent/loop_run/classify_confirm_flow.rs
@@ -33,7 +33,7 @@ use super::quality_confirm::{
     QualityConfirmation, QualityConfirmationSource, run_quality_confirm_with_strategy,
     should_request_quality_confirmation,
 };
-use super::turn::quality_confirm_cache_key;
+use super::turn_helpers::quality_confirm_cache_key;
 use super::work_mode_confirm::{
     self, WORK_MODE_CONFIRM_TIMEOUT_SECS, WorkModeConfirmInputs, WorkModeConfirmOutcome,
     run_work_mode_confirm_with_strategy,

--- a/src/agent/loop_run/repair_job_dispatch.rs
+++ b/src/agent/loop_run/repair_job_dispatch.rs
@@ -34,7 +34,7 @@ use super::repair_job;
 use super::repair_job::verifier_repair_context_from_failure;
 use super::summary::ExitReason;
 use super::task_contract::{RecoveryTargetHint, SafeStopReason};
-use super::turn::write_stdout_rendered;
+use super::turn_helpers::write_stdout_rendered;
 use super::verifier_driver::TaskContractVerifierOutcome;
 use super::verifier_orchestration::{
     TaskContractVerifierFlowArgs, VerifierDiagnosticPassOutcome,

--- a/src/agent/loop_run/scaffold_pipeline.rs
+++ b/src/agent/loop_run/scaffold_pipeline.rs
@@ -62,7 +62,7 @@ use super::tool_display::progress_path_display;
 use super::tool_history::{
     focused_edit_target_already_read, has_successful_non_plan_repo_edit, latest_user_turn_slice,
 };
-use super::turn::{
+use super::turn_helpers::{
     WrittenScaffoldArtifacts, extract_filename_with_suffix, tool_result_failed,
     write_stdout_rendered,
 };

--- a/src/agent/loop_run/streaming_reply.rs
+++ b/src/agent/loop_run/streaming_reply.rs
@@ -21,7 +21,8 @@
 
 use super::interrupt::InterruptFlag;
 use super::spinner::SpinnerStopSignal;
-use super::turn::{USER_INTERRUPT_ERROR, write_stdout_rendered};
+use super::turn::USER_INTERRUPT_ERROR;
+use super::turn_helpers::write_stdout_rendered;
 
 pub(super) struct StreamingReplyRenderState {
     pub(super) first_chunk: bool,

--- a/src/agent/loop_run/truncate_tests.rs
+++ b/src/agent/loop_run/truncate_tests.rs
@@ -36,7 +36,7 @@ mod inner {
         repo_edit_satisfies_artifact_recovery_target,
     };
     use super::super::tool_policy::focused_edit_tool_policy_error;
-    use super::super::turn::extract_filename_with_suffix;
+    use super::super::turn_helpers::extract_filename_with_suffix;
     use super::super::verifier_orchestration::{
         task_contract_needs_verification, task_contract_verifier_repair_note,
     };

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -1,8 +1,5 @@
-use super::small_helpers::raw_mode_safe_text;
 use super::workspace_walk::workspace_appears_empty;
 use super::*;
-use crate::session::store::ScaffoldArtifactFileSnapshot;
-use std::path::PathBuf;
 
 use super::quality::repo_change_request_text;
 
@@ -46,79 +43,6 @@ impl AssistantReplyRetryState {
             tool_call_format_retry_count: 0,
         }
     }
-}
-
-pub(super) fn extract_filename_with_suffix(text: &str, suffix: &str) -> Option<String> {
-    text.split(|ch: char| {
-        ch.is_whitespace()
-            || matches!(
-                ch,
-                '`' | '"'
-                    | '\''
-                    | '('
-                    | ')'
-                    | '['
-                    | ']'
-                    | '{'
-                    | '}'
-                    | '、'
-                    | '。'
-                    | '，'
-                    | '：'
-                    | ':'
-                    | ';'
-            )
-    })
-    .map(|token| token.trim_matches([',', '.', '。', '、']))
-    .find(|token| {
-        token.ends_with(suffix)
-            && token.len() <= 80
-            && !token.contains('/')
-            && !token.contains('\\')
-            && !token.starts_with('.')
-            && token
-                .chars()
-                .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.'))
-    })
-    .map(ToString::to_string)
-}
-
-pub(super) fn write_stdout_rendered(text: &str, trailing_newline: bool) {
-    let mut out = io::stdout().lock();
-    let rendered = raw_mode_safe_text(text);
-    let _ = out.write_all(rendered.as_bytes());
-    if trailing_newline {
-        let _ = out.write_all(b"\r\n");
-    }
-    let _ = out.flush();
-}
-
-pub(super) fn tool_result_failed(result: &str) -> bool {
-    result.starts_with("Error:") || result.contains("\ninterrupted=true\n")
-}
-
-/// Issue #555: carries a retrieval message and the IDs of the selected
-/// records so the photon mapper can include them without re-parsing the
-/// rendered prompt text.
-pub(super) struct RetrievalInjection {
-    pub message: ConversationMessage,
-    pub selected_ids: Vec<String>,
-}
-
-pub(super) type WrittenScaffoldArtifacts = (Vec<PathBuf>, Vec<ScaffoldArtifactFileSnapshot>);
-
-/// Issue #580: SSoT memoization key for the Quality-gate second-pass adapter.
-/// Hashes `(request, full_content)` with `DefaultHasher` (per design judgement
-/// #5: full_content avoids stale reuse when only the middle of a large file
-/// changes — the LLM still sees only the head+tail excerpt).
-pub(super) fn quality_confirm_cache_key(request: &str, content: &str) -> u64 {
-    use std::collections::hash_map::DefaultHasher;
-    use std::hash::{Hash, Hasher};
-
-    let mut hasher = DefaultHasher::new();
-    request.hash(&mut hasher);
-    content.hash(&mut hasher);
-    hasher.finish()
 }
 
 impl Agent {

--- a/src/agent/loop_run/turn_helpers.rs
+++ b/src/agent/loop_run/turn_helpers.rs
@@ -1,0 +1,103 @@
+//! Small helpers + shared types extracted from `turn.rs` (parent
+//! #680).
+//!
+//! Hosts the free functions and shared types that lived at the
+//! module level (NOT `impl Agent`) of `turn.rs`:
+//!
+//! - `extract_filename_with_suffix` — pull a bare token ending in the
+//!   given suffix out of free-form text (tool-call argument /
+//!   feedback recovery heuristics).
+//! - `write_stdout_rendered` — `io::stdout().lock()` + `raw_mode_safe_text`
+//!   write helper used by iteration status / format-iteration-status
+//!   surfaces.
+//! - `tool_result_failed` — predicate: `Error:` prefix or
+//!   `interrupted=true` marker.
+//! - `quality_confirm_cache_key` — Issue #580 SSoT memoization hash
+//!   key for the Quality-gate second-pass adapter.
+//! - `RetrievalInjection` — Issue #555 photon retrieval message +
+//!   selected-id pair (used by `anti_pattern_flow` / `case_record_flow`
+//!   / `build_request_messages`).
+//! - `WrittenScaffoldArtifacts` — type alias for the deterministic
+//!   scaffold installer return value.
+//!
+//! `pub(super)` limited / no facade re-export (DR3-001).
+
+use std::io::{self, Write};
+use std::path::PathBuf;
+
+use super::small_helpers::raw_mode_safe_text;
+use crate::session::store::{ConversationMessage, ScaffoldArtifactFileSnapshot};
+
+pub(super) fn extract_filename_with_suffix(text: &str, suffix: &str) -> Option<String> {
+    text.split(|ch: char| {
+        ch.is_whitespace()
+            || matches!(
+                ch,
+                '`' | '"'
+                    | '\''
+                    | '('
+                    | ')'
+                    | '['
+                    | ']'
+                    | '{'
+                    | '}'
+                    | '、'
+                    | '。'
+                    | '，'
+                    | '：'
+                    | ':'
+                    | ';'
+            )
+    })
+    .map(|token| token.trim_matches([',', '.', '。', '、']))
+    .find(|token| {
+        token.ends_with(suffix)
+            && token.len() <= 80
+            && !token.contains('/')
+            && !token.contains('\\')
+            && !token.starts_with('.')
+            && token
+                .chars()
+                .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.'))
+    })
+    .map(ToString::to_string)
+}
+
+pub(super) fn write_stdout_rendered(text: &str, trailing_newline: bool) {
+    let mut out = io::stdout().lock();
+    let rendered = raw_mode_safe_text(text);
+    let _ = out.write_all(rendered.as_bytes());
+    if trailing_newline {
+        let _ = out.write_all(b"\r\n");
+    }
+    let _ = out.flush();
+}
+
+pub(super) fn tool_result_failed(result: &str) -> bool {
+    result.starts_with("Error:") || result.contains("\ninterrupted=true\n")
+}
+
+/// Issue #555: carries a retrieval message and the IDs of the
+/// selected records so the photon mapper can include them without
+/// re-parsing the rendered prompt text.
+pub(super) struct RetrievalInjection {
+    pub message: ConversationMessage,
+    pub selected_ids: Vec<String>,
+}
+
+pub(super) type WrittenScaffoldArtifacts = (Vec<PathBuf>, Vec<ScaffoldArtifactFileSnapshot>);
+
+/// Issue #580: SSoT memoization key for the Quality-gate second-pass
+/// adapter. Hashes `(request, full_content)` with `DefaultHasher` (per
+/// design judgement #5: full_content avoids stale reuse when only the
+/// middle of a large file changes — the LLM still sees only the
+/// head+tail excerpt).
+pub(super) fn quality_confirm_cache_key(request: &str, content: &str) -> u64 {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+
+    let mut hasher = DefaultHasher::new();
+    request.hash(&mut hasher);
+    content.hash(&mut hasher);
+    hasher.finish()
+}

--- a/src/agent/loop_run/verifier_orchestration.rs
+++ b/src/agent/loop_run/verifier_orchestration.rs
@@ -2444,7 +2444,7 @@ pub(super) fn handle_task_contract_verifier_no_verifier(
     *args.repo_change_retries = 0;
     *args.verifier_repair_retries = 0;
     agent.repair_job_artifact_attempts = 0;
-    super::turn::write_stdout_rendered(
+    super::turn_helpers::write_stdout_rendered(
         &super::actor_loop_flow::format_iteration_status(
             args.last_iter,
             agent.config.max_iterations,
@@ -2551,7 +2551,7 @@ pub(super) fn drive_task_contract_verifier(
         args.accumulated,
         &current_verif,
     );
-    super::turn::write_stdout_rendered(
+    super::turn_helpers::write_stdout_rendered(
         &super::actor_loop_flow::format_iteration_status(
             args.last_iter,
             agent.config.max_iterations,
@@ -2816,7 +2816,7 @@ pub(super) fn handle_task_contract_verifier_failure(
     *args.repo_change_retries = 0;
     *args.verifier_repair_retries = 0;
     agent.repair_job_artifact_attempts = 0;
-    super::turn::write_stdout_rendered(
+    super::turn_helpers::write_stdout_rendered(
         &super::actor_loop_flow::format_iteration_status(
             args.last_iter,
             agent.config.max_iterations,


### PR DESCRIPTION
## Summary

Continue the meta-issue #680 split: move the module-level free
functions and shared types out of \`turn.rs\` into a focused sibling
module so \`turn.rs\` keeps shrinking toward responsibility-focused
units.

Four free fns + one struct + one type alias were extracted:

- \`extract_filename_with_suffix\`
- \`write_stdout_rendered\`
- \`tool_result_failed\`
- \`quality_confirm_cache_key\` (Issue #580)
- \`RetrievalInjection\` (Issue #555)
- \`WrittenScaffoldArtifacts\` (type alias)

Behavior unchanged: byte-for-byte identical function bodies, same
field shapes for the struct and alias.

\`pub(super)\` limited / no facade re-export (DR3-001). Callers updated
in 11 sibling modules (~30 import / call sites).

### LOC delta

- \`turn.rs\`: 175 → 99 (-76)
- new module: +103

Cumulative \`turn.rs\` reduction across the parent #680 split:
39,489 → 99 (-99.75%). Crosses below 100 LOC.

## Test plan

- [x] \`cargo build --lib\`
- [x] \`cargo fmt\`
- [x] \`cargo clippy --lib --all-targets -- -D warnings\`
- [x] \`cargo test --lib\` (3,114 passed, 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)