### PR TITLE
Issue #876: apply WorkspacePolicy across artifact paths

### DIFF
--- a/src/agent/loop_run/artifact_ledger_state.rs
+++ b/src/agent/loop_run/artifact_ledger_state.rs
@@ -17,8 +17,11 @@
 //! `pub(super)` limited / no facade re-export (DR3-001).
 
 use super::Agent;
-use crate::logging::log_llm_event;
-use crate::util::workspace_paths::is_ignored_workspace_display_path;
+use crate::logging::{log_llm_event, stable_path_hash};
+use crate::session::feedback::mask_secrets;
+use crate::util::workspace_paths::{
+    WorkspacePathAdmission, artifact_admission_decision_display_path,
+};
 
 /// Issue #659 PR-002 — per-turn reset + observability stamp. Callers
 /// pass `upcoming_turn_index` explicitly so stamp timing is decoupled
@@ -60,7 +63,7 @@ pub(super) fn seed_artifact_ledger_existing(
     role: super::task_contract::ArtifactRole,
     scope: &super::task_workspace_scope::TaskWorkspaceScope,
 ) {
-    if is_ignored_workspace_display_path(relative_path) {
+    if log_policy_rejection(agent, "artifact_ledger_existing", relative_path) {
         return;
     }
     let ctx = super::artifact_ledger::LedgerAdmissionContext::new(&agent.work_root, scope);
@@ -80,7 +83,7 @@ pub(super) fn seed_artifact_ledger_scaffold(
     post_scaffold_delta: bool,
     scope: &super::task_workspace_scope::TaskWorkspaceScope,
 ) {
-    if is_ignored_workspace_display_path(relative_path) {
+    if log_policy_rejection(agent, "artifact_ledger_scaffold", relative_path) {
         return;
     }
     let ctx = super::artifact_ledger::LedgerAdmissionContext::new(&agent.work_root, scope);
@@ -102,7 +105,7 @@ pub(super) fn seed_artifact_ledger_repo_edit(
     role: super::task_contract::ArtifactRole,
     scope: &super::task_workspace_scope::TaskWorkspaceScope,
 ) {
-    if is_ignored_workspace_display_path(relative_path) {
+    if log_policy_rejection(agent, "artifact_ledger_repo_edit", relative_path) {
         return;
     }
     // Write-through adapter (divergence anchor): keep the legacy set
@@ -134,7 +137,7 @@ pub(super) fn seed_artifact_ledger_verifier_observation(
     }
     let ctx = super::artifact_ledger::LedgerAdmissionContext::new(&agent.work_root, scope);
     for path in bound_paths {
-        if is_ignored_workspace_display_path(path) {
+        if log_policy_rejection(agent, "artifact_ledger_verifier_observation", path) {
             continue;
         }
         let _ = agent.artifact_ledger.record_verifier_observation(
@@ -145,6 +148,28 @@ pub(super) fn seed_artifact_ledger_verifier_observation(
                 last_outcome,
             },
         );
+    }
+}
+
+fn log_policy_rejection(agent: &Agent, component: &str, relative_path: &str) -> bool {
+    match artifact_admission_decision_display_path(relative_path) {
+        WorkspacePathAdmission::Accepted => false,
+        WorkspacePathAdmission::Rejected { class, reason } => {
+            let masked = mask_secrets(relative_path);
+            log_llm_event(
+                "agent.workspace_policy.rejected_path",
+                serde_json::json!({
+                    "session_id": agent.session_store.session_id(),
+                    "turn_index": agent.current_turn_index,
+                    "component": component,
+                    "path_hash": stable_path_hash(&masked),
+                    "path_len": relative_path.len() as u32,
+                    "class": format!("{:?}", class),
+                    "reason": reason.as_str(),
+                }),
+            );
+            true
+        }
     }
 }
 

--- a/src/agent/loop_run/project_probe.rs
+++ b/src/agent/loop_run/project_probe.rs
@@ -9,6 +9,7 @@ use std::collections::{BTreeSet, HashSet};
 use std::path::Path;
 
 use crate::util::file_classify::{is_implementation_file, is_setup_file, is_test_file};
+use crate::util::workspace_paths::is_workspace_artifact_admitted_relative_path;
 
 use super::task_contract::{ArtifactRole, TaskContract};
 use super::task_workspace_scope::TaskWorkspaceScope;
@@ -249,7 +250,7 @@ fn collect_files_inner(
         let Ok(relative) = path.strip_prefix(work_root) else {
             continue;
         };
-        if crate::util::workspace_paths::is_ignored_workspace_relative_path(relative) {
+        if !is_workspace_artifact_admitted_relative_path(relative) {
             continue;
         }
         let rel = relative.to_string_lossy().replace('\\', "/");

--- a/src/agent/loop_run/repo_edit_observation.rs
+++ b/src/agent/loop_run/repo_edit_observation.rs
@@ -7,8 +7,8 @@
 //!
 //! 1. `workspace_relative_path_for_tool_arg` workspace-relative
 //!    normalization.
-//! 2. `is_ignored_workspace_display_path` ignored-top-dir gate (emits
-//!    `repo_edit_ignored_controller_state` and returns).
+//! 2. `WorkspacePolicy` artifact-admission gate (emits
+//!    `repo_edit_ignored_controller_state` with a rejection reason and returns).
 //! 3. `workspace_walk::is_user_deliverable_path` excludes protected
 //!    inputs and generated metadata/log files from edited-file and
 //!    completion-evidence summaries.
@@ -41,7 +41,10 @@ use super::completion_evidence::is_repo_edit_no_op;
 use super::file_excerpt::current_file_hash_for_relative_path;
 use super::tool_policy::workspace_relative_path_for_tool_arg;
 use crate::logging::stable_path_hash;
-use crate::util::workspace_paths::is_ignored_workspace_display_path;
+use crate::session::feedback::mask_secrets;
+use crate::util::workspace_paths::{
+    WorkspacePathAdmission, artifact_admission_decision_display_path,
+};
 
 /// Issue #606 (T-1.7): post-hoc observation of an Edit/Write success
 /// as `RepoEdit` completion evidence. The path is run through
@@ -53,13 +56,19 @@ pub(super) fn observe_evidence_from_repo_edit(agent: &mut Agent, path: &str) {
     let Some(relative_path) = workspace_relative_path_for_tool_arg(&agent.work_root, path) else {
         return;
     };
-    if is_ignored_workspace_display_path(&relative_path) {
+    if let WorkspacePathAdmission::Rejected { class, reason } =
+        artifact_admission_decision_display_path(&relative_path)
+    {
+        let masked = mask_secrets(&relative_path);
         crate::logging::log_completion_evidence_observed(
             agent.current_turn_index,
             0,
             "repo_edit_ignored_controller_state",
             serde_json::json!({
-                "path_hash": stable_path_hash(&relative_path),
+                "path_hash": stable_path_hash(&masked),
+                "path_len": relative_path.len() as u32,
+                "class": format!("{:?}", class),
+                "reason": reason.as_str(),
             }),
         );
         return;

--- a/src/agent/loop_run/verifier_repair_targeting.rs
+++ b/src/agent/loop_run/verifier_repair_targeting.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 
 use crate::agent::orchestration::RepoVerification;
 use crate::safety::path_guard::resolve_user_path;
-use crate::util::workspace_paths::is_ignored_workspace_display_path;
+use crate::util::workspace_paths::is_workspace_artifact_admitted_display_path;
 
 use super::repair_framework_findings::{
     missing_python_module_name_from_output, output_or_command_looks_like_pytest,
@@ -26,7 +26,7 @@ pub(super) fn changed_files_for_verifier(
     let mut files = HashSet::new();
     for verif in accumulated.iter().chain(std::iter::once(current)) {
         for file in &verif.all_changed_files {
-            if is_ignored_workspace_display_path(file) {
+            if !is_workspace_artifact_admitted_display_path(file) {
                 continue;
             }
             files.insert(file.clone());
@@ -61,7 +61,7 @@ pub(super) fn verifier_diagnostic_path_input_is_safe(raw_path: &str) -> bool {
     if path.is_empty()
         || path.contains('\0')
         || Path::new(path).is_absolute()
-        || is_ignored_workspace_display_path(path)
+        || !is_workspace_artifact_admitted_display_path(path)
     {
         return false;
     }
@@ -93,7 +93,7 @@ pub(super) fn recovery_target_hint_for_existing_path(
     }
     let relative = canonical.strip_prefix(root).ok()?;
     let path = relative.to_string_lossy().replace('\\', "/");
-    if is_ignored_workspace_display_path(&path) {
+    if !is_workspace_artifact_admitted_display_path(&path) {
         return None;
     }
     let category = super::completion_evidence::classify_repo_edit_path(Path::new(&path));
@@ -208,17 +208,6 @@ pub(super) fn recovery_target_hint_for_missing_local_module_path(
 ) -> Option<super::task_contract::RecoveryTargetHint> {
     let path = raw_path.trim();
     if !verifier_diagnostic_path_input_is_safe(path) {
-        return None;
-    }
-    if Path::new(path)
-        .components()
-        .any(|component| match component {
-            std::path::Component::Normal(name) => {
-                super::task_workspace_scope::is_workspace_ignored_dir(&name.to_string_lossy())
-            }
-            _ => false,
-        })
-    {
         return None;
     }
     if Path::new(path)
@@ -512,7 +501,7 @@ fn verifier_repair_candidate_from_path(
         resolved.strip_prefix(work_root).ok()
     }?;
     let path = relative.to_string_lossy().replace('\\', "/");
-    if is_ignored_workspace_display_path(&path) {
+    if !is_workspace_artifact_admitted_display_path(&path) {
         return None;
     }
     let category = super::completion_evidence::classify_repo_edit_path(Path::new(&path));

--- a/src/agent/loop_run/workspace_walk.rs
+++ b/src/agent/loop_run/workspace_walk.rs
@@ -4,25 +4,20 @@
 //! artifact-recovery candidates (`meaningful_workspace_files`,
 //! `collect_meaningful_workspace_files`) and the `workspace_appears_empty`
 //! probe used by the empty-workspace scaffold gate. Honours
-//! `task_workspace_scope::is_workspace_ignored_dir` as the SSOT ignore
-//! list.
+//! `WorkspacePolicy` as the SSOT for protected metadata/runtime files.
 //!
 //! `pub(super)` limited / no facade re-export (DR3-001).
 
 use std::path::{Path, PathBuf};
 
-use crate::util::workspace_paths::{WorkspacePathClass, WorkspacePolicy};
+use crate::util::workspace_paths::{WorkspacePathAdmission, WorkspacePolicy};
 
 pub(super) fn workspace_appears_empty(work_root: &Path) -> bool {
     !workspace_contains_user_deliverable(work_root, work_root).unwrap_or(true)
 }
 
 pub(super) fn is_user_deliverable_path(relative_path: &str) -> bool {
-    WorkspacePolicy::default().is_user_deliverable_relative_path(Path::new(relative_path))
-}
-
-pub(super) fn classify_workspace_relative_path(relative: &Path) -> WorkspacePathClass {
-    WorkspacePolicy::default().classify_relative_path(relative)
+    WorkspacePolicy::default().admits_artifact_display_path(relative_path)
 }
 
 fn workspace_contains_user_deliverable(root: &Path, current: &Path) -> std::io::Result<bool> {
@@ -47,7 +42,8 @@ fn workspace_contains_user_deliverable(root: &Path, current: &Path) -> std::io::
         }
         if (file_type.is_file() || file_type.is_symlink())
             && let Ok(relative) = path.strip_prefix(root)
-            && classify_workspace_relative_path(relative) == WorkspacePathClass::UserDeliverable
+            && WorkspacePolicy::default().artifact_admission_decision_relative_path(relative)
+                == WorkspacePathAdmission::Accepted
         {
             return Ok(true);
         }
@@ -83,7 +79,8 @@ fn collect_meaningful_workspace_files(
             collect_meaningful_workspace_files(root, &path, limit, files)?;
         } else if path.is_file()
             && let Ok(relative) = path.strip_prefix(root)
-            && classify_workspace_relative_path(relative) == WorkspacePathClass::UserDeliverable
+            && WorkspacePolicy::default().artifact_admission_decision_relative_path(relative)
+                == WorkspacePathAdmission::Accepted
         {
             files.push(relative.to_path_buf());
             if files.len() > limit {
@@ -109,6 +106,9 @@ mod tests {
         std::fs::write(temp.path().join("postcheck.out"), "postcheck stdout\n").unwrap();
         std::fs::write(temp.path().join("postcheck.err"), "postcheck stderr\n").unwrap();
         std::fs::write(temp.path().join("postcheck.junit.xml"), "<testsuite />\n").unwrap();
+        std::fs::write(temp.path().join("eval.out"), "eval stdout\n").unwrap();
+        std::fs::write(temp.path().join("runtime.log"), "runtime\n").unwrap();
+        std::fs::write(temp.path().join("sidecar.log"), "sidecar\n").unwrap();
         std::fs::write(temp.path().join("session.json"), "{}\n").unwrap();
         std::fs::write(temp.path().join("meta.json"), "{}\n").unwrap();
         std::fs::create_dir_all(temp.path().join("logs")).unwrap();
@@ -132,6 +132,8 @@ mod tests {
         std::fs::write(temp.path().join("anvil.out"), "controller stdout\n").unwrap();
         std::fs::write(temp.path().join("postcheck.err"), "postcheck stderr\n").unwrap();
         std::fs::write(temp.path().join("postcheck.junit.xml"), "<testsuite />\n").unwrap();
+        std::fs::write(temp.path().join("eval.log"), "eval log\n").unwrap();
+        std::fs::write(temp.path().join("runtime.log"), "runtime\n").unwrap();
         std::fs::create_dir_all(temp.path().join("logs")).unwrap();
         std::fs::write(temp.path().join("logs/run.log"), "log\n").unwrap();
         std::fs::create_dir_all(temp.path().join(".anvil")).unwrap();

--- a/src/agent/orchestration.rs
+++ b/src/agent/orchestration.rs
@@ -6,7 +6,7 @@ use std::path::{Path, PathBuf};
 use ignore::WalkBuilder;
 
 use crate::util::file_classify::{is_implementation_file, is_setup_file, is_test_file};
-use crate::util::workspace_paths::is_ignored_workspace_relative_path;
+use crate::util::workspace_paths::is_workspace_artifact_admitted_relative_path;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RepoSnapshot {
@@ -137,7 +137,7 @@ fn stable_hash(bytes: &[u8]) -> u64 {
 fn should_skip_path(root: &Path, path: &Path) -> bool {
     path.strip_prefix(root)
         .ok()
-        .map(is_ignored_workspace_relative_path)
+        .map(|relative| !is_workspace_artifact_admitted_relative_path(relative))
         .unwrap_or(false)
 }
 

--- a/src/util/workspace_paths.rs
+++ b/src/util/workspace_paths.rs
@@ -34,8 +34,17 @@ const CONTROL_METADATA_FILES: &[&str] = &[
     "metadata.json",
     "llm-io.jsonl",
     "log.jsonl",
+    "runtime.log",
+    "run.log",
     "anvil.out",
     "anvil.err",
+    "anvil.log",
+    "sidecar.out",
+    "sidecar.err",
+    "sidecar.log",
+    "eval.out",
+    "eval.err",
+    "eval.log",
     "postcheck.out",
     "postcheck.err",
 ];
@@ -47,6 +56,30 @@ pub enum WorkspacePathClass {
     UserDeliverable,
     ProtectedInput,
     GeneratedMetadata,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WorkspacePathAdmission {
+    Accepted,
+    Rejected {
+        class: WorkspacePathClass,
+        reason: WorkspacePolicyRejectReason,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WorkspacePolicyRejectReason {
+    ProtectedInput,
+    GeneratedMetadata,
+}
+
+impl WorkspacePolicyRejectReason {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::ProtectedInput => "protected_input",
+            Self::GeneratedMetadata => "generated_metadata",
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -138,6 +171,43 @@ impl WorkspacePolicy {
         self.classify_relative_path(relative) != WorkspacePathClass::UserDeliverable
     }
 
+    pub fn artifact_admission_decision_relative_path(
+        self,
+        relative: &Path,
+    ) -> WorkspacePathAdmission {
+        let class = self.classify_relative_path(relative);
+        match class {
+            WorkspacePathClass::UserDeliverable => WorkspacePathAdmission::Accepted,
+            WorkspacePathClass::ProtectedInput => WorkspacePathAdmission::Rejected {
+                class,
+                reason: WorkspacePolicyRejectReason::ProtectedInput,
+            },
+            WorkspacePathClass::GeneratedMetadata => WorkspacePathAdmission::Rejected {
+                class,
+                reason: WorkspacePolicyRejectReason::GeneratedMetadata,
+            },
+        }
+    }
+
+    pub fn artifact_admission_decision_display_path(
+        self,
+        display_path: &str,
+    ) -> WorkspacePathAdmission {
+        let path = display_path
+            .strip_suffix(" (deleted)")
+            .unwrap_or(display_path);
+        self.artifact_admission_decision_relative_path(Path::new(path))
+    }
+
+    pub fn admits_artifact_relative_path(self, relative: &Path) -> bool {
+        self.artifact_admission_decision_relative_path(relative) == WorkspacePathAdmission::Accepted
+    }
+
+    pub fn admits_artifact_display_path(self, display_path: &str) -> bool {
+        self.artifact_admission_decision_display_path(display_path)
+            == WorkspacePathAdmission::Accepted
+    }
+
     pub fn allows_model_read_relative_path(self, relative: &Path) -> bool {
         self.protected_metadata_access == ProtectedMetadataAccess::Allow
             || !self.is_protected_metadata_relative_path(relative)
@@ -171,6 +241,22 @@ pub fn is_ignored_workspace_relative_path(relative: &Path) -> bool {
 
 pub fn is_ignored_workspace_display_path(display_path: &str) -> bool {
     WorkspacePolicy::default().is_ignored_display_path(display_path)
+}
+
+pub fn artifact_admission_decision_relative_path(relative: &Path) -> WorkspacePathAdmission {
+    WorkspacePolicy::default().artifact_admission_decision_relative_path(relative)
+}
+
+pub fn artifact_admission_decision_display_path(display_path: &str) -> WorkspacePathAdmission {
+    WorkspacePolicy::default().artifact_admission_decision_display_path(display_path)
+}
+
+pub fn is_workspace_artifact_admitted_relative_path(relative: &Path) -> bool {
+    WorkspacePolicy::default().admits_artifact_relative_path(relative)
+}
+
+pub fn is_workspace_artifact_admitted_display_path(display_path: &str) -> bool {
+    WorkspacePolicy::default().admits_artifact_display_path(display_path)
 }
 
 fn is_postcheck_file_name(name: &str) -> bool {
@@ -250,6 +336,9 @@ mod tests {
             "app/__pycache__/main.cpython-39.pyc"
         )));
         assert!(is_ignored_workspace_relative_path(Path::new("anvil.out")));
+        assert!(is_ignored_workspace_relative_path(Path::new("eval.out")));
+        assert!(is_ignored_workspace_relative_path(Path::new("runtime.log")));
+        assert!(is_ignored_workspace_relative_path(Path::new("sidecar.log")));
         assert!(is_ignored_workspace_relative_path(Path::new(
             "postcheck.err"
         )));
@@ -277,6 +366,35 @@ mod tests {
             ".anvil-state/verifier-python/site/foo.py (deleted)"
         ));
         assert!(!is_ignored_workspace_display_path("README.md (deleted)"));
+    }
+
+    #[test]
+    fn artifact_admission_decision_explains_policy_rejection() {
+        assert_eq!(
+            artifact_admission_decision_relative_path(Path::new("src/main.rs")),
+            WorkspacePathAdmission::Accepted
+        );
+        assert_eq!(
+            artifact_admission_decision_relative_path(Path::new("prompt.md")),
+            WorkspacePathAdmission::Rejected {
+                class: WorkspacePathClass::ProtectedInput,
+                reason: WorkspacePolicyRejectReason::ProtectedInput,
+            }
+        );
+        assert_eq!(
+            artifact_admission_decision_relative_path(Path::new("anvil.out")),
+            WorkspacePathAdmission::Rejected {
+                class: WorkspacePathClass::GeneratedMetadata,
+                reason: WorkspacePolicyRejectReason::GeneratedMetadata,
+            }
+        );
+        assert_eq!(
+            artifact_admission_decision_display_path("anvil.out (deleted)"),
+            WorkspacePathAdmission::Rejected {
+                class: WorkspacePathClass::GeneratedMetadata,
+                reason: WorkspacePolicyRejectReason::GeneratedMetadata,
+            }
+        );
     }
 
     #[test]

--- a/tests/orchestration_tests.rs
+++ b/tests/orchestration_tests.rs
@@ -122,6 +122,11 @@ fn controller_metadata_outputs_are_ignored() {
     std::fs::write(temp.path().join("anvil.err"), "controller stderr\n").unwrap();
     std::fs::write(temp.path().join("postcheck.out"), "postcheck stdout\n").unwrap();
     std::fs::write(temp.path().join("postcheck.err"), "postcheck stderr\n").unwrap();
+    std::fs::write(temp.path().join("postcheck.junit.xml"), "<testsuite />\n").unwrap();
+    std::fs::write(temp.path().join("eval.out"), "eval stdout\n").unwrap();
+    std::fs::write(temp.path().join("eval.err"), "eval stderr\n").unwrap();
+    std::fs::write(temp.path().join("runtime.log"), "runtime log\n").unwrap();
+    std::fs::write(temp.path().join("sidecar.log"), "sidecar log\n").unwrap();
     std::fs::write(temp.path().join("prompt.md"), "task input\n").unwrap();
     std::fs::write(temp.path().join("cmd.txt"), "python calculator.py\n").unwrap();
 

--- a/tests/tool_registry_tests.rs
+++ b/tests/tool_registry_tests.rs
@@ -70,6 +70,9 @@ fn protected_workspace_metadata_is_hidden_from_normal_discovery() {
     .unwrap();
     fs::write(dir.path().join("cmd.txt"), "anvil run").unwrap();
     fs::write(dir.path().join("anvil.out"), "runtime log").unwrap();
+    fs::write(dir.path().join("eval.out"), "eval log").unwrap();
+    fs::write(dir.path().join("runtime.log"), "runtime log").unwrap();
+    fs::write(dir.path().join("sidecar.log"), "sidecar log").unwrap();
     fs::create_dir_all(dir.path().join(".anvil")).unwrap();
     fs::write(dir.path().join(".anvil/session.json"), "{}").unwrap();
     fs::create_dir_all(dir.path().join("src")).unwrap();
@@ -96,6 +99,9 @@ fn protected_workspace_metadata_is_hidden_from_normal_discovery() {
     assert!(!listing.contains("prompt.md"), "got: {listing}");
     assert!(!listing.contains("cmd.txt"), "got: {listing}");
     assert!(!listing.contains("anvil.out"), "got: {listing}");
+    assert!(!listing.contains("eval.out"), "got: {listing}");
+    assert!(!listing.contains("runtime.log"), "got: {listing}");
+    assert!(!listing.contains("sidecar.log"), "got: {listing}");
     assert!(!listing.contains(".anvil"), "got: {listing}");
     assert!(listing.contains("src"), "got: {listing}");
 
@@ -105,6 +111,9 @@ fn protected_workspace_metadata_is_hidden_from_normal_discovery() {
     assert!(!globbed.contains("prompt.md"), "got: {globbed}");
     assert!(!globbed.contains("cmd.txt"), "got: {globbed}");
     assert!(!globbed.contains("anvil.out"), "got: {globbed}");
+    assert!(!globbed.contains("eval.out"), "got: {globbed}");
+    assert!(!globbed.contains("runtime.log"), "got: {globbed}");
+    assert!(!globbed.contains("sidecar.log"), "got: {globbed}");
     assert!(!globbed.contains(".anvil"), "got: {globbed}");
     assert!(globbed.contains("src/main.rs"), "got: {globbed}");
 


### PR DESCRIPTION
# Issue 876 Implementation Summary

## Implemented

- Extended `WorkspacePolicy` with a structured artifact admission decision:
  `Accepted` or `Rejected { class, reason }`.
- Added stable rejection reason labels:
  - `protected_input`
  - `generated_metadata`
- Expanded protected runtime/eval metadata coverage for top-level files:
  `runtime.log`, `run.log`, `anvil.log`, `sidecar.out`, `sidecar.err`,
  `sidecar.log`, `eval.out`, `eval.err`, and `eval.log`.
- Routed scan/artifact/evidence/verifier paths through the shared admission
  helper instead of local display-path predicates:
  - workspace meaningful-file scan
  - repo snapshot/progress capture
  - project probe scoped-file collection
  - repo edit completion-evidence observation
  - artifact ledger existing/scaffold/repo-edit/verifier-observation seeds
  - verifier changed-file and diagnostic target selection
- Added policy rejection logging for artifact-ledger seeding and enriched
  repo-edit ignored-controller-state logs with class/reason and masked path
  hashes.
- Preserved explicit log-analysis read behavior via `WorkspacePolicy` in the
  tool registry. Normal reads/discovery still reject protected metadata, while
  explicit log-analysis policy can read it.

## Tests Updated

- Added `WorkspacePolicy` admission-decision unit coverage.
- Extended workspace-walk tests for eval/runtime/sidecar metadata files.
- Extended tool registry discovery tests for eval/runtime/sidecar metadata.
- Extended orchestration snapshot/progress tests for eval/runtime/sidecar
  metadata outputs.

## Notes

- No new per-module deny lists were added. New protected names live in
  `src/util/workspace_paths.rs`.
- Existing path traversal, symlink, control-character, and scope checks remain
  in their current admission layers.
