### PR TITLE
feat: log PAM context decision effects

### DIFF
--- a/src/agent/loop_run.rs
+++ b/src/agent/loop_run.rs
@@ -794,7 +794,8 @@ impl Agent {
 pub(in crate::agent::loop_run) mod tests_export {
     use crate::agent::loop_run::pam_advisory::{
         MAX_PAM_DECISION_LIST_LEN, PamAdvisoryDecision, PamAdvisoryDecisionPayload,
-        PamAdvisoryMode, ShadowVsLiveDiff, SuppressedSummary, SuppressionReason,
+        PamAdvisoryMode, PamCandidateAction, PamCandidateDecision, PamDecisionEffect,
+        ShadowVsLiveDiff, SuppressedSummary, SuppressionReason,
     };
 
     /// Re-export of `MemoryReport::PAYLOAD_SCHEMA_VERSION` for the
@@ -821,6 +822,33 @@ pub(in crate::agent::loop_run) mod tests_export {
                 suppressed_summary_ids_truncated: false,
                 shadow_vs_live_diff: None,
                 active_job_role: "ArtifactRecovery:test".to_string(),
+                candidate_decisions: vec![
+                    PamCandidateDecision {
+                        summary_id: "s1".to_string(),
+                        action: PamCandidateAction::Inject,
+                        inferred_role: Some("test"),
+                        suppression_reason: None,
+                        decision_impact: "prompt_context_injected",
+                        context_excerpt: "tests/foo_test.py".to_string(),
+                        context_excerpt_truncated: false,
+                    },
+                    PamCandidateDecision {
+                        summary_id: "s2".to_string(),
+                        action: PamCandidateAction::Suppress,
+                        inferred_role: Some("implementation"),
+                        suppression_reason: Some(SuppressionReason::RoleMismatch),
+                        decision_impact: "artifact_role_mismatch_suppressed",
+                        context_excerpt: "src/lib.rs".to_string(),
+                        context_excerpt_truncated: false,
+                    },
+                ],
+                candidate_decisions_truncated: false,
+                decision_effect: PamDecisionEffect {
+                    actual_injected_count: 1,
+                    suppressed_count: 1,
+                    would_inject_in_live_count: 0,
+                    influenced_decision: "prompt_context_injection",
+                },
             };
             decision.to_json_value()
         }
@@ -837,6 +865,22 @@ pub(in crate::agent::loop_run) mod tests_export {
                     would_inject_in_live_truncated: false,
                 }),
                 active_job_role: ":".to_string(),
+                candidate_decisions: vec![PamCandidateDecision {
+                    summary_id: "sX".to_string(),
+                    action: PamCandidateAction::WouldInjectInLive,
+                    inferred_role: Some("test"),
+                    suppression_reason: None,
+                    decision_impact: "shadow_counterfactual_not_injected",
+                    context_excerpt: "tests/shadow_test.py".to_string(),
+                    context_excerpt_truncated: false,
+                }],
+                candidate_decisions_truncated: false,
+                decision_effect: PamDecisionEffect {
+                    actual_injected_count: 0,
+                    suppressed_count: 0,
+                    would_inject_in_live_count: 1,
+                    influenced_decision: "shadow_counterfactual",
+                },
             };
             decision.to_json_value()
         }
@@ -857,6 +901,14 @@ pub(in crate::agent::loop_run) mod tests_export {
             suppressed_summary_ids_truncated: false,
             shadow_vs_live_diff: None,
             active_job_role: ":".to_string(),
+            candidate_decisions: Vec::new(),
+            candidate_decisions_truncated: false,
+            decision_effect: PamDecisionEffect {
+                actual_injected_count: MAX_PAM_DECISION_LIST_LEN as u32,
+                suppressed_count: 0,
+                would_inject_in_live_count: 0,
+                influenced_decision: "prompt_context_injection",
+            },
         };
         decision.to_json_value()
     }
@@ -929,6 +981,14 @@ pub(in crate::agent::loop_run) mod tests_export {
                 would_inject_in_live_truncated: true,
             }),
             active_job_role: "ArtifactRecovery:test".to_string(),
+            candidate_decisions: Vec::new(),
+            candidate_decisions_truncated: true,
+            decision_effect: PamDecisionEffect {
+                actual_injected_count: MAX_PAM_DECISION_LIST_LEN as u32,
+                suppressed_count: MAX_PAM_DECISION_LIST_LEN as u32,
+                would_inject_in_live_count: MAX_PAM_DECISION_LIST_LEN as u32,
+                influenced_decision: "shadow_counterfactual",
+            },
         };
         decision.to_json_value()
     }

--- a/src/agent/loop_run/pam_advisory.rs
+++ b/src/agent/loop_run/pam_advisory.rs
@@ -52,6 +52,10 @@ use crate::photon::schema::ContextPackResponse;
 /// which carry different semantic ranges.
 pub(super) const MAX_PAM_DECISION_LIST_LEN: usize = 16;
 
+/// Per-candidate context excerpt cap. This keeps the decision log useful for
+/// A/B attribution while leaving final envelope bounds to `job_report`.
+const MAX_PAM_CONTEXT_EXCERPT_CHARS: usize = 160;
+
 // ---------------------------------------------------------------------------
 // Enum types
 // ---------------------------------------------------------------------------
@@ -108,6 +112,34 @@ impl SuppressionReason {
     }
 }
 
+/// Per-memory action recorded in the decision log.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub(super) enum PamCandidateAction {
+    Inject,
+    Suppress,
+    WouldInjectInLive,
+}
+
+impl PamCandidateAction {
+    fn as_str(self) -> &'static str {
+        match self {
+            PamCandidateAction::Inject => "inject",
+            PamCandidateAction::Suppress => "suppress",
+            PamCandidateAction::WouldInjectInLive => "would_inject_in_live",
+        }
+    }
+}
+
+impl serde::Serialize for PamCandidateAction {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Struct types
 // ---------------------------------------------------------------------------
@@ -146,6 +178,37 @@ pub(super) struct ShadowVsLiveDiff {
     pub(super) would_inject_in_live_truncated: bool,
 }
 
+/// Per-memory attribution entry. This is intentionally additive to the
+/// existing `pam_decision` payload: older consumers can continue reading the
+/// summary-id lists, while A/B analysis can explain why each memory was or was
+/// not allowed to affect prompt context.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(super) struct PamCandidateDecision {
+    pub(super) summary_id: String,
+    pub(super) action: PamCandidateAction,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) inferred_role: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) suppression_reason: Option<SuppressionReason>,
+    pub(super) decision_impact: &'static str,
+    pub(super) context_excerpt: String,
+    #[serde(default)]
+    pub(super) context_excerpt_truncated: bool,
+}
+
+/// Roll-up for turn-level PAM effect attribution. It describes what kind of
+/// downstream decision PAM was allowed to influence in this turn, not whether
+/// the final task outcome was good or bad.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(super) struct PamDecisionEffect {
+    pub(super) actual_injected_count: u32,
+    pub(super) suppressed_count: u32,
+    pub(super) would_inject_in_live_count: u32,
+    pub(super) influenced_decision: &'static str,
+}
+
 /// Turn-local decision value. Adapter writes exactly one of these per turn
 /// (DR1-005 single-set contract) into `Agent.last_pam_decision_this_turn`.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -160,6 +223,9 @@ pub(super) struct PamAdvisoryDecision {
     /// `"<ActiveJobKind>:<ArtifactRole?>"` string. Built ONCE by
     /// `format_active_job_role` (DR1-003 SSOT).
     pub(super) active_job_role: String,
+    pub(super) candidate_decisions: Vec<PamCandidateDecision>,
+    pub(super) candidate_decisions_truncated: bool,
+    pub(super) decision_effect: PamDecisionEffect,
 }
 
 /// Adapter evaluation result. `decision` flows into `MemoryReport.pam_decision`
@@ -193,6 +259,11 @@ pub(super) struct PamAdvisoryDecisionPayload {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(super) shadow_vs_live_diff: Option<ShadowVsLiveDiff>,
     pub(super) active_job_role: String,
+    #[serde(default)]
+    pub(super) candidate_decisions: Vec<PamCandidateDecision>,
+    #[serde(default)]
+    pub(super) candidate_decisions_truncated: bool,
+    pub(super) decision_effect: PamDecisionEffect,
 }
 
 impl From<&PamAdvisoryDecision> for PamAdvisoryDecisionPayload {
@@ -205,6 +276,9 @@ impl From<&PamAdvisoryDecision> for PamAdvisoryDecisionPayload {
             suppressed_summary_ids_truncated: d.suppressed_summary_ids_truncated,
             shadow_vs_live_diff: d.shadow_vs_live_diff.clone(),
             active_job_role: d.active_job_role.clone(),
+            candidate_decisions: d.candidate_decisions.clone(),
+            candidate_decisions_truncated: d.candidate_decisions_truncated,
+            decision_effect: d.decision_effect.clone(),
         }
     }
 }
@@ -393,18 +467,36 @@ pub(super) fn evaluate_pam_advisory(
     let mut live_admitted_views: Vec<AdmittedItemView> = Vec::new();
     let mut injected_summary_ids: Vec<String> = Vec::new();
     let mut suppressed_summary_ids: Vec<SuppressedSummary> = Vec::new();
+    let mut candidate_decisions: Vec<PamCandidateDecision> = Vec::new();
     let all_admitted_ids: Vec<String> = admitted_views
         .iter()
         .filter_map(|v| v.provenance.summary_id.clone())
         .collect();
 
     for (view, classification) in admitted_views.iter().zip(classifications.iter()) {
+        let suggested_role = infer_role_from_view(view);
         match classification {
             SummaryClassification::Inject => {
                 live_admitted_views.push(view.clone());
                 if let Some(id) = view.provenance.summary_id.clone() {
                     injected_summary_ids.push(id);
                 }
+                push_candidate_decision(
+                    &mut candidate_decisions,
+                    view,
+                    suggested_role,
+                    None,
+                    if mode_input.shadow {
+                        PamCandidateAction::WouldInjectInLive
+                    } else {
+                        PamCandidateAction::Inject
+                    },
+                    if mode_input.shadow {
+                        "shadow_counterfactual_not_injected"
+                    } else {
+                        "prompt_context_injected"
+                    },
+                );
             }
             SummaryClassification::Suppress(reason) => {
                 if let Some(id) = view.provenance.summary_id.clone() {
@@ -413,12 +505,21 @@ pub(super) fn evaluate_pam_advisory(
                         reason: *reason,
                     });
                 }
+                push_candidate_decision(
+                    &mut candidate_decisions,
+                    view,
+                    suggested_role,
+                    Some(*reason),
+                    PamCandidateAction::Suppress,
+                    suppression_impact(*reason, active_kind),
+                );
             }
         }
     }
 
     let mut injected_summary_ids_truncated = apply_cap_strings(&mut injected_summary_ids);
     let suppressed_summary_ids_truncated = apply_cap_suppressed(&mut suppressed_summary_ids);
+    let candidate_decisions_truncated = apply_cap_candidate_decisions(&mut candidate_decisions);
 
     // shadow_vs_live_diff: only populated on shadow turns.
     let shadow_vs_live_diff = if mode_input.shadow {
@@ -453,6 +554,15 @@ pub(super) fn evaluate_pam_advisory(
     }
 
     let active_job_role = format_active_job_role(active_kind, current_role_hint);
+    let decision_effect = build_decision_effect(
+        mode,
+        injected_summary_ids.len(),
+        suppressed_summary_ids.len(),
+        shadow_vs_live_diff
+            .as_ref()
+            .map(|diff| diff.would_inject_in_live.len())
+            .unwrap_or(0),
+    );
 
     let decision = PamAdvisoryDecision {
         mode,
@@ -462,6 +572,9 @@ pub(super) fn evaluate_pam_advisory(
         suppressed_summary_ids_truncated,
         shadow_vs_live_diff,
         active_job_role,
+        candidate_decisions,
+        candidate_decisions_truncated,
+        decision_effect,
     };
 
     PamAdvisoryOutcome {
@@ -493,6 +606,90 @@ fn apply_cap_suppressed(v: &mut Vec<SuppressedSummary>) -> bool {
         true
     } else {
         false
+    }
+}
+
+/// Apply `MAX_PAM_DECISION_LIST_LEN` cap to candidate attribution entries.
+fn apply_cap_candidate_decisions(v: &mut Vec<PamCandidateDecision>) -> bool {
+    if v.len() > MAX_PAM_DECISION_LIST_LEN {
+        v.truncate(MAX_PAM_DECISION_LIST_LEN);
+        true
+    } else {
+        false
+    }
+}
+
+fn push_candidate_decision(
+    out: &mut Vec<PamCandidateDecision>,
+    view: &AdmittedItemView,
+    inferred_role: Option<ArtifactRole>,
+    suppression_reason: Option<SuppressionReason>,
+    action: PamCandidateAction,
+    decision_impact: &'static str,
+) {
+    let Some(summary_id) = view.provenance.summary_id.clone() else {
+        return;
+    };
+    let (context_excerpt, context_excerpt_truncated) =
+        truncate_context_excerpt(&view.render_text, MAX_PAM_CONTEXT_EXCERPT_CHARS);
+    out.push(PamCandidateDecision {
+        summary_id,
+        action,
+        inferred_role: inferred_role.map(ArtifactRole::label),
+        suppression_reason,
+        decision_impact,
+        context_excerpt,
+        context_excerpt_truncated,
+    });
+}
+
+fn truncate_context_excerpt(text: &str, max_chars: usize) -> (String, bool) {
+    let mut out = String::new();
+    for (count, ch) in text.chars().enumerate() {
+        if count == max_chars {
+            return (out, true);
+        }
+        out.push(ch);
+    }
+    (out, false)
+}
+
+fn suppression_impact(
+    reason: SuppressionReason,
+    active_kind: Option<ActiveJobKind>,
+) -> &'static str {
+    match (reason, active_kind) {
+        (SuppressionReason::ImplExpansionBlocked, Some(ActiveJobKind::VerifierRepair)) => {
+            "repair_context_suppressed_impl_expansion"
+        }
+        (SuppressionReason::ImplExpansionBlocked, Some(ActiveJobKind::ArtifactRecovery)) => {
+            "artifact_recovery_suppressed_impl_expansion"
+        }
+        (SuppressionReason::BehaviorNonGoalMismatch, _) => "behavior_contract_suppressed_non_goal",
+        (SuppressionReason::RoleMismatch, _) => "artifact_role_mismatch_suppressed",
+        (SuppressionReason::ImplExpansionBlocked, _) => "impl_expansion_suppressed",
+    }
+}
+
+fn build_decision_effect(
+    mode: PamAdvisoryMode,
+    injected_count: usize,
+    suppressed_count: usize,
+    would_inject_count: usize,
+) -> PamDecisionEffect {
+    let influenced_decision = match mode {
+        PamAdvisoryMode::Shadow => "shadow_counterfactual",
+        PamAdvisoryMode::Live if injected_count > 0 => "prompt_context_injection",
+        PamAdvisoryMode::Suppressed | PamAdvisoryMode::Live if suppressed_count > 0 => {
+            "advisory_suppression"
+        }
+        PamAdvisoryMode::Live | PamAdvisoryMode::Suppressed => "none",
+    };
+    PamDecisionEffect {
+        actual_injected_count: injected_count as u32,
+        suppressed_count: suppressed_count as u32,
+        would_inject_in_live_count: would_inject_count as u32,
+        influenced_decision,
     }
 }
 

--- a/src/agent/loop_run/pam_advisory_e2e_tests.rs
+++ b/src/agent/loop_run/pam_advisory_e2e_tests.rs
@@ -259,6 +259,32 @@ fn t17_pam_advisory_decision_payload_schema_pin() {
         ],
         "suppressed_summary_ids_truncated": false,
         "active_job_role": "ArtifactRecovery:test",
+        "candidate_decisions": [
+            {
+                "summary_id": "s1",
+                "action": "inject",
+                "inferred_role": "test",
+                "decision_impact": "prompt_context_injected",
+                "context_excerpt": "tests/foo_test.py",
+                "context_excerpt_truncated": false
+            },
+            {
+                "summary_id": "s2",
+                "action": "suppress",
+                "inferred_role": "implementation",
+                "suppression_reason": "role_mismatch",
+                "decision_impact": "artifact_role_mismatch_suppressed",
+                "context_excerpt": "src/lib.rs",
+                "context_excerpt_truncated": false
+            }
+        ],
+        "candidate_decisions_truncated": false,
+        "decision_effect": {
+            "actual_injected_count": 1,
+            "suppressed_count": 1,
+            "would_inject_in_live_count": 0,
+            "influenced_decision": "prompt_context_injection"
+        }
     });
     let live_payload = PamAdvisoryDecisionPayloadShape::sample_live();
     assert_eq!(live_payload, expected_live);
@@ -274,6 +300,23 @@ fn t17_pam_advisory_decision_payload_schema_pin() {
             "would_inject_in_live_truncated": false,
         },
         "active_job_role": ":",
+        "candidate_decisions": [
+            {
+                "summary_id": "sX",
+                "action": "would_inject_in_live",
+                "inferred_role": "test",
+                "decision_impact": "shadow_counterfactual_not_injected",
+                "context_excerpt": "tests/shadow_test.py",
+                "context_excerpt_truncated": false
+            }
+        ],
+        "candidate_decisions_truncated": false,
+        "decision_effect": {
+            "actual_injected_count": 0,
+            "suppressed_count": 0,
+            "would_inject_in_live_count": 1,
+            "influenced_decision": "shadow_counterfactual"
+        }
     });
     let shadow_payload = PamAdvisoryDecisionPayloadShape::sample_shadow();
     assert_eq!(shadow_payload, expected_shadow);
@@ -423,6 +466,95 @@ fn t1_t2_t3_mode_precedence_branches() {
     assert_eq!(outcome_m.decision.mode, PamAdvisoryMode::Live);
     assert!(!outcome_m.decision.injected_summary_ids.is_empty());
     assert!(!outcome_m.decision.suppressed_summary_ids.is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// Issue #849 — decision log explains which PAM context was adopted or
+// suppressed and what downstream decision surface it affected.
+// ---------------------------------------------------------------------------
+#[test]
+fn issue849_decision_log_captures_context_and_decision_effect() {
+    use crate::agent::loop_run::pam_advisory::{
+        PamAdvisoryModeInput, build_active_job_selection_artifact_recovery_for_test,
+        pam_advisory_decide_for_test,
+    };
+    let resp = build_response_with_items(&[
+        (
+            "s-test-adopted",
+            "tests/foo_test.py: add regression coverage",
+        ),
+        (
+            "s-impl-blocked",
+            "src/database.py: expand implementation during repair",
+        ),
+    ]);
+    let blocked: HashSet<String> = HashSet::new();
+    let active = build_active_job_selection_artifact_recovery_for_test();
+    let outcome = pam_advisory_decide_for_test(
+        &resp,
+        &blocked,
+        Some(&active),
+        Some(crate::agent::loop_run::task_contract::ArtifactRole::Test),
+        None,
+        PamAdvisoryModeInput { shadow: false },
+    );
+    let payload = outcome.decision.to_json_value();
+    let candidates = payload
+        .get("candidate_decisions")
+        .and_then(|v| v.as_array())
+        .expect("candidate_decisions array");
+    assert_eq!(candidates.len(), 2);
+
+    let adopted = candidates
+        .iter()
+        .find(|v| v.get("summary_id").and_then(|s| s.as_str()) == Some("s-test-adopted"))
+        .expect("adopted candidate");
+    assert_eq!(
+        adopted.get("action").and_then(|v| v.as_str()),
+        Some("inject")
+    );
+    assert_eq!(
+        adopted.get("inferred_role").and_then(|v| v.as_str()),
+        Some("test")
+    );
+    assert_eq!(
+        adopted.get("decision_impact").and_then(|v| v.as_str()),
+        Some("prompt_context_injected")
+    );
+    assert!(
+        adopted
+            .get("context_excerpt")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .contains("tests/foo_test.py"),
+        "adopted PAM context excerpt should identify the memory"
+    );
+
+    let suppressed = candidates
+        .iter()
+        .find(|v| v.get("summary_id").and_then(|s| s.as_str()) == Some("s-impl-blocked"))
+        .expect("suppressed candidate");
+    assert_eq!(
+        suppressed.get("action").and_then(|v| v.as_str()),
+        Some("suppress")
+    );
+    assert_eq!(
+        suppressed
+            .get("suppression_reason")
+            .and_then(|v| v.as_str()),
+        Some("impl_expansion_blocked")
+    );
+    assert_eq!(
+        suppressed.get("decision_impact").and_then(|v| v.as_str()),
+        Some("artifact_recovery_suppressed_impl_expansion")
+    );
+    assert_eq!(
+        payload
+            .get("decision_effect")
+            .and_then(|v| v.get("influenced_decision"))
+            .and_then(|v| v.as_str()),
+        Some("prompt_context_injection")
+    );
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Linked Issue: #849

Summary:
- Add additive PAM decision telemetry for candidate decisions, truncation, and decision effect.
- Record whether each memory candidate was injected, suppressed, or would have injected in live mode.
- Preserve existing memory report schema version and add focused PAM advisory coverage.

Changed files:
- src/agent/loop_run.rs
- src/agent/loop_run/pam_advisory.rs
- src/agent/loop_run/pam_advisory_e2e_tests.rs

Tests run:
- cargo test pam_advisory
- cargo fmt --check
- cargo clippy --all-targets --all-features
- cargo test
- cargo build --release

Known risks:
- New telemetry is additive but downstream consumers should ignore unknown fields as expected.

Orchestration run ID: 20260531-145150-orchestrate