### PR TITLE
Extract turn_constants.rs from turn.rs (parent #680)

### DIFF
--- a/src/agent/loop_run.rs
+++ b/src/agent/loop_run.rs
@@ -381,6 +381,12 @@ mod turn_helpers;
 // Consumed only by `reply_retry`. `pub(super)` limited / no facade
 // re-export (DR3-001).
 mod reply_retry_types;
+// Module-level constants extracted from `turn.rs` (parent #680). Hosts
+// `LOG_ARGS_MAX_CHARS`, `PLAN_REPEATED_EXPLORATION_BLOCK_THRESHOLD`,
+// `TASK_CONTRACT_VERIFIER_ATTEMPT_LIMIT`,
+// `TASK_CONTRACT_VERIFIER_REPAIR_ATTEMPT_LIMIT`, `USER_INTERRUPT_ERROR`.
+// `pub(super)` limited / no facade re-export (DR3-001).
+mod turn_constants;
 // Issue #652: `ArtifactCompletionJob` + role-specific retry budget +
 // `ArtifactAttemptOutcome` 4-variant taxonomy +
 // `ArtifactCompletionFailureSnapshot` for #654. Module is intentionally

--- a/src/agent/loop_run/actor_loop_flow.rs
+++ b/src/agent/loop_run/actor_loop_flow.rs
@@ -73,7 +73,7 @@ use super::tool_display::tool_display;
 use super::tool_history::focused_edit_target_already_read;
 use super::tool_history::is_plan_file_tool_call;
 use super::tool_policy::EffectiveToolPolicy;
-use super::turn::{LOG_ARGS_MAX_CHARS, PLAN_REPEATED_EXPLORATION_BLOCK_THRESHOLD};
+use super::turn_constants::{LOG_ARGS_MAX_CHARS, PLAN_REPEATED_EXPLORATION_BLOCK_THRESHOLD};
 use super::turn_helpers::write_stdout_rendered;
 use crate::agent::prompting;
 use crate::session::compact::approximate_token_count;
@@ -768,14 +768,14 @@ pub(super) fn actor_loop_pre_reply_request_error(
     agent: &mut Agent,
     err: String,
 ) -> ActorLoopPreReplyOutcome {
-    let reason = if err == super::turn::USER_INTERRUPT_ERROR {
+    let reason = if err == super::turn_constants::USER_INTERRUPT_ERROR {
         ExitReason::Interrupted
     } else if super::lifecycle::is_tool_call_format_error(&err) {
         ExitReason::ToolCallFormatError
     } else {
         ExitReason::TransportError
     };
-    if err != super::turn::USER_INTERRUPT_ERROR
+    if err != super::turn_constants::USER_INTERRUPT_ERROR
         && (super::lifecycle::is_native_tool_parser_failure(&err)
             || super::lifecycle::is_tool_call_format_error(&err)
             || super::lifecycle::is_native_tool_transport_failure(&err))
@@ -2367,7 +2367,9 @@ pub(super) fn handle_actor_loop_task_contract_repair_artifact(
 ) -> ActorLoopTaskContractReplyOutcome {
     agent.repair_job_artifact_attempts = agent.repair_job_artifact_attempts.saturating_add(1);
     *verifier_repair_retries = agent.repair_job_artifact_attempts;
-    if agent.repair_job_artifact_attempts >= super::turn::TASK_CONTRACT_VERIFIER_ATTEMPT_LIMIT {
+    if agent.repair_job_artifact_attempts
+        >= super::turn_constants::TASK_CONTRACT_VERIFIER_ATTEMPT_LIMIT
+    {
         let role = agent
             .current_artifact_recovery_target
             .as_ref()
@@ -2412,7 +2414,7 @@ pub(super) fn handle_actor_loop_task_contract_repair_artifact(
     {
         agent.push_system_note(task_contract_verifier_edit_required_note(
             *verifier_repair_retries,
-            super::turn::TASK_CONTRACT_VERIFIER_ATTEMPT_LIMIT,
+            super::turn_constants::TASK_CONTRACT_VERIFIER_ATTEMPT_LIMIT,
         ));
     }
     ActorLoopTaskContractReplyOutcome::Continue

--- a/src/agent/loop_run/progress_tests.rs
+++ b/src/agent/loop_run/progress_tests.rs
@@ -13,7 +13,6 @@
 // Bring sibling modules + Agent (loop_run scope) and turn.rs pub(super) items
 // into this file's scope so `super::X` from the inner mod resolves the same
 // names that `turn.rs`'s scope would.
-use super::turn::*;
 use super::*;
 // Additional explicit imports that turn.rs's `use super::*` chain previously
 // supplied but are needed directly by test bodies (qualified `super::X`).
@@ -10818,13 +10817,16 @@ export default function App() {
         // SSOT value sanity-check (mirrors the prod constant; if this
         // breaks, the constant moved and the regression note in
         // `run_turn` needs updating).
-        assert_eq!(super::TASK_CONTRACT_VERIFIER_ATTEMPT_LIMIT, 3);
+        assert_eq!(
+            super::super::turn_constants::TASK_CONTRACT_VERIFIER_ATTEMPT_LIMIT,
+            3
+        );
 
         // Simulate the run_turn counter loop semantics: increment and
         // compare against the SSOT bound. The loop in production breaks
         // with `ExitReason::MissingRepoEdits` as soon as the counter
         // reaches the limit.
-        let limit = super::TASK_CONTRACT_VERIFIER_ATTEMPT_LIMIT;
+        let limit = super::super::turn_constants::TASK_CONTRACT_VERIFIER_ATTEMPT_LIMIT;
         let mut attempts: usize = 0;
         let mut hit_exhaustion = false;
         for _ in 0..(limit + 1) {
@@ -10881,7 +10883,7 @@ export default function App() {
         let next = agent.repair_job_artifact_attempts.saturating_add(1);
         assert_eq!(next, 1, "next RepairArtifact attempt starts at 1, not 3");
         assert!(
-            next < super::TASK_CONTRACT_VERIFIER_ATTEMPT_LIMIT,
+            next < super::super::turn_constants::TASK_CONTRACT_VERIFIER_ATTEMPT_LIMIT,
             "fresh repair cycle must not immediately trip the attempt limit"
         );
     }

--- a/src/agent/loop_run/recovery_targets.rs
+++ b/src/agent/loop_run/recovery_targets.rs
@@ -31,7 +31,7 @@ use super::Agent;
 use super::read_target_helpers::{last_read_tool_path, latest_turn_preferred_read_edit_target};
 use super::tool_display::progress_path_display;
 use super::tool_history::{focused_edit_target_already_read, has_successful_non_plan_repo_edit};
-use super::turn::TASK_CONTRACT_VERIFIER_ATTEMPT_LIMIT;
+use super::turn_constants::TASK_CONTRACT_VERIFIER_ATTEMPT_LIMIT;
 use super::verifier_orchestration::{
     task_contract_verifier_targeted_edit_required_note, verifier_repair_diagnostic_pending_note,
     verifier_repair_target_display,

--- a/src/agent/loop_run/reply_retry.rs
+++ b/src/agent/loop_run/reply_retry.rs
@@ -47,7 +47,7 @@ use super::reply_retry_types::{AssistantReplyRetryDecision, AssistantReplyRetryS
 use super::spinner::{Spinner, SpinnerStopSignal};
 use super::tool_display::progress_path_display;
 use super::tool_history::successful_non_plan_repo_edit_count;
-use super::turn::USER_INTERRUPT_ERROR;
+use super::turn_constants::USER_INTERRUPT_ERROR;
 use crate::agent::prompting;
 use crate::agent::recovery;
 use crate::model_capabilities::model_capabilities;

--- a/src/agent/loop_run/streaming_reply.rs
+++ b/src/agent/loop_run/streaming_reply.rs
@@ -21,7 +21,7 @@
 
 use super::interrupt::InterruptFlag;
 use super::spinner::SpinnerStopSignal;
-use super::turn::USER_INTERRUPT_ERROR;
+use super::turn_constants::USER_INTERRUPT_ERROR;
 use super::turn_helpers::write_stdout_rendered;
 
 pub(super) struct StreamingReplyRenderState {

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -3,17 +3,6 @@ use super::*;
 
 use super::quality::repo_change_request_text;
 
-/// Maximum number of characters of tool-call arguments retained in trace logs.
-pub(super) const LOG_ARGS_MAX_CHARS: usize = 200;
-
-// Issue #634: SSOT for specialized-fallback ログ event 名。emit 側 / test 側の
-// 双方が参照し、typo による検証無効化を防ぐ。文字列値そのものは既存テスト互換の
-// ため不変。`EVENT_DETERMINISTIC_PYTHON_TEST_FALLBACK` は本 Issue で新規追加。
-pub(super) const PLAN_REPEATED_EXPLORATION_BLOCK_THRESHOLD: usize = 2;
-pub(super) const TASK_CONTRACT_VERIFIER_ATTEMPT_LIMIT: usize = 3;
-pub(super) const TASK_CONTRACT_VERIFIER_REPAIR_ATTEMPT_LIMIT: usize = 6;
-pub(super) const USER_INTERRUPT_ERROR: &str = "__anvil_user_interrupt__";
-
 impl Agent {
     /// Issue #646: build the active `TaskWorkspaceScope` for the current
     /// task. Pure projection of `work_root` + the active user request; no

--- a/src/agent/loop_run/turn_constants.rs
+++ b/src/agent/loop_run/turn_constants.rs
@@ -1,0 +1,32 @@
+//! Module-level constants extracted from `turn.rs` (parent #680).
+//!
+//! Hosts the five shared `pub(super) const` items that other
+//! `loop_run` siblings reference for retry budgets, log truncation
+//! caps, and sentinel error strings:
+//!
+//! - `LOG_ARGS_MAX_CHARS` — maximum number of characters of
+//!   tool-call arguments retained in trace logs.
+//! - `PLAN_REPEATED_EXPLORATION_BLOCK_THRESHOLD` — the
+//!   `actor_loop_flow` plan-mode repeated-exploration detector
+//!   threshold.
+//! - `TASK_CONTRACT_VERIFIER_ATTEMPT_LIMIT` — task-contract verifier
+//!   diagnostic attempt budget.
+//! - `TASK_CONTRACT_VERIFIER_REPAIR_ATTEMPT_LIMIT` — task-contract
+//!   verifier repair attempt budget.
+//! - `USER_INTERRUPT_ERROR` — sentinel error string emitted on user
+//!   interrupt; routed through the retry / streaming paths as an
+//!   early-return marker.
+//!
+//! `pub(super)` limited / no facade re-export (DR3-001).
+
+/// Maximum number of characters of tool-call arguments retained in
+/// trace logs.
+pub(super) const LOG_ARGS_MAX_CHARS: usize = 200;
+
+// Issue #634: SSOT for specialized-fallback ログ event 名。emit 側 / test 側の
+// 双方が参照し、typo による検証無効化を防ぐ。文字列値そのものは既存テスト互換の
+// ため不変。`EVENT_DETERMINISTIC_PYTHON_TEST_FALLBACK` は本 Issue で新規追加。
+pub(super) const PLAN_REPEATED_EXPLORATION_BLOCK_THRESHOLD: usize = 2;
+pub(super) const TASK_CONTRACT_VERIFIER_ATTEMPT_LIMIT: usize = 3;
+pub(super) const TASK_CONTRACT_VERIFIER_REPAIR_ATTEMPT_LIMIT: usize = 6;
+pub(super) const USER_INTERRUPT_ERROR: &str = "__anvil_user_interrupt__";

--- a/src/agent/loop_run/verifier_orchestration.rs
+++ b/src/agent/loop_run/verifier_orchestration.rs
@@ -86,7 +86,7 @@ use super::task_contract::{
 use super::task_workspace_scope::TaskWorkspaceScope;
 use super::tool_history::focused_edit_target_already_read;
 use super::tool_policy::{EffectiveToolPolicy, EffectiveToolPolicyReason};
-use super::turn::{
+use super::turn_constants::{
     TASK_CONTRACT_VERIFIER_ATTEMPT_LIMIT, TASK_CONTRACT_VERIFIER_REPAIR_ATTEMPT_LIMIT,
 };
 use super::verifier_assessment_parser::{


### PR DESCRIPTION
## Summary

Continue the meta-issue #680 split: move the five module-level
\`pub(super) const\` items out of \`turn.rs\` into a focused sibling
module so \`turn.rs\` keeps shrinking toward responsibility-focused
units.

Five shared constants were extracted:

- \`LOG_ARGS_MAX_CHARS\` (= 200)
- \`PLAN_REPEATED_EXPLORATION_BLOCK_THRESHOLD\` (= 2)
- \`TASK_CONTRACT_VERIFIER_ATTEMPT_LIMIT\` (= 3)
- \`TASK_CONTRACT_VERIFIER_REPAIR_ATTEMPT_LIMIT\` (= 6)
- \`USER_INTERRUPT_ERROR\` (= \`"__anvil_user_interrupt__"\`)

Values byte-for-byte unchanged; only the namespace moved from
\`super::turn::X\` to \`super::turn_constants::X\`.

\`pub(super)\` limited / no facade re-export (DR3-001). Callers updated
in \`recovery_targets.rs\`, \`streaming_reply.rs\`, \`actor_loop_flow.rs\`,
\`reply_retry.rs\`, \`verifier_orchestration.rs\`, and \`progress_tests.rs\`
(import path swap, no behavioral change).

### LOC delta

- \`turn.rs\`: 68 → 57 (-11)
- new module: +32

Cumulative \`turn.rs\` reduction across the parent #680 split:
39,489 → 57 (-99.86%).

## Test plan

- [x] \`cargo build --lib\`
- [x] \`cargo fmt\`
- [x] \`cargo clippy --lib --all-targets -- -D warnings\`
- [x] \`cargo test --lib\` (3,114 passed, 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)