### PR TITLE
#890 generalize RepairJob toward CorrectionJob

### DIFF
--- a/src/agent/loop_run/repair_job.rs
+++ b/src/agent/loop_run/repair_job.rs
@@ -21,7 +21,9 @@ use super::repair_attempt_outcome::{
     RepairRejectionKind, should_promote_to_exhausted_after_push,
 };
 use super::repair_brief::AllowedChangeKind;
-use super::repair_packet::{DeliverableFailureDomain, RepairPacket, obligation_id_for_parts};
+use super::repair_packet::{
+    CorrectionKind, DeliverableFailureDomain, RepairPacket, obligation_id_for_parts,
+};
 use super::semantic_failure::{FailureClusterKey, SemanticFailureReport};
 use super::spec_authority::{RepairRole, SpecAuthority, WeakeningPattern};
 use super::task_contract::{ArtifactRole, RecoveryTargetHint};
@@ -510,6 +512,7 @@ pub(super) struct RepairAttemptKey {
     pub(super) allowed_change_kind: Option<AllowedChangeKind>,
     pub(super) obligation_id: Option<String>,
     pub(super) failure_domain: Option<DeliverableFailureDomain>,
+    pub(super) correction_kind: Option<CorrectionKind>,
 }
 
 impl RepairAttemptKey {
@@ -523,6 +526,7 @@ impl RepairAttemptKey {
             allowed_change_kind,
             obligation_id: Some(obligation_id_for_parts(target.role, Some(&target.path))),
             failure_domain: None,
+            correction_kind: Some(CorrectionKind::Patch),
         }
     }
 
@@ -541,6 +545,7 @@ impl RepairAttemptKey {
             allowed_change_kind,
             obligation_id: Some(packet.target.obligation_id.clone()),
             failure_domain: Some(packet.target.failure_domain),
+            correction_kind: Some(packet.correction_kind),
         }
     }
 }
@@ -2757,6 +2762,8 @@ pub(super) struct ExhaustedAttemptsSummary {
     pub(super) unfulfilled_obligations: Vec<super::repair_packet::RepairObligationTarget>,
     /// Invalid controller repair proposals tied back to obligation id/domain.
     pub(super) invalid_proposal_reasons: Vec<InvalidRepairProposalSummary>,
+    /// Obligation-targeted corrections that reached an exhaustion condition.
+    pub(super) exhausted_corrections: Vec<ExhaustedCorrectionSummary>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -2765,7 +2772,18 @@ pub(super) struct InvalidRepairProposalSummary {
     pub(super) role: ArtifactRole,
     pub(super) path: String,
     pub(super) failure_domain: Option<super::repair_packet::DeliverableFailureDomain>,
+    pub(super) correction_kind: Option<super::repair_packet::CorrectionKind>,
     pub(super) reason: RejectedAttemptReason,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) struct ExhaustedCorrectionSummary {
+    pub(super) obligation_id: Option<String>,
+    pub(super) role: ArtifactRole,
+    pub(super) path: String,
+    pub(super) failure_domain: Option<super::repair_packet::DeliverableFailureDomain>,
+    pub(super) correction_kind: Option<super::repair_packet::CorrectionKind>,
+    pub(super) reason: Option<RejectedAttemptReason>,
 }
 
 impl ExhaustedAttemptsSummary {
@@ -2811,9 +2829,11 @@ impl ExhaustedAttemptsSummary {
                     SAFE_STOP_PATH_CHAR_CAP,
                 ),
                 failure_domain: attempt.key.failure_domain,
+                correction_kind: attempt.key.correction_kind,
                 reason: attempt.reason,
             })
             .collect::<Vec<_>>();
+        let exhausted_corrections = exhausted_corrections_for_job(job);
         Self {
             total,
             per_cluster,
@@ -2824,8 +2844,62 @@ impl ExhaustedAttemptsSummary {
                 .cloned()
                 .collect(),
             invalid_proposal_reasons,
+            exhausted_corrections,
         }
     }
+}
+
+fn exhausted_corrections_for_job(job: &RepairJob) -> Vec<ExhaustedCorrectionSummary> {
+    let mut out = Vec::new();
+    for attempt in job.rejected_attempts.iter().rev() {
+        let repeated = job
+            .rejected_attempts
+            .iter()
+            .filter(|candidate| *candidate == attempt)
+            .count()
+            >= REPEATED_REJECTED_ATTEMPT_THRESHOLD;
+        if !repeated {
+            continue;
+        }
+        if out.iter().any(|existing: &ExhaustedCorrectionSummary| {
+            existing.obligation_id == attempt.key.obligation_id
+                && existing.role == attempt.key.role
+                && existing.path == attempt.key.path
+                && existing.failure_domain == attempt.key.failure_domain
+                && existing.correction_kind == attempt.key.correction_kind
+                && existing.reason == Some(attempt.reason)
+        }) {
+            continue;
+        }
+        out.push(ExhaustedCorrectionSummary {
+            obligation_id: attempt.key.obligation_id.clone(),
+            role: attempt.key.role,
+            path: sanitize_repair_job_text_with_char_cap(
+                &attempt.key.path,
+                SAFE_STOP_PATH_CHAR_CAP,
+            ),
+            failure_domain: attempt.key.failure_domain,
+            correction_kind: attempt.key.correction_kind,
+            reason: Some(attempt.reason),
+        });
+        if out.len() >= SAFE_STOP_INVALID_PROPOSAL_MAX {
+            return out;
+        }
+    }
+    if out.is_empty()
+        && !job.exhausted_attempts.is_empty()
+        && let Some(key) = job.current_repair_attempt_key(None)
+    {
+        out.push(ExhaustedCorrectionSummary {
+            obligation_id: key.obligation_id,
+            role: key.role,
+            path: sanitize_repair_job_text_with_char_cap(&key.path, SAFE_STOP_PATH_CHAR_CAP),
+            failure_domain: key.failure_domain,
+            correction_kind: key.correction_kind,
+            reason: None,
+        });
+    }
+    out
 }
 
 /// Issue #654 / DR1-003 — single SSOT for the "raw path string -> safe
@@ -7767,6 +7841,7 @@ mod tests {
                 allowed_change_kind: None,
                 obligation_id: Some(packet_target.obligation_id.clone()),
                 failure_domain: Some(packet_target.failure_domain),
+                correction_kind: Some(super::super::repair_packet::CorrectionKind::SectionAddition),
             },
             reason: RejectedAttemptReason::MalformedPatch,
         });
@@ -7786,6 +7861,54 @@ mod tests {
         assert_eq!(
             summary.invalid_proposal_reasons[0].failure_domain,
             Some(super::super::repair_packet::DeliverableFailureDomain::IncompleteSections)
+        );
+        assert_eq!(
+            summary.invalid_proposal_reasons[0].correction_kind,
+            Some(super::super::repair_packet::CorrectionKind::SectionAddition)
+        );
+    }
+
+    #[test]
+    fn exhausted_attempts_summary_identifies_repeated_obligation_correction() {
+        let mut job = RepairJob::new_for_test();
+        let key = RepairAttemptKey {
+            role: ArtifactRole::DataOutput,
+            path: "output.csv".to_string(),
+            allowed_change_kind: None,
+            obligation_id: Some("data_output:output.csv".to_string()),
+            failure_domain: Some(
+                super::super::repair_packet::DeliverableFailureDomain::SchemaMismatch,
+            ),
+            correction_kind: Some(super::super::repair_packet::CorrectionKind::SchemaCorrection),
+        };
+        job.rejected_attempts.push(RejectedAttempt {
+            key: key.clone(),
+            reason: RejectedAttemptReason::MalformedPatch,
+        });
+        job.rejected_attempts.push(RejectedAttempt {
+            key,
+            reason: RejectedAttemptReason::MalformedPatch,
+        });
+
+        let summary = ExhaustedAttemptsSummary::from_repair_job(&job, None, &[]);
+
+        assert_eq!(summary.exhausted_corrections.len(), 1);
+        let correction = &summary.exhausted_corrections[0];
+        assert_eq!(
+            correction.obligation_id.as_deref(),
+            Some("data_output:output.csv")
+        );
+        assert_eq!(
+            correction.correction_kind,
+            Some(super::super::repair_packet::CorrectionKind::SchemaCorrection)
+        );
+        assert_eq!(
+            correction.failure_domain,
+            Some(super::super::repair_packet::DeliverableFailureDomain::SchemaMismatch)
+        );
+        assert_eq!(
+            correction.reason,
+            Some(RejectedAttemptReason::MalformedPatch)
         );
     }
 

--- a/src/agent/loop_run/repair_packet.rs
+++ b/src/agent/loop_run/repair_packet.rs
@@ -9,6 +9,27 @@ const MAX_EXPECTED_EVIDENCE_CHARS: usize = 160;
 const MAX_REPAIR_INSTRUCTION_CHARS: usize = 360;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum CorrectionKind {
+    Patch,
+    SectionAddition,
+    SchemaCorrection,
+    CitationSupport,
+    ChecklistCompletion,
+}
+
+impl CorrectionKind {
+    pub(super) fn as_str(self) -> &'static str {
+        match self {
+            Self::Patch => "patch",
+            Self::SectionAddition => "section_addition",
+            Self::SchemaCorrection => "schema_correction",
+            Self::CitationSupport => "citation_support",
+            Self::ChecklistCompletion => "checklist_completion",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum DeliverableFailureDomain {
     MissingDeliverable,
     MalformedDeliverable,
@@ -44,8 +65,11 @@ pub(super) struct RepairObligationTarget {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct RepairPacket {
     pub(super) target: RepairObligationTarget,
+    pub(super) correction_kind: CorrectionKind,
     pub(super) instruction: String,
 }
+
+pub(super) type CorrectionPacket = RepairPacket;
 
 impl RepairPacket {
     pub(super) fn for_obligation(
@@ -55,6 +79,7 @@ impl RepairPacket {
     ) -> Self {
         let target = target_from_obligation(obligation, failure_domain);
         Self {
+            correction_kind: correction_kind_for_target(contract.task_kind, &target),
             instruction: adapter_instruction(contract.task_kind, &target),
             target,
         }
@@ -70,9 +95,17 @@ impl RepairPacket {
         }
         let target = target_from_recovery_hint(hint, failure_domain);
         Self {
+            correction_kind: correction_kind_for_target(contract.task_kind, &target),
             instruction: adapter_instruction(contract.task_kind, &target),
             target,
         }
+    }
+
+    pub(super) fn for_verifier_failure(
+        contract: &TaskContract,
+        hint: &RecoveryTargetHint,
+    ) -> CorrectionPacket {
+        Self::for_recovery_target(contract, hint, DeliverableFailureDomain::VerifierFailed)
     }
 }
 
@@ -289,6 +322,35 @@ fn adapter_instruction(task_kind: TaskKind, target: &RepairObligationTarget) -> 
     sanitize_repair_job_text_with_char_cap(instruction, MAX_REPAIR_INSTRUCTION_CHARS)
 }
 
+fn correction_kind_for_target(
+    task_kind: TaskKind,
+    target: &RepairObligationTarget,
+) -> CorrectionKind {
+    match (task_kind, target.failure_domain, target.role) {
+        (TaskKind::Docs, DeliverableFailureDomain::IncompleteSections, _)
+        | (_, DeliverableFailureDomain::IncompleteSections, ArtifactRole::UsageDocs) => {
+            CorrectionKind::SectionAddition
+        }
+        (TaskKind::Data, DeliverableFailureDomain::SchemaMismatch, _)
+        | (_, DeliverableFailureDomain::SchemaMismatch, ArtifactRole::DataOutput) => {
+            CorrectionKind::SchemaCorrection
+        }
+        (TaskKind::Research, DeliverableFailureDomain::MissingDeliverable, _)
+        | (TaskKind::Research, DeliverableFailureDomain::MalformedDeliverable, _) => {
+            CorrectionKind::CitationSupport
+        }
+        (_, DeliverableFailureDomain::MissingDeliverable, ArtifactRole::UsageDocs) => {
+            CorrectionKind::ChecklistCompletion
+        }
+        (_, DeliverableFailureDomain::MissingDeliverable, _) => CorrectionKind::ChecklistCompletion,
+        (_, DeliverableFailureDomain::MalformedDeliverable, ArtifactRole::DataOutput) => {
+            CorrectionKind::SchemaCorrection
+        }
+        (_, DeliverableFailureDomain::UnsafeOrOutOfScope, _) => CorrectionKind::ChecklistCompletion,
+        _ => CorrectionKind::Patch,
+    }
+}
+
 fn bounded_evidence(raw: String) -> String {
     sanitize_repair_job_text_with_char_cap(&raw, MAX_EXPECTED_EVIDENCE_CHARS)
 }
@@ -329,6 +391,7 @@ mod tests {
             packet.target.failure_domain,
             DeliverableFailureDomain::IncompleteSections
         );
+        assert_eq!(packet.correction_kind, CorrectionKind::SectionAddition);
         assert_eq!(packet.target.obligation_id, "usage_docs:README.md");
         assert!(
             packet
@@ -348,6 +411,7 @@ mod tests {
             packet.target.failure_domain,
             DeliverableFailureDomain::SchemaMismatch
         );
+        assert_eq!(packet.correction_kind, CorrectionKind::SchemaCorrection);
         assert_eq!(packet.target.kind, DeliverableKind::StructuredRecord);
         assert!(
             packet
@@ -366,16 +430,13 @@ mod tests {
             path: "main.py".to_string(),
             reason: "verifier failed".to_string(),
         };
-        let packet = RepairPacket::for_recovery_target(
-            &contract,
-            &hint,
-            DeliverableFailureDomain::VerifierFailed,
-        );
+        let packet = RepairPacket::for_verifier_failure(&contract, &hint);
 
         assert_eq!(
             packet.target.failure_domain,
             DeliverableFailureDomain::VerifierFailed
         );
+        assert_eq!(packet.correction_kind, CorrectionKind::Patch);
         assert_eq!(packet.target.obligation_id, "implementation:main.py");
         assert_eq!(packet.target.role, ArtifactRole::Implementation);
     }
@@ -421,5 +482,22 @@ mod tests {
                 .iter()
                 .any(|item| item.contains("bin entry"))
         );
+    }
+
+    #[test]
+    fn research_missing_deliverable_can_request_citation_support() {
+        let contract = TaskContract::from_request("Research battery safety and cite sources.");
+        let hint = RecoveryTargetHint {
+            role: ArtifactRole::UsageDocs,
+            path: "notes.md".to_string(),
+            reason: "research notes missing citation support".to_string(),
+        };
+        let packet = RepairPacket::for_recovery_target(
+            &contract,
+            &hint,
+            DeliverableFailureDomain::MissingDeliverable,
+        );
+
+        assert_eq!(packet.correction_kind, CorrectionKind::CitationSupport);
     }
 }

--- a/src/agent/loop_run/safe_stop_payload.rs
+++ b/src/agent/loop_run/safe_stop_payload.rs
@@ -148,7 +148,18 @@ fn render_safe_stop_payload(report: &SafeStopReport, truncated: bool) -> serde_j
                     "role": entry.role.label(),
                     "path": entry.path,
                     "failure_domain": entry.failure_domain.map(|domain| domain.as_str()),
+                    "correction_kind": entry.correction_kind.map(|kind| kind.as_str()),
                     "reason": entry.reason.as_str(),
+                })
+            }).collect::<Vec<_>>(),
+            "exhausted_corrections": s.exhausted_corrections.iter().map(|entry| {
+                serde_json::json!({
+                    "obligation_id": entry.obligation_id,
+                    "role": entry.role.label(),
+                    "path": entry.path,
+                    "failure_domain": entry.failure_domain.map(|domain| domain.as_str()),
+                    "correction_kind": entry.correction_kind.map(|kind| kind.as_str()),
+                    "reason": entry.reason.map(|reason| reason.as_str()),
                 })
             }).collect::<Vec<_>>(),
         })

--- a/src/agent/loop_run/turn_tests.rs
+++ b/src/agent/loop_run/turn_tests.rs
@@ -2612,6 +2612,7 @@ mod tests {
                 last_repair_hypothesis: Some(big.clone()),
                 unfulfilled_obligations: Vec::new(),
                 invalid_proposal_reasons: Vec::new(),
+                exhausted_corrections: Vec::new(),
             }),
             diagnostic_target_missing_reason: Some(
                 DiagnosticTargetMissingReason::AssessmentMissing,
@@ -3125,6 +3126,7 @@ mod tests {
                 last_repair_hypothesis: Some(big.clone()),
                 unfulfilled_obligations: Vec::new(),
                 invalid_proposal_reasons: Vec::new(),
+                exhausted_corrections: Vec::new(),
             }),
             diagnostic_target_missing_reason: Some(
                 DiagnosticTargetMissingReason::AssessmentMissing,
@@ -3214,6 +3216,7 @@ mod tests {
                 last_repair_hypothesis: Some("hypo".to_string()),
                 unfulfilled_obligations: Vec::new(),
                 invalid_proposal_reasons: Vec::new(),
+                exhausted_corrections: Vec::new(),
             }),
             diagnostic_target_missing_reason: None,
             owned_test_artifacts: vec![],

--- a/src/agent/loop_run/verifier_orchestration.rs
+++ b/src/agent/loop_run/verifier_orchestration.rs
@@ -3053,11 +3053,16 @@ fn repair_attempt_key_for_target(
         return super::repair_job::RepairAttemptKey::from_target(target_hint, None);
     }
     let contract = super::task_contract::TaskContract::from_request(active_request);
-    let packet = super::repair_packet::RepairPacket::for_recovery_target(
-        &contract,
-        target_hint,
-        failure_domain,
-    );
+    let packet = if failure_domain == super::repair_packet::DeliverableFailureDomain::VerifierFailed
+    {
+        super::repair_packet::RepairPacket::for_verifier_failure(&contract, target_hint)
+    } else {
+        super::repair_packet::RepairPacket::for_recovery_target(
+            &contract,
+            target_hint,
+            failure_domain,
+        )
+    };
     super::repair_job::RepairAttemptKey::from_packet(&packet, None)
 }
 


### PR DESCRIPTION
Closes #890

## Summary
- Generalizes repair packet/job concepts toward correction jobs.
- Keeps repair orchestration usable for docs, data, research, and ops-style deliverables.

## Changed Files
- `src/agent/loop_run/repair_job.rs`
- `src/agent/loop_run/repair_packet.rs`
- `src/agent/loop_run/safe_stop_payload.rs`
- `src/agent/loop_run/turn_tests.rs`
- `src/agent/loop_run/verifier_orchestration.rs`

## Tests Run
- Focused repair_packet, exhausted, and build_safe_stop_payload tests
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`

## Known Risks
- This touches repair and safe-stop payload semantics; merge after #888 and before verifier adapter integration.
- Local dev report files were intentionally excluded from the PR to satisfy repository hygiene policy.

## Orchestration
- Run ID: `20260602-081506-orchestrate`
