### PR TITLE
Extract message_push.rs from turn.rs (parent #680)

### DIFF
--- a/src/agent/loop_run.rs
+++ b/src/agent/loop_run.rs
@@ -387,6 +387,13 @@ mod reply_retry_types;
 // `TASK_CONTRACT_VERIFIER_REPAIR_ATTEMPT_LIMIT`, `USER_INTERRUPT_ERROR`.
 // `pub(super)` limited / no facade re-export (DR3-001).
 mod turn_constants;
+// Session message push helpers extracted from `turn.rs` (parent #680).
+// Hosts `push_system_note` (`prompting::should_skip_system_note`
+// dedup + ConversationMessage::system push) and `push_user_message`
+// (working_memory.set_active_task + ConversationMessage::user push).
+// Free fns over `&mut Agent`. `pub(super)` limited / no facade
+// re-export (DR3-001).
+mod message_push;
 // Issue #652: `ArtifactCompletionJob` + role-specific retry budget +
 // `ArtifactAttemptOutcome` 4-variant taxonomy +
 // `ArtifactCompletionFailureSnapshot` for #654. Module is intentionally

--- a/src/agent/loop_run/actor_loop_flow.rs
+++ b/src/agent/loop_run/actor_loop_flow.rs
@@ -472,7 +472,7 @@ pub(super) fn maybe_handle_answer_only_inadequate_recovery(
             ),
             true,
         );
-        agent.push_system_note(
+        super::message_push::push_system_note(agent,
             "[Answer-only Recovery] Answer the user's request now with concrete findings from the available context. Do not output a tool call, do not edit files, and do not ask the user to run anything."
                 .to_string(),
         );
@@ -549,12 +549,15 @@ pub(super) fn maybe_handle_repo_change_quality_gate_recovery(
         ),
         true,
     );
-    agent.push_system_note(recovery::repo_change_quality_gate_note(
-        &request,
-        &target_path,
-        &issue,
-        *args.repo_change_retries,
-    ));
+    super::message_push::push_system_note(
+        agent,
+        recovery::repo_change_quality_gate_note(
+            &request,
+            &target_path,
+            &issue,
+            *args.repo_change_retries,
+        ),
+    );
     Some(PostReplyRecoveryOutcome::Continue)
 }
 
@@ -593,9 +596,10 @@ pub(super) fn maybe_handle_repo_change_partial_progress_recovery(
         ),
         true,
     );
-    agent.push_system_note(recovery::repo_change_partial_progress_note(
-        *args.repo_change_retries,
-    ));
+    super::message_push::push_system_note(
+        agent,
+        recovery::repo_change_partial_progress_note(*args.repo_change_retries),
+    );
     Some(PostReplyRecoveryOutcome::Continue)
 }
 
@@ -644,7 +648,7 @@ pub(super) fn maybe_handle_python_test_artifact_recovery(
         ),
         true,
     );
-    agent.push_system_note(
+    super::message_push::push_system_note(agent,
         "[Python Test Policy] The user explicitly requested tests. Add a concrete Python test artifact now, such as test_*.py, *_test.py, or a clearly runnable self-test command. Keep the edit small and verify it if possible."
             .to_string(),
     );
@@ -695,7 +699,10 @@ pub(super) fn maybe_continue_missing_repo_framework_fallback(
         return false;
     }
     *args.framework_app_fallback_materialized = true;
-    agent.push_system_note(framework_app_fallback_continuation_note().to_string());
+    super::message_push::push_system_note(
+        agent,
+        framework_app_fallback_continuation_note().to_string(),
+    );
     true
 }
 
@@ -718,9 +725,10 @@ pub(super) fn maybe_continue_missing_repo_scaffold_fallback(
             if *args.repo_change_retries >= 3 {
                 return Some(missing_repo_edits_finalize_outcome());
             }
-            agent.push_system_note(recovery::repo_change_recovery_note(
-                *args.repo_change_retries,
-            ));
+            super::message_push::push_system_note(
+                agent,
+                recovery::repo_change_recovery_note(*args.repo_change_retries),
+            );
             Some(PostReplyRecoveryOutcome::Continue)
         }
         super::scaffold_pipeline::ScaffoldFallbackResult::NotApplicable => None,
@@ -737,11 +745,11 @@ pub(super) fn push_missing_repo_edit_retry_note(agent: &mut Agent, attempt: usiz
             target_already_read,
             attempt,
         );
-        agent.push_system_note(note);
+        super::message_push::push_system_note(agent, note);
         return;
     }
     if !super::artifact_completion_record::push_artifact_directed_recovery_note(agent, attempt) {
-        agent.push_system_note(recovery::repo_change_recovery_note(attempt));
+        super::message_push::push_system_note(agent, recovery::repo_change_recovery_note(attempt));
     }
 }
 
@@ -914,12 +922,15 @@ pub(super) fn handle_actor_loop_empty_reply(
             &missing_sections,
             *args.plan_progress_retries,
         );
-        agent.push_system_note(recovery::plan_progress_recovery_note(
-            current_stage,
-            &next_sections,
-            &missing_sections,
-            *args.plan_progress_retries,
-        ));
+        super::message_push::push_system_note(
+            agent,
+            recovery::plan_progress_recovery_note(
+                current_stage,
+                &next_sections,
+                &missing_sections,
+                *args.plan_progress_retries,
+            ),
+        );
         return ActorLoopNoToolReplyOutcome::Continue;
     }
 
@@ -940,10 +951,10 @@ pub(super) fn handle_actor_loop_empty_reply(
         ),
         true,
     );
-    agent.push_system_note(recovery::empty_response_recovery_note(
-        *args.empty_retries,
-        args.requires_action,
-    ));
+    super::message_push::push_system_note(
+        agent,
+        recovery::empty_response_recovery_note(*args.empty_retries, args.requires_action),
+    );
     ActorLoopNoToolReplyOutcome::Continue
 }
 
@@ -1018,11 +1029,14 @@ fn handle_plan_progress_prose_only_reply(
         &missing_sections,
         *args.plan_progress_retries,
     );
-    agent.push_system_note(recovery::plan_no_tool_recovery_note(
-        current_stage,
-        &next_sections,
-        *args.plan_progress_retries,
-    ));
+    super::message_push::push_system_note(
+        agent,
+        recovery::plan_no_tool_recovery_note(
+            current_stage,
+            &next_sections,
+            *args.plan_progress_retries,
+        ),
+    );
     ActorLoopNoToolReplyOutcome::Continue
 }
 
@@ -1054,7 +1068,7 @@ fn handle_generic_prose_only_retry(
         ),
         true,
     );
-    agent.push_system_note(recovery::no_tool_recovery_note(*no_tool_retries));
+    super::message_push::push_system_note(agent, recovery::no_tool_recovery_note(*no_tool_retries));
     ActorLoopNoToolReplyOutcome::Continue
 }
 
@@ -1119,7 +1133,10 @@ fn handle_empty_missing_repo_change_retry(
         agent,
         repo_change_retries,
     ) {
-        agent.push_system_note(recovery::repo_change_recovery_note(repo_change_retries));
+        super::message_push::push_system_note(
+            agent,
+            recovery::repo_change_recovery_note(repo_change_retries),
+        );
     }
     if super::artifact_completion_record::record_artifact_completion_attempt(
         agent,
@@ -1144,7 +1161,7 @@ fn handle_prose_only_missing_repo_change_retry(
             target_already_read,
             repo_change_retries,
         );
-        agent.push_system_note(note);
+        super::message_push::push_system_note(agent, note);
     } else if !super::artifact_completion_record::push_artifact_directed_recovery_note(
         agent,
         repo_change_retries,
@@ -1152,9 +1169,10 @@ fn handle_prose_only_missing_repo_change_retry(
         agent,
         repo_change_retries,
     ) {
-        agent.push_system_note(recovery::repo_change_no_tool_recovery_note(
-            repo_change_retries,
-        ));
+        super::message_push::push_system_note(
+            agent,
+            recovery::repo_change_no_tool_recovery_note(repo_change_retries),
+        );
     }
     if super::artifact_completion_record::record_artifact_completion_attempt(
         agent,
@@ -1217,7 +1235,10 @@ fn handle_actor_loop_missing_repo_change_retry_exhausted(
         )
     {
         *args.framework_app_fallback_materialized = true;
-        agent.push_system_note(framework_app_fallback_continuation_note().to_string());
+        super::message_push::push_system_note(
+            agent,
+            framework_app_fallback_continuation_note().to_string(),
+        );
         return ActorLoopNoToolReplyOutcome::Continue;
     }
     ActorLoopNoToolReplyOutcome::Exit {
@@ -1374,12 +1395,15 @@ pub(super) fn handle_actor_loop_completion(
                 &missing_sections,
                 *args.plan_progress_retries,
             );
-            agent.push_system_note(recovery::plan_progress_recovery_note(
-                current_stage,
-                &next_sections,
-                &missing_sections,
-                *args.plan_progress_retries,
-            ));
+            super::message_push::push_system_note(
+                agent,
+                recovery::plan_progress_recovery_note(
+                    current_stage,
+                    &next_sections,
+                    &missing_sections,
+                    *args.plan_progress_retries,
+                ),
+            );
             return ActorLoopCompletionOutcome::Continue;
         }
     }
@@ -1434,14 +1458,14 @@ fn record_actor_loop_post_tool_notes(
     logged_act_first_repo_edit: bool,
 ) {
     if emitted_bash_loop_note {
-        agent.push_system_note(recovery::install_loop_recovery_note());
+        super::message_push::push_system_note(agent, recovery::install_loop_recovery_note());
     } else if agent.session.mode_state.mode == super::ExecutionMode::Act
         && action_expectation == recovery::ActionExpectation::RepoChange
         && bash_only_tool_turn
         && repo_edit_calls_made_this_turn == 0
         && !logged_act_first_repo_edit
     {
-        agent.push_system_note(recovery::repo_change_after_setup_note());
+        super::message_push::push_system_note(agent, recovery::repo_change_after_setup_note());
     }
 }
 
@@ -1634,12 +1658,15 @@ fn handle_actor_loop_post_tool_repo_edit_quality_gate(
                     ),
                     true,
                 );
-                agent.push_system_note(recovery::repo_change_quality_gate_note(
-                    &request,
-                    &target_path,
-                    &issue,
-                    *repo_change_retries,
-                ));
+                super::message_push::push_system_note(
+                    agent,
+                    recovery::repo_change_quality_gate_note(
+                        &request,
+                        &target_path,
+                        &issue,
+                        *repo_change_retries,
+                    ),
+                );
                 ActorLoopPostToolFallbackOutcome::Proceed
             }
         }
@@ -1697,12 +1724,15 @@ fn handle_plan_file_edit_followup(
     if *args.plan_progress_retries >= 2 {
         return Some(handle_non_progress_plan_edit_fallback(agent));
     }
-    agent.push_system_note(recovery::plan_progress_recovery_note(
-        agent.session.mode_state.plan_stage,
-        &super::lifecycle::plan_next_stage_sections(&plan_contents),
-        &missing_after,
-        *args.plan_progress_retries,
-    ));
+    super::message_push::push_system_note(
+        agent,
+        recovery::plan_progress_recovery_note(
+            agent.session.mode_state.plan_stage,
+            &super::lifecycle::plan_next_stage_sections(&plan_contents),
+            &missing_after,
+            *args.plan_progress_retries,
+        ),
+    );
     Some(ActorLoopPlanToolFollowupOutcome::Proceed)
 }
 
@@ -1760,12 +1790,15 @@ fn handle_actor_loop_plan_exploration_only_turn(
                     &missing_sections,
                     *plan_progress_retries,
                 );
-                agent.push_system_note(recovery::plan_progress_recovery_note(
-                    current_stage,
-                    &next_sections,
-                    &missing_sections,
-                    *plan_progress_retries,
-                ));
+                super::message_push::push_system_note(
+                    agent,
+                    recovery::plan_progress_recovery_note(
+                        current_stage,
+                        &next_sections,
+                        &missing_sections,
+                        *plan_progress_retries,
+                    ),
+                );
             }
             Some(ActorLoopPlanToolFollowupOutcome::Proceed)
         }
@@ -2040,7 +2073,10 @@ pub(super) fn maybe_continue_actor_loop_framework_fallback(
         return false;
     }
     *args.framework_app_fallback_materialized = true;
-    agent.push_system_note(framework_app_fallback_continuation_note().to_string());
+    super::message_push::push_system_note(
+        agent,
+        framework_app_fallback_continuation_note().to_string(),
+    );
     true
 }
 
@@ -2190,7 +2226,7 @@ pub(super) fn handle_actor_loop_task_contract_continue_action(
             (*args.contract_completion_retries).saturating_add(1),
         );
         let scaffold_note = "[Task Contract] Deterministic fallback created framework scaffold files only. Treat them as bootstrap, edit them to satisfy the user's specific request, then update tests and docs before final response.";
-        agent.push_system_note(scaffold_note.to_string());
+        super::message_push::push_system_note(agent, scaffold_note.to_string());
         return ActorLoopTaskContractReplyOutcome::Continue;
     }
     handle_actor_loop_task_contract_incomplete_artifacts(
@@ -2280,7 +2316,7 @@ pub(super) fn handle_actor_loop_task_contract_tool_recovery(
             attempt_limit,
             args.target_hint.as_ref(),
         );
-        agent.push_system_note(note);
+        super::message_push::push_system_note(agent, note);
     }
     ActorLoopTaskContractReplyOutcome::Continue
 }
@@ -2356,7 +2392,7 @@ pub(super) fn handle_actor_loop_task_contract_incomplete_artifacts(
         attempt_limit,
         args.target_hint.as_ref(),
     );
-    agent.push_system_note(note);
+    super::message_push::push_system_note(agent, note);
     ActorLoopTaskContractReplyOutcome::Continue
 }
 
@@ -2412,10 +2448,13 @@ pub(super) fn handle_actor_loop_task_contract_repair_artifact(
             *verifier_repair_retries,
         )
     {
-        agent.push_system_note(task_contract_verifier_edit_required_note(
-            *verifier_repair_retries,
-            super::turn_constants::TASK_CONTRACT_VERIFIER_ATTEMPT_LIMIT,
-        ));
+        super::message_push::push_system_note(
+            agent,
+            task_contract_verifier_edit_required_note(
+                *verifier_repair_retries,
+                super::turn_constants::TASK_CONTRACT_VERIFIER_ATTEMPT_LIMIT,
+            ),
+        );
     }
     ActorLoopTaskContractReplyOutcome::Continue
 }
@@ -2535,12 +2574,15 @@ pub(super) fn handle_actor_loop_rejected_tool_batch(
             args.effective_tool_policy,
             *args.focused_policy_retries,
         );
-        agent.push_system_note(note);
+        super::message_push::push_system_note(agent, note);
     } else {
-        agent.push_system_note(format!(
-            "The previous tool call violated the current tool policy and was not executed. Emit exactly one allowed tool call now. tool_policy_retry_attempt={}",
-            *args.focused_policy_retries
-        ));
+        super::message_push::push_system_note(
+            agent,
+            format!(
+                "The previous tool call violated the current tool policy and was not executed. Emit exactly one allowed tool call now. tool_policy_retry_attempt={}",
+                *args.focused_policy_retries
+            ),
+        );
     }
     ActorLoopToolPreparationOutcome::Continue
 }
@@ -2634,10 +2676,13 @@ pub(super) fn maybe_handle_rejected_tool_batch_artifact(
         agent,
         artifact_attempt,
     ) {
-        agent.push_system_note(format!(
-            "[Artifact Completion] Previous tool call was rejected and was not executed. Missing role: {}. Emit exactly one allowed tool call on the current target path now. artifact_completion_attempt={artifact_attempt}/{attempt_limit}",
-            role.label()
-        ));
+        super::message_push::push_system_note(
+            agent,
+            format!(
+                "[Artifact Completion] Previous tool call was rejected and was not executed. Missing role: {}. Emit exactly one allowed tool call on the current target path now. artifact_completion_attempt={artifact_attempt}/{attempt_limit}",
+                role.label()
+            ),
+        );
     }
     Some(ActorLoopToolPreparationOutcome::Continue)
 }
@@ -2739,7 +2784,7 @@ pub(super) fn maybe_handle_answer_only_future_work_recovery(
             ),
             true,
         );
-        agent.push_system_note(
+        super::message_push::push_system_note(agent,
             "[Answer-only Recovery] Answer the user's request now using only the context already inspected. Do not announce the next action, do not use tools, do not edit files, and do not ask the user to run anything."
                 .to_string(),
         );

--- a/src/agent/loop_run/agent_misc.rs
+++ b/src/agent/loop_run/agent_misc.rs
@@ -83,11 +83,14 @@ pub(super) fn record_missing_verifier_setup_failure(
         ),
         true,
     );
-    agent.push_system_note(task_contract_no_verifier_note(
-        attempt,
-        attempt_limit,
-        agent.active_request_text().unwrap_or_default().as_str(),
-    ));
+    super::message_push::push_system_note(
+        agent,
+        task_contract_no_verifier_note(
+            attempt,
+            attempt_limit,
+            agent.active_request_text().unwrap_or_default().as_str(),
+        ),
+    );
     false
 }
 

--- a/src/agent/loop_run/artifact_completion_record.rs
+++ b/src/agent/loop_run/artifact_completion_record.rs
@@ -34,7 +34,7 @@ pub(super) fn push_artifact_directed_recovery_note(agent: &mut Agent, attempt: u
     };
     let note =
         recovery::artifact_directed_recovery_note(target.role.label(), &target.path, attempt);
-    agent.push_system_note(note);
+    super::message_push::push_system_note(agent, note);
     true
 }
 

--- a/src/agent/loop_run/artifact_recovery_flow.rs
+++ b/src/agent/loop_run/artifact_recovery_flow.rs
@@ -148,9 +148,12 @@ pub(super) fn maybe_emit_artifact_completion_failed_diagnostic(agent: &mut Agent
         .collect::<Vec<_>>()
         .join(", ");
     // Sink 1: system note — sanitized snapshot fields only.
-    agent.push_system_note(format!(
-        "[Artifact Completion Failed] Missing role: {role_label}. Expected target: {expected_target}. Recent actions: {actions_preview}. Retry budget exhausted."
-    ));
+    super::message_push::push_system_note(
+        agent,
+        format!(
+            "[Artifact Completion Failed] Missing role: {role_label}. Expected target: {expected_target}. Recent actions: {actions_preview}. Retry budget exhausted."
+        ),
+    );
     // Sink 2: working-memory error.
     agent.session.working_memory.note_error(format!(
         "artifact_completion_failed role={role_label} target={expected_target}"

--- a/src/agent/loop_run/commands.rs
+++ b/src/agent/loop_run/commands.rs
@@ -782,11 +782,14 @@ impl Agent {
             .mode_state
             .enter_plan(self.session_store.plan_dir(), task_profile)?;
         self.ensure_plan_file(&plan_path)?;
-        self.push_system_note(format!(
-            "[Plan Mode / {}] Explore with Read, Glob, and Grep. Write the plan to {}. Wait for /approve before making code changes.",
-            self.session.mode_state.task_profile.as_str(),
-            plan_path.display()
-        ));
+        super::message_push::push_system_note(
+            self,
+            format!(
+                "[Plan Mode / {}] Explore with Read, Glob, and Grep. Write the plan to {}. Wait for /approve before making code changes.",
+                self.session.mode_state.task_profile.as_str(),
+                plan_path.display()
+            ),
+        );
         self.footer.publish_flags(
             self.session.mode_state.mode,
             self.config.log_level,
@@ -817,11 +820,14 @@ impl Agent {
         }
         self.session.mode_state.approve();
         super::plan_mode_helpers::prune_plan_mode_messages(&mut self.session.messages);
-        self.push_system_note(format!(
-            "[Act Mode / {}] Execute the accepted plan in phases and keep the work aligned with its acceptance criteria and quality bar.\n\n{}",
-            self.session.mode_state.task_profile.as_str(),
-            lifecycle::plan_act_summary(&plan_contents)
-        ));
+        super::message_push::push_system_note(
+            self,
+            format!(
+                "[Act Mode / {}] Execute the accepted plan in phases and keep the work aligned with its acceptance criteria and quality bar.\n\n{}",
+                self.session.mode_state.task_profile.as_str(),
+                lifecycle::plan_act_summary(&plan_contents)
+            ),
+        );
         self.footer.publish_flags(
             self.session.mode_state.mode,
             self.config.log_level,

--- a/src/agent/loop_run/lifecycle.rs
+++ b/src/agent/loop_run/lifecycle.rs
@@ -95,16 +95,22 @@ impl Agent {
     pub(super) fn disable_native_tools_for_session(&mut self) {
         self.native_tools_enabled = false;
         self.session.native_tools_disabled = true;
-        self.push_system_note(prompting::ToolProtocol::TaggedXml.parser_downgrade_notice());
+        super::message_push::push_system_note(
+            self,
+            prompting::ToolProtocol::TaggedXml.parser_downgrade_notice(),
+        );
     }
 
     fn apply_scaffold_root(&mut self, new_root: PathBuf) {
         self.work_root = new_root.clone();
         self.session.active_root = Some(new_root.clone());
-        self.push_system_note(format!(
-            "[Workspace Root Updated] Continue work inside {} and use relative paths from there.",
-            new_root.display()
-        ));
+        super::message_push::push_system_note(
+            self,
+            format!(
+                "[Workspace Root Updated] Continue work inside {} and use relative paths from there.",
+                new_root.display()
+            ),
+        );
     }
 }
 

--- a/src/agent/loop_run/message_push.rs
+++ b/src/agent/loop_run/message_push.rs
@@ -1,0 +1,44 @@
+//! Session message push helpers extracted from `turn.rs` (parent
+//! #680).
+//!
+//! Hosts the two `pub(super)` mutators that append messages to
+//! `Agent.session.messages`:
+//!
+//! - `push_system_note` — pushes a `ConversationMessage::system`
+//!   note after the `prompting::should_skip_system_note` dedup
+//!   filter (DR4-002: redactors and other note-stacking filters
+//!   live one layer up at the prompt builder level).
+//! - `push_user_message` — pushes a `ConversationMessage::user`
+//!   message and also sets it as the active task in the working
+//!   memory (so downstream classifiers / scope detectors see the
+//!   fresh task even before the next turn starts).
+//!
+//! Originally `impl Agent` methods; converted to free functions taking
+//! `&mut Agent`, matching the `actor_loop_flow` / `reply_retry` /
+//! earlier vertical-slice precedent. `pub(super)` limited / no facade
+//! re-export (DR3-001).
+
+use super::Agent;
+use crate::agent::prompting;
+use crate::session::store::ConversationMessage;
+
+pub(super) fn push_system_note(agent: &mut Agent, note: String) {
+    if prompting::should_skip_system_note(&agent.session.messages, &note) {
+        return;
+    }
+    agent
+        .session
+        .messages
+        .push(ConversationMessage::system(note));
+}
+
+pub(super) fn push_user_message(agent: &mut Agent, content: String) {
+    agent
+        .session
+        .working_memory
+        .set_active_task(Some(content.clone()));
+    agent
+        .session
+        .messages
+        .push(ConversationMessage::user(content));
+}

--- a/src/agent/loop_run/recovery_messages.rs
+++ b/src/agent/loop_run/recovery_messages.rs
@@ -219,7 +219,10 @@ pub(super) fn push_deterministic_ui_recovery_continuation_note(
     target_path: &str,
     attempt: usize,
 ) {
-    agent.push_system_note(format!(
-        "Deterministic UI recovery updated {target_path}, but this is recovery context, not completion. Inspect the file if needed, then make one small model-produced Edit or run the project verifier before finalizing. deterministic_ui_recovery_attempt={attempt}"
-    ));
+    super::message_push::push_system_note(
+        agent,
+        format!(
+            "Deterministic UI recovery updated {target_path}, but this is recovery context, not completion. Inspect the file if needed, then make one small model-produced Edit or run the project verifier before finalizing. deterministic_ui_recovery_attempt={attempt}"
+        ),
+    );
 }

--- a/src/agent/loop_run/recovery_targets.rs
+++ b/src/agent/loop_run/recovery_targets.rs
@@ -90,7 +90,7 @@ pub(super) fn push_repo_change_no_edit_recovery_note(agent: &mut Agent, attempt:
     } else {
         recovery::repo_change_after_read_no_edit_note(&target_display, attempt)
     };
-    agent.push_system_note(note);
+    super::message_push::push_system_note(agent, note);
     true
 }
 
@@ -110,7 +110,7 @@ pub(super) fn push_verifier_repair_recovery_note(agent: &mut Agent, attempt: usi
                 super::required_behavior::project_behavior_contract(&task_contract);
             let note =
                 verifier_repair_diagnostic_pending_note(context, behavior_projection.as_ref());
-            agent.push_system_note(note);
+            super::message_push::push_system_note(agent, note);
             true
         }
         super::repair_job::RepairNextAction::RequestPatch { target_hint } => {
@@ -122,23 +122,26 @@ pub(super) fn push_verifier_repair_recovery_note(agent: &mut Agent, attempt: usi
             let target = std::fs::canonicalize(&target).unwrap_or(target);
             if !target.is_file() {
                 let target_display = verifier_repair_target_display(&target, &agent.work_root);
-                agent.push_system_note(recovery::focused_edit_missing_target_recovery_note(
-                    &target_display,
-                    attempt,
-                ));
+                super::message_push::push_system_note(
+                    agent,
+                    recovery::focused_edit_missing_target_recovery_note(&target_display, attempt),
+                );
                 return true;
             }
-            agent.push_system_note(task_contract_verifier_targeted_edit_required_note(
-                context,
-                &agent.work_root,
-                focused_edit_target_already_read(
-                    &agent.session.messages,
-                    &target,
+            super::message_push::push_system_note(
+                agent,
+                task_contract_verifier_targeted_edit_required_note(
+                    context,
                     &agent.work_root,
+                    focused_edit_target_already_read(
+                        &agent.session.messages,
+                        &target,
+                        &agent.work_root,
+                    ),
+                    attempt,
+                    TASK_CONTRACT_VERIFIER_ATTEMPT_LIMIT,
                 ),
-                attempt,
-                TASK_CONTRACT_VERIFIER_ATTEMPT_LIMIT,
-            ));
+            );
             true
         }
         super::repair_job::RepairNextAction::RerunVerifier

--- a/src/agent/loop_run/repair_job_dispatch.rs
+++ b/src/agent/loop_run/repair_job_dispatch.rs
@@ -167,13 +167,16 @@ fn handle_repair_job_verifier_failure(
         ),
         true,
     );
-    agent.push_system_note(task_contract_verifier_repair_note(
-        &command,
-        &output,
-        *args.contract_verification_retries,
-        attempt_limit,
-        agent.repair_job.as_ref(),
-    ));
+    super::message_push::push_system_note(
+        agent,
+        task_contract_verifier_repair_note(
+            &command,
+            &output,
+            *args.contract_verification_retries,
+            attempt_limit,
+            agent.repair_job.as_ref(),
+        ),
+    );
     TaskContractVerifierFlowOutcome::Continue
 }
 

--- a/src/agent/loop_run/reply_retry.rs
+++ b/src/agent/loop_run/reply_retry.rs
@@ -197,30 +197,39 @@ fn push_tool_call_format_retry_note(agent: &mut Agent, err: &str, retry_count: u
             120,
         );
         if !target.is_file() {
-            agent.push_system_note(recovery::focused_edit_missing_target_recovery_note(
-                &target_display,
-                retry_count,
-            ));
+            super::message_push::push_system_note(
+                agent,
+                recovery::focused_edit_missing_target_recovery_note(&target_display, retry_count),
+            );
             return;
         }
         if lower_err.contains("truncated tool call") {
-            agent.push_system_note(recovery::focused_edit_truncated_tool_call_note(
-                &target_display,
-                target_already_read,
-                retry_count,
-            ));
+            super::message_push::push_system_note(
+                agent,
+                recovery::focused_edit_truncated_tool_call_note(
+                    &target_display,
+                    target_already_read,
+                    retry_count,
+                ),
+            );
             return;
         }
         if lower_err.contains("unterminated <anvil_tool_call> block") {
-            agent.push_system_note(recovery::focused_edit_unterminated_tool_call_note(
-                &target_display,
-                target_already_read,
-                retry_count,
-            ));
+            super::message_push::push_system_note(
+                agent,
+                recovery::focused_edit_unterminated_tool_call_note(
+                    &target_display,
+                    target_already_read,
+                    retry_count,
+                ),
+            );
             return;
         }
     }
-    agent.push_system_note(recovery::tool_call_format_recovery_note(err, retry_count));
+    super::message_push::push_system_note(
+        agent,
+        recovery::tool_call_format_recovery_note(err, retry_count),
+    );
 }
 
 fn maybe_handle_assistant_reply_timeout_error(
@@ -264,16 +273,19 @@ fn maybe_handle_assistant_reply_timeout_error(
         if retry_state.focused_edit_timeout_retry_count >= 2 {
             return Some(AssistantReplyRetryDecision::Fail(err.to_string()));
         }
-        agent.push_system_note(recovery::focused_edit_timeout_recovery_note(
-            &progress_path_display(
-                &policy.target.display().to_string(),
-                &agent.work_root,
-                agent.session.mode_state.active_plan_path.as_deref(),
-                120,
+        super::message_push::push_system_note(
+            agent,
+            recovery::focused_edit_timeout_recovery_note(
+                &progress_path_display(
+                    &policy.target.display().to_string(),
+                    &agent.work_root,
+                    agent.session.mode_state.active_plan_path.as_deref(),
+                    120,
+                ),
+                policy.target_already_read,
+                retry_state.focused_edit_timeout_retry_count,
             ),
-            policy.target_already_read,
-            retry_state.focused_edit_timeout_retry_count,
-        ));
+        );
         return Some(AssistantReplyRetryDecision::Retry);
     }
     None

--- a/src/agent/loop_run/run_turn.rs
+++ b/src/agent/loop_run/run_turn.rs
@@ -27,7 +27,7 @@ pub(super) fn run_turn(
     stream_output: bool,
     monitor: &mut InterruptMonitor,
 ) -> LoopResult {
-    agent.push_user_message(input.to_string());
+    super::message_push::push_user_message(agent, input.to_string());
     if agent.session.mode_state.mode != ExecutionMode::Plan {
         // Issue #576: replace direct `classify_work_mode_json` + event
         // emit with the shared `classify_with_confirmation` wrapper. The

--- a/src/agent/loop_run/scaffold_pipeline.rs
+++ b/src/agent/loop_run/scaffold_pipeline.rs
@@ -877,10 +877,10 @@ pub(super) fn finalize_deterministic_scaffold_materialization(
         ),
         Vec::new(),
     ));
-    agent.push_system_note(render_deterministic_scaffold_continuation_note(
-        request,
-        &written_paths,
-    ));
+    super::message_push::push_system_note(
+        agent,
+        render_deterministic_scaffold_continuation_note(request, &written_paths),
+    );
 }
 
 pub(super) fn maybe_apply_deterministic_nextjs_scaffold(
@@ -1707,9 +1707,10 @@ pub(super) fn maybe_fallback_plan_model_after_timeout(agent: &mut Agent, err: &s
     }
 
     agent.plan_model_override = Some(sidecar.clone());
-    agent.push_system_note(format!(
-        "Main planning model timed out. Retry the plan step with sidecar model {sidecar}."
-    ));
+    super::message_push::push_system_note(
+        agent,
+        format!("Main planning model timed out. Retry the plan step with sidecar model {sidecar}."),
+    );
     true
 }
 

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -36,22 +36,4 @@ impl Agent {
             &self.session.messages,
         )
     }
-
-    pub(super) fn push_system_note(&mut self, note: String) {
-        if prompting::should_skip_system_note(&self.session.messages, &note) {
-            return;
-        }
-        self.session
-            .messages
-            .push(ConversationMessage::system(note));
-    }
-
-    pub(super) fn push_user_message(&mut self, content: String) {
-        self.session
-            .working_memory
-            .set_active_task(Some(content.clone()));
-        self.session
-            .messages
-            .push(ConversationMessage::user(content));
-    }
 }

--- a/src/agent/loop_run/verifier_orchestration.rs
+++ b/src/agent/loop_run/verifier_orchestration.rs
@@ -2459,11 +2459,14 @@ pub(super) fn handle_task_contract_verifier_no_verifier(
         .as_ref()
         .map(|job| job.retries_used as usize)
         .unwrap_or(0);
-    agent.push_system_note(task_contract_no_verifier_note(
-        job_attempt,
-        TASK_CONTRACT_VERIFIER_ATTEMPT_LIMIT,
-        agent.active_request_text().unwrap_or_default().as_str(),
-    ));
+    super::message_push::push_system_note(
+        agent,
+        task_contract_no_verifier_note(
+            job_attempt,
+            TASK_CONTRACT_VERIFIER_ATTEMPT_LIMIT,
+            agent.active_request_text().unwrap_or_default().as_str(),
+        ),
+    );
     super::actor_loop_flow::TaskContractVerifierFlowOutcome::Continue
 }
 
@@ -2826,13 +2829,16 @@ pub(super) fn handle_task_contract_verifier_failure(
         ),
         true,
     );
-    agent.push_system_note(task_contract_verifier_repair_note(
-        &command,
-        &output,
-        *args.contract_verification_retries,
-        attempt_limit,
-        agent.repair_job.as_ref(),
-    ));
+    super::message_push::push_system_note(
+        agent,
+        task_contract_verifier_repair_note(
+            &command,
+            &output,
+            *args.contract_verification_retries,
+            attempt_limit,
+            agent.repair_job.as_ref(),
+        ),
+    );
     super::actor_loop_flow::TaskContractVerifierFlowOutcome::Continue
 }
 


### PR DESCRIPTION
## Summary

Continue the meta-issue #680 split: move the two session message push
mutators out of \`turn.rs\` into a focused sibling module so \`turn.rs\`
keeps shrinking toward responsibility-focused units.

Two production helpers were extracted as free functions taking
\`&mut Agent\` (matching \`actor_loop_flow\` / \`reply_retry\` / earlier
vertical-slice precedent):

- \`push_system_note\` (\`prompting::should_skip_system_note\` dedup +
  \`ConversationMessage::system\` push)
- \`push_user_message\` (\`working_memory.set_active_task\` +
  \`ConversationMessage::user\` push)

Behavior unchanged: same dedup gate, same \`set_active_task\` order,
byte-for-byte identical push order.

\`pub(super)\` limited / no facade re-export (DR3-001). Callers updated
in 13 sibling modules (~53 \`push_system_note\` sites + 1
\`push_user_message\` site) to the free-fn form.

### LOC delta

- \`turn.rs\`: 57 → 39 (-18)
- new module: +44

Cumulative \`turn.rs\` reduction across the parent #680 split:
39,489 → 39 (-99.90%). Crosses below 40 LOC and over the -99.9%
milestone.

## Test plan

- [x] \`cargo build --lib\`
- [x] \`cargo fmt\`
- [x] \`cargo clippy --lib --all-targets -- -D warnings\`
- [x] \`cargo test --lib\` (3,114 passed, 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)