### PR TITLE
#947 P0d-A: ObjectiveContract projection and generic terminal vocabulary

### DIFF
--- a/src/agent/loop_run/summary.rs
+++ b/src/agent/loop_run/summary.rs
@@ -65,6 +65,42 @@ impl RunState {
     }
 }
 
+#[allow(dead_code)] // Issue #947: generic terminal vocabulary before every caller migrates.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum GenericTerminalState {
+    Completed,
+    MissingDeliverable,
+    MissingEvidence,
+    EvidenceFailed,
+    EvidenceBindingFailed,
+    EvidenceRunnerMissing,
+    EvidenceRepairExhausted,
+    EvidenceRepairSafeStop,
+    ControlLoopExhausted,
+    ModelOutputFailure,
+    TransportFailure,
+    Interrupted,
+}
+
+impl GenericTerminalState {
+    pub(super) fn label(self) -> &'static str {
+        match self {
+            GenericTerminalState::Completed => "completed",
+            GenericTerminalState::MissingDeliverable => "missing_deliverable",
+            GenericTerminalState::MissingEvidence => "missing_evidence",
+            GenericTerminalState::EvidenceFailed => "evidence_failed",
+            GenericTerminalState::EvidenceBindingFailed => "evidence_binding_failed",
+            GenericTerminalState::EvidenceRunnerMissing => "evidence_runner_missing",
+            GenericTerminalState::EvidenceRepairExhausted => "evidence_repair_exhausted",
+            GenericTerminalState::EvidenceRepairSafeStop => "evidence_repair_safe_stop",
+            GenericTerminalState::ControlLoopExhausted => "control_loop_exhausted",
+            GenericTerminalState::ModelOutputFailure => "model_output_failure",
+            GenericTerminalState::TransportFailure => "transport_failure",
+            GenericTerminalState::Interrupted => "interrupted",
+        }
+    }
+}
+
 #[allow(dead_code)] // Issue #888: additive context; legacy labels remain the serialized default.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum MissingDeliverable {
@@ -114,6 +150,7 @@ const VALID_VERIFICATION_RESULT_MISSING: &[MissingEvidence] =
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) struct RunTerminalOutcome {
     pub(super) state: RunState,
+    pub(super) generic_state: GenericTerminalState,
     pub(super) legacy_label: &'static str,
     pub(super) missing_deliverables: &'static [MissingDeliverable],
     pub(super) missing_evidence: &'static [MissingEvidence],
@@ -124,53 +161,101 @@ impl RunTerminalOutcome {
         match reason {
             ExitReason::Done => Self {
                 state: RunState::Completed,
+                generic_state: GenericTerminalState::Completed,
                 legacy_label: "done",
                 missing_deliverables: NO_MISSING_DELIVERABLES,
                 missing_evidence: NO_MISSING_EVIDENCE,
             },
             ExitReason::MissingRepoEdits => Self {
                 state: RunState::DeliverableMissing,
+                generic_state: GenericTerminalState::MissingDeliverable,
                 legacy_label: "missing_repo_edits",
                 missing_deliverables: REPOSITORY_CHANGE_MISSING,
                 missing_evidence: NO_MISSING_EVIDENCE,
             },
             ExitReason::MissingVerification => Self {
                 state: RunState::EvidenceMissing,
+                generic_state: GenericTerminalState::MissingEvidence,
                 legacy_label: "missing_verification",
                 missing_deliverables: NO_MISSING_DELIVERABLES,
                 missing_evidence: VERIFICATION_RESULT_MISSING,
             },
-            ExitReason::VerifierFailed | ExitReason::SafeStopVerifierWeak => Self {
+            ExitReason::VerifierFailed => Self {
                 state: RunState::EvidenceInvalid,
+                generic_state: GenericTerminalState::EvidenceFailed,
                 legacy_label: reason.legacy_label(),
+                missing_deliverables: NO_MISSING_DELIVERABLES,
+                missing_evidence: VALID_VERIFICATION_RESULT_MISSING,
+            },
+            ExitReason::SafeStopVerifierWeak => Self {
+                state: RunState::EvidenceInvalid,
+                generic_state: GenericTerminalState::EvidenceBindingFailed,
+                legacy_label: "safe_stop_verifier_weak",
                 missing_deliverables: NO_MISSING_DELIVERABLES,
                 missing_evidence: VALID_VERIFICATION_RESULT_MISSING,
             },
             ExitReason::SafeStopVerifierMissing => Self {
                 state: RunState::EvidenceMissing,
+                generic_state: GenericTerminalState::EvidenceRunnerMissing,
                 legacy_label: "safe_stop_verifier_missing",
                 missing_deliverables: NO_MISSING_DELIVERABLES,
                 missing_evidence: VERIFICATION_ENVIRONMENT_MISSING,
             },
-            ExitReason::RepairExhausted | ExitReason::RepairSafeStop => Self {
+            ExitReason::RepairExhausted => Self {
                 state: RunState::SafeStopped,
+                generic_state: GenericTerminalState::EvidenceRepairExhausted,
+                legacy_label: "repair_exhausted",
+                missing_deliverables: NO_MISSING_DELIVERABLES,
+                missing_evidence: NO_MISSING_EVIDENCE,
+            },
+            ExitReason::RepairSafeStop => Self {
+                state: RunState::SafeStopped,
+                generic_state: GenericTerminalState::EvidenceRepairSafeStop,
+                legacy_label: "repair_safe_stop",
+                missing_deliverables: NO_MISSING_DELIVERABLES,
+                missing_evidence: NO_MISSING_EVIDENCE,
+            },
+            ExitReason::MaxIterations | ExitReason::PlanIncomplete => Self {
+                state: RunState::SafeStopped,
+                generic_state: GenericTerminalState::ControlLoopExhausted,
                 legacy_label: reason.legacy_label(),
                 missing_deliverables: NO_MISSING_DELIVERABLES,
                 missing_evidence: NO_MISSING_EVIDENCE,
             },
-            ExitReason::MaxIterations
-            | ExitReason::EmptyResponses
+            ExitReason::EmptyResponses
             | ExitReason::NoToolCalls
-            | ExitReason::PlanIncomplete
-            | ExitReason::ToolCallFormatError
-            | ExitReason::TransportError
-            | ExitReason::Interrupted => Self {
+            | ExitReason::ToolCallFormatError => Self {
                 state: RunState::SafeStopped,
+                generic_state: GenericTerminalState::ModelOutputFailure,
                 legacy_label: reason.legacy_label(),
+                missing_deliverables: NO_MISSING_DELIVERABLES,
+                missing_evidence: NO_MISSING_EVIDENCE,
+            },
+            ExitReason::TransportError => Self {
+                state: RunState::SafeStopped,
+                generic_state: GenericTerminalState::TransportFailure,
+                legacy_label: "transport_error",
+                missing_deliverables: NO_MISSING_DELIVERABLES,
+                missing_evidence: NO_MISSING_EVIDENCE,
+            },
+            ExitReason::Interrupted => Self {
+                state: RunState::SafeStopped,
+                generic_state: GenericTerminalState::Interrupted,
+                legacy_label: "interrupted",
                 missing_deliverables: NO_MISSING_DELIVERABLES,
                 missing_evidence: NO_MISSING_EVIDENCE,
             },
         }
+    }
+
+    #[allow(dead_code)] // Issue #947: compatibility projection for eval/report migrations.
+    pub(super) fn generic_label(self) -> &'static str {
+        self.generic_state.label()
+    }
+
+    #[allow(dead_code)] // Issue #947: keeps legacy evaluation labels explicit.
+    pub(super) fn legacy_label_for_eval(self) -> &'static str {
+        self.legacy_label
     }
 }
 
@@ -238,6 +323,16 @@ impl ExitReason {
 
     pub(super) fn label(self) -> &'static str {
         RunTerminalOutcome::from_exit_reason(self).legacy_label
+    }
+
+    #[allow(dead_code)] // Issue #947: generic internal terminal vocabulary.
+    pub(super) fn generic_terminal_state(self) -> GenericTerminalState {
+        RunTerminalOutcome::from_exit_reason(self).generic_state
+    }
+
+    #[allow(dead_code)] // Issue #947: generic internal terminal vocabulary.
+    pub(super) fn generic_label(self) -> &'static str {
+        self.generic_terminal_state().label()
     }
 
     fn legacy_label(self) -> &'static str {
@@ -471,6 +566,7 @@ mod tests {
     fn run_terminal_outcome_describes_legacy_missing_states_generically() {
         let deliverable = RunTerminalOutcome::from_exit_reason(ExitReason::MissingRepoEdits);
         assert_eq!(deliverable.legacy_label, "missing_repo_edits");
+        assert_eq!(deliverable.generic_label(), "missing_deliverable");
         assert_eq!(deliverable.state, RunState::DeliverableMissing);
         assert_eq!(
             deliverable
@@ -484,6 +580,7 @@ mod tests {
 
         let evidence = RunTerminalOutcome::from_exit_reason(ExitReason::MissingVerification);
         assert_eq!(evidence.legacy_label, "missing_verification");
+        assert_eq!(evidence.generic_label(), "missing_evidence");
         assert_eq!(evidence.state, RunState::EvidenceMissing);
         assert!(evidence.missing_deliverables.is_empty());
         assert_eq!(
@@ -494,6 +591,62 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec!["verification_result"]
         );
+    }
+
+    #[test]
+    fn terminal_outcome_projects_generic_states_and_legacy_eval_labels() {
+        let cases = [
+            (
+                ExitReason::MissingRepoEdits,
+                GenericTerminalState::MissingDeliverable,
+                "missing_deliverable",
+                "missing_repo_edits",
+            ),
+            (
+                ExitReason::MissingVerification,
+                GenericTerminalState::MissingEvidence,
+                "missing_evidence",
+                "missing_verification",
+            ),
+            (
+                ExitReason::SafeStopVerifierMissing,
+                GenericTerminalState::EvidenceRunnerMissing,
+                "evidence_runner_missing",
+                "safe_stop_verifier_missing",
+            ),
+            (
+                ExitReason::SafeStopVerifierWeak,
+                GenericTerminalState::EvidenceBindingFailed,
+                "evidence_binding_failed",
+                "safe_stop_verifier_weak",
+            ),
+            (
+                ExitReason::RepairExhausted,
+                GenericTerminalState::EvidenceRepairExhausted,
+                "evidence_repair_exhausted",
+                "repair_exhausted",
+            ),
+            (
+                ExitReason::RepairSafeStop,
+                GenericTerminalState::EvidenceRepairSafeStop,
+                "evidence_repair_safe_stop",
+                "repair_safe_stop",
+            ),
+        ];
+
+        for (reason, generic_state, generic_label, legacy_label) in cases {
+            let outcome = RunTerminalOutcome::from_exit_reason(reason);
+            assert_eq!(outcome.generic_state, generic_state, "reason={reason:?}");
+            assert_eq!(outcome.generic_label(), generic_label, "reason={reason:?}");
+            assert_eq!(
+                outcome.legacy_label_for_eval(),
+                legacy_label,
+                "reason={reason:?}"
+            );
+            assert_eq!(reason.generic_terminal_state(), generic_state);
+            assert_eq!(reason.generic_label(), generic_label);
+            assert_eq!(reason.label(), legacy_label);
+        }
     }
 
     #[test]

--- a/src/agent/loop_run/task_contract.rs
+++ b/src/agent/loop_run/task_contract.rs
@@ -169,6 +169,111 @@ impl TaskClassification {
     }
 }
 
+#[allow(dead_code)] // Issue #947: projection vocabulary before all telemetry consumers are wired.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ObjectiveDeliverableKind {
+    SourceFiles,
+    DocumentSections,
+    OutputFile,
+    ResearchNotes,
+    CommandObservation,
+    ProseArtifact,
+    Answer,
+}
+
+impl ObjectiveDeliverableKind {
+    #[allow(dead_code)] // Issue #947: label projection is currently test/telemetry migration surface.
+    pub(super) fn label(self) -> &'static str {
+        match self {
+            ObjectiveDeliverableKind::SourceFiles => "source_files",
+            ObjectiveDeliverableKind::DocumentSections => "document_sections",
+            ObjectiveDeliverableKind::OutputFile => "output_file",
+            ObjectiveDeliverableKind::ResearchNotes => "research_notes",
+            ObjectiveDeliverableKind::CommandObservation => "command_observation",
+            ObjectiveDeliverableKind::ProseArtifact => "prose_artifact",
+            ObjectiveDeliverableKind::Answer => "answer",
+        }
+    }
+}
+
+#[allow(dead_code)] // Issue #947: projection vocabulary before all telemetry consumers are wired.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ObjectiveEvidenceKind {
+    TestRun,
+    ContentCheck,
+    SchemaCheck,
+    SourceFetchEvidence,
+    SafetyBoundaryEvidence,
+    ContentAcceptance,
+}
+
+impl ObjectiveEvidenceKind {
+    #[allow(dead_code)] // Issue #947: label projection is currently test/telemetry migration surface.
+    pub(super) fn label(self) -> &'static str {
+        match self {
+            ObjectiveEvidenceKind::TestRun => "test_run",
+            ObjectiveEvidenceKind::ContentCheck => "content_check",
+            ObjectiveEvidenceKind::SchemaCheck => "schema_check",
+            ObjectiveEvidenceKind::SourceFetchEvidence => "source_fetch_evidence",
+            ObjectiveEvidenceKind::SafetyBoundaryEvidence => "safety_boundary_evidence",
+            ObjectiveEvidenceKind::ContentAcceptance => "content_acceptance",
+        }
+    }
+}
+
+#[allow(dead_code)] // Issue #947: read-only ObjectiveContract projection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct ObjectiveContract {
+    pub(super) task_kind: TaskKind,
+    pub(super) deliverable_kind: ObjectiveDeliverableKind,
+    pub(super) evidence_kind: ObjectiveEvidenceKind,
+}
+
+impl ObjectiveContract {
+    fn from_task_contract(contract: &TaskContract) -> Self {
+        if contract.completion_policy.project_intent == CompletionProjectIntent::AnswerOnly {
+            return Self {
+                task_kind: contract.task_kind,
+                deliverable_kind: ObjectiveDeliverableKind::Answer,
+                evidence_kind: ObjectiveEvidenceKind::ContentAcceptance,
+            };
+        }
+
+        let (deliverable_kind, evidence_kind) = match contract.task_kind {
+            TaskKind::Coding => (
+                ObjectiveDeliverableKind::SourceFiles,
+                ObjectiveEvidenceKind::TestRun,
+            ),
+            TaskKind::Docs => (
+                ObjectiveDeliverableKind::DocumentSections,
+                ObjectiveEvidenceKind::ContentCheck,
+            ),
+            TaskKind::Data => (
+                ObjectiveDeliverableKind::OutputFile,
+                ObjectiveEvidenceKind::SchemaCheck,
+            ),
+            TaskKind::Research => (
+                ObjectiveDeliverableKind::ResearchNotes,
+                ObjectiveEvidenceKind::SourceFetchEvidence,
+            ),
+            TaskKind::Ops => (
+                ObjectiveDeliverableKind::CommandObservation,
+                ObjectiveEvidenceKind::SafetyBoundaryEvidence,
+            ),
+            TaskKind::Authoring => (
+                ObjectiveDeliverableKind::ProseArtifact,
+                ObjectiveEvidenceKind::ContentAcceptance,
+            ),
+        };
+
+        Self {
+            task_kind: contract.task_kind,
+            deliverable_kind,
+            evidence_kind,
+        }
+    }
+}
+
 #[allow(dead_code)] // Issue #864: generic deliverable variants are part of the model before every producer is wired.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum DeliverableKind {
@@ -1883,6 +1988,14 @@ impl TaskContract {
             task_kind: self.task_kind,
             confidence: self.classification_confidence,
         }
+    }
+
+    /// Issue #947: project the existing coding-centered `TaskContract` into
+    /// generic objective lifecycle vocabulary. This is read-only; the legacy
+    /// artifact and verifier gates above remain the completion authority.
+    #[allow(dead_code)] // First consumer is focused tests; telemetry wiring is additive follow-up.
+    pub(super) fn objective_contract(&self) -> ObjectiveContract {
+        ObjectiveContract::from_task_contract(self)
     }
 
     /// Back-compat entrypoint that bypasses the Issue #651 test-execution
@@ -6359,6 +6472,103 @@ mod tests {
                 contract.deliverables
             );
         }
+    }
+
+    #[test]
+    fn objective_contract_projects_deliverable_and_evidence_kinds() {
+        let cases = [
+            (
+                "Implement a Rust library feature X and add tests",
+                TaskKind::Coding,
+                ObjectiveDeliverableKind::SourceFiles,
+                ObjectiveEvidenceKind::TestRun,
+                "source_files",
+                "test_run",
+            ),
+            (
+                "Update README.md with installation, usage, and testing sections",
+                TaskKind::Docs,
+                ObjectiveDeliverableKind::DocumentSections,
+                ObjectiveEvidenceKind::ContentCheck,
+                "document_sections",
+                "content_check",
+            ),
+            (
+                "Clean data.csv and write summary.csv with grouped totals",
+                TaskKind::Data,
+                ObjectiveDeliverableKind::OutputFile,
+                ObjectiveEvidenceKind::SchemaCheck,
+                "output_file",
+                "schema_check",
+            ),
+            (
+                "Research and compare local LLM options, include sources and a recommendation",
+                TaskKind::Research,
+                ObjectiveDeliverableKind::ResearchNotes,
+                ObjectiveEvidenceKind::SourceFetchEvidence,
+                "research_notes",
+                "source_fetch_evidence",
+            ),
+            (
+                "Prepare a deployment runbook checklist with rollback steps",
+                TaskKind::Ops,
+                ObjectiveDeliverableKind::CommandObservation,
+                ObjectiveEvidenceKind::SafetyBoundaryEvidence,
+                "command_observation",
+                "safety_boundary_evidence",
+            ),
+        ];
+
+        for (
+            request,
+            task_kind,
+            deliverable_kind,
+            evidence_kind,
+            deliverable_label,
+            evidence_label,
+        ) in cases
+        {
+            let projection = TaskContract::from_request(request).objective_contract();
+            assert_eq!(projection.task_kind, task_kind, "request={request}");
+            assert_eq!(
+                projection.deliverable_kind, deliverable_kind,
+                "request={request}"
+            );
+            assert_eq!(projection.evidence_kind, evidence_kind, "request={request}");
+            assert_eq!(projection.deliverable_kind.label(), deliverable_label);
+            assert_eq!(projection.evidence_kind.label(), evidence_label);
+        }
+    }
+
+    #[test]
+    fn objective_contract_distinguishes_authoring_artifact_from_answer_only() {
+        let authoring =
+            TaskContract::from_request("Translate README.ja.md into English and write README.md");
+        let authoring_projection = authoring.objective_contract();
+        assert_eq!(authoring_projection.task_kind, TaskKind::Authoring);
+        assert_eq!(
+            authoring_projection.deliverable_kind,
+            ObjectiveDeliverableKind::ProseArtifact
+        );
+        assert_eq!(
+            authoring_projection.evidence_kind,
+            ObjectiveEvidenceKind::ContentAcceptance
+        );
+
+        let answer = TaskContract::from_request("Explain how Rust ownership works");
+        let answer_projection = answer.objective_contract();
+        assert_eq!(
+            answer.completion_policy.project_intent,
+            CompletionProjectIntent::AnswerOnly
+        );
+        assert_eq!(
+            answer_projection.deliverable_kind,
+            ObjectiveDeliverableKind::Answer
+        );
+        assert_eq!(
+            answer_projection.evidence_kind,
+            ObjectiveEvidenceKind::ContentAcceptance
+        );
     }
 
     #[test]


### PR DESCRIPTION
Linked Issue: #947
Parent Epic: #946

## Summary
- Added a read-only `ObjectiveContract` projection on top of the existing `TaskContract` path.
- Added objective-level deliverable/evidence vocabulary for coding, docs, data, research, shell/ops, authoring, and answer-only tasks.
- Added generic terminal-state projection while preserving legacy eval labels such as `missing_repo_edits`, `missing_verification`, `safe_stop_verifier_missing`, `repair_exhausted`, and `repair_safe_stop`.

## Changed Files
- `src/agent/loop_run/task_contract.rs`
- `src/agent/loop_run/summary.rs`

Local ignored reports were written in the worktree under `dev-reports/issue-947/` and intentionally left untracked because repo hygiene forbids tracked `dev-reports/` artifacts.

## Tests Run
- `cargo fmt`
- `cargo test objective_contract`
- `cargo test terminal_outcome_projects_generic_states_and_legacy_eval_labels`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test` passed after rerunning outside the sandbox so local `mockito` HTTP servers could bind.
- GitHub Actions: all PR checks passed after removing tracked `dev-reports/` artifacts.

## Known Risks
- The new projection is intentionally data-only and keeps existing coding gates unchanged. Follow-up issues #948-#952 still need to wire recovery, EvidenceRunner, persistence policy, partial deliverable completion, and eval reporting.

## Orchestration
- Parent dry-run: `20260604-154239-orchestrate`
- Issue #947 dev run: `20260604-154354-orchestrate`
- Commit: `13f2afa`