### PR TITLE
fix: classify workspace metadata for scaffold decisions

### DIFF
--- a/src/agent/loop_run/commands.rs
+++ b/src/agent/loop_run/commands.rs
@@ -1066,17 +1066,7 @@ impl Agent {
     }
 
     fn command_workspace_appears_empty(work_root: &std::path::Path) -> bool {
-        let Ok(entries) = std::fs::read_dir(work_root) else {
-            return false;
-        };
-        entries.flatten().all(|entry| {
-            let name = entry.file_name();
-            let name = name.to_string_lossy();
-            matches!(
-                name.as_ref(),
-                ".git" | ".anvil" | ".anvil-state" | "node_modules" | "target"
-            )
-        })
+        super::workspace_walk::workspace_appears_empty(work_root)
     }
 
     pub fn initial_prompt_from_cli_or_stdin(&self) -> Result<Option<String>, String> {

--- a/src/agent/loop_run/progress_tests.rs
+++ b/src/agent/loop_run/progress_tests.rs
@@ -7230,10 +7230,48 @@ E   assert [{'id': 1}] == []\n";
         std::fs::create_dir_all(work_root.join(".anvil/plans")).unwrap();
         std::fs::create_dir_all(work_root.join(".anvil-state")).unwrap();
         std::fs::write(work_root.join("ANVIL.md"), "# rules\n").unwrap();
+        std::fs::write(work_root.join("prompt.md"), "build a Rust CLI\n").unwrap();
+        std::fs::write(work_root.join("cmd.txt"), "cargo test\n").unwrap();
         assert!(workspace_appears_empty(work_root));
 
         std::fs::write(work_root.join("README.md"), "# app\n").unwrap();
         assert!(!workspace_appears_empty(work_root));
+    }
+
+    #[test]
+    fn protected_prompt_and_cmd_metadata_edit_is_rejected() {
+        use crate::agent::loop_run::commands::test_agent_with_config;
+        use crate::config::Config;
+
+        let (mut agent, temp) = test_agent_with_config(Config::default());
+        std::fs::write(temp.path().join("prompt.md"), "original prompt\n").unwrap();
+        std::fs::write(temp.path().join("cmd.txt"), "original command\n").unwrap();
+
+        let prompt_result = super::super::tool_call_execution::execute_tool_call(
+            &mut agent,
+            "Write",
+            &json!({"path":"prompt.md","content":"mutated\n"}),
+            None,
+            None,
+        );
+        let cmd_result = super::super::tool_call_execution::execute_tool_call(
+            &mut agent,
+            "Edit",
+            &json!({"path":"cmd.txt","old_string":"original","new_string":"mutated"}),
+            None,
+            None,
+        );
+
+        assert!(prompt_result.contains("protected workspace metadata rejected Write"));
+        assert!(cmd_result.contains("protected workspace metadata rejected Edit"));
+        assert_eq!(
+            std::fs::read_to_string(temp.path().join("prompt.md")).unwrap(),
+            "original prompt\n"
+        );
+        assert_eq!(
+            std::fs::read_to_string(temp.path().join("cmd.txt")).unwrap(),
+            "original command\n"
+        );
     }
 
     #[test]
@@ -7266,6 +7304,34 @@ E   assert [{'id': 1}] == []\n";
                 .repo_edit_projection_set()
                 .contains(rel),
             "controller-owned state must not enter artifact ledger repo edit projection"
+        );
+    }
+
+    #[test]
+    fn repo_edit_observation_ignores_protected_input_metadata() {
+        use crate::agent::loop_run::commands::test_agent_with_config;
+        use crate::config::Config;
+
+        let (mut agent, temp) = test_agent_with_config(Config::default());
+        std::fs::write(temp.path().join("prompt.md"), "mutated\n").unwrap();
+
+        super::super::repo_edit_observation::observe_evidence_from_repo_edit(
+            &mut agent,
+            "prompt.md",
+        );
+
+        assert!(
+            !agent.turn_edited_relative_paths.contains("prompt.md"),
+            "protected input metadata must not become repo edit evidence"
+        );
+        assert!(agent.evidence_set_this_turn.is_empty());
+        assert!(agent.task_contract_evidence_set_this_turn.is_empty());
+        assert!(
+            !agent
+                .artifact_ledger
+                .repo_edit_projection_set()
+                .contains("prompt.md"),
+            "protected input metadata must not enter artifact ledger repo edit projection"
         );
     }
 

--- a/src/agent/loop_run/repo_edit_observation.rs
+++ b/src/agent/loop_run/repo_edit_observation.rs
@@ -61,6 +61,17 @@ pub(super) fn observe_evidence_from_repo_edit(agent: &mut Agent, path: &str) {
         );
         return;
     }
+    if super::workspace_walk::is_protected_input_metadata_path(&relative_path) {
+        crate::logging::log_completion_evidence_observed(
+            agent.current_turn_index,
+            0,
+            "repo_edit_protected_input_metadata",
+            serde_json::json!({
+                "path_hash": stable_path_hash(&relative_path),
+            }),
+        );
+        return;
+    }
     let category =
         super::completion_evidence::classify_repo_edit_path(std::path::Path::new(&relative_path));
     if !super::scaffold_pipeline::repo_edit_has_post_scaffold_delta(agent, &relative_path) {

--- a/src/agent/loop_run/scaffold_pipeline.rs
+++ b/src/agent/loop_run/scaffold_pipeline.rs
@@ -2253,4 +2253,62 @@ mod tests {
         assert!(temp.path().join("src/main.rs").is_file());
         assert!(temp.path().join("tests/cli.rs").is_file());
     }
+
+    #[test]
+    fn rust_scaffold_materializes_when_prompt_metadata_exists() {
+        use crate::agent::loop_run::commands::test_agent_with_config;
+        use crate::config::{Config, DeterministicFallbackMode};
+        use crate::modes::plan_act::WorkMode;
+        use crate::session::store::ConversationMessage;
+
+        let cfg = Config {
+            deterministic_fallback: DeterministicFallbackMode::FullTemplate,
+            ..Config::default()
+        };
+        let (mut agent, temp) = test_agent_with_config(cfg);
+        std::fs::write(temp.path().join("prompt.md"), "Create a Rust CLI\n").unwrap();
+        agent.session.mode_state.work_mode = WorkMode::GenericCode;
+        agent.session.messages.push(ConversationMessage::user(
+            "Create a Rust CLI word counter with tests".to_string(),
+        ));
+
+        let fired = maybe_materialize_mode_deterministic_fallback(&mut agent, 0);
+
+        assert!(fired);
+        assert!(temp.path().join("Cargo.toml").is_file());
+        assert!(temp.path().join("src/main.rs").is_file());
+        assert_eq!(
+            std::fs::read_to_string(temp.path().join("prompt.md")).unwrap(),
+            "Create a Rust CLI\n"
+        );
+    }
+
+    #[test]
+    fn node_scaffold_materializes_when_prompt_metadata_exists() {
+        use crate::agent::loop_run::commands::test_agent_with_config;
+        use crate::config::{Config, DeterministicFallbackMode};
+        use crate::modes::plan_act::WorkMode;
+        use crate::session::store::ConversationMessage;
+
+        let cfg = Config {
+            deterministic_fallback: DeterministicFallbackMode::FullTemplate,
+            ..Config::default()
+        };
+        let (mut agent, temp) = test_agent_with_config(cfg);
+        std::fs::write(temp.path().join("prompt.md"), "Build a Node CLI\n").unwrap();
+        agent.session.mode_state.work_mode = WorkMode::GenericCode;
+        agent.session.messages.push(ConversationMessage::user(
+            "Build a Node.js JSON formatter CLI with node --test".to_string(),
+        ));
+
+        let fired = maybe_materialize_mode_deterministic_fallback(&mut agent, 0);
+
+        assert!(fired);
+        assert!(temp.path().join("package.json").is_file());
+        assert!(temp.path().join("src/index.js").is_file());
+        assert_eq!(
+            std::fs::read_to_string(temp.path().join("prompt.md")).unwrap(),
+            "Build a Node CLI\n"
+        );
+    }
 }

--- a/src/agent/loop_run/tool_call_execution.rs
+++ b/src/agent/loop_run/tool_call_execution.rs
@@ -67,6 +67,10 @@ pub(super) fn execute_tool_call(
         agent.session.working_memory.note_error(err.clone());
         return lifecycle::format_tool_error(&err);
     }
+    if let Some(err) = protected_metadata_edit_policy_error(agent, name, arguments) {
+        agent.session.working_memory.note_error(err.clone());
+        return lifecycle::format_tool_error(&err);
+    }
     if let Some(err) =
         super::scaffold_pipeline::empty_workspace_scaffold_policy_error(agent, name, arguments)
     {
@@ -93,6 +97,24 @@ pub(super) fn execute_tool_call(
         return execute_bash_tool_call(agent, name, arguments, &context);
     }
     execute_non_bash_tool_call(agent, name, arguments, &context)
+}
+
+fn protected_metadata_edit_policy_error(
+    agent: &Agent,
+    name: &str,
+    arguments: &serde_json::Value,
+) -> Option<String> {
+    if !matches!(name, "Write" | "Edit") {
+        return None;
+    }
+    let raw_path = arguments.get("path").and_then(serde_json::Value::as_str)?;
+    let relative = workspace_relative_path_for_tool_arg(&agent.work_root, raw_path)?;
+    if !super::workspace_walk::is_protected_input_metadata_path(&relative) {
+        return None;
+    }
+    Some(format!(
+        "protected workspace metadata rejected {name}; prompt/cmd input files are not project artifacts: {relative}"
+    ))
 }
 
 fn effective_tool_policy_error_for_execution(

--- a/src/agent/loop_run/workspace_walk.rs
+++ b/src/agent/loop_run/workspace_walk.rs
@@ -11,18 +11,94 @@
 
 use std::path::{Path, PathBuf};
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum WorkspaceFileClass {
+    ProjectArtifact,
+    ProtectedInputMetadata,
+    GeneratedMetadata,
+}
+
 pub(super) fn workspace_appears_empty(work_root: &Path) -> bool {
-    let Ok(entries) = std::fs::read_dir(work_root) else {
-        return false;
+    !workspace_contains_project_artifact(work_root, work_root).unwrap_or(true)
+}
+
+pub(super) fn is_protected_input_metadata_path(relative_path: &str) -> bool {
+    classify_workspace_relative_path(Path::new(relative_path))
+        == WorkspaceFileClass::ProtectedInputMetadata
+}
+
+pub(super) fn classify_workspace_relative_path(relative: &Path) -> WorkspaceFileClass {
+    if relative.components().any(|component| {
+        matches!(component, std::path::Component::Normal(name) if name.to_str().is_some_and(super::task_workspace_scope::is_workspace_ignored_dir))
+    }) {
+        return WorkspaceFileClass::GeneratedMetadata;
+    }
+    if first_component_name(relative).is_some_and(|name| name.eq_ignore_ascii_case("logs")) {
+        return WorkspaceFileClass::GeneratedMetadata;
+    }
+    let Some(name) = top_level_file_name(relative) else {
+        return WorkspaceFileClass::ProjectArtifact;
     };
-    !entries.flatten().any(|entry| {
+    let lower = name.to_ascii_lowercase();
+    if matches!(
+        lower.as_str(),
+        "prompt.md" | "prompt.txt" | "cmd.txt" | "command.txt"
+    ) {
+        return WorkspaceFileClass::ProtectedInputMetadata;
+    }
+    if matches!(
+        lower.as_str(),
+        "anvil.md" | "session.json" | "meta.json" | "metadata.json" | "llm-io.jsonl" | "log.jsonl"
+    ) {
+        return WorkspaceFileClass::GeneratedMetadata;
+    }
+    WorkspaceFileClass::ProjectArtifact
+}
+
+fn first_component_name(relative: &Path) -> Option<&str> {
+    match relative.components().next()? {
+        std::path::Component::Normal(name) => name.to_str(),
+        _ => None,
+    }
+}
+
+fn top_level_file_name(relative: &Path) -> Option<&str> {
+    let mut components = relative.components();
+    let first = match components.next()? {
+        std::path::Component::Normal(name) => name.to_str()?,
+        _ => return None,
+    };
+    components.next().is_none().then_some(first)
+}
+
+fn workspace_contains_project_artifact(root: &Path, current: &Path) -> std::io::Result<bool> {
+    let Ok(entries) = std::fs::read_dir(current) else {
+        return Ok(true);
+    };
+    for entry in entries.flatten() {
         let name = entry.file_name();
         let name = name.to_string_lossy();
-        !matches!(
-            name.as_ref(),
-            ".git" | ".anvil" | ".anvil-state" | "ANVIL.md" | "node_modules" | "target"
-        )
-    })
+        if super::task_workspace_scope::is_workspace_ignored_dir(&name) {
+            continue;
+        }
+        let path = entry.path();
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        if file_type.is_dir() {
+            if workspace_contains_project_artifact(root, &path)? {
+                return Ok(true);
+            }
+            continue;
+        }
+        if (file_type.is_file() || file_type.is_symlink())
+            && let Ok(relative) = path.strip_prefix(root)
+            && classify_workspace_relative_path(relative) == WorkspaceFileClass::ProjectArtifact
+        {
+            return Ok(true);
+        }
+    }
+    Ok(false)
 }
 
 pub(super) fn meaningful_workspace_files(work_root: &Path, limit: usize) -> Option<Vec<PathBuf>> {
@@ -53,6 +129,7 @@ fn collect_meaningful_workspace_files(
             collect_meaningful_workspace_files(root, &path, limit, files)?;
         } else if path.is_file()
             && let Ok(relative) = path.strip_prefix(root)
+            && classify_workspace_relative_path(relative) == WorkspaceFileClass::ProjectArtifact
         {
             files.push(relative.to_path_buf());
             if files.len() > limit {
@@ -61,4 +138,43 @@ fn collect_meaningful_workspace_files(
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn prompt_and_cmd_metadata_do_not_make_workspace_project_non_empty() {
+        let temp = tempdir().unwrap();
+        std::fs::write(temp.path().join("prompt.md"), "build a Rust CLI\n").unwrap();
+        std::fs::write(temp.path().join("cmd.txt"), "cargo test\n").unwrap();
+        std::fs::write(temp.path().join("session.json"), "{}\n").unwrap();
+        std::fs::write(temp.path().join("meta.json"), "{}\n").unwrap();
+        std::fs::create_dir_all(temp.path().join("logs")).unwrap();
+        std::fs::write(temp.path().join("logs/llm-io.jsonl"), "{}\n").unwrap();
+        std::fs::create_dir_all(temp.path().join(".anvil-state/sessions")).unwrap();
+
+        assert!(workspace_appears_empty(temp.path()));
+
+        std::fs::write(temp.path().join("Cargo.toml"), "[package]\n").unwrap();
+        assert!(!workspace_appears_empty(temp.path()));
+    }
+
+    #[test]
+    fn meaningful_workspace_files_excludes_protected_input_metadata() {
+        let temp = tempdir().unwrap();
+        std::fs::write(temp.path().join("prompt.txt"), "task\n").unwrap();
+        std::fs::write(temp.path().join("command.txt"), "npm test\n").unwrap();
+        std::fs::write(temp.path().join("llm-io.jsonl"), "{}\n").unwrap();
+        std::fs::create_dir_all(temp.path().join("logs")).unwrap();
+        std::fs::write(temp.path().join("logs/run.log"), "log\n").unwrap();
+        std::fs::create_dir_all(temp.path().join("src")).unwrap();
+        std::fs::write(temp.path().join("src/main.rs"), "fn main() {}\n").unwrap();
+
+        let files = meaningful_workspace_files(temp.path(), 16).unwrap();
+
+        assert_eq!(files, vec![PathBuf::from("src/main.rs")]);
+    }
 }


### PR DESCRIPTION
Linked Issue: #847

Summary:
- Add workspace file classification for project artifacts, protected input metadata, and generated metadata.
- Make empty-workspace scaffold decisions ignore prompt/cmd/log/session metadata.
- Reject writes to protected prompt/cmd files and ignore them in repo-edit evidence.

Changed files:
- src/agent/loop_run/commands.rs
- src/agent/loop_run/progress_tests.rs
- src/agent/loop_run/repo_edit_observation.rs
- src/agent/loop_run/scaffold_pipeline.rs
- src/agent/loop_run/tool_call_execution.rs
- src/agent/loop_run/workspace_walk.rs

Tests run:
- cargo test metadata --lib
- cargo fmt --check
- cargo clippy --all-targets --all-features
- cargo test
- cargo build --release

Known risks:
- Metadata filename policy is intentionally narrow and may need expansion if more harness files are introduced.

Orchestration run ID: 20260531-145150-orchestrate