### PR TITLE
#887 define DeliverableObligation as minimum deliverable unit

### DIFF
--- a/src/agent/loop_run/repair_packet.rs
+++ b/src/agent/loop_run/repair_packet.rs
@@ -1,6 +1,7 @@
 use super::repair_job::sanitize_repair_job_text_with_char_cap;
 use super::task_contract::{
-    ArtifactObligation, ArtifactRole, DeliverableKind, RecoveryTargetHint, TaskContract, TaskKind,
+    ArtifactObligation, ArtifactRole, DeliverableKind, DeliverableSchema, RecoveryTargetHint,
+    TaskContract, TaskKind,
 };
 
 const MAX_EXPECTED_EVIDENCE_ITEMS: usize = 8;
@@ -80,6 +81,36 @@ pub(super) fn obligation_id_for_parts(role: ArtifactRole, path: Option<&str>) ->
     format!("{}:{path}", role.label())
 }
 
+fn obligation_id_for_obligation(obligation: &ArtifactObligation) -> String {
+    let base = obligation_id_for_parts(obligation.role, Some(&obligation.path));
+    let Some(suffix) = (match obligation.schema.as_ref() {
+        Some(DeliverableSchema::JsonFields(fields)) => fields.first(),
+        _ => None,
+    }) else {
+        return base;
+    };
+    let suffix = suffix
+        .chars()
+        .filter_map(|ch| {
+            if ch.is_ascii_alphanumeric() {
+                Some(ch.to_ascii_lowercase())
+            } else if ch.is_ascii_whitespace() || matches!(ch, '-' | '_' | '.') {
+                Some('_')
+            } else {
+                None
+            }
+        })
+        .take(40)
+        .collect::<String>()
+        .trim_matches('_')
+        .to_string();
+    if suffix.is_empty() {
+        base
+    } else {
+        format!("{base}#{suffix}")
+    }
+}
+
 pub(super) fn default_failure_domain_for_obligation(
     obligation: &ArtifactObligation,
 ) -> DeliverableFailureDomain {
@@ -88,6 +119,12 @@ pub(super) fn default_failure_domain_for_obligation(
     }
     if obligation.role == ArtifactRole::DataOutput && obligation.structured_record_schema.is_some()
     {
+        return DeliverableFailureDomain::SchemaMismatch;
+    }
+    if matches!(
+        obligation.schema.as_ref(),
+        Some(DeliverableSchema::JsonFields(_))
+    ) {
         return DeliverableFailureDomain::SchemaMismatch;
     }
     DeliverableFailureDomain::MissingDeliverable
@@ -127,7 +164,7 @@ fn target_from_obligation(
     failure_domain: DeliverableFailureDomain,
 ) -> RepairObligationTarget {
     RepairObligationTarget {
-        obligation_id: obligation_id_for_parts(obligation.role, Some(&obligation.path)),
+        obligation_id: obligation_id_for_obligation(obligation),
         role: obligation.role,
         kind: obligation.kind,
         path: Some(sanitize_repair_job_text_with_char_cap(
@@ -185,6 +222,31 @@ fn expected_evidence_for_obligation(obligation: &ArtifactObligation) -> Vec<Stri
             "required columns: {}",
             schema
                 .columns
+                .iter()
+                .take(MAX_EXPECTED_EVIDENCE_ITEMS)
+                .cloned()
+                .collect::<Vec<_>>()
+                .join(", ")
+        )));
+    }
+    if let Some(DeliverableSchema::JsonFields(fields)) = obligation.schema.as_ref()
+        && !fields.is_empty()
+    {
+        evidence.push(bounded_evidence(format!(
+            "required JSON field(s): {}",
+            fields
+                .iter()
+                .take(MAX_EXPECTED_EVIDENCE_ITEMS)
+                .cloned()
+                .collect::<Vec<_>>()
+                .join(", ")
+        )));
+    }
+    if !obligation.acceptance_criteria.is_empty() {
+        evidence.push(bounded_evidence(format!(
+            "acceptance criteria: {}",
+            obligation
+                .acceptance_criteria
                 .iter()
                 .take(MAX_EXPECTED_EVIDENCE_ITEMS)
                 .cloned()
@@ -316,5 +378,48 @@ mod tests {
         );
         assert_eq!(packet.target.obligation_id, "implementation:main.py");
         assert_eq!(packet.target.role, ArtifactRole::Implementation);
+    }
+
+    #[test]
+    fn node_cli_bin_entry_packet_exposes_json_field_obligation() {
+        let contract = TaskContract::from_request(
+            "Create a Node CLI. Include package.json with a bin entry, source, tests, and README.md.",
+        );
+        let obligation = contract
+            .required_artifact_identities
+            .iter()
+            .find(|obligation| {
+                obligation.path == "package.json"
+                    && matches!(
+                        obligation.schema.as_ref(),
+                        Some(DeliverableSchema::JsonFields(fields)) if fields.as_slice() == ["bin"]
+                    )
+            })
+            .expect("bin entry obligation");
+        let packet = RepairPacket::for_obligation(
+            &contract,
+            obligation,
+            default_failure_domain_for_obligation(obligation),
+        );
+
+        assert_eq!(
+            packet.target.failure_domain,
+            DeliverableFailureDomain::SchemaMismatch
+        );
+        assert!(packet.target.obligation_id.contains("package.json#"));
+        assert!(
+            packet
+                .target
+                .expected_evidence
+                .iter()
+                .any(|item| item.contains("required JSON field(s): bin"))
+        );
+        assert!(
+            packet
+                .target
+                .expected_evidence
+                .iter()
+                .any(|item| item.contains("bin entry"))
+        );
     }
 }

--- a/src/agent/loop_run/task_contract.rs
+++ b/src/agent/loop_run/task_contract.rs
@@ -95,42 +95,150 @@ pub(super) struct StructuredRecordSchema {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(super) struct ArtifactObligation {
+pub(super) enum DeliverableFormat {
+    RustSource,
+    JavaScriptSource,
+    TypeScriptSource,
+    Markdown,
+    Toml,
+    Json,
+    Csv,
+    Tsv,
+    JsonLines,
+    Text,
+}
+
+impl DeliverableFormat {
+    fn from_path(path: &str) -> Option<Self> {
+        let lower = path.to_ascii_lowercase();
+        if lower == "cargo.toml" || lower.ends_with(".toml") {
+            return Some(Self::Toml);
+        }
+        if lower == "package.json" || lower.ends_with(".json") {
+            return Some(Self::Json);
+        }
+        if lower.ends_with(".rs") {
+            return Some(Self::RustSource);
+        }
+        if lower.ends_with(".ts") || lower.ends_with(".tsx") {
+            return Some(Self::TypeScriptSource);
+        }
+        if lower.ends_with(".js") || lower.ends_with(".jsx") {
+            return Some(Self::JavaScriptSource);
+        }
+        if lower.ends_with(".md") || lower.ends_with(".mdx") {
+            return Some(Self::Markdown);
+        }
+        if lower.ends_with(".csv") {
+            return Some(Self::Csv);
+        }
+        if lower.ends_with(".tsv") {
+            return Some(Self::Tsv);
+        }
+        if lower.ends_with(".jsonl") || lower.ends_with(".ndjson") {
+            return Some(Self::JsonLines);
+        }
+        if lower.ends_with(".txt") || lower.ends_with(".rst") {
+            return Some(Self::Text);
+        }
+        None
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum DeliverableSchema {
+    StructuredRecord(StructuredRecordSchema),
+    JsonFields(Vec<String>),
+    RequiredSections(Vec<String>),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct DeliverableObligation {
     pub(super) role: ArtifactRole,
     pub(super) kind: DeliverableKind,
     pub(super) path: String,
+    pub(super) format: Option<DeliverableFormat>,
+    pub(super) schema: Option<DeliverableSchema>,
     pub(super) required_sections: Vec<String>,
+    pub(super) acceptance_criteria: Vec<String>,
     pub(super) structured_record_schema: Option<StructuredRecordSchema>,
 }
 
-impl ArtifactObligation {
+pub(super) type ArtifactObligation = DeliverableObligation;
+
+impl DeliverableObligation {
     pub(super) fn file(role: ArtifactRole, path: impl Into<String>) -> Self {
+        let path = path.into();
         Self {
             role,
             kind: DeliverableKind::File,
-            path: path.into(),
+            format: DeliverableFormat::from_path(&path),
+            path,
+            schema: None,
             required_sections: Vec::new(),
+            acceptance_criteria: Vec::new(),
             structured_record_schema: None,
         }
     }
 
     fn readme(path: impl Into<String>, required_sections: Vec<String>) -> Self {
+        let path = path.into();
         Self {
             role: ArtifactRole::UsageDocs,
             kind: DeliverableKind::File,
-            path: path.into(),
-            required_sections,
+            format: DeliverableFormat::from_path(&path),
+            path,
+            schema: Some(DeliverableSchema::RequiredSections(
+                required_sections.clone(),
+            )),
+            required_sections: required_sections.clone(),
+            acceptance_criteria: required_sections
+                .iter()
+                .map(|section| format!("README includes a {section} section"))
+                .collect(),
             structured_record_schema: None,
         }
     }
 
     fn structured_record(path: impl Into<String>, columns: Vec<String>) -> Self {
+        let path = path.into();
+        let schema = StructuredRecordSchema { columns };
         Self {
             role: ArtifactRole::DataOutput,
             kind: DeliverableKind::StructuredRecord,
-            path: path.into(),
+            format: DeliverableFormat::from_path(&path),
+            path,
+            schema: Some(DeliverableSchema::StructuredRecord(schema.clone())),
             required_sections: Vec::new(),
-            structured_record_schema: Some(StructuredRecordSchema { columns }),
+            acceptance_criteria: if schema.columns.is_empty() {
+                Vec::new()
+            } else {
+                vec![format!(
+                    "structured output includes columns: {}",
+                    schema.columns.join(", ")
+                )]
+            },
+            structured_record_schema: Some(schema),
+        }
+    }
+
+    fn json_field(
+        role: ArtifactRole,
+        path: impl Into<String>,
+        field: impl Into<String>,
+        criterion: impl Into<String>,
+    ) -> Self {
+        let path = path.into();
+        let field = field.into();
+        Self {
+            role,
+            kind: DeliverableKind::StructuredRecord,
+            format: DeliverableFormat::from_path(&path),
+            path,
+            schema: Some(DeliverableSchema::JsonFields(vec![field])),
+            required_sections: Vec::new(),
+            acceptance_criteria: vec![criterion.into()],
+            structured_record_schema: None,
         }
     }
 }
@@ -981,10 +1089,50 @@ fn recovery_target_hint_for_missing_with_contract(
         return Some(RecoveryTargetHint {
             role,
             path: identity.path.clone(),
-            reason: "required artifact identity is still missing".to_string(),
+            reason: format!(
+                "required deliverable obligation is still missing: {}",
+                obligation_report_label(identity)
+            ),
         });
     }
     recovery_target_hint_for_missing(artifacts, missing)
+}
+
+fn obligation_report_label(obligation: &ArtifactObligation) -> String {
+    let mut parts = vec![format!(
+        "role={}, kind={}, path={}",
+        obligation.role.label(),
+        obligation.kind.label(),
+        obligation.path
+    )];
+    if !obligation.required_sections.is_empty() {
+        parts.push(format!(
+            "required_sections={}",
+            obligation.required_sections.join("|")
+        ));
+    }
+    if !obligation.acceptance_criteria.is_empty() {
+        parts.push(format!(
+            "acceptance_criteria={}",
+            obligation.acceptance_criteria.join("|")
+        ));
+    }
+    if let Some(DeliverableSchema::JsonFields(fields)) = obligation.schema.as_ref()
+        && !fields.is_empty()
+    {
+        parts.push(format!("schema_fields={}", fields.join("|")));
+    }
+    if let Some(DeliverableSchema::StructuredRecord(schema)) = obligation.schema.as_ref()
+        && !schema.columns.is_empty()
+    {
+        parts.push(format!("schema_columns={}", schema.columns.join("|")));
+    }
+    if let Some(DeliverableSchema::RequiredSections(sections)) = obligation.schema.as_ref()
+        && !sections.is_empty()
+    {
+        parts.push(format!("schema_sections={}", sections.join("|")));
+    }
+    parts.join(", ")
 }
 
 fn synthesized_missing_role_target_hint(
@@ -1127,12 +1275,18 @@ impl TaskContract {
         for identity in
             inferred_artifact_obligations_from_project_intent(&project_intent, &required)
         {
+            if inferred_obligation_shadowed_by_explicit_identity(
+                &required_artifact_identities,
+                &identity,
+            ) {
+                continue;
+            }
             if !required.contains(&identity.role) {
                 required.push(identity.role);
             }
             push_or_merge_artifact_obligation(&mut required_artifact_identities, identity);
         }
-        for identity in inferred_docs_obligations_from_request(&lower, &required) {
+        for identity in inferred_docs_obligations_from_request(request, &lower, &required) {
             push_or_merge_artifact_obligation(&mut required_artifact_identities, identity);
         }
         for identity in inferred_data_obligations_from_request(request, &lower) {
@@ -1568,7 +1722,9 @@ pub(super) fn render_contract_recovery_note_with_hint(
     );
     if let Some(hint) = target_hint {
         note.push_str(&format!(
-            " Recovery target: role={}, path={}, reason={}. Prefer a Write/Edit tool call for this same artifact role now; scaffold-only files do not count until their content changes.",
+            " Missing obligation: role={}, path={}. Recovery target: role={}, path={}, reason={}. Prefer a Write/Edit tool call for this same deliverable obligation now; scaffold-only files do not count until their content changes.",
+            hint.role.label(),
+            hint.path,
             hint.role.label(),
             hint.path,
             hint.reason
@@ -2583,6 +2739,21 @@ fn inferred_artifact_obligations_from_project_intent(
     match project_intent.language.unwrap_or(ProjectLanguage::Unknown) {
         ProjectLanguage::Rust => {
             obligations.push(ArtifactObligation::file(ArtifactRole::Setup, "Cargo.toml"));
+            if matches!(shape, ProjectShape::Cli) {
+                obligations.push(ArtifactObligation::file(
+                    ArtifactRole::Implementation,
+                    "src/main.rs",
+                ));
+                if required_artifacts.contains(&ArtifactRole::Test) {
+                    obligations.push(ArtifactObligation::file(ArtifactRole::Test, "tests/cli.rs"));
+                }
+                if required_artifacts.contains(&ArtifactRole::UsageDocs) {
+                    obligations.push(ArtifactObligation::readme(
+                        "README.md",
+                        default_readme_required_sections(),
+                    ));
+                }
+            }
         }
         ProjectLanguage::Node => {
             obligations.push(ArtifactObligation::file(
@@ -2590,6 +2761,12 @@ fn inferred_artifact_obligations_from_project_intent(
                 "package.json",
             ));
             if matches!(shape, ProjectShape::Cli) {
+                obligations.push(ArtifactObligation::json_field(
+                    ArtifactRole::Setup,
+                    "package.json",
+                    "bin",
+                    "package.json declares a bin entry for the CLI",
+                ));
                 obligations.push(ArtifactObligation::file(
                     ArtifactRole::Implementation,
                     "src/index.js",
@@ -2639,7 +2816,7 @@ fn push_or_merge_artifact_obligation(
 ) {
     let Some(existing) = obligations
         .iter_mut()
-        .find(|existing| existing.role == incoming.role && existing.path == incoming.path)
+        .find(|existing| should_merge_artifact_obligations(existing, &incoming))
     else {
         obligations.push(incoming);
         return;
@@ -2650,12 +2827,53 @@ fn push_or_merge_artifact_obligation(
     if existing.required_sections.is_empty() && !incoming.required_sections.is_empty() {
         existing.required_sections = incoming.required_sections;
     }
+    if existing.acceptance_criteria.is_empty() && !incoming.acceptance_criteria.is_empty() {
+        existing.acceptance_criteria = incoming.acceptance_criteria;
+    }
     if existing.structured_record_schema.is_none() {
         existing.structured_record_schema = incoming.structured_record_schema;
     }
+    if existing.schema.is_none() {
+        existing.schema = incoming.schema;
+    }
+}
+
+fn inferred_obligation_shadowed_by_explicit_identity(
+    existing: &[ArtifactObligation],
+    incoming: &ArtifactObligation,
+) -> bool {
+    matches!(
+        incoming.role,
+        ArtifactRole::Implementation | ArtifactRole::Test
+    ) && existing
+        .iter()
+        .any(|identity| identity.role == incoming.role && identity.path != incoming.path)
+}
+
+fn should_merge_artifact_obligations(
+    existing: &ArtifactObligation,
+    incoming: &ArtifactObligation,
+) -> bool {
+    if existing.role != incoming.role || existing.path != incoming.path {
+        return false;
+    }
+    if existing.role == ArtifactRole::Setup
+        && existing.path == "package.json"
+        && (matches!(
+            existing.schema.as_ref(),
+            Some(DeliverableSchema::JsonFields(_))
+        ) || matches!(
+            incoming.schema.as_ref(),
+            Some(DeliverableSchema::JsonFields(_))
+        ))
+    {
+        return false;
+    }
+    true
 }
 
 fn inferred_docs_obligations_from_request(
+    request: &str,
     lower: &str,
     required_artifacts: &[ArtifactRole],
 ) -> Vec<ArtifactObligation> {
@@ -2665,22 +2883,7 @@ fn inferred_docs_obligations_from_request(
     {
         return Vec::new();
     }
-    let mut sections = Vec::new();
-    if contains_any(lower, &["setup", "install", "dependency", "dependencies"]) {
-        sections.push("setup".to_string());
-    }
-    if contains_any(
-        lower,
-        &["usage", "run", "example", "使い方", "実行", "使用"],
-    ) {
-        sections.push("usage".to_string());
-    }
-    if contains_any(lower, &["test", "verify", "verification", "テスト", "検証"]) {
-        sections.push("test".to_string());
-    }
-    if lower.contains("section") && sections.is_empty() {
-        sections = default_readme_required_sections();
-    }
+    let sections = required_doc_sections_from_request(request);
     if sections.is_empty() {
         return Vec::new();
     }
@@ -3280,6 +3483,98 @@ mod tests {
     }
 
     #[test]
+    fn rust_cli_contract_requires_manifest_impl_test_and_readme_obligations() {
+        let contract = TaskContract::from_request(
+            "Create a Rust CLI. Include Cargo.toml, implementation, tests, and README.md.",
+        );
+
+        let manifest = required_obligation(&contract, ArtifactRole::Setup, "Cargo.toml");
+        assert_eq!(manifest.format, Some(DeliverableFormat::Toml));
+        assert_eq!(manifest.kind, DeliverableKind::File);
+        assert_eq!(
+            required_obligation(&contract, ArtifactRole::Implementation, "src/main.rs").format,
+            Some(DeliverableFormat::RustSource)
+        );
+        assert_eq!(
+            required_obligation(&contract, ArtifactRole::Test, "tests/cli.rs").format,
+            Some(DeliverableFormat::RustSource)
+        );
+        let readme = required_obligation(&contract, ArtifactRole::UsageDocs, "README.md");
+        assert_eq!(readme.format, Some(DeliverableFormat::Markdown));
+        assert_eq!(readme.required_sections, default_readme_required_sections());
+    }
+
+    #[test]
+    fn node_cli_contract_requires_package_bin_source_test_and_readme_obligations() {
+        let contract = TaskContract::from_request(
+            "Create a Node CLI. Include package.json with a bin entry, source, tests, and README.md.",
+        );
+        let setup_obligations = contract.required_identities_for_role(ArtifactRole::Setup);
+
+        assert!(
+            setup_obligations
+                .iter()
+                .any(|obligation| obligation.path == "package.json"
+                    && obligation.kind == DeliverableKind::File),
+            "setup_obligations={setup_obligations:?}"
+        );
+        let bin = setup_obligations
+            .iter()
+            .find(|obligation| {
+                obligation.path == "package.json"
+                    && matches!(
+                        obligation.schema.as_ref(),
+                        Some(DeliverableSchema::JsonFields(fields)) if fields.as_slice() == ["bin"]
+                    )
+            })
+            .expect("bin entry obligation");
+        assert_eq!(bin.format, Some(DeliverableFormat::Json));
+        assert!(
+            bin.acceptance_criteria
+                .iter()
+                .any(|criterion| { criterion.contains("bin entry") })
+        );
+        assert_eq!(
+            required_obligation(&contract, ArtifactRole::Implementation, "src/index.js").format,
+            Some(DeliverableFormat::JavaScriptSource)
+        );
+        assert_eq!(
+            required_obligation(&contract, ArtifactRole::Test, "tests/index.test.js").format,
+            Some(DeliverableFormat::JavaScriptSource)
+        );
+        assert!(
+            required_obligation(&contract, ArtifactRole::UsageDocs, "README.md")
+                .acceptance_criteria
+                .iter()
+                .any(|criterion| criterion.contains("setup section"))
+        );
+    }
+
+    #[test]
+    fn docs_only_task_requires_sections_as_deliverable_obligation() {
+        let contract = TaskContract::from_request(
+            "Update README.md with installation, usage, and testing sections.",
+        );
+
+        assert_eq!(contract.task_kind, TaskKind::Docs);
+        let readme = required_obligation(&contract, ArtifactRole::UsageDocs, "README.md");
+        assert_eq!(
+            readme.required_sections,
+            vec![
+                "installation".to_string(),
+                "usage".to_string(),
+                "testing".to_string()
+            ]
+        );
+        assert!(matches!(
+            readme.schema.as_ref(),
+            Some(DeliverableSchema::RequiredSections(sections))
+                if sections == &readme.required_sections
+        ));
+        assert_eq!(readme.acceptance_criteria.len(), 3);
+    }
+
+    #[test]
     fn python_cli_main_py_alone_leaves_tests_and_readme_missing() {
         let contract = TaskContract::from_request(
             "Create a Python CLI in main.py with tests and README.md usage docs.",
@@ -3307,7 +3602,7 @@ mod tests {
                 target_hint: Some(RecoveryTargetHint {
                     role: ArtifactRole::Test,
                     path: "tests/test_main.py".to_string(),
-                    reason: "required artifact identity is still missing".to_string(),
+                    reason: "required deliverable obligation is still missing: role=test, kind=file, path=tests/test_main.py".to_string(),
                 }),
             }
         );
@@ -3434,7 +3729,7 @@ mod tests {
         )];
         let excerpts = build_excerpts(&[(
             ArtifactRole::UsageDocs,
-            "# Usage\n\n## Setup\nInstall dependencies.\n\n## Usage\nRun the CLI.\n\n## Test\nRun verification checks.\n",
+            "# Usage\n\n## Installation\nInstall dependencies.\n\n## Usage\nRun the CLI.\n\n## Testing\nRun verification checks.\n",
         )]);
         let repair_state = VerifierRepairState::None;
 
@@ -3698,6 +3993,49 @@ mod tests {
     }
 
     #[test]
+    fn recovery_note_identifies_missing_deliverable_obligation_path() {
+        let contract = TaskContract::from_request(
+            "Create a Rust CLI. Include Cargo.toml, implementation, tests, and README.md.",
+        );
+        let mut evidence = EvidenceSet::new();
+        evidence.push(repo_edit_path(RepoEditCategory::Setup, "Cargo.toml"));
+        let repair_state = VerifierRepairState::None;
+        let action = plan_artifact_recovery(ArtifactRecoveryInputs {
+            contract: &contract,
+            evidence: &evidence,
+            artifacts: &[ArtifactState::changed_at(ArtifactRole::Setup, "Cargo.toml")],
+            repair_state: &repair_state,
+            artifact_excerpts: &ArtifactExcerpts::new(),
+            missing_verifier_suppress_retry: false,
+            owned_test_artifacts: &[],
+        });
+        let ArtifactRecoveryAction::Continue {
+            missing,
+            target_hint,
+        } = action
+        else {
+            panic!("expected missing obligation action: {action:?}");
+        };
+        let decision = CompletionDecision::Continue { missing };
+        let hint = target_hint.expect("missing obligation target");
+        let note = render_contract_recovery_note_with_hint(
+            &decision,
+            "Create a Rust CLI. Include Cargo.toml, implementation, tests, and README.md.",
+            1,
+            4,
+            Some(&hint),
+        );
+
+        assert!(note.contains("Missing obligation"), "got: {note}");
+        assert!(note.contains("role=implementation"), "got: {note}");
+        assert!(note.contains("path=src/main.rs"), "got: {note}");
+        assert!(
+            note.contains("required deliverable obligation is still missing"),
+            "got: {note}"
+        );
+    }
+
+    #[test]
     fn readme_only_does_not_complete_implementation_contract() {
         let contract =
             TaskContract::from_request("Rust CLIを作成してREADMEに使い方も書いてください");
@@ -3763,7 +4101,7 @@ mod tests {
                 target_hint: Some(RecoveryTargetHint {
                     role: ArtifactRole::Implementation,
                     path: "lru_cache.py".to_string(),
-                    reason: "required artifact identity is still missing".to_string(),
+                    reason: "required deliverable obligation is still missing: role=implementation, kind=file, path=lru_cache.py".to_string(),
                 }),
             }
         );
@@ -3825,7 +4163,7 @@ mod tests {
                 target_hint: Some(RecoveryTargetHint {
                     role: ArtifactRole::Setup,
                     path: "Cargo.toml".to_string(),
-                    reason: "required artifact identity is still missing".to_string(),
+                    reason: "required deliverable obligation is still missing: role=setup, kind=file, path=Cargo.toml".to_string(),
                 }),
             }
         );
@@ -3864,7 +4202,7 @@ mod tests {
                 target_hint: Some(RecoveryTargetHint {
                     role: ArtifactRole::Setup,
                     path: "package.json".to_string(),
-                    reason: "required artifact identity is still missing".to_string(),
+                    reason: "required deliverable obligation is still missing: role=setup, kind=file, path=package.json".to_string(),
                 }),
             }
         );
@@ -4104,7 +4442,7 @@ mod tests {
                 target_hint: Some(RecoveryTargetHint {
                     role: ArtifactRole::UsageDocs,
                     path: "README.md".to_string(),
-                    reason: "required artifact identity is still missing".to_string(),
+                    reason: "required deliverable obligation is still missing: role=usage_docs, kind=file, path=README.md".to_string(),
                 }),
             }
         );
@@ -4243,7 +4581,7 @@ mod tests {
 
         let complete = build_excerpts(&[(
             ArtifactRole::UsageDocs,
-            "# Project\n\n## Setup\ninstall\n\n## Usage\nrun it\n\n## Test\npytest\n",
+            "# Project\n\n## Installation\ninstall\n\n## Usage\nrun it\n\n## Testing\npytest\n",
         )]);
         assert_eq!(
             plan_artifact_recovery(ArtifactRecoveryInputs {


### PR DESCRIPTION
Closes #887

## Summary
- Defines DeliverableObligation as the minimum deliverable unit.
- Connects repair packet context to deliverable obligations instead of only coding artifacts.

## Changed Files
- `src/agent/loop_run/task_contract.rs`
- `src/agent/loop_run/repair_packet.rs`

## Tests Run
- Focused task_contract and repair_packet tests
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test -q`

## Known Risks
- Worker report noted one order-sensitive artifact-ledger failure during `cargo test --lib -q`; isolated rerun and full `cargo test -q` passed.
- Local dev report files were intentionally excluded from the PR to satisfy repository hygiene policy.

## Orchestration
- Run ID: `20260602-081506-orchestrate`
