### PR TITLE
Issue #877: make RepairPacket target deliverable obligations

### DIFF
--- a/src/agent/loop_run.rs
+++ b/src/agent/loop_run.rs
@@ -473,7 +473,11 @@ mod repair_plan_admission;
 // v0.4.13 Phase 2: small diagnostic schema returned by the short-lived
 // diagnostic LLM. Private module; no direct provider abstraction.
 mod repair_brief;
+// Issue #877: deliverable-obligation repair packet projection. Private
+// adapter over TaskContract + RepairJob state; repair loop ownership stays
+// with the repair modules.
 mod repair_job;
+mod repair_packet;
 // Issue #653: `RepairAttemptOutcome` lifecycle ledger. Module is intentionally
 // *not* re-exported (DR3-001) — `turn.rs` and `repair_job.rs` are the only
 // in-crate consumers via `super::repair_attempt_outcome::*`.

--- a/src/agent/loop_run/repair_job.rs
+++ b/src/agent/loop_run/repair_job.rs
@@ -21,6 +21,7 @@ use super::repair_attempt_outcome::{
     RepairRejectionKind, should_promote_to_exhausted_after_push,
 };
 use super::repair_brief::AllowedChangeKind;
+use super::repair_packet::{DeliverableFailureDomain, RepairPacket, obligation_id_for_parts};
 use super::semantic_failure::{FailureClusterKey, SemanticFailureReport};
 use super::spec_authority::{RepairRole, SpecAuthority, WeakeningPattern};
 use super::task_contract::{ArtifactRole, RecoveryTargetHint};
@@ -507,6 +508,8 @@ pub(super) struct RepairAttemptKey {
     pub(super) role: ArtifactRole,
     pub(super) path: String,
     pub(super) allowed_change_kind: Option<AllowedChangeKind>,
+    pub(super) obligation_id: Option<String>,
+    pub(super) failure_domain: Option<DeliverableFailureDomain>,
 }
 
 impl RepairAttemptKey {
@@ -518,6 +521,26 @@ impl RepairAttemptKey {
             role: target.role,
             path: sanitize_repair_job_text_with_char_cap(&target.path, 240),
             allowed_change_kind,
+            obligation_id: Some(obligation_id_for_parts(target.role, Some(&target.path))),
+            failure_domain: None,
+        }
+    }
+
+    pub(super) fn from_packet(
+        packet: &RepairPacket,
+        allowed_change_kind: Option<AllowedChangeKind>,
+    ) -> Self {
+        Self {
+            role: packet.target.role,
+            path: packet
+                .target
+                .path
+                .as_deref()
+                .map(|path| sanitize_repair_job_text_with_char_cap(path, 240))
+                .unwrap_or_default(),
+            allowed_change_kind,
+            obligation_id: Some(packet.target.obligation_id.clone()),
+            failure_domain: Some(packet.target.failure_domain),
         }
     }
 }
@@ -2652,6 +2675,12 @@ pub(super) const SAFE_STOP_PER_CLUSTER_MAX: usize = 8;
 /// Maximum number of role labels per cluster in `ExhaustedAttemptsSummary.per_cluster`.
 pub(super) const SAFE_STOP_PER_CLUSTER_ROLE_MAX: usize = 4;
 
+/// Maximum number of obligation targets retained in terminal diagnostics.
+pub(super) const SAFE_STOP_OBLIGATION_TARGET_MAX: usize = 8;
+
+/// Maximum number of invalid proposal summaries retained in terminal diagnostics.
+pub(super) const SAFE_STOP_INVALID_PROPOSAL_MAX: usize = 8;
+
 /// Issue #654 — per-turn dedup key. Each variant maps 1:1 to a `stop_reason`
 /// label that appears in the `agent.safe_stop.report` event payload.
 ///
@@ -2724,12 +2753,29 @@ pub(super) struct ExhaustedAttemptsSummary {
     pub(super) per_cluster: Vec<(String, Vec<&'static str>)>,
     /// Sanitized + 240-char-capped repair hypothesis. `None` when no plan / no hypothesis.
     pub(super) last_repair_hypothesis: Option<String>,
+    /// Obligation-level targets that remain unsatisfied at terminal repair.
+    pub(super) unfulfilled_obligations: Vec<super::repair_packet::RepairObligationTarget>,
+    /// Invalid controller repair proposals tied back to obligation id/domain.
+    pub(super) invalid_proposal_reasons: Vec<InvalidRepairProposalSummary>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) struct InvalidRepairProposalSummary {
+    pub(super) obligation_id: Option<String>,
+    pub(super) role: ArtifactRole,
+    pub(super) path: String,
+    pub(super) failure_domain: Option<super::repair_packet::DeliverableFailureDomain>,
+    pub(super) reason: RejectedAttemptReason,
 }
 
 impl ExhaustedAttemptsSummary {
     /// Build a bounded summary from a `RepairJob` and an optional last
     /// hypothesis text (raw, will be sanitized + capped here).
-    pub(super) fn from_repair_job(job: &RepairJob, last_hyp: Option<&str>) -> Self {
+    pub(super) fn from_repair_job(
+        job: &RepairJob,
+        last_hyp: Option<&str>,
+        unfulfilled_obligations: &[super::repair_packet::RepairObligationTarget],
+    ) -> Self {
         let total = job.exhausted_attempts.len();
         let mut per_cluster: Vec<(String, Vec<&'static str>)> = Vec::new();
         for (cluster_key, role) in job.exhausted_attempts.iter() {
@@ -2752,10 +2798,32 @@ impl ExhaustedAttemptsSummary {
         let last_repair_hypothesis = last_hyp.map(|raw| {
             sanitize_repair_job_text_with_char_cap(raw, SAFE_STOP_LAST_REPAIR_HYPOTHESIS_CHAR_CAP)
         });
+        let invalid_proposal_reasons = job
+            .rejected_attempts
+            .iter()
+            .rev()
+            .take(SAFE_STOP_INVALID_PROPOSAL_MAX)
+            .map(|attempt| InvalidRepairProposalSummary {
+                obligation_id: attempt.key.obligation_id.clone(),
+                role: attempt.key.role,
+                path: sanitize_repair_job_text_with_char_cap(
+                    &attempt.key.path,
+                    SAFE_STOP_PATH_CHAR_CAP,
+                ),
+                failure_domain: attempt.key.failure_domain,
+                reason: attempt.reason,
+            })
+            .collect::<Vec<_>>();
         Self {
             total,
             per_cluster,
             last_repair_hypothesis,
+            unfulfilled_obligations: unfulfilled_obligations
+                .iter()
+                .take(SAFE_STOP_OBLIGATION_TARGET_MAX)
+                .cloned()
+                .collect(),
+            invalid_proposal_reasons,
         }
     }
 }
@@ -2910,6 +2978,8 @@ pub(super) struct SafeStopContext<'a> {
     pub(super) task_workspace_scope: &'a super::task_workspace_scope::TaskWorkspaceScope,
     /// Candidate paths considered during diagnostic target selection.
     pub(super) candidates: Vec<String>,
+    /// Obligation-level targets known to remain unsatisfied at terminal repair.
+    pub(super) unfulfilled_obligations: Vec<super::repair_packet::RepairObligationTarget>,
     /// For event-payload `session_id` and `turn_index` fields.
     pub(super) session_id: &'a str,
     pub(super) turn_index: u64,
@@ -2991,7 +3061,11 @@ impl SafeStopReport {
                     .semantic_plan
                     .as_ref()
                     .map(|plan| plan.repair_hypothesis.as_str());
-                let summary = Some(ExhaustedAttemptsSummary::from_repair_job(job, last_hyp));
+                let summary = Some(ExhaustedAttemptsSummary::from_repair_job(
+                    job,
+                    last_hyp,
+                    &ctx.unfulfilled_obligations,
+                ));
                 Self {
                     failure_signature: snapshot.failure_signature,
                     command: snapshot.command,
@@ -7651,7 +7725,7 @@ mod tests {
             key_b.clone(),
             super::super::task_contract::ArtifactRole::Implementation,
         ));
-        let summary = ExhaustedAttemptsSummary::from_repair_job(&job, None);
+        let summary = ExhaustedAttemptsSummary::from_repair_job(&job, None, &[]);
         assert_eq!(summary.total, 4);
         assert_eq!(summary.per_cluster.len(), 2);
         // Cluster A has 2 unique roles (Implementation + Test).
@@ -7669,9 +7743,50 @@ mod tests {
     fn exhausted_attempts_summary_caps_hypothesis_to_240_chars() {
         let job = RepairJob::new_for_test();
         let hyp = "h".repeat(500);
-        let summary = ExhaustedAttemptsSummary::from_repair_job(&job, Some(&hyp));
+        let summary = ExhaustedAttemptsSummary::from_repair_job(&job, Some(&hyp), &[]);
         let stored = summary.last_repair_hypothesis.expect("hypothesis stored");
         assert!(stored.chars().count() <= SAFE_STOP_LAST_REPAIR_HYPOTHESIS_CHAR_CAP + 3);
+    }
+
+    #[test]
+    fn exhausted_attempts_summary_includes_obligations_and_invalid_reasons() {
+        let mut job = RepairJob::new_for_test();
+        let packet_target = super::super::repair_packet::RepairObligationTarget {
+            obligation_id: "usage_docs:README.md".to_string(),
+            role: ArtifactRole::UsageDocs,
+            kind: super::super::task_contract::DeliverableKind::UsageDocs,
+            path: Some("README.md".to_string()),
+            expected_evidence: vec!["required sections: usage".to_string()],
+            failure_domain:
+                super::super::repair_packet::DeliverableFailureDomain::IncompleteSections,
+        };
+        job.rejected_attempts.push(RejectedAttempt {
+            key: RepairAttemptKey {
+                role: ArtifactRole::UsageDocs,
+                path: "README.md".to_string(),
+                allowed_change_kind: None,
+                obligation_id: Some(packet_target.obligation_id.clone()),
+                failure_domain: Some(packet_target.failure_domain),
+            },
+            reason: RejectedAttemptReason::MalformedPatch,
+        });
+
+        let summary = ExhaustedAttemptsSummary::from_repair_job(
+            &job,
+            None,
+            std::slice::from_ref(&packet_target),
+        );
+
+        assert_eq!(summary.unfulfilled_obligations, vec![packet_target]);
+        assert_eq!(summary.invalid_proposal_reasons.len(), 1);
+        assert_eq!(
+            summary.invalid_proposal_reasons[0].obligation_id.as_deref(),
+            Some("usage_docs:README.md")
+        );
+        assert_eq!(
+            summary.invalid_proposal_reasons[0].failure_domain,
+            Some(super::super::repair_packet::DeliverableFailureDomain::IncompleteSections)
+        );
     }
 
     #[test]
@@ -7774,6 +7889,7 @@ mod tests {
             latest_successful_read: None,
             task_workspace_scope: &scope,
             candidates: Vec::new(),
+            unfulfilled_obligations: Vec::new(),
             session_id: "session-1",
             turn_index: 1,
         };
@@ -7807,6 +7923,7 @@ mod tests {
             latest_successful_read: None,
             task_workspace_scope: &scope,
             candidates: Vec::new(),
+            unfulfilled_obligations: Vec::new(),
             session_id: "s",
             turn_index: 0,
         };
@@ -7839,6 +7956,7 @@ mod tests {
             latest_successful_read: None,
             task_workspace_scope: &scope,
             candidates: Vec::new(),
+            unfulfilled_obligations: Vec::new(),
             session_id: "s",
             turn_index: 0,
         };
@@ -7878,6 +7996,7 @@ mod tests {
             latest_successful_read: None,
             task_workspace_scope: &scope,
             candidates: Vec::new(),
+            unfulfilled_obligations: Vec::new(),
             session_id: "s",
             turn_index: 0,
         };

--- a/src/agent/loop_run/repair_packet.rs
+++ b/src/agent/loop_run/repair_packet.rs
@@ -1,0 +1,320 @@
+use super::repair_job::sanitize_repair_job_text_with_char_cap;
+use super::task_contract::{
+    ArtifactObligation, ArtifactRole, DeliverableKind, RecoveryTargetHint, TaskContract, TaskKind,
+};
+
+const MAX_EXPECTED_EVIDENCE_ITEMS: usize = 8;
+const MAX_EXPECTED_EVIDENCE_CHARS: usize = 160;
+const MAX_REPAIR_INSTRUCTION_CHARS: usize = 360;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum DeliverableFailureDomain {
+    MissingDeliverable,
+    MalformedDeliverable,
+    VerifierFailed,
+    SchemaMismatch,
+    IncompleteSections,
+    UnsafeOrOutOfScope,
+}
+
+impl DeliverableFailureDomain {
+    pub(super) fn as_str(self) -> &'static str {
+        match self {
+            Self::MissingDeliverable => "missing_deliverable",
+            Self::MalformedDeliverable => "malformed_deliverable",
+            Self::VerifierFailed => "verifier_failed",
+            Self::SchemaMismatch => "schema_mismatch",
+            Self::IncompleteSections => "incomplete_sections",
+            Self::UnsafeOrOutOfScope => "unsafe_or_out_of_scope",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct RepairObligationTarget {
+    pub(super) obligation_id: String,
+    pub(super) role: ArtifactRole,
+    pub(super) kind: DeliverableKind,
+    pub(super) path: Option<String>,
+    pub(super) expected_evidence: Vec<String>,
+    pub(super) failure_domain: DeliverableFailureDomain,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct RepairPacket {
+    pub(super) target: RepairObligationTarget,
+    pub(super) instruction: String,
+}
+
+impl RepairPacket {
+    pub(super) fn for_obligation(
+        contract: &TaskContract,
+        obligation: &ArtifactObligation,
+        failure_domain: DeliverableFailureDomain,
+    ) -> Self {
+        let target = target_from_obligation(obligation, failure_domain);
+        Self {
+            instruction: adapter_instruction(contract.task_kind, &target),
+            target,
+        }
+    }
+
+    pub(super) fn for_recovery_target(
+        contract: &TaskContract,
+        hint: &RecoveryTargetHint,
+        failure_domain: DeliverableFailureDomain,
+    ) -> Self {
+        if let Some(obligation) = contract.obligation_for_target(hint) {
+            return Self::for_obligation(contract, obligation, failure_domain);
+        }
+        let target = target_from_recovery_hint(hint, failure_domain);
+        Self {
+            instruction: adapter_instruction(contract.task_kind, &target),
+            target,
+        }
+    }
+}
+
+pub(super) fn obligation_id_for_parts(role: ArtifactRole, path: Option<&str>) -> String {
+    let path = path.unwrap_or("*");
+    format!("{}:{path}", role.label())
+}
+
+pub(super) fn default_failure_domain_for_obligation(
+    obligation: &ArtifactObligation,
+) -> DeliverableFailureDomain {
+    if obligation.role == ArtifactRole::UsageDocs && !obligation.required_sections.is_empty() {
+        return DeliverableFailureDomain::IncompleteSections;
+    }
+    if obligation.role == ArtifactRole::DataOutput && obligation.structured_record_schema.is_some()
+    {
+        return DeliverableFailureDomain::SchemaMismatch;
+    }
+    DeliverableFailureDomain::MissingDeliverable
+}
+
+pub(super) fn repair_packets_for_contract(contract: &TaskContract) -> Vec<RepairPacket> {
+    let mut packets = contract
+        .required_artifact_identities
+        .iter()
+        .map(|obligation| {
+            RepairPacket::for_obligation(
+                contract,
+                obligation,
+                default_failure_domain_for_obligation(obligation),
+            )
+        })
+        .collect::<Vec<_>>();
+    if packets.is_empty() {
+        packets.extend(contract.required_artifacts.iter().map(|role| {
+            let hint = RecoveryTargetHint {
+                role: *role,
+                path: String::new(),
+                reason: "required artifact role remains unsatisfied".to_string(),
+            };
+            RepairPacket::for_recovery_target(
+                contract,
+                &hint,
+                DeliverableFailureDomain::MissingDeliverable,
+            )
+        }));
+    }
+    packets
+}
+
+fn target_from_obligation(
+    obligation: &ArtifactObligation,
+    failure_domain: DeliverableFailureDomain,
+) -> RepairObligationTarget {
+    RepairObligationTarget {
+        obligation_id: obligation_id_for_parts(obligation.role, Some(&obligation.path)),
+        role: obligation.role,
+        kind: obligation.kind,
+        path: Some(sanitize_repair_job_text_with_char_cap(
+            &obligation.path,
+            MAX_EXPECTED_EVIDENCE_CHARS,
+        )),
+        expected_evidence: expected_evidence_for_obligation(obligation),
+        failure_domain,
+    }
+}
+
+fn target_from_recovery_hint(
+    hint: &RecoveryTargetHint,
+    failure_domain: DeliverableFailureDomain,
+) -> RepairObligationTarget {
+    let path = if hint.path.is_empty() {
+        None
+    } else {
+        Some(sanitize_repair_job_text_with_char_cap(
+            &hint.path,
+            MAX_EXPECTED_EVIDENCE_CHARS,
+        ))
+    };
+    RepairObligationTarget {
+        obligation_id: obligation_id_for_parts(hint.role, path.as_deref()),
+        role: hint.role,
+        kind: default_kind_for_role(hint.role),
+        path,
+        expected_evidence: vec![bounded_evidence(format!(
+            "repair target path for {}",
+            hint.role.label()
+        ))],
+        failure_domain,
+    }
+}
+
+fn expected_evidence_for_obligation(obligation: &ArtifactObligation) -> Vec<String> {
+    let mut evidence = Vec::new();
+    if !obligation.required_sections.is_empty() {
+        evidence.push(bounded_evidence(format!(
+            "required sections: {}",
+            obligation
+                .required_sections
+                .iter()
+                .take(MAX_EXPECTED_EVIDENCE_ITEMS)
+                .cloned()
+                .collect::<Vec<_>>()
+                .join(", ")
+        )));
+    }
+    if let Some(schema) = obligation.structured_record_schema.as_ref()
+        && !schema.columns.is_empty()
+    {
+        evidence.push(bounded_evidence(format!(
+            "required columns: {}",
+            schema
+                .columns
+                .iter()
+                .take(MAX_EXPECTED_EVIDENCE_ITEMS)
+                .cloned()
+                .collect::<Vec<_>>()
+                .join(", ")
+        )));
+    }
+    evidence.push(bounded_evidence(format!(
+        "deliverable path: {}",
+        obligation.path
+    )));
+    evidence.truncate(MAX_EXPECTED_EVIDENCE_ITEMS);
+    evidence
+}
+
+fn adapter_instruction(task_kind: TaskKind, target: &RepairObligationTarget) -> String {
+    let instruction = match (task_kind, target.failure_domain) {
+        (TaskKind::Docs, DeliverableFailureDomain::IncompleteSections)
+        | (_, DeliverableFailureDomain::IncompleteSections) => {
+            "add or repair the required documentation sections for this deliverable obligation"
+        }
+        (TaskKind::Data, DeliverableFailureDomain::SchemaMismatch)
+        | (_, DeliverableFailureDomain::SchemaMismatch) => {
+            "repair the structured data deliverable so its schema matches the required evidence"
+        }
+        (TaskKind::Coding, DeliverableFailureDomain::VerifierFailed)
+        | (_, DeliverableFailureDomain::VerifierFailed) => {
+            "repair the selected deliverable obligation while preserving verifier safety gates"
+        }
+        (_, DeliverableFailureDomain::UnsafeOrOutOfScope) => {
+            "discard the unsafe or out-of-scope proposal and choose an admitted obligation target"
+        }
+        (_, DeliverableFailureDomain::MalformedDeliverable) => {
+            "repair malformed deliverable content for the obligation target"
+        }
+        (_, DeliverableFailureDomain::MissingDeliverable) => {
+            "create or complete the missing deliverable obligation"
+        }
+    };
+    sanitize_repair_job_text_with_char_cap(instruction, MAX_REPAIR_INSTRUCTION_CHARS)
+}
+
+fn bounded_evidence(raw: String) -> String {
+    sanitize_repair_job_text_with_char_cap(&raw, MAX_EXPECTED_EVIDENCE_CHARS)
+}
+
+fn default_kind_for_role(role: ArtifactRole) -> DeliverableKind {
+    match role {
+        ArtifactRole::Implementation => DeliverableKind::Code,
+        ArtifactRole::Test => DeliverableKind::Tests,
+        ArtifactRole::UsageDocs => DeliverableKind::UsageDocs,
+        ArtifactRole::Setup => DeliverableKind::Setup,
+        ArtifactRole::DataOutput => DeliverableKind::Data,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn packet_for_first_obligation(request: &str) -> RepairPacket {
+        let contract = TaskContract::from_request(request);
+        let obligation = contract
+            .required_artifact_identities
+            .first()
+            .expect("expected a required obligation");
+        RepairPacket::for_obligation(
+            &contract,
+            obligation,
+            default_failure_domain_for_obligation(obligation),
+        )
+    }
+
+    #[test]
+    fn docs_required_sections_produce_incomplete_sections_packet() {
+        let packet =
+            packet_for_first_obligation("Update README.md with setup, usage, and test sections.");
+
+        assert_eq!(
+            packet.target.failure_domain,
+            DeliverableFailureDomain::IncompleteSections
+        );
+        assert_eq!(packet.target.obligation_id, "usage_docs:README.md");
+        assert!(
+            packet
+                .target
+                .expected_evidence
+                .iter()
+                .any(|item| item.contains("required sections"))
+        );
+    }
+
+    #[test]
+    fn data_schema_mismatch_produces_structured_record_packet() {
+        let packet =
+            packet_for_first_obligation("Generate output.csv with columns id, name, score.");
+
+        assert_eq!(
+            packet.target.failure_domain,
+            DeliverableFailureDomain::SchemaMismatch
+        );
+        assert_eq!(packet.target.kind, DeliverableKind::StructuredRecord);
+        assert!(
+            packet
+                .target
+                .expected_evidence
+                .iter()
+                .any(|item| item.contains("required columns"))
+        );
+    }
+
+    #[test]
+    fn coding_verifier_failure_packet_targets_obligation() {
+        let contract = TaskContract::from_request("Create main.py as a Python CLI and add tests.");
+        let hint = RecoveryTargetHint {
+            role: ArtifactRole::Implementation,
+            path: "main.py".to_string(),
+            reason: "verifier failed".to_string(),
+        };
+        let packet = RepairPacket::for_recovery_target(
+            &contract,
+            &hint,
+            DeliverableFailureDomain::VerifierFailed,
+        );
+
+        assert_eq!(
+            packet.target.failure_domain,
+            DeliverableFailureDomain::VerifierFailed
+        );
+        assert_eq!(packet.target.obligation_id, "implementation:main.py");
+        assert_eq!(packet.target.role, ArtifactRole::Implementation);
+    }
+}

--- a/src/agent/loop_run/safe_stop_emit.rs
+++ b/src/agent/loop_run/safe_stop_emit.rs
@@ -125,6 +125,7 @@ pub(super) fn emit_safe_stop_report_for_diagnostic_target_missing(agent: &mut Ag
         latest_successful_read: latest_read.as_deref(),
         task_workspace_scope: &scope,
         candidates,
+        unfulfilled_obligations: repair_terminal_obligation_targets(agent),
         session_id: &session_id,
         turn_index,
     };
@@ -255,6 +256,7 @@ pub(super) fn emit_safe_stop_report_for_artifact_completion_failed(
         latest_successful_read: None,
         task_workspace_scope: &scope,
         candidates,
+        unfulfilled_obligations: repair_terminal_obligation_targets(agent),
         session_id: &session_id,
         turn_index,
     };
@@ -301,6 +303,7 @@ pub(super) fn emit_repair_safe_stop_report(
         latest_successful_read: None,
         task_workspace_scope: &scope,
         candidates,
+        unfulfilled_obligations: Vec::new(),
         session_id: &session_id,
         turn_index,
     };
@@ -339,10 +342,25 @@ pub(super) fn emit_safe_stop_report_for_verifier_missing(agent: &mut Agent) {
         latest_successful_read: None,
         task_workspace_scope: &scope,
         candidates: Vec::new(),
+        unfulfilled_obligations: Vec::new(),
         session_id: &session_id,
         turn_index,
     };
     record_safe_stop_report(agent, input, ctx);
+}
+
+fn repair_terminal_obligation_targets(
+    agent: &Agent,
+) -> Vec<super::repair_packet::RepairObligationTarget> {
+    let request = super::workspace_access::active_request_text(agent).unwrap_or_default();
+    if request.is_empty() {
+        return Vec::new();
+    }
+    let contract = super::task_contract::TaskContract::from_request(&request);
+    super::repair_packet::repair_packets_for_contract(&contract)
+        .into_iter()
+        .map(|packet| packet.target)
+        .collect()
 }
 
 /// Issue #654 (DR3-002 / Task D.6) — collect Owned-validated test

--- a/src/agent/loop_run/safe_stop_payload.rs
+++ b/src/agent/loop_run/safe_stop_payload.rs
@@ -132,6 +132,25 @@ fn render_safe_stop_payload(report: &SafeStopReport, truncated: bool) -> serde_j
                 serde_json::json!([k, roles])
             }).collect::<Vec<_>>(),
             "last_repair_hypothesis": s.last_repair_hypothesis,
+            "unfulfilled_obligations": s.unfulfilled_obligations.iter().map(|target| {
+                serde_json::json!({
+                    "obligation_id": target.obligation_id,
+                    "role": target.role.label(),
+                    "kind": target.kind.label(),
+                    "path": target.path,
+                    "expected_evidence": target.expected_evidence,
+                    "failure_domain": target.failure_domain.as_str(),
+                })
+            }).collect::<Vec<_>>(),
+            "invalid_proposal_reasons": s.invalid_proposal_reasons.iter().map(|entry| {
+                serde_json::json!({
+                    "obligation_id": entry.obligation_id,
+                    "role": entry.role.label(),
+                    "path": entry.path,
+                    "failure_domain": entry.failure_domain.map(|domain| domain.as_str()),
+                    "reason": entry.reason.as_str(),
+                })
+            }).collect::<Vec<_>>(),
         })
     });
     serde_json::json!({

--- a/src/agent/loop_run/task_contract.rs
+++ b/src/agent/loop_run/task_contract.rs
@@ -62,6 +62,25 @@ pub(super) enum DeliverableKind {
     ExternalReference,
 }
 
+impl DeliverableKind {
+    pub(super) fn label(self) -> &'static str {
+        match self {
+            DeliverableKind::Code => "code",
+            DeliverableKind::Tests => "tests",
+            DeliverableKind::UsageDocs => "usage_docs",
+            DeliverableKind::Setup => "setup",
+            DeliverableKind::Data => "data",
+            DeliverableKind::ResearchNotes => "research_notes",
+            DeliverableKind::OpsRunbook => "ops_runbook",
+            DeliverableKind::File => "file",
+            DeliverableKind::Directory => "directory",
+            DeliverableKind::CommandOutput => "command_output",
+            DeliverableKind::StructuredRecord => "structured_record",
+            DeliverableKind::ExternalReference => "external_reference",
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct TaskDeliverable {
     pub(super) kind: DeliverableKind,
@@ -1151,6 +1170,20 @@ impl TaskContract {
             .iter()
             .filter(|identity| identity.role == role)
             .collect()
+    }
+
+    pub(super) fn obligation_for_target(
+        &self,
+        target_hint: &RecoveryTargetHint,
+    ) -> Option<&ArtifactObligation> {
+        self.required_artifact_identities
+            .iter()
+            .find(|identity| identity.role == target_hint.role && identity.path == target_hint.path)
+            .or_else(|| {
+                self.required_artifact_identities
+                    .iter()
+                    .find(|identity| identity.role == target_hint.role)
+            })
     }
 
     /// Issue #651 Task 4.1 / PR-001: evaluate completion with awareness

--- a/src/agent/loop_run/turn_tests.rs
+++ b/src/agent/loop_run/turn_tests.rs
@@ -2610,6 +2610,8 @@ mod tests {
                 total: 3,
                 per_cluster: vec![(big.clone(), vec!["implementation", "test"])],
                 last_repair_hypothesis: Some(big.clone()),
+                unfulfilled_obligations: Vec::new(),
+                invalid_proposal_reasons: Vec::new(),
             }),
             diagnostic_target_missing_reason: Some(
                 DiagnosticTargetMissingReason::AssessmentMissing,
@@ -3121,6 +3123,8 @@ mod tests {
                     .map(|_| (big.clone(), vec!["implementation", "test"]))
                     .collect(),
                 last_repair_hypothesis: Some(big.clone()),
+                unfulfilled_obligations: Vec::new(),
+                invalid_proposal_reasons: Vec::new(),
             }),
             diagnostic_target_missing_reason: Some(
                 DiagnosticTargetMissingReason::AssessmentMissing,
@@ -3208,6 +3212,8 @@ mod tests {
                     vec!["implementation", "test"],
                 )],
                 last_repair_hypothesis: Some("hypo".to_string()),
+                unfulfilled_obligations: Vec::new(),
+                invalid_proposal_reasons: Vec::new(),
             }),
             diagnostic_target_missing_reason: None,
             owned_test_artifacts: vec![],

--- a/src/agent/loop_run/verifier_orchestration.rs
+++ b/src/agent/loop_run/verifier_orchestration.rs
@@ -2145,6 +2145,7 @@ pub(super) fn record_controller_verifier_repair_edit(
     fingerprint: &str,
     target_hint: &RecoveryTargetHint,
 ) {
+    let active_request = super::workspace_access::active_request_text(agent).unwrap_or_default();
     agent.session.repo_edit_succeeded_this_turn = true;
     agent
         .session
@@ -2160,7 +2161,11 @@ pub(super) fn record_controller_verifier_repair_edit(
             context.applied_repair_intents.push(fingerprint.to_string());
             context.repair_error = None;
         }
-        let key = super::repair_job::RepairAttemptKey::from_target(target_hint, None);
+        let key = repair_attempt_key_for_target(
+            &active_request,
+            target_hint,
+            super::repair_packet::DeliverableFailureDomain::VerifierFailed,
+        );
         context.apply_event(super::repair_job::RepairJobEvent::PatchApplied { key });
     }
     log_llm_event(
@@ -2984,6 +2989,7 @@ pub(super) fn record_controller_verifier_repair_invalid(
         .as_ref()
         .and_then(verifier_repair_effective_target_hint)
         .cloned();
+    let active_request = super::workspace_access::active_request_text(agent).unwrap_or_default();
     if let Some(context) = agent.repair_job.as_mut() {
         context.repair_error = Some(compact.clone());
         let mut lifecycle_reject_recorded = false;
@@ -3002,7 +3008,11 @@ pub(super) fn record_controller_verifier_repair_invalid(
                 active_target_hint.as_ref(),
                 super::repair_job::rejected_reason_for_repair_attempt_outcome_kind(&o.kind),
             ) {
-                let key = super::repair_job::RepairAttemptKey::from_target(target_hint, None);
+                let key = repair_attempt_key_for_target(
+                    &active_request,
+                    target_hint,
+                    failure_domain_for_rejected_attempt(reason),
+                );
                 context
                     .apply_event(super::repair_job::RepairJobEvent::PatchRejected { key, reason });
                 lifecycle_reject_recorded = true;
@@ -3032,6 +3042,44 @@ pub(super) fn record_controller_verifier_repair_invalid(
         }),
     );
     maybe_emit_repair_exhausted_from_promotion(agent, promotion_result);
+}
+
+fn repair_attempt_key_for_target(
+    active_request: &str,
+    target_hint: &RecoveryTargetHint,
+    failure_domain: super::repair_packet::DeliverableFailureDomain,
+) -> super::repair_job::RepairAttemptKey {
+    if active_request.is_empty() {
+        return super::repair_job::RepairAttemptKey::from_target(target_hint, None);
+    }
+    let contract = super::task_contract::TaskContract::from_request(active_request);
+    let packet = super::repair_packet::RepairPacket::for_recovery_target(
+        &contract,
+        target_hint,
+        failure_domain,
+    );
+    super::repair_job::RepairAttemptKey::from_packet(&packet, None)
+}
+
+fn failure_domain_for_rejected_attempt(
+    reason: super::repair_job::RejectedAttemptReason,
+) -> super::repair_packet::DeliverableFailureDomain {
+    match reason {
+        super::repair_job::RejectedAttemptReason::MalformedPatch => {
+            super::repair_packet::DeliverableFailureDomain::MalformedDeliverable
+        }
+        super::repair_job::RejectedAttemptReason::UnsafePatch
+        | super::repair_job::RejectedAttemptReason::WrongTarget
+        | super::repair_job::RejectedAttemptReason::NoSafeCandidate => {
+            super::repair_packet::DeliverableFailureDomain::UnsafeOrOutOfScope
+        }
+        super::repair_job::RejectedAttemptReason::ProviderTimeout
+        | super::repair_job::RejectedAttemptReason::AmbiguousAuthority
+        | super::repair_job::RejectedAttemptReason::NoopPatch
+        | super::repair_job::RejectedAttemptReason::DuplicatePatch => {
+            super::repair_packet::DeliverableFailureDomain::VerifierFailed
+        }
+    }
 }
 
 pub(super) fn run_verifier_diagnostic_pass(agent: &mut Agent) -> VerifierDiagnosticPassOutcome {


### PR DESCRIPTION
# Issue 877 Implementation Summary

## Implemented

- Added `repair_packet` as the deliverable-obligation repair projection layer.
  - `RepairPacket`
  - `RepairObligationTarget`
  - `DeliverableFailureDomain`
- Added deterministic obligation ids from role/path, for example `usage_docs:README.md`.
- Added task-kind/domain adapter instructions for docs, data, coding verifier repair, malformed deliverables, missing deliverables, and unsafe/out-of-scope proposals.
- Added `TaskContract::obligation_for_target` and `DeliverableKind::label` as read-only projection helpers.
- Extended `RepairAttemptKey` with obligation id and failure domain.
- Wired controller repair edit/rejection events through obligation-aware repair packets when the active request is available.
- Extended repair terminal diagnostics:
  - `exhausted_attempts_summary.unfulfilled_obligations`
  - `exhausted_attempts_summary.invalid_proposal_reasons`
- Kept existing verifier repair admission/safety gates intact; obligation metadata is projection/diagnostic data, not a bypass.

## Tests Added

- Docs required section packet: `incomplete_sections` with README obligation id.
- Data schema packet: `schema_mismatch` with structured-record required columns.
- Coding verifier failure packet: `verifier_failed` on implementation obligation.
- Repair exhausted summary includes unfulfilled obligations and invalid proposal reasons tied to obligation/domain.

## Files Changed

- `src/agent/loop_run/repair_packet.rs`
- `src/agent/loop_run.rs`
- `src/agent/loop_run/task_contract.rs`
- `src/agent/loop_run/repair_job.rs`
- `src/agent/loop_run/verifier_orchestration.rs`
- `src/agent/loop_run/safe_stop_emit.rs`
- `src/agent/loop_run/safe_stop_payload.rs`
- `src/agent/loop_run/turn_tests.rs`
