### PR TITLE
Issue #874: generalize TaskContract deliverables and completion evidence

### DIFF
--- a/src/agent/loop_run/completion_evidence.rs
+++ b/src/agent/loop_run/completion_evidence.rs
@@ -123,6 +123,22 @@ pub(crate) enum CompletionEvidence {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         path: Option<String>,
     },
+    /// A non-shell deliverable checker proved that a structured data
+    /// artifact satisfies its requested shape, such as required CSV columns
+    /// or a structured-record schema. This keeps data completion independent
+    /// from coding verifier exits.
+    StructuredDataPass {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        path: Option<String>,
+    },
+    /// A non-shell deliverable checker proved that a report-like artifact is
+    /// complete enough for the active obligation. This is intentionally
+    /// generic so docs/research/ops producers can emit completion evidence
+    /// without pretending they ran a coding verifier.
+    ReportCompletenessPass {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        path: Option<String>,
+    },
     /// The model produced an answer-only reply (no tool calls). Reserved
     /// for AnswerOnly protocol acceptance.
     AnswerOnly,

--- a/src/agent/loop_run/protocol.rs
+++ b/src/agent/loop_run/protocol.rs
@@ -94,6 +94,7 @@ impl ProtocolKind {
                 },
             ) => true,
             (ProtocolKind::Docs, CompletionEvidence::RequiredSectionsPass { .. }) => true,
+            (ProtocolKind::Docs, CompletionEvidence::ReportCompletenessPass { .. }) => true,
             _ => false,
         }
     }
@@ -317,9 +318,10 @@ impl ProtocolKind {
                             category: RepoEditCategory::Docs,
                             ..
                         } | CompletionEvidence::RequiredSectionsPass { .. }
+                            | CompletionEvidence::ReportCompletenessPass { .. }
                     )
                 }) {
-                    missing.push("repo_edit_docs_or_required_sections_pass");
+                    missing.push("repo_edit_docs_or_deliverable_pass");
                 }
             }
         }
@@ -1048,6 +1050,12 @@ mod tests {
         }
     }
 
+    fn ev_report_completeness() -> CompletionEvidence {
+        CompletionEvidence::ReportCompletenessPass {
+            path: Some("README.md".to_string()),
+        }
+    }
+
     /// U-09 — 5 ProtocolKind × evidence variant matrix smoke.
     #[test]
     fn protocol_kind_accepts_each_completion_evidence_kind() {
@@ -1058,6 +1066,7 @@ mod tests {
         let setup_edit = ev_repo_edit(RepoEditCategory::Setup);
         let other_edit = ev_repo_edit(RepoEditCategory::Other);
         let sections_pass = ev_required_sections();
+        let report_pass = ev_report_completeness();
         let answer_only = CompletionEvidence::AnswerOnly;
 
         // Python
@@ -1068,6 +1077,7 @@ mod tests {
         assert!(!ProtocolKind::Python.accepts(&setup_edit));
         assert!(!ProtocolKind::Python.accepts(&other_edit));
         assert!(!ProtocolKind::Python.accepts(&sections_pass));
+        assert!(!ProtocolKind::Python.accepts(&report_pass));
         assert!(!ProtocolKind::Python.accepts(&answer_only));
 
         // TypeScriptUi
@@ -1076,6 +1086,7 @@ mod tests {
         assert!(!ProtocolKind::TypeScriptUi.accepts(&test_edit));
         assert!(!ProtocolKind::TypeScriptUi.accepts(&docs_edit));
         assert!(!ProtocolKind::TypeScriptUi.accepts(&sections_pass));
+        assert!(!ProtocolKind::TypeScriptUi.accepts(&report_pass));
 
         // GenericCode — any RepoEdit, plus VerifierExitZero
         assert!(ProtocolKind::GenericCode.accepts(&verifier));
@@ -1085,6 +1096,7 @@ mod tests {
         assert!(ProtocolKind::GenericCode.accepts(&setup_edit));
         assert!(ProtocolKind::GenericCode.accepts(&other_edit));
         assert!(!ProtocolKind::GenericCode.accepts(&sections_pass));
+        assert!(!ProtocolKind::GenericCode.accepts(&report_pass));
         assert!(!ProtocolKind::GenericCode.accepts(&answer_only));
 
         // AnswerOnly
@@ -1093,10 +1105,12 @@ mod tests {
         assert!(!ProtocolKind::AnswerOnly.accepts(&impl_edit));
         assert!(!ProtocolKind::AnswerOnly.accepts(&docs_edit));
         assert!(!ProtocolKind::AnswerOnly.accepts(&sections_pass));
+        assert!(!ProtocolKind::AnswerOnly.accepts(&report_pass));
 
         // Docs
         assert!(ProtocolKind::Docs.accepts(&docs_edit));
         assert!(ProtocolKind::Docs.accepts(&sections_pass));
+        assert!(ProtocolKind::Docs.accepts(&report_pass));
         assert!(!ProtocolKind::Docs.accepts(&verifier));
         assert!(!ProtocolKind::Docs.accepts(&impl_edit));
         assert!(!ProtocolKind::Docs.accepts(&answer_only));
@@ -1189,7 +1203,7 @@ mod tests {
         );
         assert_eq!(
             ProtocolKind::Docs.evidence_set_missing_shapes(&empty),
-            vec!["repo_edit_docs_or_required_sections_pass"]
+            vec!["repo_edit_docs_or_deliverable_pass"]
         );
 
         // Partial — a Test edit satisfies Python's repo-edit slot but

--- a/src/agent/loop_run/task_contract.rs
+++ b/src/agent/loop_run/task_contract.rs
@@ -264,6 +264,13 @@ impl CompletionPolicy {
                 self.project_intent == CompletionProjectIntent::DocsOnly
                     || self.required_artifacts.contains(&ArtifactRole::UsageDocs)
             }
+            CompletionEvidence::StructuredDataPass { .. } => {
+                self.required_artifacts.contains(&ArtifactRole::DataOutput)
+            }
+            CompletionEvidence::ReportCompletenessPass { .. } => {
+                self.project_intent == CompletionProjectIntent::DocsOnly
+                    || self.required_artifacts.contains(&ArtifactRole::UsageDocs)
+            }
             CompletionEvidence::AnswerOnly => {
                 self.project_intent == CompletionProjectIntent::AnswerOnly
             }
@@ -889,6 +896,14 @@ fn artifact_identity_observed_in_evidence(
                 && normalized_artifact_path_eq(path, &identity.path)
         }
         CompletionEvidence::RequiredSectionsPass { path: Some(path) } => {
+            identity.role == ArtifactRole::UsageDocs
+                && normalized_artifact_path_eq(path, &identity.path)
+        }
+        CompletionEvidence::StructuredDataPass { path: Some(path) } => {
+            identity.role == ArtifactRole::DataOutput
+                && normalized_artifact_path_eq(path, &identity.path)
+        }
+        CompletionEvidence::ReportCompletenessPass { path: Some(path) } => {
             identity.role == ArtifactRole::UsageDocs
                 && normalized_artifact_path_eq(path, &identity.path)
         }
@@ -2824,6 +2839,10 @@ fn observed_artifacts(evidence: &EvidenceSet) -> Vec<ArtifactRole> {
             } => roles.push(ArtifactRole::Setup),
             CompletionEvidence::VerifierExitZero { .. } => {}
             CompletionEvidence::RequiredSectionsPass { .. } => roles.push(ArtifactRole::UsageDocs),
+            CompletionEvidence::StructuredDataPass { .. } => roles.push(ArtifactRole::DataOutput),
+            CompletionEvidence::ReportCompletenessPass { .. } => {
+                roles.push(ArtifactRole::UsageDocs)
+            }
             CompletionEvidence::AnswerOnly => {}
         }
     }
@@ -3296,6 +3315,23 @@ mod tests {
     }
 
     #[test]
+    fn docs_report_completeness_pass_satisfies_docs_completion() {
+        let contract = TaskContract::from_request("Update README.md with usage documentation");
+        let mut evidence = EvidenceSet::new();
+        evidence.push(CompletionEvidence::ReportCompletenessPass {
+            path: Some("README.md".to_string()),
+        });
+
+        assert_eq!(contract.task_kind, TaskKind::Docs);
+        assert_eq!(contract.required_artifacts, vec![ArtifactRole::UsageDocs]);
+        assert!(!contract.verification_required);
+        assert_eq!(
+            contract.evaluate_with_owned_test_artifacts(&evidence, &[]),
+            CompletionDecision::Done
+        );
+    }
+
+    #[test]
     fn docs_only_check_request_reaches_done_without_coding_verifier() {
         let contract =
             TaskContract::from_request("Check and update the README documentation for usage");
@@ -3321,6 +3357,7 @@ mod tests {
         let mut evidence = EvidenceSet::new();
         evidence.push(repo_edit_path(RepoEditCategory::Impl, "main.py"));
 
+        assert_eq!(contract.task_kind, TaskKind::Coding);
         assert!(contract.verification_required);
         assert_eq!(
             contract.evaluate_with_owned_test_artifacts(&evidence, &[]),
@@ -4224,6 +4261,40 @@ mod tests {
                 owned_test_artifacts: &[],
             }),
             ArtifactRecoveryAction::Done
+        );
+    }
+
+    #[test]
+    fn data_structured_evidence_satisfies_data_completion() {
+        let contract = TaskContract::from_request(
+            "Generate output.csv with columns Category and Total from the input CSV.",
+        );
+        let mut evidence = EvidenceSet::new();
+        evidence.push(CompletionEvidence::StructuredDataPass {
+            path: Some("output.csv".to_string()),
+        });
+
+        assert_eq!(contract.task_kind, TaskKind::Data);
+        assert_eq!(contract.required_artifacts, vec![ArtifactRole::DataOutput]);
+        assert_eq!(
+            contract.evaluate_with_owned_test_artifacts(&evidence, &[]),
+            CompletionDecision::Done
+        );
+    }
+
+    #[test]
+    fn data_structured_evidence_must_match_required_path() {
+        let contract = TaskContract::from_request(
+            "Generate output.csv with columns Category and Total from the input CSV.",
+        );
+        let mut evidence = EvidenceSet::new();
+        evidence.push(CompletionEvidence::StructuredDataPass {
+            path: Some("summary.csv".to_string()),
+        });
+
+        assert_eq!(
+            missing_labels(&contract.evaluate_with_owned_test_artifacts(&evidence, &[])),
+            vec!["data_output"]
         );
     }
 


### PR DESCRIPTION
# Issue #874 Implementation Summary

## Summary

Implemented a focused generalization of completion evidence so deliverable obligations can be satisfied by non-coding proof, not only repository edits or shell verifier exits.

## Changes

- Added `CompletionEvidence::StructuredDataPass` for structured data deliverables.
- Added `CompletionEvidence::ReportCompletenessPass` for report-like deliverables.
- Wired the new evidence into `CompletionPolicy`, artifact observation, and path-bound `ArtifactObligation` matching.
- Updated docs protocol acceptance to treat report completeness as docs deliverable evidence.
- Preserved existing coding behavior:
  - implementation tasks still require verifier execution when the contract requires verification;
  - test-required coding tasks still use the owned/bound verifier gate.

## Tests Added

- Docs flow: report completeness evidence completes a README/docs-only task without coding verifier.
- Coding flow: Python CLI implementation evidence still returns `Verify` before `Done`.
- Data flow: structured-data evidence completes a path-bound `output.csv` obligation.
- Data negative flow: structured-data evidence for the wrong path leaves `data_output` missing.
- Protocol matrix: docs protocol accepts report-completeness evidence while code/answer protocols reject it.
