### PR TITLE
test: stop bash_policy e2e tests leaking empty dirs into repo root

### DIFF
--- a/src/agent/loop_run/bash_policy_e2e_tests.rs
+++ b/src/agent/loop_run/bash_policy_e2e_tests.rs
@@ -26,8 +26,6 @@
 
 #![cfg(test)]
 
-use std::path::PathBuf;
-
 use tempfile::{TempDir, tempdir};
 
 use crate::agent::Agent;
@@ -723,12 +721,9 @@ fn bash_out_of_policy_recorded_under_artifact_recovery() {
 
     // Install an ArtifactCompletionJob via the test seam — the
     // `artifact_directed_from_job` policy below reads its target from
-    // this job.
-    let _ = std::fs::create_dir_all(PathBuf::from(
-        crate::agent::loop_run::agent_session_ref(&agent)
-            .workspace_key
-            .clone(),
-    ));
+    // this job. The seam materialises the target file (and its parents)
+    // under `agent.work_root` (the per-test tempdir), so no workspace
+    // directory needs to be pre-created here.
     seed_artifact_completion_job_pending_for_test(&mut agent, "test", "tests/cb2_003_target.rs");
 
     // Drive a Bash call under the artifact-directed policy. Before the
@@ -868,14 +863,10 @@ fn seed_artifact_completion_job_pending_for_test_installs_job_under_work_root() 
     let server = mockito::Server::new();
     let (mut agent, _dir) = build_live_agent(&session_id, &server.url());
 
-    // The seam materialises the target under `agent.work_root` and installs
-    // a fresh `ArtifactCompletionJob`. The seam accepts the role as a
-    // string (primitives only) so `ArtifactRole` stays `pub(super)`.
-    let _ = std::fs::create_dir_all(PathBuf::from(
-        crate::agent::loop_run::agent_session_ref(&agent)
-            .workspace_key
-            .clone(),
-    ));
+    // The seam materialises the target under `agent.work_root` (the
+    // per-test tempdir) and installs a fresh `ArtifactCompletionJob`. The
+    // seam accepts the role as a string (primitives only) so `ArtifactRole`
+    // stays `pub(super)`. No workspace directory needs to be pre-created.
     seed_artifact_completion_job_pending_for_test(&mut agent, "test", "tests/seeded_artifact.rs");
 
     // Drive `build_arbiter_candidates_for_test` again to confirm the


### PR DESCRIPTION
## 概要
Issue #664 の E2E テストが `cargo test` のたびにリポジトリ直下へ空ディレクトリを漏らしていた問題を修正します。調査時点で `anvil-664-664-cb2-003-route-*` / `anvil-664-664-seed-smoke-*` が **78個**蓄積していました（別途削除済み）。

## 根本原因
`src/agent/loop_run/bash_policy_e2e_tests.rs` の2つのテストが以下を呼んでいました:

```rust
std::fs::create_dir_all(PathBuf::from(
    agent_session_ref(&agent).workspace_key.clone(),  // = "anvil-664-664-<prefix>-<nanos>" (相対パス)
));
```

- `workspace_key` は相対パス文字列のため、`create_dir_all` はプロセスの CWD（`cargo test` 実行時はクレートルート＝リポジトリ直下）基準で作成。
- 他のテスト用ファイルは `tempdir()` 配下に作られ自動クリーンされるが、この1行だけがサンドボックス外に出てリポジトリ直下に残留し、消えなかった。
- git は空ディレクトリを追跡しないため `git status` にも出ず、不可視で蓄積していた。

## 修正
- 両テストの `create_dir_all(workspace_key)` 呼び出しを**削除**。シード seam `seed_artifact_completion_job_pending_for_test` は成果物を `agent.work_root`（per-test tempdir）配下に作るため、`workspace_key` をファイルパスとして使う必要はなく、この呼び出しは vestigial でした。
- 未使用になった `use std::path::PathBuf;` を削除。
- 各箇所に「成果物は work_root 配下に作られるので workspace ディレクトリの事前作成は不要」というコメントを追加。

## 検証
- `cargo test --lib bash_policy_e2e_tests` → **27件全パス**（影響を受けた2テスト含む）。
- テスト実行後にリポジトリ直下を再チェック → `anvil-664-664-*` は **0個**（リークなしを確認）。
- `cargo fmt --check` 該当ファイル OK。

🤖 Generated with [Claude Code](https://claude.com/claude-code)