### PR TITLE
Extract workspace_access.rs from turn.rs (parent #680 — final extraction)

### DIFF
--- a/src/agent/loop_run.rs
+++ b/src/agent/loop_run.rs
@@ -3,6 +3,10 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use crate::agent::prompting;
+// Re-exposed for legacy `super::recovery::*` paths in `progress_tests.rs`
+// (parent #680: after `turn.rs` became empty, this import is no longer
+// referenced from within `loop_run` itself).
+#[allow(unused_imports)]
 use crate::agent::recovery;
 use crate::config::Config;
 use crate::format_model_banner;
@@ -394,6 +398,12 @@ mod turn_constants;
 // Free fns over `&mut Agent`. `pub(super)` limited / no facade
 // re-export (DR3-001).
 mod message_push;
+// Per-Agent workspace + active-request accessors extracted from
+// `turn.rs` (parent #680). Hosts `current_workspace_scope` (Issue
+// #646), `workspace_appears_empty`, `active_task_expects_repo_change`,
+// and `active_request_text`. Free fns over `&Agent`. `pub(super)`
+// limited / no facade re-export (DR3-001).
+mod workspace_access;
 // Issue #652: `ArtifactCompletionJob` + role-specific retry budget +
 // `ArtifactAttemptOutcome` 4-variant taxonomy +
 // `ArtifactCompletionFailureSnapshot` for #654. Module is intentionally
@@ -1467,7 +1477,7 @@ pub(crate) fn seed_artifact_ledger_repo_edit_for_test(agent: &mut Agent, path: S
         return;
     };
 
-    let scope = agent.current_workspace_scope();
+    let scope = workspace_access::current_workspace_scope(agent);
     crate::agent::loop_run::artifact_ledger_state::seed_artifact_ledger_repo_edit(
         agent, &path, role, &scope,
     );
@@ -1525,7 +1535,7 @@ pub(crate) fn seed_artifact_completion_job_pending_for_test(
         reason: "664 e2e seed".to_string(),
     };
 
-    let scope = agent.current_workspace_scope();
+    let scope = workspace_access::current_workspace_scope(agent);
     let work_root = agent.work_root.clone();
     if let Ok(job) = artifact_completion_job::ArtifactCompletionJob::new(
         &work_root, &scope, hint, true,  // edited_this_session
@@ -2553,8 +2563,7 @@ impl Agent {
         // `first_missing_required_role` is evidence-aware and not available
         // here, so we fall back to the first required role hint
         // (DR3-004 — same pattern as `refresh_artifact_completion_satisfied`).
-        let task_contract = self
-            .active_request_text()
+        let task_contract = workspace_access::active_request_text(self)
             .map(|text| task_contract::TaskContract::from_request(&text));
         let role_hint_from_contract = task_contract
             .as_ref()

--- a/src/agent/loop_run/actor_loop_flow.rs
+++ b/src/agent/loop_run/actor_loop_flow.rs
@@ -487,7 +487,7 @@ pub(super) fn maybe_handle_repo_change_quality_gate_recovery(
 ) -> Option<PostReplyRecoveryOutcome> {
     if !(should_apply_repo_change_quality_gate(
         args.action_expectation,
-        agent.active_task_expects_repo_change(),
+        super::workspace_access::active_task_expects_repo_change(agent),
         agent.session.mode_state.mode,
     ) || super::quality_gate::current_request_needs_playable_ui_quality_gate(agent))
         || !args.recovery_dispatch_gate.allows_deterministic_fallback()
@@ -1209,7 +1209,7 @@ fn handle_actor_loop_missing_repo_change_retry_exhausted(
         );
         return ActorLoopNoToolReplyOutcome::Continue;
     }
-    let request = agent.active_request_text().unwrap_or_default();
+    let request = super::workspace_access::active_request_text(agent).unwrap_or_default();
     let fallback = match super::scaffold_pipeline::maybe_apply_local_llm_small_edit_fallback(
         agent, &request,
     ) {
@@ -1603,7 +1603,7 @@ fn handle_actor_loop_post_tool_repo_edit_quality_gate(
         || !recovery_dispatch_gate.allows_deterministic_fallback()
         || !(should_apply_repo_change_quality_gate(
             action_expectation,
-            agent.active_task_expects_repo_change(),
+            super::workspace_access::active_task_expects_repo_change(agent),
             agent.session.mode_state.mode,
         ) || super::quality_gate::current_request_needs_playable_ui_quality_gate(agent))
     {
@@ -1828,7 +1828,7 @@ pub(super) fn drive_actor_loop_tool_preparation_phase(
         .is_some()
     {
         let batch_scope = if agent.missing_verifier_job.is_some() {
-            Some(agent.current_workspace_scope())
+            Some(super::workspace_access::current_workspace_scope(agent))
         } else {
             None
         };
@@ -2311,7 +2311,9 @@ pub(super) fn handle_actor_loop_task_contract_tool_recovery(
     ) {
         let note = super::task_contract::render_contract_recovery_note_with_hint(
             args.decision,
-            agent.active_request_text().as_deref().unwrap_or_default(),
+            super::workspace_access::active_request_text(agent)
+                .as_deref()
+                .unwrap_or_default(),
             artifact_attempt,
             attempt_limit,
             args.target_hint.as_ref(),
@@ -2387,7 +2389,9 @@ pub(super) fn handle_actor_loop_task_contract_incomplete_artifacts(
     );
     let note = super::task_contract::render_contract_recovery_note_with_hint(
         &args.decision,
-        agent.active_request_text().as_deref().unwrap_or_default(),
+        super::workspace_access::active_request_text(agent)
+            .as_deref()
+            .unwrap_or_default(),
         artifact_attempt,
         attempt_limit,
         args.target_hint.as_ref(),
@@ -2705,7 +2709,7 @@ pub(super) fn maybe_handle_rejected_tool_batch_focused_retry_exhausted(
                     .to_string(),
         });
     }
-    let request = agent.active_request_text().unwrap_or_default();
+    let request = super::workspace_access::active_request_text(agent).unwrap_or_default();
     let fallback = match super::scaffold_pipeline::maybe_apply_local_llm_small_edit_fallback(
         agent, &request,
     ) {
@@ -2861,7 +2865,7 @@ pub(super) fn repair_job_done_outcome() -> TaskContractVerifierFlowOutcome {
 pub(super) fn finalize_missing_repo_edit_retry_exhausted(
     agent: &mut Agent,
 ) -> PostReplyRecoveryOutcome {
-    let request = agent.active_request_text().unwrap_or_default();
+    let request = super::workspace_access::active_request_text(agent).unwrap_or_default();
     match super::scaffold_pipeline::maybe_apply_local_llm_small_edit_fallback(agent, &request) {
         Ok(Some(relative)) => PostReplyRecoveryOutcome::Finalize {
             final_prose: format!(

--- a/src/agent/loop_run/agent_misc.rs
+++ b/src/agent/loop_run/agent_misc.rs
@@ -36,7 +36,7 @@ pub(super) fn refresh_artifact_completion_satisfied(agent: &mut Agent) {
     if agent.artifact_completion_job.is_none() {
         return;
     }
-    let task_contract = match agent.active_request_text() {
+    let task_contract = match super::workspace_access::active_request_text(agent) {
         Some(req) => super::task_contract::TaskContract::from_request(&req),
         None => return,
     };
@@ -88,7 +88,9 @@ pub(super) fn record_missing_verifier_setup_failure(
         task_contract_no_verifier_note(
             attempt,
             attempt_limit,
-            agent.active_request_text().unwrap_or_default().as_str(),
+            super::workspace_access::active_request_text(agent)
+                .unwrap_or_default()
+                .as_str(),
         ),
     );
     false

--- a/src/agent/loop_run/artifact_recovery_flow.rs
+++ b/src/agent/loop_run/artifact_recovery_flow.rs
@@ -94,7 +94,7 @@ pub(super) fn maybe_install_artifact_completion_job_for_hint(
     // `current_artifact_recovery_target` so no stale projection
     // remains (signalled by `JobInstallOutcome::ValidationFailed`).
     agent.artifact_completion_job = None;
-    let scope = agent.current_workspace_scope();
+    let scope = super::workspace_access::current_workspace_scope(agent);
     match ArtifactCompletionJob::new(
         &agent.work_root,
         &scope,

--- a/src/agent/loop_run/artifact_state_projection.rs
+++ b/src/agent/loop_run/artifact_state_projection.rs
@@ -84,7 +84,7 @@ fn task_contract_artifact_states_legacy(
     agent: &mut Agent,
     contract: &super::task_contract::TaskContract,
 ) -> Vec<super::task_contract::ArtifactState> {
-    let scope = agent.current_workspace_scope();
+    let scope = super::workspace_access::current_workspace_scope(agent);
     let mut states = Vec::new();
     for role in &contract.required_artifacts {
         if let Some(path) =

--- a/src/agent/loop_run/build_request_messages.rs
+++ b/src/agent/loop_run/build_request_messages.rs
@@ -116,7 +116,9 @@ fn append_general_request_context_messages(
     agent: &mut Agent,
     messages: &mut Vec<ConversationMessage>,
 ) {
-    if agent.active_task_expects_repo_change() && agent.workspace_appears_empty() {
+    if super::workspace_access::active_task_expects_repo_change(agent)
+        && super::workspace_access::workspace_appears_empty(agent)
+    {
         if let Some(framework) =
             super::scaffold_pipeline::active_task_requested_scaffold_framework(agent)
         {

--- a/src/agent/loop_run/effective_tool_policy_flow.rs
+++ b/src/agent/loop_run/effective_tool_policy_flow.rs
@@ -43,7 +43,7 @@ pub(super) fn effective_tool_policy(agent: &Agent) -> EffectiveToolPolicy {
     // in §4 of the design policy). The arbiter never sees it; we early-
     // return before constructing any selectable `JobCandidate`.
     if super::tool_policy_decisions::answer_only_mode_active(agent) {
-        if agent.workspace_appears_empty() {
+        if super::workspace_access::workspace_appears_empty(agent) {
             return EffectiveToolPolicy::restricted(
                 EffectiveToolPolicyReason::AnswerOnly,
                 Vec::new(),
@@ -238,7 +238,7 @@ fn setup_bootstrap_candidate(agent: &Agent) -> Option<JobCandidate> {
     ) {
         return None;
     }
-    let request = agent.active_request_text()?;
+    let request = super::workspace_access::active_request_text(agent)?;
     let task_contract = super::task_contract::TaskContract::from_request(&request);
     let behavior_projection = super::required_behavior::project_behavior_contract(&task_contract);
     let verifier_signal = super::task_contract::VerifierPrerequisiteSignal::from_sources(

--- a/src/agent/loop_run/feedback_builders.rs
+++ b/src/agent/loop_run/feedback_builders.rs
@@ -216,7 +216,7 @@ pub(super) fn extract_path_tokens_from_text(text: &str, work_root: &Path) -> Vec
 pub(super) fn extract_current_request_paths(agent: &Agent, work_root: &Path) -> Vec<String> {
     let mut out = Vec::new();
 
-    if let Some(text) = agent.active_request_text() {
+    if let Some(text) = super::workspace_access::active_request_text(agent) {
         for p in extract_path_tokens_from_text(&text, work_root) {
             if !out.contains(&p) {
                 out.push(p);

--- a/src/agent/loop_run/owned_test_projection.rs
+++ b/src/agent/loop_run/owned_test_projection.rs
@@ -35,7 +35,7 @@ pub(super) fn owned_test_artifacts_for_verifier(
     agent: &mut Agent,
     contract: &super::task_contract::TaskContract,
 ) -> Vec<String> {
-    let scope = agent.current_workspace_scope();
+    let scope = super::workspace_access::current_workspace_scope(agent);
     // `task_contract_artifact_states` has the side effect of seeding the
     // ledger with Existing / Scaffold baseline events. We MUST call it
     // before reading the ledger projection so the Phase 3 path sees the

--- a/src/agent/loop_run/prepare_actor_loop_state.rs
+++ b/src/agent/loop_run/prepare_actor_loop_state.rs
@@ -69,7 +69,7 @@ pub(super) fn prepare_actor_loop_turn_state(agent: &mut Agent) -> Option<TaskCon
     // the current request key, then clear the per-turn flag.
     let promoted = match (
         agent.owned_test_verifier_missing_observed_carryover.take(),
-        agent.active_request_text(),
+        super::workspace_access::active_request_text(agent),
     ) {
         (Some(stored), Some(current)) => {
             let current_key = RequestCarryoverKey::from_request(&current);
@@ -119,8 +119,7 @@ pub(super) fn prepare_actor_loop_turn_state(agent: &mut Agent) -> Option<TaskCon
     // Issue #638 (Task 1.4): clear the turn-local failure snapshot at the
     // same boundary as `repair_job` (design policy §5, A-only).
     agent.repair_failure_snapshot = None;
-    let task_contract = agent
-        .active_request_text()
+    let task_contract = super::workspace_access::active_request_text(agent)
         .map(|request| TaskContract::from_request(&request));
     if agent.session.mode_state.mode != ExecutionMode::Plan
         && let Some(contract) = task_contract.as_ref()

--- a/src/agent/loop_run/python_request_helpers.rs
+++ b/src/agent/loop_run/python_request_helpers.rs
@@ -23,8 +23,7 @@ use crate::modes::plan_act::WorkMode;
 
 pub(super) fn active_python_request_requires_tests(agent: &Agent) -> bool {
     agent.session.mode_state.work_mode == WorkMode::Python
-        && agent
-            .active_request_text()
+        && super::workspace_access::active_request_text(agent)
             .as_deref()
             .is_some_and(request_explicitly_requires_tests)
 }

--- a/src/agent/loop_run/quality_gate.rs
+++ b/src/agent/loop_run/quality_gate.rs
@@ -40,8 +40,7 @@ pub(super) fn current_request_needs_playable_ui_quality_gate(agent: &Agent) -> b
     agent.session.mode_state.mode == ExecutionMode::Act
         && agent.session.mode_state.policy().quality_gate_enabled
         && !unsupported_ui_framework_context(agent)
-        && agent
-            .active_request_text()
+        && super::workspace_access::active_request_text(agent)
             .as_deref()
             .is_some_and(request_needs_playable_ui_quality_gate)
 }
@@ -55,7 +54,7 @@ pub(super) fn accepted_repo_change_quality_issue(
     if unsupported_ui_framework_context(agent) {
         return None;
     }
-    let request = agent.active_request_text()?;
+    let request = super::workspace_access::active_request_text(agent)?;
     let request = request.trim().to_string();
     if !request_needs_playable_ui_quality_gate(&request) {
         return None;
@@ -82,7 +81,7 @@ pub(super) fn accepted_repo_change_polish_target(agent: &mut Agent) -> Option<(S
     if unsupported_ui_framework_context(agent) {
         return None;
     }
-    let request = agent.active_request_text()?;
+    let request = super::workspace_access::active_request_text(agent)?;
     let request = request.trim().to_string();
     if !request_allows_fast_polish_fallback(&request) {
         return None;
@@ -110,8 +109,7 @@ pub(super) fn accepted_repo_change_polish_target(agent: &mut Agent) -> Option<(S
 }
 
 fn unsupported_ui_framework_context(agent: &Agent) -> bool {
-    agent
-        .active_request_text()
+    super::workspace_access::active_request_text(agent)
         .as_deref()
         .is_some_and(request_mentions_unsupported_ui_framework)
         || workspace_has_unsupported_ui_framework(&agent.work_root)

--- a/src/agent/loop_run/recovery_messages.rs
+++ b/src/agent/loop_run/recovery_messages.rs
@@ -149,16 +149,16 @@ pub(super) fn verifier_repair_policy_message(
                 super::repair_job::RepairNextAction::RerunVerifier
                 | super::repair_job::RepairNextAction::VerifiedDone,
             ) => verifier_repair_transition_message(),
-            None if agent.missing_verifier_job.is_some() => {
-                verifier_setup_policy_message(&agent.active_request_text().unwrap_or_default())
-            }
+            None if agent.missing_verifier_job.is_some() => verifier_setup_policy_message(
+                &super::workspace_access::active_request_text(agent).unwrap_or_default(),
+            ),
             None => verifier_repair_transition_message(),
         }
     })
 }
 
 fn verifier_repair_diagnostic_policy_message(agent: &Agent) -> String {
-    let active_request = agent.active_request_text().unwrap_or_default();
+    let active_request = super::workspace_access::active_request_text(agent).unwrap_or_default();
     let task_contract = super::task_contract::TaskContract::from_request(&active_request);
     let behavior_projection = super::required_behavior::project_behavior_contract(&task_contract);
     agent

--- a/src/agent/loop_run/recovery_targets.rs
+++ b/src/agent/loop_run/recovery_targets.rs
@@ -49,7 +49,7 @@ pub(super) fn focused_edit_recovery_target(agent: &Agent) -> Option<PathBuf> {
 fn repo_change_no_edit_recovery_target(agent: &Agent) -> Option<PathBuf> {
     if agent.session.mode_state.mode != ExecutionMode::Act
         || !agent.session.mode_state.policy().repo_edit_required
-        || !agent.active_task_expects_repo_change()
+        || !super::workspace_access::active_task_expects_repo_change(agent)
         || has_successful_non_plan_repo_edit(
             &agent.session.messages,
             &agent.work_root,
@@ -104,7 +104,8 @@ pub(super) fn push_verifier_repair_recovery_note(agent: &mut Agent, attempt: usi
             // Issue #665 Phase 5: caller-side projection (S5-005 では
             // raw label/excerpt は system note に出さないため helper
             // 内部で metadata のみに縮退する)。
-            let active_request = agent.active_request_text().unwrap_or_default();
+            let active_request =
+                super::workspace_access::active_request_text(agent).unwrap_or_default();
             let task_contract = super::task_contract::TaskContract::from_request(&active_request);
             let behavior_projection =
                 super::required_behavior::project_behavior_contract(&task_contract);

--- a/src/agent/loop_run/repo_edit_observation.rs
+++ b/src/agent/loop_run/repo_edit_observation.rs
@@ -112,7 +112,8 @@ pub(super) fn observe_evidence_from_repo_edit(agent: &mut Agent, path: &str) {
     // Issue #646 (A1/B2): once an in-scope edit has landed, the
     // MissingVerifierJob can begin retrying verifier creation.
     if agent.missing_verifier_job.is_some() {
-        let in_scope = agent.current_workspace_scope().contains(&relative_path);
+        let in_scope =
+            super::workspace_access::current_workspace_scope(agent).contains(&relative_path);
         if in_scope && let Some(job) = agent.missing_verifier_job.as_mut() {
             job.record_in_scope_edit();
         }
@@ -157,7 +158,7 @@ pub(super) fn observe_evidence_from_repo_edit(agent: &mut Agent, path: &str) {
     // mapping so the `Other` category (which legacy callers do not
     // classify into a role) does not inject an ambiguous event.
     if let Some(role) = super::task_contract::role_from_repo_edit(category) {
-        let scope = agent.current_workspace_scope();
+        let scope = super::workspace_access::current_workspace_scope(agent);
         super::artifact_ledger_state::seed_artifact_ledger_repo_edit(
             agent,
             &relative_path,

--- a/src/agent/loop_run/safe_stop_emit.rs
+++ b/src/agent/loop_run/safe_stop_emit.rs
@@ -69,7 +69,7 @@ pub(super) fn resolve_current_role_for_safe_stop(
     {
         return Some(hint.role);
     }
-    let request = agent.active_request_text().unwrap_or_default();
+    let request = super::workspace_access::active_request_text(agent).unwrap_or_default();
     if !request.is_empty() {
         let contract = super::task_contract::TaskContract::from_request(&request);
         if let Some(role) = contract.required_artifacts.first().copied() {
@@ -92,7 +92,9 @@ pub(super) fn emit_safe_stop_report_for_diagnostic_target_missing(agent: &mut Ag
     let turn_index = agent.current_turn_index as u64;
     let scope = super::task_workspace_scope::TaskWorkspaceScope::detect(
         &agent.work_root,
-        agent.active_request_text().unwrap_or_default().as_str(),
+        super::workspace_access::active_request_text(agent)
+            .unwrap_or_default()
+            .as_str(),
     );
     let candidates: Vec<String> = job
         .changed_file_hints
@@ -199,7 +201,9 @@ pub(super) fn emit_safe_stop_report_for_artifact_completion_failed(
     let turn_index = agent.current_turn_index as u64;
     let scope = super::task_workspace_scope::TaskWorkspaceScope::detect(
         &agent.work_root,
-        agent.active_request_text().unwrap_or_default().as_str(),
+        super::workspace_access::active_request_text(agent)
+            .unwrap_or_default()
+            .as_str(),
     );
     let owned_test_artifacts = collect_owned_test_artifacts(agent);
     // Prefer the real RepairJob (when one exists, e.g. the
@@ -269,7 +273,9 @@ pub(super) fn emit_repair_safe_stop_report(
     let turn_index = agent.current_turn_index as u64;
     let scope = super::task_workspace_scope::TaskWorkspaceScope::detect(
         &agent.work_root,
-        agent.active_request_text().unwrap_or_default().as_str(),
+        super::workspace_access::active_request_text(agent)
+            .unwrap_or_default()
+            .as_str(),
     );
     let owned_test_artifacts = collect_owned_test_artifacts(agent);
     let expected = job
@@ -312,7 +318,9 @@ pub(super) fn emit_safe_stop_report_for_verifier_missing(agent: &mut Agent) {
     let turn_index = agent.current_turn_index as u64;
     let scope = super::task_workspace_scope::TaskWorkspaceScope::detect(
         &agent.work_root,
-        agent.active_request_text().unwrap_or_default().as_str(),
+        super::workspace_access::active_request_text(agent)
+            .unwrap_or_default()
+            .as_str(),
     );
     let owned_test_artifacts = collect_owned_test_artifacts(agent);
     let input = super::repair_job::SafeStopInput::FromMissingVerifier {
@@ -344,7 +352,9 @@ pub(super) fn emit_safe_stop_report_for_verifier_missing(agent: &mut Agent) {
 fn collect_owned_test_artifacts(agent: &Agent) -> Vec<String> {
     let scope = super::task_workspace_scope::TaskWorkspaceScope::detect(
         &agent.work_root,
-        agent.active_request_text().unwrap_or_default().as_str(),
+        super::workspace_access::active_request_text(agent)
+            .unwrap_or_default()
+            .as_str(),
     );
     let mut out: Vec<String> = Vec::new();
     for rel in agent.turn_edited_relative_paths.iter() {

--- a/src/agent/loop_run/scaffold_pipeline.rs
+++ b/src/agent/loop_run/scaffold_pipeline.rs
@@ -617,7 +617,7 @@ pub(super) fn active_task_requires_nextjs_scaffold(agent: &Agent) -> bool {
     }
     let plan_contents = agent.current_plan_contents().ok().flatten();
     task_or_plan_requires_nextjs_scaffold(
-        agent.active_request_text().as_deref(),
+        super::workspace_access::active_request_text(agent).as_deref(),
         plan_contents.as_deref(),
     )
 }
@@ -626,8 +626,7 @@ pub(super) fn active_task_requested_scaffold_framework(agent: &Agent) -> Option<
     if agent.session.mode_state.mode != ExecutionMode::Act {
         return None;
     }
-    agent
-        .active_request_text()
+    super::workspace_access::active_request_text(agent)
         .as_deref()
         .and_then(requested_scaffold_framework)
 }
@@ -1002,7 +1001,7 @@ pub(super) fn maybe_materialize_mode_deterministic_fallback(
         return false;
     }
     let policy = agent.session.mode_state.policy();
-    let Some(request) = agent.active_request_text() else {
+    let Some(request) = super::workspace_access::active_request_text(agent) else {
         return false;
     };
     let Some(mut spec) = mode_deterministic_scaffold_spec(agent, &request, &policy) else {
@@ -1104,7 +1103,7 @@ pub(super) fn maybe_materialize_task_contract_fallback(
     if !workspace_appears_empty(&agent.work_root) {
         return false;
     }
-    let Some(request) = agent.active_request_text() else {
+    let Some(request) = super::workspace_access::active_request_text(agent) else {
         return false;
     };
     let Some(files) = deterministic::fastapi_scaffold_files(&request) else {
@@ -1154,7 +1153,7 @@ pub(super) fn maybe_materialize_framework_game_fallback(
     {
         return false;
     }
-    let Some(request) = agent.active_request_text() else {
+    let Some(request) = super::workspace_access::active_request_text(agent) else {
         return false;
     };
     let Some(files) = deterministic::empty_framework_app_files(&request) else {
@@ -1275,7 +1274,7 @@ pub(super) fn maybe_materialize_python_test_fallback(
     ) {
         return Ok(None);
     }
-    let request = agent.active_request_text().unwrap_or_default();
+    let request = super::workspace_access::active_request_text(agent).unwrap_or_default();
     let mut python_files = std::fs::read_dir(&agent.work_root)
         .map_err(|err| format!("failed to read {}: {err}", agent.work_root.display()))?
         .flatten()
@@ -1467,7 +1466,7 @@ pub(super) fn maybe_apply_local_llm_small_edit_fallback(
 pub(super) fn local_llm_small_edit_fallback_target(agent: &Agent) -> Option<PathBuf> {
     if agent.session.mode_state.mode != ExecutionMode::Act
         || !agent.session.mode_state.policy().repo_edit_required
-        || !agent.active_task_expects_repo_change()
+        || !super::workspace_access::active_task_expects_repo_change(agent)
     {
         return None;
     }

--- a/src/agent/loop_run/set_artifact_recovery_target.rs
+++ b/src/agent/loop_run/set_artifact_recovery_target.rs
@@ -62,7 +62,7 @@ fn align_recovery_target_hint_to_request(
     if hint.role != ArtifactRole::Test {
         return hint;
     }
-    let Some(request) = agent.active_request_text() else {
+    let Some(request) = super::workspace_access::active_request_text(agent) else {
         return hint;
     };
     let Some((target_path, stack_label)) =

--- a/src/agent/loop_run/success.rs
+++ b/src/agent/loop_run/success.rs
@@ -133,8 +133,9 @@ impl Agent {
         if !recent_successful_bash_commands_since_last_user(&self.session.messages).is_empty() {
             return true;
         }
-        let scope = self.current_workspace_scope();
-        let project_unit = if let Some(request) = self.active_request_text() {
+        let scope = super::workspace_access::current_workspace_scope(self);
+        let project_unit = if let Some(request) = super::workspace_access::active_request_text(self)
+        {
             super::project_probe::probe_project_unit_for_request(
                 &self.work_root,
                 &request,
@@ -151,7 +152,7 @@ impl Agent {
         if project_unit.is_some_and(|unit| !unit.verifier_candidates.is_empty()) {
             return true;
         }
-        self.active_request_text()
+        super::workspace_access::active_request_text(self)
             .is_some_and(|request| super::quality::request_explicitly_requires_tests(&request))
     }
 
@@ -161,7 +162,7 @@ impl Agent {
     /// `evidence_set_missing_shapes_with_context`, and
     /// `should_run_auto_test_for_success_with_context`.
     pub(super) fn current_request_context(&self) -> RequestContext {
-        let request = self.active_request_text().unwrap_or_default();
+        let request = super::workspace_access::active_request_text(self).unwrap_or_default();
         RequestContext {
             requires_tests: super::quality::request_explicitly_requires_tests(&request),
             is_env_setup_only: super::quality::request_is_env_setup_only(&request),
@@ -196,7 +197,7 @@ impl Agent {
     /// structured Weak/Missing branch is then skipped and the legacy
     /// `detect_with_recent_successes -> run` path runs verbatim.
     fn success_verifier_test_binding(&mut self) -> (Vec<String>, bool) {
-        let Some(request) = self.active_request_text() else {
+        let Some(request) = super::workspace_access::active_request_text(self) else {
             return (Vec::new(), false);
         };
         let contract = TaskContract::from_request(&request);
@@ -225,8 +226,7 @@ impl Agent {
                 self.session.last_feedback.as_ref().is_some_and(|frame| {
                     frame.primary_error.as_deref() == Some(DETERMINISTIC_CONTENT_FALLBACK_TAG)
                 });
-            let requested_paths = self
-                .active_request_text()
+            let requested_paths = super::workspace_access::active_request_text(self)
                 .map(|text| requested_paths_from_text(&text))
                 .unwrap_or_default();
             // Issue #606 T-1.5 / Issue #607: Stage-2 short-circuit. Context-
@@ -309,8 +309,10 @@ impl Agent {
             recent_successful_bash_commands_since_last_user(&self.session.messages);
         // Issue #651 Phase 5.1: structured verifier binding inputs.
         let (owned_test_artifacts, test_execution_required) = self.success_verifier_test_binding();
-        let workspace_scope: TaskWorkspaceScope = self.current_workspace_scope();
-        let project_unit = if let Some(request) = self.active_request_text() {
+        let workspace_scope: TaskWorkspaceScope =
+            super::workspace_access::current_workspace_scope(self);
+        let project_unit = if let Some(request) = super::workspace_access::active_request_text(self)
+        {
             super::project_probe::probe_project_unit_for_request(
                 &self.work_root,
                 &request,

--- a/src/agent/loop_run/task_contract_recovery.rs
+++ b/src/agent/loop_run/task_contract_recovery.rs
@@ -91,8 +91,8 @@ pub(super) fn task_contract_recovery_action(
         action,
         super::task_contract::ArtifactRecoveryAction::Continue { .. }
     ) {
-        let request = agent.active_request_text().unwrap_or_default();
-        let scope = agent.current_workspace_scope();
+        let request = super::workspace_access::active_request_text(agent).unwrap_or_default();
+        let scope = super::workspace_access::current_workspace_scope(agent);
         let probe = super::project_probe::probe_completion(
             &agent.work_root,
             &request,
@@ -156,7 +156,7 @@ pub(super) fn task_contract_recovery_target(
     // mentioned) MUST NOT be surfaced as a recovery target either. The
     // ownership signal — edit / scaffold delta / explicit scope mention
     // — is the same one the planner uses upstream.
-    let scope = agent.current_workspace_scope();
+    let scope = super::workspace_access::current_workspace_scope(agent);
     if let Some(path) =
         existing_workspace_candidate_for_role_in_scope(&agent.work_root, role, &scope)
     {
@@ -189,8 +189,7 @@ pub(super) fn task_contract_recovery_target(
             });
         }
     }
-    if let Some(path) = agent
-        .active_request_text()
+    if let Some(path) = super::workspace_access::active_request_text(agent)
         .as_deref()
         .and_then(|req| synthesized_missing_implementation_target_path_for_request(role, req))
     {

--- a/src/agent/loop_run/test_seams.rs
+++ b/src/agent/loop_run/test_seams.rs
@@ -59,7 +59,7 @@ pub(super) fn drive_policy_error_for_test(
         .map(|j| j.attempts().len())
         .unwrap_or(0);
     let scope_for_policy = if agent.missing_verifier_job.is_some() {
-        Some(agent.current_workspace_scope())
+        Some(super::workspace_access::current_workspace_scope(agent))
     } else {
         None
     };

--- a/src/agent/loop_run/tool_call_execution.rs
+++ b/src/agent/loop_run/tool_call_execution.rs
@@ -104,7 +104,7 @@ fn effective_tool_policy_error_for_execution(
     let scope_for_policy = agent
         .missing_verifier_job
         .as_ref()
-        .map(|_| agent.current_workspace_scope());
+        .map(|_| super::workspace_access::current_workspace_scope(agent));
     if let Some(policy) = effective_tool_policy {
         effective_tool_policy_error_for_call_with_scope(
             policy,

--- a/src/agent/loop_run/tool_policy_decisions.rs
+++ b/src/agent/loop_run/tool_policy_decisions.rs
@@ -65,8 +65,7 @@ pub(super) fn answer_only_mode_active(agent: &Agent) -> bool {
 }
 
 pub(super) fn script_execution_requested(agent: &Agent) -> bool {
-    agent
-        .active_request_text()
+    super::workspace_access::active_request_text(agent)
         .as_deref()
         .is_some_and(request_explicitly_requests_script_execution)
 }
@@ -78,7 +77,7 @@ pub(super) fn effective_tool_policy_error(
 ) -> Option<String> {
     let effective_tool_policy = super::effective_tool_policy_flow::effective_tool_policy(agent);
     let scope = if agent.missing_verifier_job.is_some() {
-        Some(agent.current_workspace_scope())
+        Some(super::workspace_access::current_workspace_scope(agent))
     } else {
         None
     };

--- a/src/agent/loop_run/tool_prep.rs
+++ b/src/agent/loop_run/tool_prep.rs
@@ -46,7 +46,7 @@ pub(super) fn local_llm_small_edit_target(agent: &Agent) -> Option<PathBuf> {
     }
     if agent.session.mode_state.mode != ExecutionMode::Act
         || !agent.session.mode_state.policy().repo_edit_required
-        || !agent.active_task_expects_repo_change()
+        || !super::workspace_access::active_task_expects_repo_change(agent)
     {
         return None;
     }

--- a/src/agent/loop_run/turn.rs
+++ b/src/agent/loop_run/turn.rs
@@ -1,39 +1,12 @@
-use super::workspace_walk::workspace_appears_empty;
-use super::*;
-
-use super::quality::repo_change_request_text;
-
-impl Agent {
-    /// Issue #646: build the active `TaskWorkspaceScope` for the current
-    /// task. Pure projection of `work_root` + the active user request; no
-    /// filesystem mutation. Called from `task_contract_artifact_states` and
-    /// `task_contract_recovery_target`; not cached because the bounded
-    /// shallow read of `work_root` is cheap and the scope is recomputed
-    /// only a handful of times per turn.
-    pub(super) fn current_workspace_scope(
-        &self,
-    ) -> super::task_workspace_scope::TaskWorkspaceScope {
-        let request = self.active_request_text().unwrap_or_default();
-        super::task_workspace_scope::TaskWorkspaceScope::detect(&self.work_root, &request)
-    }
-
-    pub(super) fn workspace_appears_empty(&self) -> bool {
-        workspace_appears_empty(&self.work_root)
-    }
-
-    pub(super) fn active_task_expects_repo_change(&self) -> bool {
-        self.session.mode_state.mode == ExecutionMode::Act
-            && self.session.mode_state.policy().repo_edit_required
-            && self.active_request_text().as_deref().is_some_and(|task| {
-                recovery::classify_action_expectation(task, self.session.mode_state.mode)
-                    == recovery::ActionExpectation::RepoChange
-            })
-    }
-
-    pub(super) fn active_request_text(&self) -> Option<String> {
-        repo_change_request_text(
-            self.session.working_memory.active_task.as_deref(),
-            &self.session.messages,
-        )
-    }
-}
+//! Issue #680 (parent): residual `turn.rs` scaffold.
+//!
+//! Historically this file housed the assistant-loop dispatcher and
+//! its many supporting helpers (peak: ~39,489 LOC). The split has
+//! migrated every responsibility to a sibling module under
+//! `src/agent/loop_run/`. The file is intentionally left empty: the
+//! `mod turn;` registration in `loop_run.rs` is kept so historical
+//! line-anchored references in `dev-reports/` / commit messages
+//! remain resolvable, but no production code lives here.
+//!
+//! See the per-module doc comments in `loop_run.rs` for the full
+//! responsibility map.

--- a/src/agent/loop_run/turn_tests.rs
+++ b/src/agent/loop_run/turn_tests.rs
@@ -3452,7 +3452,7 @@ mod tests {
         std::fs::create_dir_all(agent.work_root.join("src")).unwrap();
         std::fs::write(agent.work_root.join("src/main.py"), "# stub\n").unwrap();
 
-        let scope = agent.current_workspace_scope();
+        let scope = super::workspace_access::current_workspace_scope(&agent);
         let artifact_hint = RecoveryTargetHint {
             role: ArtifactRole::Implementation,
             path: "src/main.py".to_string(),
@@ -3508,7 +3508,7 @@ mod tests {
         // candidate (regression guard for write policy bypass).
         std::fs::create_dir_all(agent.work_root.join("src")).unwrap();
         std::fs::write(agent.work_root.join("src/main.py"), "# stub\n").unwrap();
-        let scope = agent.current_workspace_scope();
+        let scope = super::workspace_access::current_workspace_scope(&agent);
         let job = ArtifactCompletionJob::new(
             &agent.work_root,
             &scope,

--- a/src/agent/loop_run/verifier_diagnostic_flow.rs
+++ b/src/agent/loop_run/verifier_diagnostic_flow.rs
@@ -63,7 +63,7 @@ pub(super) fn prepare_verifier_diagnostic_pass(
         current.diagnostic_attempted = true;
         current.assessment_attempts = current.assessment_attempts.saturating_add(1);
     }
-    let active_request = agent.active_request_text().unwrap_or_default();
+    let active_request = super::workspace_access::active_request_text(agent).unwrap_or_default();
     let task_contract = super::task_contract::TaskContract::from_request(&active_request);
     let behavior_projection = super::required_behavior::project_behavior_contract(&task_contract);
     super::active_job_emit::emit_behavior_contract_projected_if_changed(

--- a/src/agent/loop_run/verifier_orchestration.rs
+++ b/src/agent/loop_run/verifier_orchestration.rs
@@ -2159,14 +2159,14 @@ pub(super) fn verifier_repair_pass_client(
 pub(super) fn task_contract_verifier_test_binding(
     agent: &mut Agent,
 ) -> (Vec<String>, bool, Option<TaskWorkspaceScope>) {
-    let Some(request) = agent.active_request_text() else {
+    let Some(request) = super::workspace_access::active_request_text(agent) else {
         return (Vec::new(), false, None);
     };
     let contract = TaskContract::from_request(&request);
     let test_execution_required = contract.required_behavior.test_execution_required;
     let owned_test_artifacts =
         super::owned_test_projection::owned_test_artifacts_for_verifier(agent, &contract);
-    let scope = agent.current_workspace_scope();
+    let scope = super::workspace_access::current_workspace_scope(agent);
     (owned_test_artifacts, test_execution_required, Some(scope))
 }
 
@@ -2191,10 +2191,10 @@ pub(super) fn handle_missing_task_contract_verifier_selection(
     owned_test_artifacts_count: usize,
 ) -> TaskContractVerifierOutcome {
     agent.owned_test_verifier_missing_observed_this_turn = true;
-    agent.owned_test_verifier_missing_observed_carryover = agent
-        .active_request_text()
-        .as_deref()
-        .map(RequestCarryoverKey::from_request);
+    agent.owned_test_verifier_missing_observed_carryover =
+        super::workspace_access::active_request_text(agent)
+            .as_deref()
+            .map(RequestCarryoverKey::from_request);
     let frame = super::success::build_feedback_for_no_verifier(&agent.work_root);
     agent.session.record_feedback_if_unset(frame);
     if matches!(outcome, TaskContractVerifierOutcome::NoVerifier) {
@@ -2288,7 +2288,7 @@ pub(super) fn select_task_contract_verifier_once(
         super::success::recent_successful_bash_commands_since_last_user(&agent.session.messages);
     let (owned_test_artifacts, test_execution_required, workspace_scope_opt) =
         task_contract_verifier_test_binding(agent);
-    let active_request = agent.active_request_text();
+    let active_request = super::workspace_access::active_request_text(agent);
     let task_contract_project_unit = super::verifier_driver::select_task_contract_project_unit(
         &agent.work_root,
         active_request.as_deref(),
@@ -2464,7 +2464,9 @@ pub(super) fn handle_task_contract_verifier_no_verifier(
         task_contract_no_verifier_note(
             job_attempt,
             TASK_CONTRACT_VERIFIER_ATTEMPT_LIMIT,
-            agent.active_request_text().unwrap_or_default().as_str(),
+            super::workspace_access::active_request_text(agent)
+                .unwrap_or_default()
+                .as_str(),
         ),
     );
     super::actor_loop_flow::TaskContractVerifierFlowOutcome::Continue
@@ -3056,11 +3058,11 @@ pub(super) fn run_verifier_diagnostic_pass(agent: &mut Agent) -> VerifierDiagnos
     };
     let authority_input =
         super::semantic_repair_planning::build_spec_authority_input_for_active_request(
-            agent.active_request_text().as_deref(),
+            super::workspace_access::active_request_text(agent).as_deref(),
             semantic_report.as_ref(),
             agent_history_hint,
         );
-    let scope = agent.current_workspace_scope();
+    let scope = super::workspace_access::current_workspace_scope(agent);
     let turn_edited = agent.turn_edited_relative_paths.clone();
     let edited_predicate = |path: &str| turn_edited.contains(path);
     let scaffold_predicate =

--- a/src/agent/loop_run/verifier_repair_pass_flow.rs
+++ b/src/agent/loop_run/verifier_repair_pass_flow.rs
@@ -151,7 +151,7 @@ pub(super) fn prepare_verifier_repair_pass(
     let Some(context) = agent.repair_job.clone() else {
         return Err(VerifierRepairPassOutcome::Skipped);
     };
-    let active_request = agent.active_request_text().unwrap_or_default();
+    let active_request = super::workspace_access::active_request_text(agent).unwrap_or_default();
     let task_contract = super::task_contract::TaskContract::from_request(&active_request);
     let behavior_projection = super::required_behavior::project_behavior_contract(&task_contract);
     super::active_job_emit::emit_behavior_contract_projected_if_changed(

--- a/src/agent/loop_run/working_memory_messages.rs
+++ b/src/agent/loop_run/working_memory_messages.rs
@@ -75,7 +75,7 @@ pub(super) fn working_memory_message(agent: &mut Agent) -> Option<ConversationMe
 }
 
 pub(super) fn answer_only_fallback_response(agent: &Agent) -> String {
-    let request = agent.active_request_text().unwrap_or_default();
+    let request = super::workspace_access::active_request_text(agent).unwrap_or_default();
     let lower = request.to_ascii_lowercase();
     if request_explicitly_requests_script_execution(&request)
         && let Some(output) = latest_tool_result_since_last_user(&agent.session.messages, "Bash")

--- a/src/agent/loop_run/workspace_access.rs
+++ b/src/agent/loop_run/workspace_access.rs
@@ -1,0 +1,52 @@
+//! Per-Agent workspace + active-request accessors extracted from
+//! `turn.rs` (parent #680).
+//!
+//! Hosts the four foundational `&self` accessors that the rest of the
+//! `loop_run` module consults on every turn:
+//!
+//! - `current_workspace_scope` — Issue #646: build the active
+//!   `TaskWorkspaceScope` (pure projection of `work_root` + the
+//!   active user request; no filesystem mutation).
+//! - `workspace_appears_empty` — thin wrapper over
+//!   `workspace_walk::workspace_appears_empty(&work_root)`.
+//! - `active_task_expects_repo_change` — Act mode + repo-edit-required
+//!   policy + request classified as `ActionExpectation::RepoChange`.
+//! - `active_request_text` — surface the current user request via
+//!   `repo_change_request_text(active_task, messages)`.
+//!
+//! Originally `impl Agent` methods; converted to free functions taking
+//! `&Agent`, matching the `actor_loop_flow` / `reply_retry` / earlier
+//! vertical-slice precedent. `pub(super)` limited / no facade
+//! re-export (DR3-001).
+
+use super::Agent;
+use super::quality::repo_change_request_text;
+use super::task_workspace_scope::TaskWorkspaceScope;
+use super::workspace_walk::workspace_appears_empty as workspace_walk_appears_empty;
+use crate::agent::recovery;
+use crate::modes::plan_act::ExecutionMode;
+
+pub(super) fn current_workspace_scope(agent: &Agent) -> TaskWorkspaceScope {
+    let request = active_request_text(agent).unwrap_or_default();
+    TaskWorkspaceScope::detect(&agent.work_root, &request)
+}
+
+pub(super) fn workspace_appears_empty(agent: &Agent) -> bool {
+    workspace_walk_appears_empty(&agent.work_root)
+}
+
+pub(super) fn active_task_expects_repo_change(agent: &Agent) -> bool {
+    agent.session.mode_state.mode == ExecutionMode::Act
+        && agent.session.mode_state.policy().repo_edit_required
+        && active_request_text(agent).as_deref().is_some_and(|task| {
+            recovery::classify_action_expectation(task, agent.session.mode_state.mode)
+                == recovery::ActionExpectation::RepoChange
+        })
+}
+
+pub(super) fn active_request_text(agent: &Agent) -> Option<String> {
+    repo_change_request_text(
+        agent.session.working_memory.active_task.as_deref(),
+        &agent.session.messages,
+    )
+}


### PR DESCRIPTION
## Summary

Final extraction in the meta-issue #680 split: move the last four
\`impl Agent\` accessor methods out of \`turn.rs\` into a focused sibling
module so \`turn.rs\` becomes effectively empty.

Four production accessors were extracted as free functions taking
\`&Agent\` (matching \`actor_loop_flow\` / \`reply_retry\` / earlier
vertical-slice precedent):

- \`current_workspace_scope\` (Issue #646)
- \`workspace_appears_empty\`
- \`active_task_expects_repo_change\`
- \`active_request_text\`

\`turn.rs\` is now a 12-line vestigial doc-only file. The \`mod turn;\`
registration in \`loop_run.rs\` is kept so historical line-anchored
references in \`dev-reports/\` / commit messages remain resolvable, but
no production code lives there.

The \`use crate::agent::recovery;\` import in \`loop_run.rs\` was
preserved under \`#[allow(unused_imports)]\` so the legacy
\`super::recovery::*\` paths in \`progress_tests.rs\` continue to resolve
through the \`loop_run\` mod namespace.

Behavior unchanged: byte-for-byte identical scope-detection /
\`workspace_appears_empty\` / Act-mode + repo-edit-required + recovery
classification / \`repo_change_request_text\` invocations.

\`pub(super)\` limited / no facade re-export (DR3-001). Callers updated
in 27 sibling modules + 2 in-crate test sites (~76 method-call sites
to free-fn form).

### LOC delta

- \`turn.rs\`: 39 → 12 (-27)
- new module: +52

Cumulative \`turn.rs\` reduction across the parent #680 split:
39,489 → 12 (-99.97%). Final extraction; \`turn.rs\` is now empty.

## Test plan

- [x] \`cargo build --lib\`
- [x] \`cargo fmt\`
- [x] \`cargo clippy --lib --all-targets -- -D warnings\`
- [x] \`cargo test --lib\` (3,114 passed, 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)