### PR TITLE
feat(agent/loop_run): single per-turn task classification authority (#917)

### DIFF
--- a/src/agent/loop_run.rs
+++ b/src/agent/loop_run.rs
@@ -1074,6 +1074,10 @@ pub(crate) fn maybe_emit_job_reports_for_test(agent: &mut Agent) {
 mod behavior_contract_projection_e2e_tests;
 mod summary;
 mod task_contract;
+// Issue #917 (P0.5): per-turn single classification authority accessor.
+// Private module, not re-exported (DR3-001) — the 18 former `from_request`
+// sites and `run_turn` consume it via `super::task_classification::*`.
+mod task_classification;
 // Issue #646: task workspace scope detection. Module is intentionally
 // *not* re-exported (DR3-001) — `turn.rs` is the only in-crate consumer
 // via `super::task_workspace_scope::*`.
@@ -1920,6 +1924,16 @@ pub struct Agent {
     /// `handle_user_message`, set to `true` only when an actual sidecar call
     /// was attempted (Completed/Failed); Skipped does not consume the cap.
     reminder_called_this_turn: bool,
+    /// Issue #917 (P0.5): per-turn single task-classification authority. The
+    /// `OnceCell` enforces "classify exactly once per turn" at the type level;
+    /// eager-populated right after `push_user_message` (run_turn) and shared by
+    /// the 18 former `TaskContract::from_request` sites via
+    /// `task_classification::task_contract_authority`. Reset (`OnceCell::new()`)
+    /// at the top of every `handle_user_message`. `std::cell::OnceCell` + `Rc`
+    /// suit the synchronous single-thread agent loop; if `Agent: Send` is ever
+    /// required, switch to `std::sync::OnceLock` + `Arc`.
+    pub(in crate::agent::loop_run) task_contract_this_turn:
+        std::cell::OnceCell<std::rc::Rc<task_contract::TaskContract>>,
     /// Issue #459: per-turn cap for the Tester Skill. Reset at the top of every
     /// `handle_user_message`. Consumed only when a Tester smoke run actually
     /// dispatched (Recorded / Aborted); NotInvoked does not consume the cap.
@@ -2576,6 +2590,7 @@ impl Agent {
             repo_context_cache: None,
             footer,
             reminder_called_this_turn: false,
+            task_contract_this_turn: std::cell::OnceCell::new(),
             tester_called_this_turn: false,
             work_mode_confirm_called_this_turn: false,
             feedback_kind_confirm_called_this_turn: false,
@@ -2666,8 +2681,8 @@ impl Agent {
         // `first_missing_required_role` is evidence-aware and not available
         // here, so we fall back to the first required role hint
         // (DR3-004 — same pattern as `refresh_artifact_completion_satisfied`).
-        let task_contract = workspace_access::active_request_text(self)
-            .map(|text| task_contract::TaskContract::from_request(&text));
+        // Issue #917: per-turn classification authority (None → no role hint).
+        let task_contract = task_classification::task_contract_authority(self);
         let role_hint_from_contract = task_contract
             .as_ref()
             .and_then(|tc| tc.required_artifacts.first().copied());
@@ -2678,7 +2693,7 @@ impl Agent {
 
         let behavior = task_contract
             .as_ref()
-            .and_then(required_behavior::project_behavior_contract);
+            .and_then(|tc| required_behavior::project_behavior_contract(tc));
 
         pam_advisory::PamAdvisoryInputs {
             role_hint,

--- a/src/agent/loop_run/agent_misc.rs
+++ b/src/agent/loop_run/agent_misc.rs
@@ -36,8 +36,11 @@ pub(super) fn refresh_artifact_completion_satisfied(agent: &mut Agent) {
     if agent.artifact_completion_job.is_none() {
         return;
     }
-    let task_contract = match super::workspace_access::active_request_text(agent) {
-        Some(req) => super::task_contract::TaskContract::from_request(&req),
+    // Issue #917: read the per-turn classification authority instead of
+    // recomputing. `None` (no current-turn request) keeps the legacy early
+    // return. `&Rc<TaskContract>` deref-coerces to `&TaskContract`.
+    let task_contract = match super::task_classification::task_contract_authority(agent) {
+        Some(contract) => contract,
         None => return,
     };
     let projection = agent

--- a/src/agent/loop_run/artifact_completion_job.rs
+++ b/src/agent/loop_run/artifact_completion_job.rs
@@ -1297,6 +1297,8 @@ mod tests {
             verification_required: true,
             completion_policy,
             required_behavior,
+            // Issue #917: synthetic test contract — neutral matched confidence.
+            classification_confidence: 1.0,
         };
         ledger.required_artifacts_completed_projection(&contract)
     }

--- a/src/agent/loop_run/artifact_ledger.rs
+++ b/src/agent/loop_run/artifact_ledger.rs
@@ -1056,6 +1056,8 @@ mod tests {
             verification_required,
             completion_policy,
             required_behavior,
+            // Issue #917: synthetic test contract — neutral matched confidence.
+            classification_confidence: 1.0,
         }
     }
 

--- a/src/agent/loop_run/effective_tool_policy_flow.rs
+++ b/src/agent/loop_run/effective_tool_policy_flow.rs
@@ -238,8 +238,9 @@ fn setup_bootstrap_candidate(agent: &Agent) -> Option<JobCandidate> {
     ) {
         return None;
     }
-    let request = super::workspace_access::active_request_text(agent)?;
-    let task_contract = super::task_contract::TaskContract::from_request(&request);
+    // Issue #917: per-turn classification authority (`None` keeps the legacy
+    // early return via `?`). `&Rc<TaskContract>` deref-coerces to `&TaskContract`.
+    let task_contract = super::task_classification::task_contract_authority(agent)?;
     let behavior_projection = super::required_behavior::project_behavior_contract(&task_contract);
     let verifier_signal = super::task_contract::VerifierPrerequisiteSignal::from_sources(
         agent.owned_test_verifier_missing_observed_this_turn,

--- a/src/agent/loop_run/handle_user_message.rs
+++ b/src/agent/loop_run/handle_user_message.rs
@@ -32,6 +32,11 @@ pub(super) fn handle_user_message(
     // user message — reset here so a fresh handle_user_message can fire
     // the Reminder once even if the previous turn already did.
     agent.reminder_called_this_turn = false;
+    // Issue #917 (P0.5): reset the per-turn task-classification authority so a
+    // fresh turn re-classifies its own request. Eager-populated in `run_turn`
+    // right after `push_user_message`. (The unified confirm cap is reset in
+    // `process_line`, not here — see `work_mode_confirm_called_this_turn`.)
+    agent.task_contract_this_turn = std::cell::OnceCell::new();
     // Issue #646 (C1): per-turn ownership reset. Each user turn starts a
     // fresh task — prior-turn edits do NOT auto-confer ownership on the
     // new task. Clearing here also wipes the MissingVerifierJob so

--- a/src/agent/loop_run/prepare_actor_loop_state.rs
+++ b/src/agent/loop_run/prepare_actor_loop_state.rs
@@ -119,8 +119,11 @@ pub(super) fn prepare_actor_loop_turn_state(agent: &mut Agent) -> Option<TaskCon
     // Issue #638 (Task 1.4): clear the turn-local failure snapshot at the
     // same boundary as `repair_job` (design policy §5, A-only).
     agent.repair_failure_snapshot = None;
-    let task_contract = super::workspace_access::active_request_text(agent)
-        .map(|request| TaskContract::from_request(&request));
+    // Issue #917: read the per-turn classification authority. This fn returns
+    // an owned `Option<TaskContract>`, so clone out of the `Rc` (classification
+    // is still computed exactly once — only the result is cloned).
+    let task_contract =
+        super::task_classification::task_contract_authority(agent).map(|rc| (*rc).clone());
     if agent.session.mode_state.mode != ExecutionMode::Plan
         && let Some(contract) = task_contract.as_ref()
     {

--- a/src/agent/loop_run/python_request_helpers.rs
+++ b/src/agent/loop_run/python_request_helpers.rs
@@ -18,16 +18,15 @@
 
 use super::Agent;
 use super::auto_test::{AutoTestKind, AutoTestRunner};
-use super::task_contract::TaskContract;
 use crate::modes::plan_act::WorkMode;
 
 pub(super) fn active_python_request_requires_tests(agent: &Agent) -> bool {
+    // Issue #917: read the per-turn classification authority (CB-001). The
+    // `WorkMode::Python` gate short-circuits first, preserving prior behavior;
+    // `None` (no current-turn request) keeps `false`.
     agent.session.mode_state.work_mode == WorkMode::Python
-        && super::workspace_access::active_request_text(agent).is_some_and(|request| {
-            TaskContract::from_request(&request)
-                .completion_policy
-                .test_execution_required()
-        })
+        && super::task_classification::task_contract_authority(agent)
+            .is_some_and(|contract| contract.completion_policy.test_execution_required())
 }
 
 pub(super) fn python_verifier_available_for_requested_tests(agent: &Agent) -> bool {

--- a/src/agent/loop_run/recovery_messages.rs
+++ b/src/agent/loop_run/recovery_messages.rs
@@ -158,8 +158,11 @@ pub(super) fn verifier_repair_policy_message(
 }
 
 fn verifier_repair_diagnostic_policy_message(agent: &Agent) -> String {
-    let active_request = super::workspace_access::active_request_text(agent).unwrap_or_default();
-    let task_contract = super::task_contract::TaskContract::from_request(&active_request);
+    // Issue #917: per-turn classification authority. Preserve the legacy
+    // `unwrap_or_default()` semantics: a missing request maps to the empty-input
+    // contract (`from_request("")`).
+    let task_contract = super::task_classification::task_contract_authority(agent)
+        .unwrap_or_else(|| std::rc::Rc::new(super::task_contract::TaskContract::from_request("")));
     let behavior_projection = super::required_behavior::project_behavior_contract(&task_contract);
     agent
         .repair_job

--- a/src/agent/loop_run/recovery_targets.rs
+++ b/src/agent/loop_run/recovery_targets.rs
@@ -104,9 +104,12 @@ pub(super) fn push_verifier_repair_recovery_note(agent: &mut Agent, attempt: usi
             // Issue #665 Phase 5: caller-side projection (S5-005 では
             // raw label/excerpt は system note に出さないため helper
             // 内部で metadata のみに縮退する)。
-            let active_request =
-                super::workspace_access::active_request_text(agent).unwrap_or_default();
-            let task_contract = super::task_contract::TaskContract::from_request(&active_request);
+            // Issue #917: per-turn classification authority (None → empty-input
+            // contract, matching the legacy `unwrap_or_default`).
+            let task_contract = super::task_classification::task_contract_authority(agent)
+                .unwrap_or_else(|| {
+                    std::rc::Rc::new(super::task_contract::TaskContract::from_request(""))
+                });
             let behavior_projection =
                 super::required_behavior::project_behavior_contract(&task_contract);
             let note =

--- a/src/agent/loop_run/run_turn.rs
+++ b/src/agent/loop_run/run_turn.rs
@@ -28,6 +28,11 @@ pub(super) fn run_turn(
     monitor: &mut InterruptMonitor,
 ) -> LoopResult {
     super::message_push::push_user_message(agent, input.to_string());
+    // Issue #917 (P0.5): eager-populate the per-turn classification authority at
+    // this single known point — right after the request is set, before any
+    // reader and regardless of mode. `active_request_text` strips the auto-plan
+    // wrapper so the memo classifies the original user request (D7/D9).
+    super::task_classification::populate_task_contract_authority(agent);
     if agent.session.mode_state.mode != ExecutionMode::Plan {
         // Issue #576: replace direct `classify_work_mode_json` + event
         // emit with the shared `classify_with_confirmation` wrapper. The

--- a/src/agent/loop_run/safe_stop_emit.rs
+++ b/src/agent/loop_run/safe_stop_emit.rs
@@ -71,7 +71,12 @@ pub(super) fn resolve_current_role_for_safe_stop(
     }
     let request = super::workspace_access::active_request_text(agent).unwrap_or_default();
     if !request.is_empty() {
-        let contract = super::task_contract::TaskContract::from_request(&request);
+        // Issue #917: per-turn classification authority (fallback preserves the
+        // non-empty-request behavior in the unlikely None case).
+        let contract =
+            super::task_classification::task_contract_authority(agent).unwrap_or_else(|| {
+                std::rc::Rc::new(super::task_contract::TaskContract::from_request(&request))
+            });
         if let Some(role) = contract.required_artifacts.first().copied() {
             return Some(role);
         }
@@ -356,7 +361,12 @@ fn repair_terminal_obligation_targets(
     if request.is_empty() {
         return Vec::new();
     }
-    let contract = super::task_contract::TaskContract::from_request(&request);
+    // Issue #917: per-turn classification authority (fallback preserves the
+    // non-empty-request behavior in the unlikely None case).
+    let contract =
+        super::task_classification::task_contract_authority(agent).unwrap_or_else(|| {
+            std::rc::Rc::new(super::task_contract::TaskContract::from_request(&request))
+        });
     super::repair_packet::repair_packets_for_contract(&contract)
         .into_iter()
         .map(|packet| packet.target)

--- a/src/agent/loop_run/success.rs
+++ b/src/agent/loop_run/success.rs
@@ -152,11 +152,9 @@ impl Agent {
         if project_unit.is_some_and(|unit| !unit.verifier_candidates.is_empty()) {
             return true;
         }
-        super::workspace_access::active_request_text(self).is_some_and(|request| {
-            TaskContract::from_request(&request)
-                .completion_policy
-                .test_execution_required()
-        })
+        // Issue #917: per-turn classification authority (None → false).
+        super::task_classification::task_contract_authority(self)
+            .is_some_and(|contract| contract.completion_policy.test_execution_required())
     }
 
     /// Issue #607 (DR1-001 SSOT): build the current `RequestContext` from
@@ -165,10 +163,14 @@ impl Agent {
     /// `evidence_set_missing_shapes_with_context`, and
     /// `should_run_auto_test_for_success_with_context`.
     pub(super) fn current_request_context(&self) -> RequestContext {
+        // Issue #917: per-turn classification authority. `request` is still
+        // needed for `request_is_env_setup_only`; the contract comes from the
+        // memo (None → empty-input contract, matching `unwrap_or_default`).
         let request = super::workspace_access::active_request_text(self).unwrap_or_default();
-        let contract = TaskContract::from_request(&request);
+        let contract = super::task_classification::task_contract_authority(self)
+            .unwrap_or_else(|| std::rc::Rc::new(TaskContract::from_request(&request)));
         let requires_tests = contract.completion_policy.test_execution_required();
-        let completion_policy = contract.completion_policy;
+        let completion_policy = contract.completion_policy.clone();
         RequestContext {
             requires_tests,
             is_env_setup_only: super::quality::request_is_env_setup_only(&request),
@@ -204,10 +206,10 @@ impl Agent {
     /// structured Weak/Missing branch is then skipped and the legacy
     /// `detect_with_recent_successes -> run` path runs verbatim.
     fn success_verifier_test_binding(&mut self) -> (Vec<String>, bool) {
-        let Some(request) = super::workspace_access::active_request_text(self) else {
+        // Issue #917: per-turn classification authority (None → no binding).
+        let Some(contract) = super::task_classification::task_contract_authority(self) else {
             return (Vec::new(), false);
         };
-        let contract = TaskContract::from_request(&request);
         let test_execution_required = contract.completion_policy.test_execution_required();
         let owned_test_artifacts =
             super::owned_test_projection::owned_test_artifacts_for_verifier(self, &contract);

--- a/src/agent/loop_run/task_classification.rs
+++ b/src/agent/loop_run/task_classification.rs
@@ -1,0 +1,75 @@
+//! Issue #917 (P0.5): the per-turn single task-classification authority.
+//!
+//! `TaskContract::from_request` used to be recomputed at ~18 production sites
+//! with no memoization, and `infer_task_kind` silently defaulted to `Coding`
+//! on a no-keyword match. This module is the single chokepoint that classifies
+//! the current-turn request exactly once and memoizes the full `TaskContract`
+//! (the 18 reader sites need the whole contract, not just the `TaskKind` — see
+//! design policy §3 / S5-001).
+//!
+//! Free functions (not `impl Agent`) match the dominant `loop_run` convention
+//! (DR2-003). Private module, not re-exported (DR3-001).
+//!
+//! Phase 2 scope: deterministic first-pass populate + read accessor. The
+//! low-confidence TaskKind confirm second-pass (which can rebuild the contract
+//! before `OnceCell::set`) is layered on in Phase 4 and is the reason the
+//! populate entry point is the only mutation-capable path.
+
+use std::rc::Rc;
+
+use super::Agent;
+use super::task_contract::TaskContract;
+
+/// Eager populate at the single known point: called once in `run_turn`
+/// immediately after `push_user_message`. Idempotent via `OnceCell`; a no-op
+/// when the request is absent (degenerate turn) or already populated.
+///
+/// Placing the populate here means every downstream reader (including
+/// `agent_misc::refresh_artifact_completion_satisfied`, which runs *after*
+/// `run_turn` returns) observes a memo that was built from the original
+/// user request — `active_request_text` strips any auto-plan wrapper (D9).
+pub(super) fn populate_task_contract_authority(agent: &Agent) {
+    if agent.task_contract_this_turn.get().is_some() {
+        return;
+    }
+    let Some(request) = super::workspace_access::active_request_text(agent) else {
+        return;
+    };
+    // `set` returns `Err` only if another path won the race within this turn;
+    // both produce the same deterministic first-pass contract, so ignore it.
+    let _ = agent
+        .task_contract_this_turn
+        .set(Rc::new(TaskContract::from_request(&request)));
+}
+
+/// Per-turn classification authority read by the former `from_request` sites.
+/// Returns the memoized contract, lazily populating as a defensive net if the
+/// eager `populate_*` has not run yet. Returns `None` only when there is no
+/// current-turn request (the caller then keeps its legacy local behavior).
+pub(super) fn task_contract_authority(agent: &Agent) -> Option<Rc<TaskContract>> {
+    let request = super::workspace_access::active_request_text(agent)?;
+    let contract = agent
+        .task_contract_this_turn
+        .get_or_init(|| Rc::new(TaskContract::from_request(&request)));
+    #[cfg(debug_assertions)]
+    {
+        // Divergence assert (S1-008 / S3-001): the memo must equal a fresh
+        // recompute of the same `active_request_text`. The branch tolerates a
+        // *legal* confirm override (Phase 4): when the memoized kind differs
+        // from the deterministic first pass, the first pass must have been
+        // low-confidence (i.e. eligible for confirm).
+        let first_pass = TaskContract::from_request(&request);
+        if contract.task_kind == first_pass.task_kind {
+            debug_assert_eq!(
+                **contract, first_pass,
+                "task classification divergence: memo != recompute(active_request_text)"
+            );
+        } else {
+            debug_assert!(
+                first_pass.classification().needs_confirm(),
+                "task classification override without a low-confidence first pass"
+            );
+        }
+    }
+    Some(contract.clone())
+}

--- a/src/agent/loop_run/task_contract.rs
+++ b/src/agent/loop_run/task_contract.rs
@@ -45,6 +45,48 @@ impl TaskKind {
     }
 }
 
+/// Issue #917 (P0.5): result of [`infer_task_kind`]. `matched` records whether
+/// a keyword branch actually fired; `matched == false` is reached *only* by the
+/// no-keyword-match fallthrough (the historical silent `TaskKind::Coding`
+/// default). This is the single signal that distinguishes a genuine `Coding`
+/// match from "we gave up and defaulted to Coding" — the root of the v0.4.35
+/// non-coding misroute. See design policy §4 D1/D2 (DR2-002).
+struct TaskKindInference {
+    kind: TaskKind,
+    matched: bool,
+}
+
+/// Issue #917 (P0.5): per-turn classification head, projected from
+/// [`TaskContract`] via [`TaskContract::classification`]. The P0.5 frozen shape
+/// is `{ task_kind, confidence }`; `needs_confirm()` is *derived* (no
+/// independent bool) so `confidence` is the single source of truth (DR1-004).
+/// `#[non_exhaustive]` keeps the P1 additions (coding sub-profile / behavior
+/// flags) additive (DR1-003).
+// Issue #917: `#[allow(dead_code)]` is transient — the per-turn authority
+// accessor (`task_classification.rs`, Phase 2) and the confirm path (Phase 4)
+// are the production consumers; the allow is removed once they are wired.
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
+pub(super) struct TaskClassification {
+    pub(super) task_kind: TaskKind,
+    /// 0.0..=1.0. P0.5 is a 2-value approximation (matched → 1.0, no-match →
+    /// 0.0); the f32 type leaves room for additive refinement toward
+    /// `ModeClassification.confidence`'s continuous scale.
+    pub(super) confidence: f32,
+}
+
+impl TaskClassification {
+    /// "Unknown" signal (D1/D5): a no-keyword-match request (`confidence` below
+    /// the confirm threshold) routes to the confirm path instead of silently
+    /// staying `Coding`. Reuses the WorkMode confirm threshold (DR2-001 path:
+    /// `crate::modes::plan_act`, not `super::super::modes`).
+    #[allow(dead_code)] // Issue #917: wired by the confirm path (Phase 4).
+    pub(super) fn needs_confirm(&self) -> bool {
+        self.confidence < crate::modes::plan_act::WORK_MODE_CONFIRM_CONFIDENCE_THRESHOLD
+    }
+}
+
 #[allow(dead_code)] // Issue #864: generic deliverable variants are part of the model before every producer is wired.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum DeliverableKind {
@@ -526,6 +568,12 @@ pub(super) struct TaskContract {
     // existing `required_artifacts` gate based on it (non-destructive).
     #[allow(dead_code)]
     pub(super) required_behavior: RequiredBehaviorContract,
+    // Issue #917 (P0.5): classification confidence captured at construction.
+    // 1.0 when `infer_task_kind` matched a keyword branch, 0.0 when it hit the
+    // no-keyword-match fallthrough. Projected via `classification()` and read
+    // by the per-turn authority's `needs_confirm()` gate. The `task_kind` above
+    // is UNCHANGED by this field (D6: verifier gate does not regress).
+    pub(super) classification_confidence: f32,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1306,7 +1354,10 @@ impl TaskContract {
         let asks_for_usage_docs = request_asks_for_usage_docs(request, &lower);
         let asks_for_setup = request_asks_for_setup(request, &lower);
         let asks_for_data_output = request_asks_for_data_output_artifact(request, &lower);
-        let task_kind = infer_task_kind(
+        let TaskKindInference {
+            kind: task_kind,
+            matched: task_kind_matched,
+        } = infer_task_kind(
             request,
             &lower,
             intent,
@@ -1314,6 +1365,10 @@ impl TaskContract {
             asks_for_usage_docs,
             asks_for_setup,
         );
+        // Issue #917: 2-value confidence from the keyword-match signal. Only the
+        // no-keyword-match fallthrough (matched == false) lands below the
+        // confirm threshold and triggers `needs_confirm()`.
+        let classification_confidence = if task_kind_matched { 1.0 } else { 0.0 };
         let mut required = Vec::new();
         let mut optional = Vec::new();
 
@@ -1415,6 +1470,17 @@ impl TaskContract {
             verification_required: completion_policy.verification_required(),
             completion_policy,
             required_behavior,
+            classification_confidence,
+        }
+    }
+
+    /// Issue #917 (P0.5): project the per-turn classification head. No added
+    /// state — reads the existing `task_kind` plus `classification_confidence`.
+    #[allow(dead_code)] // Issue #917: wired by the per-turn authority (Phase 2).
+    pub(super) fn classification(&self) -> TaskClassification {
+        TaskClassification {
+            task_kind: self.task_kind,
+            confidence: self.classification_confidence,
         }
     }
 
@@ -1842,7 +1908,11 @@ fn infer_task_kind(
     asks_for_tests: bool,
     asks_for_usage_docs: bool,
     asks_for_setup: bool,
-) -> TaskKind {
+) -> TaskKindInference {
+    // Issue #917: every keyword branch sets `matched: true`; only the final
+    // no-keyword-match fallthrough is `matched: false`. The returned `kind` is
+    // byte-for-byte identical to the pre-#917 `TaskKind` so downstream artifact
+    // derivation / verifier gating is unchanged (D6).
     let code_work = request_asks_for_code_work(request, lower);
     let data_task = request_asks_for_data_task(request, lower);
     let implementation_artifact = request_asks_for_implementation_artifact(
@@ -1853,27 +1923,53 @@ fn infer_task_kind(
         asks_for_setup,
     );
     if asks_for_tests {
-        return TaskKind::Coding;
+        return TaskKindInference {
+            kind: TaskKind::Coding,
+            matched: true,
+        };
     }
     if asks_for_usage_docs && !implementation_artifact {
-        return TaskKind::Docs;
+        return TaskKindInference {
+            kind: TaskKind::Docs,
+            matched: true,
+        };
     }
     if data_task && !request_has_explicit_coding_subject(request, lower) {
-        return TaskKind::Data;
+        return TaskKindInference {
+            kind: TaskKind::Data,
+            matched: true,
+        };
     }
     if code_work {
-        return TaskKind::Coding;
+        return TaskKindInference {
+            kind: TaskKind::Coding,
+            matched: true,
+        };
     }
     if request_asks_for_research_task(request, lower, intent) {
-        return TaskKind::Research;
+        return TaskKindInference {
+            kind: TaskKind::Research,
+            matched: true,
+        };
     }
     if request_asks_for_ops_task(request, lower) || asks_for_setup {
-        return TaskKind::Ops;
+        return TaskKindInference {
+            kind: TaskKind::Ops,
+            matched: true,
+        };
     }
     if asks_for_usage_docs {
-        return TaskKind::Docs;
+        return TaskKindInference {
+            kind: TaskKind::Docs,
+            matched: true,
+        };
     }
-    TaskKind::Coding
+    // No keyword matched: the historical silent `Coding` default. `matched:
+    // false` is the single signal that drives `needs_confirm()` → confirm path.
+    TaskKindInference {
+        kind: TaskKind::Coding,
+        matched: false,
+    }
 }
 
 fn deliverables_from_contract_parts(
@@ -3692,6 +3788,123 @@ fn suggested_next_action(role: ArtifactRole, request: &str) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ---- Issue #917 Phase 1: classification confidence / needs_confirm -----
+
+    #[test]
+    fn issue917_no_keyword_match_yields_zero_confidence_and_needs_confirm() {
+        // A greeting matches no TaskKind keyword branch — historically a silent
+        // `Coding` default. The classification must now flag low confidence so
+        // it routes to confirm instead of silently staying Coding.
+        let contract = TaskContract::from_request("こんにちは");
+        assert_eq!(contract.task_kind, TaskKind::Coding, "kind unchanged (D6)");
+        assert_eq!(contract.classification_confidence, 0.0);
+        assert!(
+            contract.classification().needs_confirm(),
+            "no-keyword-match must route to confirm"
+        );
+
+        let en = TaskContract::from_request("hello there");
+        assert_eq!(en.classification_confidence, 0.0);
+        assert!(en.classification().needs_confirm());
+    }
+
+    #[test]
+    fn issue917_keyword_match_yields_full_confidence_no_confirm() {
+        // A real coding request matches a keyword branch → high confidence → no
+        // confirm. This is the case that must NOT be perturbed.
+        let contract = TaskContract::from_request("Create a Rust CLI word counter");
+        assert_eq!(contract.task_kind, TaskKind::Coding);
+        assert_eq!(contract.classification_confidence, 1.0);
+        assert!(!contract.classification().needs_confirm());
+
+        // Non-coding keyword matches also classify with full confidence.
+        let docs = TaskContract::from_request("Update README.md with usage documentation");
+        assert_eq!(docs.task_kind, TaskKind::Docs);
+        assert_eq!(docs.classification_confidence, 1.0);
+        assert!(!docs.classification().needs_confirm());
+    }
+
+    #[test]
+    fn issue917_en_jp_task_kind_parity() {
+        // AC4: per-language eval cases assert the same `task_kind`. This guards
+        // the *authority* classifier (`infer_task_kind`); the separate
+        // `infer_eval_task_kind` (session layer) is scope-out per D8.
+        // Each pair is (EN request, JP request, expected TaskKind).
+        let cases: &[(&str, &str, TaskKind)] = &[
+            (
+                "Implement a Rust library feature X",
+                "Rustのライブラリ機能Xを実装してください",
+                TaskKind::Coding,
+            ),
+            (
+                "Update README.md with usage documentation",
+                "READMEに使い方のドキュメントを記載してください",
+                TaskKind::Docs,
+            ),
+            (
+                "Generate output.csv with columns id and total",
+                "idとtotalの列を持つoutput.csvを生成してください",
+                TaskKind::Data,
+            ),
+            (
+                "Research battery safety and compare sources",
+                "バッテリー安全性を調査して比較レポートにまとめてください",
+                TaskKind::Research,
+            ),
+            (
+                "Deploy the service and set up monitoring",
+                "サービスをデプロイして監視を設定してください",
+                TaskKind::Ops,
+            ),
+        ];
+        for (en, jp, expected) in cases {
+            let en_kind = TaskContract::from_request(en).task_kind;
+            let jp_kind = TaskContract::from_request(jp).task_kind;
+            assert_eq!(en_kind, *expected, "EN `{en}` should be {expected:?}");
+            assert_eq!(jp_kind, *expected, "JP `{jp}` should be {expected:?}");
+            assert_eq!(en_kind, jp_kind, "EN/JP parity for {expected:?}");
+        }
+    }
+
+    #[test]
+    fn issue917_classification_projection_matches_contract_fields() {
+        let contract = TaskContract::from_request("Create a Python CLI in main.py");
+        let projected = contract.classification();
+        assert_eq!(projected.task_kind, contract.task_kind);
+        assert_eq!(projected.confidence, contract.classification_confidence);
+    }
+
+    #[test]
+    fn issue917_d6_no_match_keeps_coding_kind_and_verifier_gate_intact() {
+        // D6 regression guard. The `classification_confidence` field is purely
+        // additive: it must not change `task_kind` (the input to the
+        // `coding_verifier_required` gate) nor relax test gating.
+        //
+        // (a) a no-keyword-match request still classifies as `Coding`, so the
+        //     gate's task_kind input is unchanged.
+        let ambiguous = TaskContract::from_request("Build feature X");
+        assert_eq!(ambiguous.task_kind, TaskKind::Coding);
+        assert!(
+            ambiguous.classification().needs_confirm()
+                || ambiguous.classification_confidence == 1.0,
+            "confidence is well-formed (0.0 or 1.0)"
+        );
+
+        // (b) the verifier/test gate still fires for an explicit coding+tests
+        //     request — the field addition did not disable it.
+        let coding_tests =
+            TaskContract::from_request("Implement a Rust library feature X and add tests");
+        assert_eq!(coding_tests.task_kind, TaskKind::Coding);
+        assert!(
+            coding_tests.completion_policy.verification_required(),
+            "coding+tests request must still require verification (gate intact)"
+        );
+        assert!(
+            coding_tests.completion_policy.test_execution_required(),
+            "coding+tests request must still require test execution (gate intact)"
+        );
+    }
 
     fn repo_edit(category: RepoEditCategory) -> CompletionEvidence {
         CompletionEvidence::RepoEdit {

--- a/src/agent/loop_run/verifier_diagnostic_flow.rs
+++ b/src/agent/loop_run/verifier_diagnostic_flow.rs
@@ -64,7 +64,14 @@ pub(super) fn prepare_verifier_diagnostic_pass(
         current.assessment_attempts = current.assessment_attempts.saturating_add(1);
     }
     let active_request = super::workspace_access::active_request_text(agent).unwrap_or_default();
-    let task_contract = super::task_contract::TaskContract::from_request(&active_request);
+    // Issue #917: per-turn classification authority (None → empty-input
+    // contract, matching the legacy `unwrap_or_default`).
+    let task_contract =
+        super::task_classification::task_contract_authority(agent).unwrap_or_else(|| {
+            std::rc::Rc::new(super::task_contract::TaskContract::from_request(
+                &active_request,
+            ))
+        });
     let behavior_projection = super::required_behavior::project_behavior_contract(&task_contract);
     super::active_job_emit::emit_behavior_contract_projected_if_changed(
         agent,

--- a/src/agent/loop_run/verifier_orchestration.rs
+++ b/src/agent/loop_run/verifier_orchestration.rs
@@ -2208,10 +2208,10 @@ pub(super) fn verifier_repair_pass_client(
 pub(super) fn task_contract_verifier_test_binding(
     agent: &mut Agent,
 ) -> (Vec<String>, bool, Option<TaskWorkspaceScope>) {
-    let Some(request) = super::workspace_access::active_request_text(agent) else {
+    // Issue #917: per-turn classification authority (None → no binding).
+    let Some(contract) = super::task_classification::task_contract_authority(agent) else {
         return (Vec::new(), false, None);
     };
-    let contract = TaskContract::from_request(&request);
     let test_execution_required = contract.completion_policy.test_execution_required();
     let owned_test_artifacts =
         super::owned_test_projection::owned_test_artifacts_for_verifier(agent, &contract);
@@ -3220,7 +3220,14 @@ pub(super) fn run_verifier_diagnostic_pass(agent: &mut Agent) -> VerifierDiagnos
     let correction_packet = if active_request.trim().is_empty() {
         None
     } else {
-        let contract = super::task_contract::TaskContract::from_request(&active_request);
+        // Issue #917: per-turn classification authority (fallback to the
+        // non-empty active_request keeps behavior in the unlikely None case).
+        let contract =
+            super::task_classification::task_contract_authority(agent).unwrap_or_else(|| {
+                std::rc::Rc::new(super::task_contract::TaskContract::from_request(
+                    &active_request,
+                ))
+            });
         assessment.repair_target_hint.as_ref().map(|hint| {
             super::repair_packet::RepairPacket::for_diagnostic_failure(
                 &contract,

--- a/src/agent/loop_run/verifier_repair_pass_flow.rs
+++ b/src/agent/loop_run/verifier_repair_pass_flow.rs
@@ -152,7 +152,14 @@ pub(super) fn prepare_verifier_repair_pass(
         return Err(VerifierRepairPassOutcome::Skipped);
     };
     let active_request = super::workspace_access::active_request_text(agent).unwrap_or_default();
-    let task_contract = super::task_contract::TaskContract::from_request(&active_request);
+    // Issue #917: per-turn classification authority (None → empty-input
+    // contract, matching the legacy `unwrap_or_default`).
+    let task_contract =
+        super::task_classification::task_contract_authority(agent).unwrap_or_else(|| {
+            std::rc::Rc::new(super::task_contract::TaskContract::from_request(
+                &active_request,
+            ))
+        });
     let behavior_projection = super::required_behavior::project_behavior_contract(&task_contract);
     super::active_job_emit::emit_behavior_contract_projected_if_changed(
         agent,


### PR DESCRIPTION
Closes #917. Part of epic #916 (v0.4 TaskCapability generalization). Follow-up: #926.

## Summary
Introduces a **memoized single per-turn task classification authority** (P0.5) — the foundational
prerequisite for the generalization spine. Task classification now runs once per turn and is read from
a memo, instead of being recomputed at ~18 production sites.

- New `task_classification.rs`: `OnceCell<Rc<TaskContract>>` eager-populated in `run_turn`, read
  accessor, per-turn reset, debug-assert divergence check.
- `TaskKindInference { kind, matched }` / `classification_confidence` / `TaskClassification` +
  `needs_confirm()` (exposes the no-keyword silent-Coding signal).
- Migrated **16 agent-scoped recompute sites** to the memo (2 param-based cold/no-agent sites excluded
  intentionally). Includes the hot-path fix in `python_request_helpers` found by Codex review (CB-001).
- EN/JP task_kind parity tests.

## Scope note (AC2)
The full **TaskKind confirm sidecar dispatch** (security-sensitive ~1000-line increment) is split into
follow-up **#926**. Here AC2 is structurally mitigated: `needs_confirm()` is exposed and the verifier
gate is preserved (no silent-Coding completion harm), but the actual confirm dispatch lands in #926.

## Verification
- `cargo fmt --check` ✅ · `cargo clippy --all-targets` 0 warnings ✅ · `cargo test` green ✅
  (3886 tests per worker+Codex run; independently re-verified by the orchestrator)
- Independent Codex code review during dev: verdict needs_fix → 1 medium (CB-001) fixed → clean.

Design SSOT: `dev-reports/design/v0.4/v0.4-taskcapability-generalization.md` (§5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)