### PR TITLE
Issue #902: split verifier diagnostics by task kind

### DIFF
--- a/src/agent/loop_run.rs
+++ b/src/agent/loop_run.rs
@@ -2434,6 +2434,12 @@ enum VerifierRepairAssessmentSource {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum VerifierDiagnosticFailureKind {
+    MissingFile,
+    InvalidManifest,
+    BadTest,
+    WrongSemantics,
+    EvidenceMissing,
+    SchemaMismatch,
     DependencyMissing,
     LocalImportContractMismatch,
     CompileOrSyntaxError,
@@ -2447,6 +2453,12 @@ enum VerifierDiagnosticFailureKind {
 impl VerifierDiagnosticFailureKind {
     fn as_str(self) -> &'static str {
         match self {
+            Self::MissingFile => "missing_file",
+            Self::InvalidManifest => "invalid_manifest",
+            Self::BadTest => "bad_test",
+            Self::WrongSemantics => "wrong_semantics",
+            Self::EvidenceMissing => "evidence_missing",
+            Self::SchemaMismatch => "schema_mismatch",
             Self::DependencyMissing => "dependency_missing",
             Self::LocalImportContractMismatch => "local_import_contract_mismatch",
             Self::CompileOrSyntaxError => "compile_or_syntax_error",
@@ -2459,7 +2471,13 @@ impl VerifierDiagnosticFailureKind {
     }
 
     fn allows_setup_target(self) -> bool {
-        matches!(self, Self::DependencyMissing | Self::ConfigOrVerifierError)
+        matches!(
+            self,
+            Self::DependencyMissing
+                | Self::InvalidManifest
+                | Self::EvidenceMissing
+                | Self::ConfigOrVerifierError
+        )
     }
 }
 
@@ -2896,7 +2914,7 @@ mod tests {
     }
 
     #[test]
-    fn verifier_diagnostic_failure_kind_has_8_variants() {
+    fn verifier_diagnostic_failure_kind_has_14_variants() {
         // S1-001: SemanticFailureReport is an upper-layer wrapper that
         // **reuses** the existing 8-variant `VerifierDiagnosticFailureKind`
         // enum. Adding or removing a variant breaks the SSOT invariant
@@ -2904,6 +2922,12 @@ mod tests {
         // enum surface drifts.
         use super::VerifierDiagnosticFailureKind as K;
         let all = [
+            K::MissingFile,
+            K::InvalidManifest,
+            K::BadTest,
+            K::WrongSemantics,
+            K::EvidenceMissing,
+            K::SchemaMismatch,
             K::DependencyMissing,
             K::LocalImportContractMismatch,
             K::CompileOrSyntaxError,
@@ -2917,6 +2941,12 @@ mod tests {
             // Exhaustive match — extension of the enum forces this to
             // be updated (compile-time lock).
             let label: &'static str = match v {
+                K::MissingFile => "missing_file",
+                K::InvalidManifest => "invalid_manifest",
+                K::BadTest => "bad_test",
+                K::WrongSemantics => "wrong_semantics",
+                K::EvidenceMissing => "evidence_missing",
+                K::SchemaMismatch => "schema_mismatch",
                 K::DependencyMissing => "dependency_missing",
                 K::LocalImportContractMismatch => "local_import_contract_mismatch",
                 K::CompileOrSyntaxError => "compile_or_syntax_error",
@@ -2928,6 +2958,6 @@ mod tests {
             };
             assert!(!label.is_empty());
         }
-        assert_eq!(all.len(), 8);
+        assert_eq!(all.len(), 14);
     }
 }

--- a/src/agent/loop_run/failure_packet.rs
+++ b/src/agent/loop_run/failure_packet.rs
@@ -27,6 +27,7 @@ pub(super) struct FailurePacket {
     pub(super) verifier_command: String,
     pub(super) failure_signature: String,
     pub(super) failure_kind: String,
+    pub(super) diagnostic_code: Option<String>,
     pub(super) timeout_kind: Option<FailurePacketTimeoutKind>,
     pub(super) bounded_output_excerpt: String,
     pub(super) affected_cases: Vec<String>,
@@ -174,6 +175,8 @@ impl FailurePacket {
             sanitize_repair_job_text_with_char_cap(verifier_output, MAX_OUTPUT_EXCERPT_CHARS);
         let timeout_kind = timeout_kind_from_output(&bounded_output_excerpt);
         let failure_kind = sanitize_short(failure_kind);
+        let diagnostic_code =
+            structured_diagnostic_code_from_failure_kind(&failure_kind).map(ToString::to_string);
         let affected_cases = affected_cases
             .into_iter()
             .take(MAX_CASES)
@@ -211,6 +214,7 @@ impl FailurePacket {
             ),
             failure_signature,
             failure_kind,
+            diagnostic_code,
             timeout_kind,
             bounded_output_excerpt,
             affected_cases,
@@ -238,6 +242,7 @@ impl FailurePacket {
             "verifier_command": &self.verifier_command,
             "failure_signature": &self.failure_signature,
             "failure_kind": &self.failure_kind,
+            "diagnostic_code": self.diagnostic_code.as_deref(),
             "timeout_kind": self.timeout_kind.map(FailurePacketTimeoutKind::as_str),
             "bounded_output_excerpt": &self.bounded_output_excerpt,
             "affected_cases": &self.affected_cases,
@@ -263,6 +268,20 @@ impl FailurePacket {
                 })
             }).collect::<Vec<_>>(),
         })
+    }
+}
+
+fn structured_diagnostic_code_from_failure_kind(failure_kind: &str) -> Option<&'static str> {
+    match failure_kind {
+        "missing_file" => Some("missing_file"),
+        "invalid_manifest" => Some("invalid_manifest"),
+        "bad_test" | "test_bug" => Some("bad_test"),
+        "wrong_semantics" | "assertion_mismatch" | "assertion_failure" => Some("wrong_semantics"),
+        "evidence_missing" | "missing_verifier_or_config" | "config_or_verifier_error" => {
+            Some("evidence_missing")
+        }
+        "schema_mismatch" | "structured_data_schema_missing" => Some("schema_mismatch"),
+        _ => None,
     }
 }
 
@@ -558,6 +577,25 @@ assertion `left == right` failed
         assert!(packet.observed_expected_pairs.is_empty());
         assert!(!packet.bounded_output_excerpt.is_empty());
         assert_eq!(packet.timeout_kind, None);
+    }
+
+    #[test]
+    fn failure_packet_exposes_structured_diagnostic_code() {
+        let packet = FailurePacket::new(
+            "npm test",
+            "invalid_manifest",
+            "package.json is not valid JSON",
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        );
+
+        assert_eq!(packet.diagnostic_code.as_deref(), Some("invalid_manifest"));
+        assert_eq!(
+            packet.to_json_value()["diagnostic_code"],
+            serde_json::json!("invalid_manifest")
+        );
     }
 
     #[test]

--- a/src/agent/loop_run/repair_job.rs
+++ b/src/agent/loop_run/repair_job.rs
@@ -3930,6 +3930,12 @@ mod tests {
     #[cfg(test)]
     fn kind_label(kind: VerifierDiagnosticFailureKind) -> &'static str {
         match kind {
+            VerifierDiagnosticFailureKind::MissingFile => "missing_file",
+            VerifierDiagnosticFailureKind::InvalidManifest => "invalid_manifest",
+            VerifierDiagnosticFailureKind::BadTest => "bad_test",
+            VerifierDiagnosticFailureKind::WrongSemantics => "wrong_semantics",
+            VerifierDiagnosticFailureKind::EvidenceMissing => "evidence_missing",
+            VerifierDiagnosticFailureKind::SchemaMismatch => "schema_mismatch",
             VerifierDiagnosticFailureKind::DependencyMissing => "dependency_missing",
             VerifierDiagnosticFailureKind::LocalImportContractMismatch => {
                 "local_import_contract_mismatch"

--- a/src/agent/loop_run/repair_packet.rs
+++ b/src/agent/loop_run/repair_packet.rs
@@ -11,9 +11,7 @@ const MAX_REPAIR_INSTRUCTION_CHARS: usize = 360;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum CorrectionKind {
     Patch,
-    #[cfg(test)]
     TestCorrection,
-    #[cfg(test)]
     ManifestCorrection,
     SectionAddition,
     SchemaCorrection,
@@ -25,9 +23,7 @@ impl CorrectionKind {
     pub(super) fn as_str(self) -> &'static str {
         match self {
             Self::Patch => "patch",
-            #[cfg(test)]
             Self::TestCorrection => "test_correction",
-            #[cfg(test)]
             Self::ManifestCorrection => "manifest_correction",
             Self::SectionAddition => "section_addition",
             Self::SchemaCorrection => "schema_correction",
@@ -37,14 +33,13 @@ impl CorrectionKind {
     }
 }
 
+#[allow(dead_code)] // Issue #902: diagnostic domains are selected when structured verifier diagnostics reach repair.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum DeliverableFailureDomain {
     MissingDeliverable,
     MalformedDeliverable,
     VerifierFailed,
-    #[cfg(test)]
     GeneratedTestBug,
-    #[cfg(test)]
     InvalidManifest,
     SchemaMismatch,
     IncompleteSections,
@@ -57,9 +52,7 @@ impl DeliverableFailureDomain {
             Self::MissingDeliverable => "missing_deliverable",
             Self::MalformedDeliverable => "malformed_deliverable",
             Self::VerifierFailed => "verifier_failed",
-            #[cfg(test)]
             Self::GeneratedTestBug => "generated_test_bug",
-            #[cfg(test)]
             Self::InvalidManifest => "invalid_manifest",
             Self::SchemaMismatch => "schema_mismatch",
             Self::IncompleteSections => "incomplete_sections",
@@ -124,7 +117,24 @@ impl RepairPacket {
         Self::for_recovery_target(contract, hint, DeliverableFailureDomain::VerifierFailed)
     }
 
-    #[cfg(test)]
+    #[allow(dead_code)] // Issue #902 migration surface; exercised by repair_packet tests.
+    pub(super) fn for_structured_diagnostic(
+        contract: &TaskContract,
+        diagnostic: &super::verifier::VerifierDiagnostic,
+    ) -> CorrectionPacket {
+        let hint = RecoveryTargetHint {
+            role: diagnostic.role,
+            path: diagnostic.path.clone().unwrap_or_default(),
+            reason: diagnostic.reason(),
+        };
+        Self::for_recovery_target(
+            contract,
+            &hint,
+            failure_domain_for_verifier_diagnostic_code(diagnostic.code),
+        )
+    }
+
+    #[allow(dead_code)] // Issue #902 migration surface; exercised by repair_packet tests.
     pub(super) fn for_diagnostic_failure(
         contract: &TaskContract,
         hint: &RecoveryTargetHint,
@@ -338,11 +348,9 @@ fn adapter_instruction(task_kind: TaskKind, target: &RepairObligationTarget) -> 
         | (_, DeliverableFailureDomain::VerifierFailed) => {
             "repair the selected deliverable obligation while preserving verifier safety gates"
         }
-        #[cfg(test)]
         (_, DeliverableFailureDomain::GeneratedTestBug) => {
             "repair or replace the generated test artifact before using it as verifier authority"
         }
-        #[cfg(test)]
         (_, DeliverableFailureDomain::InvalidManifest) => {
             "repair the setup or manifest artifact so verifier setup is structurally valid"
         }
@@ -364,9 +372,7 @@ fn correction_kind_for_target(
     target: &RepairObligationTarget,
 ) -> CorrectionKind {
     match (task_kind, target.failure_domain, target.role) {
-        #[cfg(test)]
         (_, DeliverableFailureDomain::GeneratedTestBug, _) => CorrectionKind::TestCorrection,
-        #[cfg(test)]
         (_, DeliverableFailureDomain::InvalidManifest, _) => CorrectionKind::ManifestCorrection,
         (TaskKind::Docs, DeliverableFailureDomain::IncompleteSections, _)
         | (_, DeliverableFailureDomain::IncompleteSections, ArtifactRole::UsageDocs) => {
@@ -392,13 +398,56 @@ fn correction_kind_for_target(
     }
 }
 
-#[cfg(test)]
+#[allow(dead_code)] // Issue #902 migration surface; exercised by repair_packet tests.
+pub(super) fn failure_domain_for_verifier_diagnostic_code(
+    code: super::verifier::VerifierDiagnosticCode,
+) -> DeliverableFailureDomain {
+    match code {
+        super::verifier::VerifierDiagnosticCode::MissingFile => {
+            DeliverableFailureDomain::MissingDeliverable
+        }
+        super::verifier::VerifierDiagnosticCode::InvalidManifest => {
+            DeliverableFailureDomain::InvalidManifest
+        }
+        super::verifier::VerifierDiagnosticCode::BadTest => {
+            DeliverableFailureDomain::GeneratedTestBug
+        }
+        super::verifier::VerifierDiagnosticCode::WrongSemantics => {
+            DeliverableFailureDomain::VerifierFailed
+        }
+        super::verifier::VerifierDiagnosticCode::EvidenceMissing => {
+            DeliverableFailureDomain::IncompleteSections
+        }
+        super::verifier::VerifierDiagnosticCode::SchemaMismatch => {
+            DeliverableFailureDomain::SchemaMismatch
+        }
+    }
+}
+
+#[allow(dead_code)] // Issue #902 migration surface; exercised by repair_packet tests.
 fn failure_domain_for_diagnostic_failure(
     hint: &RecoveryTargetHint,
     failure_kind: super::VerifierDiagnosticFailureKind,
 ) -> DeliverableFailureDomain {
     match failure_kind {
-        super::VerifierDiagnosticFailureKind::TestBug => DeliverableFailureDomain::GeneratedTestBug,
+        super::VerifierDiagnosticFailureKind::BadTest
+        | super::VerifierDiagnosticFailureKind::TestBug => {
+            DeliverableFailureDomain::GeneratedTestBug
+        }
+        super::VerifierDiagnosticFailureKind::InvalidManifest => {
+            DeliverableFailureDomain::InvalidManifest
+        }
+        super::VerifierDiagnosticFailureKind::MissingFile
+        | super::VerifierDiagnosticFailureKind::EvidenceMissing => {
+            DeliverableFailureDomain::MissingDeliverable
+        }
+        super::VerifierDiagnosticFailureKind::SchemaMismatch => {
+            DeliverableFailureDomain::SchemaMismatch
+        }
+        super::VerifierDiagnosticFailureKind::WrongSemantics
+        | super::VerifierDiagnosticFailureKind::AssertionMismatch => {
+            DeliverableFailureDomain::VerifierFailed
+        }
         super::VerifierDiagnosticFailureKind::ConfigOrVerifierError
             if hint.role == ArtifactRole::Setup =>
         {
@@ -603,5 +652,93 @@ mod tests {
         );
         assert_eq!(packet.correction_kind, CorrectionKind::ManifestCorrection);
         assert_eq!(packet.correction_kind.as_str(), "manifest_correction");
+    }
+
+    #[test]
+    fn invalid_manifest_diagnostic_creates_manifest_correction_packet() {
+        let contract = TaskContract::from_request("Create a Node CLI with package.json and tests.");
+        let hint = RecoveryTargetHint {
+            role: ArtifactRole::Setup,
+            path: "package.json".to_string(),
+            reason: "package.json is not valid JSON".to_string(),
+        };
+        let packet = RepairPacket::for_diagnostic_failure(
+            &contract,
+            &hint,
+            super::super::VerifierDiagnosticFailureKind::InvalidManifest,
+        );
+
+        assert_eq!(
+            packet.target.failure_domain,
+            DeliverableFailureDomain::InvalidManifest
+        );
+        assert_eq!(packet.correction_kind, CorrectionKind::ManifestCorrection);
+    }
+
+    #[test]
+    fn structured_verifier_diagnostic_feeds_repair_packet_generation() {
+        let contract = TaskContract::from_request(
+            "Create a Node CLI. Include package.json with a bin entry, source, tests, and README.md.",
+        );
+        let obligation = contract
+            .required_identities_for_role(ArtifactRole::Setup)
+            .into_iter()
+            .find(|obligation| obligation.path == "package.json")
+            .expect("package manifest obligation");
+        let diagnostic = super::super::verifier::verifier_diagnostic_for_obligation(
+            contract.task_kind,
+            obligation,
+            Some(r#"{"bin":"#),
+            true,
+        )
+        .expect("structured manifest diagnostic");
+        let packet = RepairPacket::for_structured_diagnostic(&contract, &diagnostic);
+
+        assert_eq!(
+            packet.target.failure_domain,
+            DeliverableFailureDomain::InvalidManifest
+        );
+        assert_eq!(packet.correction_kind, CorrectionKind::ManifestCorrection);
+        assert_eq!(packet.target.path.as_deref(), Some("package.json"));
+    }
+
+    #[test]
+    fn schema_mismatch_diagnostic_creates_schema_correction_packet() {
+        let contract = TaskContract::from_request("Generate output.csv with columns id and total.");
+        let hint = RecoveryTargetHint {
+            role: ArtifactRole::DataOutput,
+            path: "output.csv".to_string(),
+            reason: "required column total is missing".to_string(),
+        };
+        let packet = RepairPacket::for_diagnostic_failure(
+            &contract,
+            &hint,
+            super::super::VerifierDiagnosticFailureKind::SchemaMismatch,
+        );
+
+        assert_eq!(
+            packet.target.failure_domain,
+            DeliverableFailureDomain::SchemaMismatch
+        );
+        assert_eq!(packet.correction_kind, CorrectionKind::SchemaCorrection);
+    }
+
+    #[test]
+    fn structured_verifier_diagnostic_creates_repair_packet() {
+        let contract = TaskContract::from_request("Generate output.csv with columns id and total.");
+        let diagnostic = super::super::verifier::VerifierDiagnostic {
+            task_kind: super::super::verifier::VerifierTaskKind::Data,
+            code: super::super::verifier::VerifierDiagnosticCode::SchemaMismatch,
+            role: ArtifactRole::DataOutput,
+            path: Some("output.csv".to_string()),
+            message: "required column total is missing".to_string(),
+        };
+        let packet = RepairPacket::for_structured_diagnostic(&contract, &diagnostic);
+
+        assert_eq!(
+            packet.target.failure_domain,
+            DeliverableFailureDomain::SchemaMismatch
+        );
+        assert_eq!(packet.correction_kind, CorrectionKind::SchemaCorrection);
     }
 }

--- a/src/agent/loop_run/semantic_failure.rs
+++ b/src/agent/loop_run/semantic_failure.rs
@@ -640,7 +640,13 @@ pub(super) fn parse_semantic_failure_report(
 /// failure kind continues through semantic repair planning.
 pub(super) fn dispatch_target(report: &SemanticFailureReport) -> SemanticDispatchTarget {
     match report.failure_kind {
-        VerifierDiagnosticFailureKind::DependencyMissing
+        VerifierDiagnosticFailureKind::MissingFile
+        | VerifierDiagnosticFailureKind::EvidenceMissing
+        | VerifierDiagnosticFailureKind::SchemaMismatch
+        | VerifierDiagnosticFailureKind::WrongSemantics
+        | VerifierDiagnosticFailureKind::BadTest => SemanticDispatchTarget::SemanticRepair,
+        VerifierDiagnosticFailureKind::InvalidManifest
+        | VerifierDiagnosticFailureKind::DependencyMissing
         | VerifierDiagnosticFailureKind::ConfigOrVerifierError => {
             SemanticDispatchTarget::SetupRepair
         }
@@ -652,6 +658,12 @@ pub(super) fn dispatch_target(report: &SemanticFailureReport) -> SemanticDispatc
 /// existing SSOT (`loop_run.rs::VerifierDiagnosticFailureKind::as_str`).
 fn parse_failure_kind(v: &serde_json::Value) -> Option<VerifierDiagnosticFailureKind> {
     Some(match v.as_str()? {
+        "missing_file" => VerifierDiagnosticFailureKind::MissingFile,
+        "invalid_manifest" => VerifierDiagnosticFailureKind::InvalidManifest,
+        "bad_test" => VerifierDiagnosticFailureKind::BadTest,
+        "wrong_semantics" => VerifierDiagnosticFailureKind::WrongSemantics,
+        "evidence_missing" => VerifierDiagnosticFailureKind::EvidenceMissing,
+        "schema_mismatch" => VerifierDiagnosticFailureKind::SchemaMismatch,
         "dependency_missing" => VerifierDiagnosticFailureKind::DependencyMissing,
         "local_import_contract_mismatch" => {
             VerifierDiagnosticFailureKind::LocalImportContractMismatch

--- a/src/agent/loop_run/task_contract.rs
+++ b/src/agent/loop_run/task_contract.rs
@@ -865,6 +865,7 @@ pub(super) fn plan_artifact_recovery(inputs: ArtifactRecoveryInputs<'_>) -> Arti
             inputs.contract,
             inputs.evidence,
             inputs.artifacts,
+            inputs.artifact_excerpts,
             &observed,
             *role,
         ) {
@@ -878,6 +879,7 @@ pub(super) fn plan_artifact_recovery(inputs: ArtifactRecoveryInputs<'_>) -> Arti
             target_hint: recovery_target_hint_for_missing_with_contract(
                 inputs.contract,
                 inputs.artifacts,
+                inputs.artifact_excerpts,
                 &missing,
             ),
             missing,
@@ -921,6 +923,7 @@ pub(super) fn plan_artifact_recovery(inputs: ArtifactRecoveryInputs<'_>) -> Arti
                     target_hint: recovery_target_hint_for_missing_with_contract(
                         inputs.contract,
                         inputs.artifacts,
+                        inputs.artifact_excerpts,
                         &missing,
                     ),
                     missing,
@@ -984,6 +987,7 @@ fn required_role_satisfied(
     contract: &TaskContract,
     evidence: &EvidenceSet,
     artifacts: &[ArtifactState],
+    artifact_excerpts: &ArtifactExcerpts,
     observed: &[ArtifactRole],
     role: ArtifactRole,
 ) -> bool {
@@ -995,12 +999,40 @@ fn required_role_satisfied(
         return true;
     }
     identities.iter().all(|identity| {
-        artifact_identity_ready_for_verification(artifacts, identity)
-            || artifact_identity_observed_in_evidence(evidence, identity)
+        artifact_identity_satisfied_for_verification(
+            contract.task_kind,
+            evidence,
+            artifacts,
+            artifact_excerpts,
+            identity,
+        )
     })
 }
 
-fn artifact_identity_ready_for_verification(
+fn artifact_identity_satisfied_for_verification(
+    task_kind: TaskKind,
+    evidence: &EvidenceSet,
+    artifacts: &[ArtifactState],
+    artifact_excerpts: &ArtifactExcerpts,
+    identity: &ArtifactObligation,
+) -> bool {
+    let path_exists = artifact_identity_path_ready_for_verification(artifacts, identity)
+        || artifact_identity_observed_in_evidence(evidence, identity);
+    let excerpt = artifact_excerpts.get(&identity.role).map(String::as_str);
+    let Some(diagnostic) = super::verifier::verifier_diagnostic_for_obligation(
+        task_kind,
+        identity,
+        excerpt,
+        path_exists,
+    ) else {
+        return true;
+    };
+    diagnostic.code == super::verifier::VerifierDiagnosticCode::EvidenceMissing
+        && excerpt.is_none()
+        && path_exists
+}
+
+fn artifact_identity_path_ready_for_verification(
     artifacts: &[ArtifactState],
     identity: &ArtifactObligation,
 ) -> bool {
@@ -1107,21 +1139,44 @@ fn recovery_target_hint_for_missing(
 fn recovery_target_hint_for_missing_with_contract(
     contract: &TaskContract,
     artifacts: &[ArtifactState],
+    artifact_excerpts: &ArtifactExcerpts,
     missing: &[ArtifactRole],
 ) -> Option<RecoveryTargetHint> {
     let role = missing.first().copied()?;
-    if let Some(identity) = contract
+    if let Some((identity, diagnostic)) = contract
         .required_identities_for_role(role)
         .into_iter()
-        .find(|identity| !artifact_identity_ready_for_verification(artifacts, identity))
+        .filter_map(|identity| {
+            let path_exists = artifact_identity_path_ready_for_verification(artifacts, identity);
+            let excerpt = artifact_excerpts.get(&identity.role).map(String::as_str);
+            let diagnostic = super::verifier::verifier_diagnostic_for_obligation(
+                contract.task_kind,
+                identity,
+                excerpt,
+                path_exists,
+            )?;
+            if diagnostic.code == super::verifier::VerifierDiagnosticCode::EvidenceMissing
+                && excerpt.is_none()
+                && path_exists
+            {
+                return None;
+            }
+            Some((identity, diagnostic))
+        })
+        .next()
     {
+        let reason = if diagnostic.code == super::verifier::VerifierDiagnosticCode::MissingFile {
+            format!(
+                "required deliverable obligation is still missing: {}",
+                obligation_report_label(identity)
+            )
+        } else {
+            diagnostic.reason()
+        };
         return Some(RecoveryTargetHint {
             role,
             path: identity.path.clone(),
-            reason: format!(
-                "required deliverable obligation is still missing: {}",
-                obligation_report_label(identity)
-            ),
+            reason,
         });
     }
     recovery_target_hint_for_missing(artifacts, missing)
@@ -5267,6 +5322,77 @@ mod tests {
         assert_eq!(
             missing_labels(&contract.evaluate_with_owned_test_artifacts(&evidence, &[])),
             vec!["data_output"]
+        );
+    }
+
+    #[test]
+    fn malformed_package_manifest_is_not_ready_just_because_path_exists() {
+        let contract = TaskContract::from_request(
+            "Create a Node CLI. Include package.json with a bin entry, source, tests, and README.md.",
+        );
+        let evidence = EvidenceSet::new();
+        let excerpts = build_excerpts(&[(ArtifactRole::Setup, r#"{"bin":"#)]);
+        let repair_state = VerifierRepairState::None;
+        let action = plan_artifact_recovery(ArtifactRecoveryInputs {
+            contract: &contract,
+            evidence: &evidence,
+            artifacts: &[
+                ArtifactState::exists(ArtifactRole::Setup, "package.json"),
+                ArtifactState::exists(ArtifactRole::Implementation, "src/index.js"),
+                ArtifactState::exists(ArtifactRole::Test, "tests/index.test.js"),
+                ArtifactState::exists(ArtifactRole::UsageDocs, "README.md"),
+            ],
+            repair_state: &repair_state,
+            artifact_excerpts: &excerpts,
+            missing_verifier_suppress_retry: false,
+            owned_test_artifacts: &[],
+        });
+
+        assert_eq!(
+            action,
+            ArtifactRecoveryAction::Continue {
+                missing: vec![ArtifactRole::Setup],
+                target_hint: Some(RecoveryTargetHint {
+                    role: ArtifactRole::Setup,
+                    path: "package.json".to_string(),
+                    reason: "structured verifier diagnostic: kind=invalid_manifest, task_kind=coding, summary=package.json is not valid JSON".to_string(),
+                }),
+            }
+        );
+    }
+
+    #[test]
+    fn data_schema_mismatch_is_not_ready_just_because_path_exists() {
+        let contract = TaskContract::from_request(
+            "Generate output.csv with columns Category and Total from the input CSV.",
+        );
+        let mut evidence = EvidenceSet::new();
+        evidence.push(repo_edit_path(RepoEditCategory::Data, "output.csv"));
+        let excerpts = build_excerpts(&[(ArtifactRole::DataOutput, "Category,Amount\nA,1\n")]);
+        let repair_state = VerifierRepairState::None;
+        let action = plan_artifact_recovery(ArtifactRecoveryInputs {
+            contract: &contract,
+            evidence: &evidence,
+            artifacts: &[ArtifactState::exists(
+                ArtifactRole::DataOutput,
+                "output.csv",
+            )],
+            repair_state: &repair_state,
+            artifact_excerpts: &excerpts,
+            missing_verifier_suppress_retry: false,
+            owned_test_artifacts: &[],
+        });
+
+        assert_eq!(
+            action,
+            ArtifactRecoveryAction::Continue {
+                missing: vec![ArtifactRole::DataOutput],
+                target_hint: Some(RecoveryTargetHint {
+                    role: ArtifactRole::DataOutput,
+                    path: "output.csv".to_string(),
+                    reason: "structured verifier diagnostic: kind=schema_mismatch, task_kind=data, summary=structured data evidence is missing required columns or parse-ready records".to_string(),
+                }),
+            }
         );
     }
 

--- a/src/agent/loop_run/turn_tests.rs
+++ b/src/agent/loop_run/turn_tests.rs
@@ -61,9 +61,11 @@ use super::verifier_driver::classify_verifier_timeout;
 use super::verifier_driver::task_contract_structured_missing_outcome;
 use super::verifier_orchestration::{
     build_task_contract_verifier_exit_zero_evidence,
-    build_task_contract_verifier_exit_zero_evidence_bound, build_verifier_exit_zero_evidence,
-    repair_terminal_exit_reason, verifier_repair_context_diagnostics,
-    verifier_repair_safe_stop_message, verifier_repair_transition_message,
+    build_task_contract_verifier_exit_zero_evidence_bound,
+    build_task_contract_verifier_exit_zero_evidence_for_task_kind,
+    build_verifier_exit_zero_evidence, repair_terminal_exit_reason,
+    verifier_repair_context_diagnostics, verifier_repair_safe_stop_message,
+    verifier_repair_transition_message,
 };
 use super::work_mode_confirm::{self, WorkModeConfirmOutcome};
 use super::*;
@@ -84,18 +86,19 @@ mod tests {
         PlanExplorationKey, TaskContractVerifierOutcome, answer_only_script_command_allowed,
         answer_only_script_execution_fallback_response, assistant_model_for_mode,
         build_task_contract_verifier_exit_zero_evidence,
-        build_task_contract_verifier_exit_zero_evidence_bound, build_verifier_exit_zero_evidence,
-        classify_verifier_timeout, effective_non_streaming_timeout_secs,
-        latest_tool_result_since_last_user, non_streaming_assistant_reply_timeout_secs,
-        repair_terminal_exit_reason, should_fallback_plan_model_after_timeout,
-        should_materialize_plan_after_timeout,
+        build_task_contract_verifier_exit_zero_evidence_bound,
+        build_task_contract_verifier_exit_zero_evidence_for_task_kind,
+        build_verifier_exit_zero_evidence, classify_verifier_timeout,
+        effective_non_streaming_timeout_secs, latest_tool_result_since_last_user,
+        non_streaming_assistant_reply_timeout_secs, repair_terminal_exit_reason,
+        should_fallback_plan_model_after_timeout, should_materialize_plan_after_timeout,
         should_materialize_plan_after_tool_call_format_error, should_use_streaming_transport,
         task_contract_structured_missing_outcome, verifier_repair_context_from_failure,
     };
     use crate::agent::loop_run::completion_evidence::CompletionEvidence;
     use crate::agent::loop_run::failure_packet::FailurePacketTimeoutKind;
     use crate::agent::loop_run::repair_job::RepairTerminalReason;
-    use crate::agent::loop_run::task_contract::SafeStopReason;
+    use crate::agent::loop_run::task_contract::{SafeStopReason, TaskKind};
     use crate::agent::loop_run::verifier_driver::task_contract_verifier_transport_error_to_outcome;
     use crate::modes::plan_act::{ExecutionMode, TaskProfile};
     use crate::session::store::ConversationMessage;
@@ -207,6 +210,21 @@ mod tests {
             }
             other => panic!("expected VerifierExitZero, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn task_kind_verifier_builder_selects_docs_adapter() {
+        let evidence = build_task_contract_verifier_exit_zero_evidence_for_task_kind(
+            TaskKind::Docs,
+            "docs evidence",
+            None,
+        )
+        .expect("docs verifier evidence");
+
+        assert_eq!(
+            evidence,
+            CompletionEvidence::RequiredSectionsPass { path: None }
+        );
     }
 
     /// VR-β-04 (i): secret-bearing install args are masked before reaching

--- a/src/agent/loop_run/verifier.rs
+++ b/src/agent/loop_run/verifier.rs
@@ -1,6 +1,8 @@
 use super::completion_evidence::CompletionEvidence;
 use super::failure_packet::{CandidateArtifact, FailurePacket};
-use super::task_contract::{ArtifactRole, TaskKind};
+use super::task_contract::{
+    ArtifactObligation, ArtifactRole, DeliverableFormat, DeliverableSchema, TaskKind,
+};
 use crate::tools::bash::BashCommandClass;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -11,6 +13,113 @@ pub(super) enum VerifierTaskKind {
     Data,
     Research,
     Ops,
+}
+
+impl VerifierTaskKind {
+    pub(super) fn as_str(self) -> &'static str {
+        match self {
+            Self::Coding => "coding",
+            Self::Docs => "docs",
+            Self::Data => "data",
+            Self::Research => "research",
+            Self::Ops => "ops",
+        }
+    }
+
+    #[allow(dead_code)] // Issue #902 migration surface; exercised by verifier tests.
+    pub(super) fn task_kind(self) -> TaskKind {
+        match self {
+            Self::Coding => TaskKind::Coding,
+            Self::Docs => TaskKind::Docs,
+            Self::Data => TaskKind::Data,
+            Self::Research => TaskKind::Research,
+            Self::Ops => TaskKind::Ops,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum VerifierDiagnosticCode {
+    MissingFile,
+    InvalidManifest,
+    BadTest,
+    WrongSemantics,
+    EvidenceMissing,
+    SchemaMismatch,
+}
+
+impl VerifierDiagnosticCode {
+    pub(super) fn as_str(self) -> &'static str {
+        match self {
+            Self::MissingFile => "missing_file",
+            Self::InvalidManifest => "invalid_manifest",
+            Self::BadTest => "bad_test",
+            Self::WrongSemantics => "wrong_semantics",
+            Self::EvidenceMissing => "evidence_missing",
+            Self::SchemaMismatch => "schema_mismatch",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct VerifierDiagnostic {
+    pub(super) task_kind: VerifierTaskKind,
+    pub(super) code: VerifierDiagnosticCode,
+    pub(super) role: ArtifactRole,
+    pub(super) path: Option<String>,
+    pub(super) message: String,
+}
+
+impl VerifierDiagnostic {
+    fn new(
+        task_kind: VerifierTaskKind,
+        code: VerifierDiagnosticCode,
+        role: ArtifactRole,
+        path: Option<&str>,
+        message: impl Into<String>,
+    ) -> Self {
+        Self {
+            task_kind,
+            code,
+            role,
+            path: path.map(ToString::to_string),
+            message: message.into(),
+        }
+    }
+
+    #[allow(dead_code)] // Issue #902 migration surface; exercised by verifier tests.
+    pub(super) fn to_failure_packet(&self, command: &str, output: &str) -> FailurePacket {
+        let candidate_artifacts = self
+            .path
+            .as_ref()
+            .map(|path| {
+                let reason = format!(
+                    "{} verifier diagnostic: {}",
+                    self.task_kind.as_str(),
+                    self.message
+                );
+                vec![CandidateArtifact::new(self.role, path, &reason)]
+            })
+            .unwrap_or_default();
+        FailurePacket::new(
+            command,
+            self.code.as_str(),
+            output,
+            Vec::new(),
+            Vec::new(),
+            candidate_artifacts,
+            Vec::new(),
+        )
+    }
+
+    pub(super) fn reason(&self) -> String {
+        format!(
+            "structured verifier diagnostic: kind={}, task_kind={}, summary={}",
+            self.code.as_str(),
+            self.task_kind.as_str(),
+            self.message
+        )
+    }
 }
 
 #[allow(dead_code)]
@@ -24,6 +133,19 @@ pub(super) trait Verifier {
     ) -> CompletionEvidence;
 
     fn artifact_evidence(&self, artifact: VerifierArtifact<'_>) -> Option<CompletionEvidence>;
+
+    fn diagnostic(&self, artifact: VerifierArtifact<'_>) -> Option<VerifierDiagnostic> {
+        verifier_diagnostic_for_artifact(self.task_kind(), artifact)
+    }
+
+    fn diagnose_obligation(
+        &self,
+        obligation: &ArtifactObligation,
+        excerpt: Option<&str>,
+        path_exists: bool,
+    ) -> Option<VerifierDiagnostic> {
+        verifier_diagnostic_for_obligation_parts(self.task_kind(), obligation, excerpt, path_exists)
+    }
 
     fn failure_packet(&self, command: &str, failure_kind: &str, output: &str) -> FailurePacket;
 }
@@ -70,6 +192,15 @@ pub(super) fn verifier_for_task_kind(task_kind: TaskKind) -> &'static dyn Verifi
         TaskKind::Research => &RESEARCH_VERIFIER,
         TaskKind::Ops => &OPS_VERIFIER,
     }
+}
+
+pub(super) fn verifier_diagnostic_for_obligation(
+    task_kind: TaskKind,
+    obligation: &ArtifactObligation,
+    excerpt: Option<&str>,
+    path_exists: bool,
+) -> Option<VerifierDiagnostic> {
+    verifier_for_task_kind(task_kind).diagnose_obligation(obligation, excerpt, path_exists)
 }
 
 impl Verifier for CodingVerifier {
@@ -328,6 +459,455 @@ fn generic_verifier_failure_packet(
     )
 }
 
+fn verifier_diagnostic_for_artifact(
+    task_kind: VerifierTaskKind,
+    artifact: VerifierArtifact<'_>,
+) -> Option<VerifierDiagnostic> {
+    let Some(path) = artifact.path else {
+        return Some(VerifierDiagnostic::new(
+            task_kind,
+            VerifierDiagnosticCode::MissingFile,
+            default_role_for_task_kind(task_kind),
+            None,
+            "artifact path is missing",
+        ));
+    };
+    if path.trim().is_empty() {
+        return Some(VerifierDiagnostic::new(
+            task_kind,
+            VerifierDiagnosticCode::MissingFile,
+            default_role_for_task_kind(task_kind),
+            Some(path),
+            "artifact path is empty",
+        ));
+    }
+    if let Some(diagnostic) = manifest_readiness_diagnostic(task_kind, path, artifact.excerpt) {
+        return Some(diagnostic);
+    }
+    if artifact.excerpt.trim().is_empty() {
+        return Some(VerifierDiagnostic::new(
+            task_kind,
+            VerifierDiagnosticCode::EvidenceMissing,
+            role_for_path_or_task_kind(path, task_kind),
+            Some(path),
+            "artifact evidence is empty",
+        ));
+    }
+    match task_kind {
+        VerifierTaskKind::Coding => coding_artifact_diagnostic(task_kind, path, artifact.excerpt),
+        VerifierTaskKind::Docs => (!docs_required_sections_pass(artifact.excerpt)).then(|| {
+            VerifierDiagnostic::new(
+                task_kind,
+                VerifierDiagnosticCode::EvidenceMissing,
+                ArtifactRole::UsageDocs,
+                Some(path),
+                "documentation evidence is missing required setup/run/verify coverage",
+            )
+        }),
+        VerifierTaskKind::Data => {
+            data_artifact_diagnostic(task_kind, path, artifact.excerpt, artifact.required_columns)
+        }
+        VerifierTaskKind::Research => (!research_report_pass(artifact.excerpt)).then(|| {
+            VerifierDiagnostic::new(
+                task_kind,
+                VerifierDiagnosticCode::EvidenceMissing,
+                ArtifactRole::UsageDocs,
+                Some(path),
+                "research evidence is missing claim/source/limitation coverage",
+            )
+        }),
+        VerifierTaskKind::Ops => (!ops_runbook_pass(artifact.excerpt)).then(|| {
+            VerifierDiagnostic::new(
+                task_kind,
+                VerifierDiagnosticCode::EvidenceMissing,
+                ArtifactRole::UsageDocs,
+                Some(path),
+                "ops evidence is missing checklist/validation/rollback/risk coverage",
+            )
+        }),
+    }
+}
+
+fn verifier_diagnostic_for_obligation_parts(
+    task_kind: VerifierTaskKind,
+    obligation: &ArtifactObligation,
+    excerpt: Option<&str>,
+    path_exists: bool,
+) -> Option<VerifierDiagnostic> {
+    if !path_exists {
+        return Some(VerifierDiagnostic::new(
+            task_kind,
+            VerifierDiagnosticCode::MissingFile,
+            obligation.role,
+            Some(&obligation.path),
+            "required deliverable path was not observed",
+        ));
+    }
+    if obligation_requires_manifest_parse(obligation) {
+        let Some(excerpt) = excerpt else {
+            return Some(VerifierDiagnostic::new(
+                task_kind,
+                VerifierDiagnosticCode::EvidenceMissing,
+                obligation.role,
+                Some(&obligation.path),
+                "manifest path exists but no parse evidence is available",
+            ));
+        };
+        if let Some(detail) = manifest_readiness_diagnostic(task_kind, &obligation.path, excerpt) {
+            return Some(VerifierDiagnostic::new(
+                task_kind,
+                detail.code,
+                obligation.role,
+                Some(&obligation.path),
+                detail.message,
+            ));
+        }
+    }
+    if let Some(DeliverableSchema::JsonFields(fields)) = obligation.schema.as_ref() {
+        let Some(excerpt) = excerpt else {
+            return Some(VerifierDiagnostic::new(
+                task_kind,
+                VerifierDiagnosticCode::EvidenceMissing,
+                obligation.role,
+                Some(&obligation.path),
+                "JSON schema obligation has no field evidence",
+            ));
+        };
+        if !json_fields_present(excerpt, fields) {
+            return Some(VerifierDiagnostic::new(
+                task_kind,
+                VerifierDiagnosticCode::SchemaMismatch,
+                obligation.role,
+                Some(&obligation.path),
+                "JSON manifest is missing required field evidence",
+            ));
+        }
+    }
+    if let Some(DeliverableSchema::StructuredRecord(schema)) = obligation.schema.as_ref() {
+        let Some(excerpt) = excerpt else {
+            return Some(VerifierDiagnostic::new(
+                task_kind,
+                VerifierDiagnosticCode::EvidenceMissing,
+                obligation.role,
+                Some(&obligation.path),
+                "structured data schema obligation has no parse evidence",
+            ));
+        };
+        if let Some(diagnostic) =
+            data_artifact_diagnostic(task_kind, &obligation.path, excerpt, &schema.columns)
+        {
+            return Some(diagnostic);
+        }
+    }
+    if let Some(DeliverableSchema::RequiredSections(sections)) = obligation.schema.as_ref()
+        && !sections.is_empty()
+        && let Some(excerpt) = excerpt
+        && (!required_sections_present(excerpt, sections) || !docs_required_sections_pass(excerpt))
+    {
+        return Some(VerifierDiagnostic::new(
+            task_kind,
+            VerifierDiagnosticCode::EvidenceMissing,
+            obligation.role,
+            Some(&obligation.path),
+            "documentation required sections are absent from the observed content",
+        ));
+    }
+    if task_kind == VerifierTaskKind::Coding
+        && obligation.role == ArtifactRole::Test
+        && let Some(excerpt) = excerpt
+        && !contains_test_assertion_shape(excerpt)
+    {
+        return Some(VerifierDiagnostic::new(
+            task_kind,
+            VerifierDiagnosticCode::BadTest,
+            obligation.role,
+            Some(&obligation.path),
+            "test artifact lacks a recognizable assertion or test case shape",
+        ));
+    }
+    if task_kind == VerifierTaskKind::Coding
+        && obligation.role == ArtifactRole::Implementation
+        && let Some(excerpt) = excerpt
+        && implementation_looks_semantically_wrong(excerpt)
+    {
+        return Some(VerifierDiagnostic::new(
+            task_kind,
+            VerifierDiagnosticCode::WrongSemantics,
+            obligation.role,
+            Some(&obligation.path),
+            "implementation artifact still looks placeholder or non-semantic",
+        ));
+    }
+    if task_kind == VerifierTaskKind::Research
+        && let Some(excerpt) = excerpt
+        && !research_report_pass(excerpt)
+    {
+        return Some(VerifierDiagnostic::new(
+            task_kind,
+            VerifierDiagnosticCode::EvidenceMissing,
+            obligation.role,
+            Some(&obligation.path),
+            "research evidence is missing claim/source/limitation coverage",
+        ));
+    }
+    if task_kind == VerifierTaskKind::Ops
+        && let Some(excerpt) = excerpt
+        && !ops_runbook_pass(excerpt)
+    {
+        return Some(VerifierDiagnostic::new(
+            task_kind,
+            VerifierDiagnosticCode::EvidenceMissing,
+            obligation.role,
+            Some(&obligation.path),
+            "ops evidence is missing checklist/validation/rollback/risk coverage",
+        ));
+    }
+    None
+}
+
+fn coding_artifact_diagnostic(
+    task_kind: VerifierTaskKind,
+    path: &str,
+    excerpt: &str,
+) -> Option<VerifierDiagnostic> {
+    if is_test_artifact_path(path) && !contains_test_assertion_shape(excerpt) {
+        return Some(VerifierDiagnostic::new(
+            task_kind,
+            VerifierDiagnosticCode::BadTest,
+            ArtifactRole::Test,
+            Some(path),
+            "test artifact lacks a recognizable assertion or test case shape",
+        ));
+    }
+    None
+}
+
+fn data_artifact_diagnostic(
+    task_kind: VerifierTaskKind,
+    path: &str,
+    excerpt: &str,
+    required_columns: &[String],
+) -> Option<VerifierDiagnostic> {
+    if let Some(message) = structured_data_parse_error(path, excerpt) {
+        return Some(VerifierDiagnostic::new(
+            task_kind,
+            VerifierDiagnosticCode::SchemaMismatch,
+            ArtifactRole::DataOutput,
+            Some(path),
+            message,
+        ));
+    }
+    if !structured_data_pass(Some(path), excerpt, required_columns) {
+        return Some(VerifierDiagnostic::new(
+            task_kind,
+            VerifierDiagnosticCode::SchemaMismatch,
+            ArtifactRole::DataOutput,
+            Some(path),
+            "structured data evidence is missing required columns or parse-ready records",
+        ));
+    }
+    None
+}
+
+fn manifest_readiness_diagnostic(
+    task_kind: VerifierTaskKind,
+    path: &str,
+    excerpt: &str,
+) -> Option<VerifierDiagnostic> {
+    let normalized = normalize_path_label(path);
+    let message = if normalized == "package.json" {
+        invalid_package_manifest_excerpt_detail(excerpt)
+    } else if normalized == "cargo.toml" {
+        invalid_cargo_manifest_excerpt_detail(excerpt)
+    } else {
+        None
+    }?;
+    Some(VerifierDiagnostic::new(
+        task_kind,
+        VerifierDiagnosticCode::InvalidManifest,
+        ArtifactRole::Setup,
+        Some(path),
+        message,
+    ))
+}
+
+fn obligation_requires_manifest_parse(obligation: &ArtifactObligation) -> bool {
+    obligation.role == ArtifactRole::Setup
+        && matches!(
+            obligation.format,
+            Some(DeliverableFormat::Json | DeliverableFormat::Toml)
+        )
+}
+
+fn json_fields_present(excerpt: &str, fields: &[String]) -> bool {
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(excerpt) else {
+        return false;
+    };
+    fields.iter().all(|field| value.get(field).is_some())
+}
+
+fn required_sections_present(excerpt: &str, sections: &[String]) -> bool {
+    let lower = excerpt.to_ascii_lowercase();
+    sections.iter().all(|section| {
+        let normalized = section.to_ascii_lowercase();
+        lower.contains(&format!("## {normalized}"))
+            || lower.contains(&format!("# {normalized}"))
+            || lower.contains(&normalized)
+    })
+}
+
+fn implementation_looks_semantically_wrong(excerpt: &str) -> bool {
+    let lower = excerpt.to_ascii_lowercase();
+    contains_any(
+        &lower,
+        &[
+            "todo",
+            "placeholder",
+            "not implemented",
+            "unimplemented",
+            "dummy",
+        ],
+    )
+}
+
+fn structured_data_parse_error(path: &str, excerpt: &str) -> Option<&'static str> {
+    match path_extension(path).as_deref() {
+        Some("json") => serde_json::from_str::<serde_json::Value>(excerpt)
+            .is_err()
+            .then_some("JSON data artifact is not parse-ready"),
+        Some("jsonl") | Some("ndjson") => excerpt
+            .lines()
+            .filter(|line| !line.trim().is_empty())
+            .any(|line| serde_json::from_str::<serde_json::Value>(line).is_err())
+            .then_some("JSONL data artifact contains a non-parseable record"),
+        Some("csv") => delimited_header_columns(excerpt, ',')
+            .is_empty()
+            .then_some("CSV data artifact is missing a parse-ready header"),
+        Some("tsv") => delimited_header_columns(excerpt, '\t')
+            .is_empty()
+            .then_some("TSV data artifact is missing a parse-ready header"),
+        _ => None,
+    }
+}
+
+fn invalid_package_manifest_excerpt_detail(excerpt: &str) -> Option<&'static str> {
+    serde_json::from_str::<serde_json::Value>(excerpt)
+        .is_err()
+        .then_some("package.json is not valid JSON")
+}
+
+fn invalid_cargo_manifest_excerpt_detail(excerpt: &str) -> Option<&'static str> {
+    let mut in_package = false;
+    let mut saw_package = false;
+    let mut saw_name = false;
+    for raw_line in excerpt.lines() {
+        let line = strip_toml_comment(raw_line).trim();
+        if line.starts_with('[') {
+            if !line.ends_with(']') {
+                return Some("Cargo.toml contains a malformed table header");
+            }
+            in_package = line == "[package]";
+            saw_package |= in_package;
+            continue;
+        }
+        if in_package
+            && let Some((key, value)) = line.split_once('=')
+            && key.trim() == "name"
+        {
+            let Some(value) = parse_toml_string_value(value.trim()) else {
+                return Some("Cargo.toml [package] name is malformed");
+            };
+            saw_name = !value.is_empty();
+        }
+    }
+    if !saw_package {
+        return Some("Cargo.toml does not contain a [package] section");
+    }
+    if !saw_name {
+        return Some("Cargo.toml [package] does not declare a non-empty name");
+    }
+    None
+}
+
+fn parse_toml_string_value(value: &str) -> Option<String> {
+    let value = value.trim();
+    if !(value.starts_with('"') && value.ends_with('"')) || value.len() < 2 {
+        return None;
+    }
+    Some(value[1..value.len() - 1].trim().to_string())
+}
+
+fn strip_toml_comment(line: &str) -> &str {
+    line.split_once('#')
+        .map(|(before, _)| before)
+        .unwrap_or(line)
+}
+
+fn default_role_for_task_kind(task_kind: VerifierTaskKind) -> ArtifactRole {
+    match task_kind {
+        VerifierTaskKind::Coding => ArtifactRole::Implementation,
+        VerifierTaskKind::Docs | VerifierTaskKind::Research | VerifierTaskKind::Ops => {
+            ArtifactRole::UsageDocs
+        }
+        VerifierTaskKind::Data => ArtifactRole::DataOutput,
+    }
+}
+
+fn role_for_path_or_task_kind(path: &str, task_kind: VerifierTaskKind) -> ArtifactRole {
+    let normalized = normalize_path_label(path);
+    if normalized == "package.json" || normalized == "cargo.toml" {
+        return ArtifactRole::Setup;
+    }
+    if is_test_artifact_path(path) {
+        return ArtifactRole::Test;
+    }
+    default_role_for_task_kind(task_kind)
+}
+
+fn is_test_artifact_path(path: &str) -> bool {
+    let lower = path.to_ascii_lowercase();
+    lower.contains("/tests/")
+        || lower.starts_with("tests/")
+        || lower.contains("__tests__")
+        || lower.contains(".test.")
+        || lower.contains(".spec.")
+        || lower.ends_with("_test.py")
+        || lower.ends_with("test.rs")
+}
+
+fn contains_test_assertion_shape(excerpt: &str) -> bool {
+    let lower = excerpt.to_ascii_lowercase();
+    contains_any(
+        &lower,
+        &[
+            "#[test]",
+            "assert!",
+            "assert_eq!",
+            "assert ",
+            "expect(",
+            "it(",
+            "test(",
+            "pytest",
+        ],
+    )
+}
+
+fn normalize_path_label(path: &str) -> String {
+    path.trim()
+        .trim_start_matches("./")
+        .rsplit('/')
+        .next()
+        .unwrap_or(path)
+        .to_ascii_lowercase()
+}
+
+fn path_extension(path: &str) -> Option<String> {
+    std::path::Path::new(path)
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .map(str::to_ascii_lowercase)
+}
+
 const USAGE_DOCS_SETUP_MARKERS: &[(&str, bool)] = &[
     ("install", true),
     ("setup", false),
@@ -573,6 +1153,16 @@ mod tests {
     }
 
     #[test]
+    fn docs_verifier_pass_evidence_is_docs_only_not_build_test() {
+        let verifier = DocsVerifier;
+
+        assert_eq!(
+            verifier.pass_evidence("docs evidence", None),
+            CompletionEvidence::RequiredSectionsPass { path: None }
+        );
+    }
+
+    #[test]
     fn verifier_failure_packet_is_task_kind_independent() {
         let verifier = DocsVerifier;
         let packet = verifier.required_sections_failure_packet("README.md", "only title");
@@ -580,6 +1170,42 @@ mod tests {
         assert!(json.get("task_kind").is_none());
         assert_eq!(json["failure_kind"], "required_sections_missing");
         assert_eq!(json["candidate_artifacts"][0]["role"], "usage_docs");
+    }
+
+    #[test]
+    fn coding_verifier_diagnoses_malformed_package_manifest() {
+        let verifier = CodingVerifier;
+        let diagnostic = verifier
+            .diagnostic(VerifierArtifact {
+                path: Some("package.json"),
+                excerpt: r#"{"scripts":"#,
+                required_columns: &[],
+            })
+            .expect("malformed manifest diagnostic");
+
+        assert_eq!(diagnostic.code, VerifierDiagnosticCode::InvalidManifest);
+        assert_eq!(diagnostic.role, ArtifactRole::Setup);
+
+        let packet = diagnostic.to_failure_packet("npm test", "package parse failed");
+        let json = packet.to_json_value();
+        assert_eq!(json["failure_kind"], "invalid_manifest");
+        assert_eq!(json["diagnostic_code"], "invalid_manifest");
+        assert_eq!(json["candidate_artifacts"][0]["role"], "setup");
+    }
+
+    #[test]
+    fn coding_verifier_diagnoses_bad_test_artifact() {
+        let verifier = CodingVerifier;
+        let diagnostic = verifier
+            .diagnostic(VerifierArtifact {
+                path: Some("tests/cli.rs"),
+                excerpt: "fn helper() {}",
+                required_columns: &[],
+            })
+            .expect("bad test diagnostic");
+
+        assert_eq!(diagnostic.code, VerifierDiagnosticCode::BadTest);
+        assert_eq!(diagnostic.role, ArtifactRole::Test);
     }
 
     #[test]
@@ -616,6 +1242,37 @@ mod tests {
             ),
             None
         );
+    }
+
+    #[test]
+    fn data_verifier_diagnoses_malformed_json_before_schema_pass() {
+        let verifier = DataVerifier;
+        let required = vec!["category".to_string(), "total".to_string()];
+        let diagnostic = verifier
+            .diagnostic(VerifierArtifact {
+                path: Some("output.json"),
+                excerpt: r#"{"category":"#,
+                required_columns: &required,
+            })
+            .expect("schema diagnostic");
+
+        assert_eq!(diagnostic.code, VerifierDiagnosticCode::SchemaMismatch);
+        assert_eq!(diagnostic.role, ArtifactRole::DataOutput);
+    }
+
+    #[test]
+    fn data_verifier_diagnoses_missing_required_column() {
+        let verifier = DataVerifier;
+        let required = vec!["Category".to_string(), "Total".to_string()];
+        let diagnostic = verifier
+            .diagnostic(VerifierArtifact {
+                path: Some("output.csv"),
+                excerpt: "Category,Amount\nA,1\n",
+                required_columns: &required,
+            })
+            .expect("missing column diagnostic");
+
+        assert_eq!(diagnostic.code, VerifierDiagnosticCode::SchemaMismatch);
     }
 
     #[test]
@@ -671,6 +1328,7 @@ mod tests {
 
         for (task_kind, expected) in cases {
             assert_eq!(verifier_for_task_kind(task_kind).task_kind(), expected);
+            assert_eq!(expected.task_kind(), task_kind);
         }
     }
 

--- a/src/agent/loop_run/verifier_assessment_parser.rs
+++ b/src/agent/loop_run/verifier_assessment_parser.rs
@@ -148,6 +148,22 @@ pub(super) fn verifier_failure_type_for_diagnostic_kind(
     fallback: super::VerifierFailureType,
 ) -> super::VerifierFailureType {
     match kind {
+        super::VerifierDiagnosticFailureKind::MissingFile => {
+            super::VerifierFailureType::MissingVerifierOrConfig
+        }
+        super::VerifierDiagnosticFailureKind::InvalidManifest => {
+            super::VerifierFailureType::MissingVerifierOrConfig
+        }
+        super::VerifierDiagnosticFailureKind::BadTest => super::VerifierFailureType::RuntimeError,
+        super::VerifierDiagnosticFailureKind::WrongSemantics => {
+            super::VerifierFailureType::AssertionFailure
+        }
+        super::VerifierDiagnosticFailureKind::EvidenceMissing => {
+            super::VerifierFailureType::MissingVerifierOrConfig
+        }
+        super::VerifierDiagnosticFailureKind::SchemaMismatch => {
+            super::VerifierFailureType::AssertionFailure
+        }
         super::VerifierDiagnosticFailureKind::DependencyMissing => {
             super::VerifierFailureType::ImportOrDependency
         }
@@ -212,6 +228,12 @@ fn framework_finding_can_override_diagnostic_kind(
     kind: super::VerifierDiagnosticFailureKind,
 ) -> bool {
     match kind {
+        super::VerifierDiagnosticFailureKind::MissingFile
+        | super::VerifierDiagnosticFailureKind::InvalidManifest
+        | super::VerifierDiagnosticFailureKind::EvidenceMissing
+        | super::VerifierDiagnosticFailureKind::SchemaMismatch => false,
+        super::VerifierDiagnosticFailureKind::BadTest => true,
+        super::VerifierDiagnosticFailureKind::WrongSemantics => false,
         super::VerifierDiagnosticFailureKind::DependencyMissing
         | super::VerifierDiagnosticFailureKind::LocalImportContractMismatch => {
             matches!(
@@ -345,6 +367,22 @@ fn verifier_diagnostic_failure_kind_from_str(
     value: &str,
 ) -> Option<super::VerifierDiagnosticFailureKind> {
     match value.trim().to_ascii_lowercase().as_str() {
+        "missing_file" | "missing_path" | "path_missing" => {
+            Some(super::VerifierDiagnosticFailureKind::MissingFile)
+        }
+        "invalid_manifest" | "manifest_error" | "malformed_manifest" => {
+            Some(super::VerifierDiagnosticFailureKind::InvalidManifest)
+        }
+        "bad_test" => Some(super::VerifierDiagnosticFailureKind::BadTest),
+        "wrong_semantics" | "wrong_behavior" | "semantic_mismatch" => {
+            Some(super::VerifierDiagnosticFailureKind::WrongSemantics)
+        }
+        "evidence_missing" | "missing_evidence" => {
+            Some(super::VerifierDiagnosticFailureKind::EvidenceMissing)
+        }
+        "schema_mismatch" | "schema_error" | "invalid_schema" => {
+            Some(super::VerifierDiagnosticFailureKind::SchemaMismatch)
+        }
         "dependency_missing" | "import_or_dependency" | "dependency" | "missing_dependency" => {
             Some(super::VerifierDiagnosticFailureKind::DependencyMissing)
         }
@@ -358,7 +396,7 @@ fn verifier_diagnostic_failure_kind_from_str(
             Some(super::VerifierDiagnosticFailureKind::AssertionMismatch)
         }
         "runtime_error" | "runtime" => Some(super::VerifierDiagnosticFailureKind::RuntimeError),
-        "test_bug" | "bad_test" => Some(super::VerifierDiagnosticFailureKind::TestBug),
+        "test_bug" => Some(super::VerifierDiagnosticFailureKind::TestBug),
         "config_or_verifier_error"
         | "missing_verifier_or_config"
         | "missing_verifier"

--- a/src/agent/loop_run/verifier_orchestration.rs
+++ b/src/agent/loop_run/verifier_orchestration.rs
@@ -82,6 +82,7 @@ use super::semantic_repair_planning::{
 use super::summary::ExitReason;
 use super::task_contract::{
     ArtifactRole, CompletionDecision, RecoveryTargetHint, RequestCarryoverKey, TaskContract,
+    TaskKind,
 };
 use super::task_workspace_scope::TaskWorkspaceScope;
 use super::tool_history::focused_edit_target_already_read;
@@ -89,6 +90,7 @@ use super::tool_policy::{EffectiveToolPolicy, EffectiveToolPolicyReason};
 use super::turn_constants::{
     TASK_CONTRACT_VERIFIER_ATTEMPT_LIMIT, TASK_CONTRACT_VERIFIER_REPAIR_ATTEMPT_LIMIT,
 };
+use super::verifier::verifier_for_task_kind;
 use super::verifier_assessment_parser::{
     ParsedVerifierRepairAssessment, verifier_failure_type_for_diagnostic_kind,
 };
@@ -852,7 +854,7 @@ pub(super) fn verifier_diagnostic_messages(
         ),
         ConversationMessage::user(format!(
             "Diagnose the verifier failure and choose safe workspace repair targets.\n\
-Allowed failure_kind values: dependency_missing, local_import_contract_mismatch, compile_or_syntax_error, assertion_mismatch, runtime_error, test_bug, config_or_verifier_error, unknown.\n\
+Allowed failure_kind values: missing_file, invalid_manifest, bad_test, wrong_semantics, evidence_missing, schema_mismatch, dependency_missing, local_import_contract_mismatch, compile_or_syntax_error, assertion_mismatch, runtime_error, test_bug, config_or_verifier_error, unknown.\n\
 Allowed probable_cause_role values: implementation, test, setup, usage_docs, unknown.\n\
 Schema: {{\"failure_kind\":\"...\",\"probable_cause_role\":\"...\",\"repair_targets\":[{{\"path\":\"workspace-relative existing file or controller-provided missing setup candidate\",\"confidence\":0.0,\"reason\":\"short bounded reason\"}}],\"repair_plan\":[{{\"target\":\"workspace-relative existing file or controller-provided missing setup candidate\",\"intent\":\"short bounded intent\",\"confidence\":0.0}}],\"secondary_targets\":[\"workspace-relative existing file\"],\"do_not_edit_tests_without_evidence\":true,\"summary\":\"short bounded summary\"}}.\n\
 Also return a compact SemanticFailureReport in the SAME JSON object; keep these fields top-level next to the legacy fields above, not under a wrapper key:\n\
@@ -1396,30 +1398,30 @@ pub(super) fn build_task_contract_verifier_exit_zero_evidence(
     // paths. It records `bound_test_artifacts_count: None`. The structured
     // `AutoTestRunner::run_structured` path goes through
     // `build_task_contract_verifier_exit_zero_evidence_bound(command, n)`.
-    let masked = redact_verifier_command_for_storage(command);
-    if masked.trim().is_empty() {
-        return None;
-    }
-    Some(CompletionEvidence::VerifierExitZero {
-        class: BashCommandClass::BuildTest,
-        command: masked,
-        bound_test_artifacts_count: None,
-    })
+    build_task_contract_verifier_exit_zero_evidence_for_task_kind(TaskKind::Coding, command, None)
 }
 
 pub(super) fn build_task_contract_verifier_exit_zero_evidence_bound(
     command: &str,
     bound_count: usize,
 ) -> Option<CompletionEvidence> {
+    build_task_contract_verifier_exit_zero_evidence_for_task_kind(
+        TaskKind::Coding,
+        command,
+        Some(bound_count),
+    )
+}
+
+pub(super) fn build_task_contract_verifier_exit_zero_evidence_for_task_kind(
+    task_kind: TaskKind,
+    command: &str,
+    bound_count: Option<usize>,
+) -> Option<CompletionEvidence> {
     let masked = redact_verifier_command_for_storage(command);
     if masked.trim().is_empty() {
         return None;
     }
-    Some(CompletionEvidence::VerifierExitZero {
-        class: BashCommandClass::BuildTest,
-        command: masked,
-        bound_test_artifacts_count: Some(bound_count),
-    })
+    Some(verifier_for_task_kind(task_kind).pass_evidence(&masked, bound_count))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Closes #902.

## Summary
- Add task-kind verifier adapters with structured diagnostic codes for missing files, invalid manifests, bad tests, wrong semantics, missing evidence, and schema mismatches.
- Validate manifest/data/docs readiness before treating artifact path existence as sufficient.
- Thread structured diagnostic codes into failure packets, semantic diagnostic parsing, and repair packet domain/correction mapping.

## Verification
- cargo fmt --check
- cargo clippy --all-targets
- cargo test
- bash scripts/check_repo_hygiene.sh
- git diff --check