### PR TITLE
Add delegated persistence controller policy

### DIFF
--- a/src/agent/loop_run.rs
+++ b/src/agent/loop_run.rs
@@ -424,6 +424,10 @@ pub mod commands;
 // reaching into private module state — see `is_completion_verifier_command`
 // / `classify_repo_edit_path` in `loop_run::completion_evidence`.
 pub(crate) mod completion_evidence;
+// Issue #950: delegated local-LLM persistence policy. Records static
+// controller recovery strategy labels and gates prose-only recovery exits
+// without widening provider abstractions.
+mod controller_policy;
 mod deterministic;
 pub(crate) mod feedback_kind_confirm;
 mod footer;
@@ -2185,6 +2189,11 @@ pub struct Agent {
     /// projection_recovery_target()` at the same call sites — there is no
     /// divergent independent assignment outside of `set_artifact_recovery_target_from_hint`.
     current_artifact_recovery_target: Option<crate::agent::loop_run::task_contract::RecoveryTarget>,
+    /// Issue #950: turn-local controller strategy ledger for delegated
+    /// local-LLM persistence. Static labels only; no commands, paths, tool
+    /// args, or approval details. Reset at every user turn and actor-loop
+    /// entry, consumed by eval logging and focused controller tests.
+    controller_policy_ledger: crate::agent::loop_run::controller_policy::ControllerPolicyLedger,
     /// Issue #652: in-flight artifact-completion job (role-specific retry
     /// budget, sanitized attempt history, wrong-target / no-tool / prose-only
     /// / role-policy-violation taxonomy). Reset at every
@@ -2685,6 +2694,7 @@ impl Agent {
             evidence_set_this_turn: completion_evidence::EvidenceSet::new(),
             task_contract_evidence_set_this_turn: completion_evidence::EvidenceSet::new(),
             current_artifact_recovery_target: None,
+            controller_policy_ledger: controller_policy::ControllerPolicyLedger::default(),
             artifact_completion_job: None,
             artifact_completion_exhausted_this_turn: false,
             artifact_completion_failed_diagnostic_emitted_this_turn: false,

--- a/src/agent/loop_run/actor_loop_flow.rs
+++ b/src/agent/loop_run/actor_loop_flow.rs
@@ -54,6 +54,7 @@ use crate::tools::registry::resolve_plan_mode_write_target;
 
 use super::Agent;
 use super::active_job_arbiter::{LoopControlAction, RecoveryDispatchGate, RecoveryOwner};
+use super::controller_policy::ControllerRecoveryStrategy;
 use super::interrupt::{InterruptFlag, InterruptMonitor};
 use super::lifecycle;
 use super::path_helpers::normalize_exploration_path;
@@ -503,6 +504,9 @@ pub(super) fn maybe_handle_repo_change_quality_gate_recovery(
         &target_path,
     ) {
         Ok(true) => {
+            agent
+                .controller_policy_ledger
+                .record(ControllerRecoveryStrategy::DeterministicFallback);
             super::turn_helpers::write_stdout_rendered(
                 &format_iteration_status(
                     args.last_iter,
@@ -533,6 +537,9 @@ pub(super) fn maybe_handle_repo_change_quality_gate_recovery(
         }
     }
     *args.repo_change_retries += 1;
+    agent
+        .controller_policy_ledger
+        .record(ControllerRecoveryStrategy::TargetedArtifactRetry);
     if *args.repo_change_retries >= 3 {
         return Some(PostReplyRecoveryOutcome::Finalize {
             final_prose: String::new(),
@@ -578,6 +585,9 @@ pub(super) fn maybe_handle_repo_change_partial_progress_recovery(
         return None;
     }
     *args.repo_change_retries += 1;
+    agent
+        .controller_policy_ledger
+        .record(ControllerRecoveryStrategy::ToolFirstRetry);
     if *args.repo_change_retries >= 3 {
         return Some(PostReplyRecoveryOutcome::Finalize {
             final_prose: String::new(),
@@ -616,6 +626,9 @@ pub(super) fn maybe_handle_python_test_artifact_recovery(
         return None;
     }
     *args.python_test_retries += 1;
+    agent
+        .controller_policy_ledger
+        .record(ControllerRecoveryStrategy::TargetedArtifactRetry);
     if *args.python_test_retries >= 2 {
         let (final_prose, exit_reason, error_text) =
             match super::scaffold_pipeline::maybe_materialize_python_test_fallback(agent) {
@@ -670,6 +683,9 @@ pub(super) fn maybe_handle_missing_repo_edit_recovery(
         return Some(outcome);
     }
     *args.repo_change_retries += 1;
+    agent
+        .controller_policy_ledger
+        .record(ControllerRecoveryStrategy::ToolFirstRetry);
     if *args.repo_change_retries >= 3 {
         return Some(finalize_missing_repo_edit_retry_exhausted(agent));
     }
@@ -700,6 +716,9 @@ pub(super) fn maybe_continue_missing_repo_framework_fallback(
         return false;
     }
     *args.framework_app_fallback_materialized = true;
+    agent
+        .controller_policy_ledger
+        .record(ControllerRecoveryStrategy::DeterministicFallback);
     super::message_push::push_system_note(
         agent,
         framework_app_fallback_continuation_note().to_string(),
@@ -718,11 +737,17 @@ pub(super) fn maybe_continue_missing_repo_scaffold_fallback(
     ) {
         super::scaffold_pipeline::ScaffoldFallbackResult::Applied => {
             *args.repo_change_retries = 0;
+            agent
+                .controller_policy_ledger
+                .record(ControllerRecoveryStrategy::DeterministicFallback);
             Some(PostReplyRecoveryOutcome::Continue)
         }
         super::scaffold_pipeline::ScaffoldFallbackResult::Failed
         | super::scaffold_pipeline::ScaffoldFallbackResult::Skipped => {
             *args.repo_change_retries += 1;
+            agent
+                .controller_policy_ledger
+                .record(ControllerRecoveryStrategy::ToolFirstRetry);
             if *args.repo_change_retries >= 3 {
                 return Some(missing_repo_edits_finalize_outcome());
             }
@@ -738,6 +763,9 @@ pub(super) fn maybe_continue_missing_repo_scaffold_fallback(
 
 pub(super) fn push_missing_repo_edit_retry_note(agent: &mut Agent, attempt: usize) {
     if let Some(target) = super::recovery_targets::focused_edit_recovery_target(agent) {
+        agent
+            .controller_policy_ledger
+            .record(ControllerRecoveryStrategy::TargetedArtifactRetry);
         let target_already_read =
             focused_edit_target_already_read(&agent.session.messages, &target, &agent.work_root);
         let note = super::recovery_messages::focused_edit_no_tool_note_for_target(
@@ -751,6 +779,10 @@ pub(super) fn push_missing_repo_edit_retry_note(agent: &mut Agent, attempt: usiz
     }
     if !super::artifact_completion_record::push_artifact_directed_recovery_note(agent, attempt) {
         super::message_push::push_system_note(agent, recovery::repo_change_recovery_note(attempt));
+    } else {
+        agent
+            .controller_policy_ledger
+            .record(ControllerRecoveryStrategy::TargetedArtifactRetry);
     }
 }
 
@@ -1047,6 +1079,9 @@ fn handle_generic_prose_only_retry(
     no_tool_retries: &mut usize,
 ) -> ActorLoopNoToolReplyOutcome {
     *no_tool_retries += 1;
+    agent
+        .controller_policy_ledger
+        .record(ControllerRecoveryStrategy::ToolFirstRetry);
     if *no_tool_retries >= 3 {
         agent
             .session
@@ -1127,6 +1162,9 @@ fn handle_empty_missing_repo_change_retry(
     agent: &mut Agent,
     repo_change_retries: usize,
 ) -> ActorLoopNoToolReplyOutcome {
+    agent
+        .controller_policy_ledger
+        .record(ControllerRecoveryStrategy::ToolFirstRetry);
     if !super::artifact_completion_record::push_artifact_directed_recovery_note(
         agent,
         repo_change_retries,
@@ -1138,6 +1176,10 @@ fn handle_empty_missing_repo_change_retry(
             agent,
             recovery::repo_change_recovery_note(repo_change_retries),
         );
+    } else {
+        agent
+            .controller_policy_ledger
+            .record(ControllerRecoveryStrategy::TargetedArtifactRetry);
     }
     if super::artifact_completion_record::record_artifact_completion_attempt(
         agent,
@@ -1153,7 +1195,13 @@ fn handle_prose_only_missing_repo_change_retry(
     agent: &mut Agent,
     repo_change_retries: usize,
 ) -> ActorLoopNoToolReplyOutcome {
+    agent
+        .controller_policy_ledger
+        .record(ControllerRecoveryStrategy::ToolFirstRetry);
     if let Some(target) = super::recovery_targets::focused_edit_recovery_target(agent) {
+        agent
+            .controller_policy_ledger
+            .record(ControllerRecoveryStrategy::TargetedArtifactRetry);
         let target_already_read =
             focused_edit_target_already_read(&agent.session.messages, &target, &agent.work_root);
         let note = super::recovery_messages::focused_edit_no_tool_note_for_target(
@@ -1174,6 +1222,10 @@ fn handle_prose_only_missing_repo_change_retry(
             agent,
             recovery::repo_change_no_tool_recovery_note(repo_change_retries),
         );
+    } else {
+        agent
+            .controller_policy_ledger
+            .record(ControllerRecoveryStrategy::TargetedArtifactRetry);
     }
     if super::artifact_completion_record::record_artifact_completion_attempt(
         agent,
@@ -1222,6 +1274,9 @@ fn handle_actor_loop_missing_repo_change_retry_exhausted(
             };
         }
     };
+    agent
+        .controller_policy_ledger
+        .record(ControllerRecoveryStrategy::DeterministicFallback);
     if let Some(relative) = fallback {
         return ActorLoopNoToolReplyOutcome::Done {
             final_prose: format!(
@@ -1236,6 +1291,9 @@ fn handle_actor_loop_missing_repo_change_retry_exhausted(
         )
     {
         *args.framework_app_fallback_materialized = true;
+        agent
+            .controller_policy_ledger
+            .record(ControllerRecoveryStrategy::DeterministicFallback);
         super::message_push::push_system_note(
             agent,
             framework_app_fallback_continuation_note().to_string(),
@@ -1407,6 +1465,16 @@ pub(super) fn handle_actor_loop_completion(
             );
             return ActorLoopCompletionOutcome::Continue;
         }
+    }
+    if matches!(
+        super::controller_policy::prose_only_terminal_decision(
+            args.task_contract_action,
+            &agent.controller_policy_ledger,
+        ),
+        super::controller_policy::ProseOnlyTerminalDecision::BlockForRecovery
+    ) {
+        push_controller_persistence_retry_note(agent, args.last_iter);
+        return ActorLoopCompletionOutcome::Continue;
     }
     if let Some((reason, error_text)) =
         task_contract_action_completion_exit(args.task_contract_action)
@@ -2204,6 +2272,9 @@ pub(super) fn handle_actor_loop_task_contract_continue_action(
         Some(args.action),
         args.current_reply_tool_call_count,
     ) {
+        agent
+            .controller_policy_ledger
+            .record(ControllerRecoveryStrategy::ToolFirstRetry);
         return handle_actor_loop_task_contract_tool_recovery(
             agent,
             ActorLoopTaskContractToolRecoveryArgs {
@@ -2226,6 +2297,9 @@ pub(super) fn handle_actor_loop_task_contract_continue_action(
         )
     {
         *args.contract_deterministic_fallback_materialized = true;
+        agent
+            .controller_policy_ledger
+            .record(ControllerRecoveryStrategy::DeterministicFallback);
         super::set_artifact_recovery_target::set_artifact_recovery_target_for_decision(
             agent,
             &decision,
@@ -2254,6 +2328,9 @@ pub(super) fn handle_actor_loop_task_contract_tool_recovery(
     args: ActorLoopTaskContractToolRecoveryArgs<'_, '_>,
 ) -> ActorLoopTaskContractReplyOutcome {
     *args.contract_completion_retries = (*args.contract_completion_retries).saturating_add(1);
+    agent
+        .controller_policy_ledger
+        .record(ControllerRecoveryStrategy::ToolFirstRetry);
     let role = args
         .missing
         .first()
@@ -2269,6 +2346,10 @@ pub(super) fn handle_actor_loop_task_contract_tool_recovery(
         kind,
         Vec::new(),
     ) {
+        if !agent.controller_policy_ledger.persistent_failure_allowed() {
+            push_controller_persistence_retry_note(agent, args.last_iter);
+            return ActorLoopTaskContractReplyOutcome::Continue;
+        }
         return ActorLoopTaskContractReplyOutcome::Exit {
             reason: ExitReason::MissingRepoEdits,
             error_text: ARTIFACT_COMPLETION_BUDGET_EXHAUSTED_TEXT.to_string(),
@@ -2276,8 +2357,15 @@ pub(super) fn handle_actor_loop_task_contract_tool_recovery(
     }
     let artifact_attempt =
         increment_artifact_completion_role_attempt(args.contract_completion_role_retries, role);
+    agent
+        .controller_policy_ledger
+        .record(ControllerRecoveryStrategy::TargetedArtifactRetry);
     let attempt_limit = args.contract.artifact_completion_attempt_limit();
     if artifact_attempt >= attempt_limit {
+        if !agent.controller_policy_ledger.persistent_failure_allowed() {
+            push_controller_persistence_retry_note(agent, args.last_iter);
+            return ActorLoopTaskContractReplyOutcome::Continue;
+        }
         let expected_target = args
             .target_hint
             .as_ref()
@@ -2325,6 +2413,10 @@ pub(super) fn handle_actor_loop_task_contract_tool_recovery(
             args.target_hint.as_ref(),
         );
         super::message_push::push_system_note(agent, note);
+    } else {
+        agent
+            .controller_policy_ledger
+            .record(ControllerRecoveryStrategy::TargetedArtifactRetry);
     }
     ActorLoopTaskContractReplyOutcome::Continue
 }
@@ -2334,6 +2426,9 @@ pub(super) fn handle_actor_loop_task_contract_incomplete_artifacts(
     args: ActorLoopTaskContractIncompleteArgs<'_, '_>,
 ) -> ActorLoopTaskContractReplyOutcome {
     *args.contract_completion_retries += 1;
+    agent
+        .controller_policy_ledger
+        .record(ControllerRecoveryStrategy::TargetedArtifactRetry);
     let missing_labels = args
         .missing
         .iter()
@@ -2348,6 +2443,10 @@ pub(super) fn handle_actor_loop_task_contract_incomplete_artifacts(
         increment_artifact_completion_role_attempt(args.contract_completion_role_retries, role);
     let attempt_limit = args.contract.artifact_completion_attempt_limit();
     if artifact_attempt >= attempt_limit {
+        if !agent.controller_policy_ledger.persistent_failure_allowed() {
+            push_controller_persistence_retry_note(agent, args.last_iter);
+            return ActorLoopTaskContractReplyOutcome::Continue;
+        }
         let expected_target = args
             .target_hint
             .as_ref()
@@ -2412,10 +2511,17 @@ pub(super) fn handle_actor_loop_task_contract_repair_artifact(
     verifier_repair_retries: &mut usize,
 ) -> ActorLoopTaskContractReplyOutcome {
     agent.repair_job_artifact_attempts = agent.repair_job_artifact_attempts.saturating_add(1);
+    agent
+        .controller_policy_ledger
+        .record(ControllerRecoveryStrategy::VerifierRepairEdit);
     *verifier_repair_retries = agent.repair_job_artifact_attempts;
     if agent.repair_job_artifact_attempts
         >= super::turn_constants::TASK_CONTRACT_VERIFIER_ATTEMPT_LIMIT
     {
+        if !agent.controller_policy_ledger.persistent_failure_allowed() {
+            push_controller_persistence_retry_note(agent, last_iter);
+            return ActorLoopTaskContractReplyOutcome::Continue;
+        }
         let role = agent
             .current_artifact_recovery_target
             .as_ref()
@@ -2473,6 +2579,9 @@ pub(super) fn handle_actor_loop_task_contract_run_verifier(
     agent: &mut Agent,
     args: ActorLoopTaskContractReplyArgs<'_, '_>,
 ) -> ActorLoopTaskContractReplyOutcome {
+    agent
+        .controller_policy_ledger
+        .record(ControllerRecoveryStrategy::EvidenceAction);
     match super::verifier_orchestration::drive_task_contract_verifier(
         agent,
         super::verifier_orchestration::TaskContractVerifierFlowArgs {
@@ -2523,10 +2632,32 @@ pub(super) fn handle_actor_loop_task_contract_safe_stop(
     }
 }
 
+fn push_controller_persistence_retry_note(agent: &mut Agent, last_iter: usize) {
+    let strategy = agent.controller_policy_ledger.record_next_for_prose_block();
+    let strategy_count = agent.controller_policy_ledger.distinct_strategy_count();
+    super::turn_helpers::write_stdout_rendered(
+        &format_iteration_status(
+            last_iter,
+            agent.config.max_iterations,
+            "Recovery required",
+            "Persistent recoverable failure needs another distinct local strategy before reporting failure.",
+            agent.footer.current_cols(),
+        ),
+        true,
+    );
+    super::message_push::push_system_note(
+        agent,
+        super::controller_policy::prose_block_recovery_note(strategy, strategy_count),
+    );
+}
+
 pub(super) fn handle_actor_loop_rejected_tool_batch(
     agent: &mut Agent,
     args: ActorLoopRejectedToolBatchArgs<'_, '_>,
 ) -> ActorLoopToolPreparationOutcome {
+    agent
+        .controller_policy_ledger
+        .record(ControllerRecoveryStrategy::ToolPolicyRetry);
     let focused_retry = args.effective_tool_policy.focused_edit_policy().cloned();
     let artifact_retry = args
         .effective_tool_policy
@@ -2605,6 +2736,9 @@ pub(super) fn maybe_handle_rejected_tool_batch_missing_verifier(
     if !missing_verifier_setup_turn {
         return None;
     }
+    agent
+        .controller_policy_ledger
+        .record(ControllerRecoveryStrategy::MissingVerifierSetup);
     if super::agent_misc::record_missing_verifier_setup_failure(
         agent,
         last_iter,
@@ -2630,6 +2764,9 @@ pub(super) fn maybe_handle_rejected_tool_batch_artifact(
     if !artifact_retry_present {
         return None;
     }
+    agent
+        .controller_policy_ledger
+        .record(ControllerRecoveryStrategy::TargetedArtifactRetry);
     let role = agent
         .current_artifact_recovery_target
         .as_ref()
@@ -2640,6 +2777,10 @@ pub(super) fn maybe_handle_rejected_tool_batch_artifact(
         super::artifact_completion_job::ArtifactAttemptOutcomeKind::RolePolicyViolation,
         vec!["focused_edit_batch_reject".to_string()],
     ) {
+        if !agent.controller_policy_ledger.persistent_failure_allowed() {
+            push_controller_persistence_retry_note(agent, last_iter);
+            return Some(ActorLoopToolPreparationOutcome::Continue);
+        }
         return Some(ActorLoopToolPreparationOutcome::Exit {
             reason: ExitReason::MissingRepoEdits,
             error_text: format!(
@@ -2655,6 +2796,10 @@ pub(super) fn maybe_handle_rejected_tool_batch_artifact(
         .map(|contract| contract.artifact_completion_attempt_limit())
         .unwrap_or(4);
     if artifact_attempt >= attempt_limit {
+        if !agent.controller_policy_ledger.persistent_failure_allowed() {
+            push_controller_persistence_retry_note(agent, last_iter);
+            return Some(ActorLoopToolPreparationOutcome::Continue);
+        }
         let expected_target = agent
             .current_artifact_recovery_target
             .as_ref()
@@ -2727,6 +2872,9 @@ pub(super) fn maybe_handle_rejected_tool_batch_focused_retry_exhausted(
             });
         }
     };
+    agent
+        .controller_policy_ledger
+        .record(ControllerRecoveryStrategy::DeterministicFallback);
     if let Some(relative) = fallback {
         return Some(ActorLoopToolPreparationOutcome::Done {
             final_prose: format!(
@@ -3612,6 +3760,9 @@ pub(super) fn run_actor_loop(
 
         let final_reply = reply_content.trim().to_string();
         if missing_verifier_setup_turn {
+            agent
+                .controller_policy_ledger
+                .record(ControllerRecoveryStrategy::MissingVerifierSetup);
             if super::agent_misc::record_missing_verifier_setup_failure(
                 agent,
                 last_iter,
@@ -4055,6 +4206,8 @@ pub(super) fn run_actor_loop(
             exit_reason.label(),
             last_failure_signature.as_deref(),
         );
+        record.recovery_strategy_count = agent.controller_policy_ledger.distinct_strategy_count();
+        record.recovery_strategies = agent.controller_policy_ledger.strategy_labels();
         record.pam_eval = agent
             .last_pam_decision_this_turn
             .as_ref()

--- a/src/agent/loop_run/controller_policy.rs
+++ b/src/agent/loop_run/controller_policy.rs
@@ -1,0 +1,219 @@
+//! Issue #950: controller policy for delegated local-LLM persistence.
+//!
+//! The policy is intentionally small and local-first. It records only static
+//! strategy labels selected by the controller, never raw commands, paths, tool
+//! arguments, verifier output, or approval decisions.
+
+use super::task_contract::ArtifactRecoveryAction;
+
+pub(super) const MIN_DISTINCT_RECOVERY_STRATEGIES: usize = 3;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ControllerRecoveryStrategy {
+    ToolFirstRetry,
+    TargetedArtifactRetry,
+    DeterministicFallback,
+    EvidenceAction,
+    VerifierRepairEdit,
+    MissingVerifierSetup,
+    ToolPolicyRetry,
+}
+
+impl ControllerRecoveryStrategy {
+    pub(super) fn label(self) -> &'static str {
+        match self {
+            Self::ToolFirstRetry => "tool_first_retry",
+            Self::TargetedArtifactRetry => "targeted_artifact_retry",
+            Self::DeterministicFallback => "deterministic_fallback",
+            Self::EvidenceAction => "evidence_action",
+            Self::VerifierRepairEdit => "verifier_repair_edit",
+            Self::MissingVerifierSetup => "missing_verifier_setup",
+            Self::ToolPolicyRetry => "tool_policy_retry",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(super) struct ControllerPolicyLedger {
+    strategies: Vec<ControllerRecoveryStrategy>,
+}
+
+impl ControllerPolicyLedger {
+    pub(super) fn clear(&mut self) {
+        self.strategies.clear();
+    }
+
+    pub(super) fn record(&mut self, strategy: ControllerRecoveryStrategy) {
+        if !self.strategies.contains(&strategy) {
+            self.strategies.push(strategy);
+        }
+    }
+
+    pub(super) fn distinct_strategy_count(&self) -> usize {
+        self.strategies.len()
+    }
+
+    pub(super) fn strategy_labels(&self) -> Vec<String> {
+        self.strategies
+            .iter()
+            .map(|strategy| strategy.label().to_string())
+            .collect()
+    }
+
+    fn first_untried(&self) -> Option<ControllerRecoveryStrategy> {
+        [
+            ControllerRecoveryStrategy::ToolFirstRetry,
+            ControllerRecoveryStrategy::TargetedArtifactRetry,
+            ControllerRecoveryStrategy::EvidenceAction,
+            ControllerRecoveryStrategy::VerifierRepairEdit,
+            ControllerRecoveryStrategy::DeterministicFallback,
+        ]
+        .into_iter()
+        .find(|strategy| !self.strategies.contains(strategy))
+    }
+
+    pub(super) fn record_next_for_prose_block(&mut self) -> ControllerRecoveryStrategy {
+        let strategy = self
+            .first_untried()
+            .unwrap_or(ControllerRecoveryStrategy::ToolFirstRetry);
+        self.record(strategy);
+        strategy
+    }
+
+    pub(super) fn persistent_failure_allowed(&self) -> bool {
+        self.distinct_strategy_count() >= MIN_DISTINCT_RECOVERY_STRATEGIES
+    }
+}
+
+pub(super) fn recoverable_action_available(action: Option<&ArtifactRecoveryAction>) -> bool {
+    matches!(
+        action,
+        Some(
+            ArtifactRecoveryAction::Continue { .. }
+                | ArtifactRecoveryAction::RunVerifier
+                | ArtifactRecoveryAction::RepairArtifact { .. }
+        )
+    )
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ProseOnlyTerminalDecision {
+    BlockForRecovery,
+    AllowTerminalReport,
+    BoundaryStop,
+}
+
+pub(super) fn prose_only_terminal_decision(
+    action: Option<&ArtifactRecoveryAction>,
+    ledger: &ControllerPolicyLedger,
+) -> ProseOnlyTerminalDecision {
+    if matches!(action, Some(ArtifactRecoveryAction::SafeStop { .. })) {
+        return ProseOnlyTerminalDecision::BoundaryStop;
+    }
+    if recoverable_action_available(action) && !ledger.persistent_failure_allowed() {
+        return ProseOnlyTerminalDecision::BlockForRecovery;
+    }
+    ProseOnlyTerminalDecision::AllowTerminalReport
+}
+
+#[cfg(test)]
+pub(super) fn safe_boundary_action(action: Option<&ArtifactRecoveryAction>) -> bool {
+    matches!(action, Some(ArtifactRecoveryAction::SafeStop { .. }))
+}
+
+pub(super) fn prose_block_recovery_note(
+    strategy: ControllerRecoveryStrategy,
+    strategy_count: usize,
+) -> String {
+    let strategy_label = strategy.label();
+    format!(
+        "[Controller Persistence Policy] A recoverable action is still available, so do not finish with assistant prose only. Emit exactly one valid local tool action or continue the active recovery job now. Preserve approval, permission, secret, destructive-action, and external-state boundaries; if one of those boundaries blocks continuation, report that boundary explicitly. controller_recovery_strategy={strategy_label} controller_recovery_strategy_count={strategy_count}/{MIN_DISTINCT_RECOVERY_STRATEGIES}"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::task_contract::{ArtifactRole, RecoveryTargetHint, SafeStopReason};
+    use super::*;
+
+    #[test]
+    fn recoverable_actions_are_distinct_from_safe_boundaries() {
+        let continue_action = ArtifactRecoveryAction::Continue {
+            missing: vec![ArtifactRole::Implementation],
+            target_hint: Some(RecoveryTargetHint {
+                role: ArtifactRole::Implementation,
+                path: "src/lib.rs".to_string(),
+                reason: "test target".to_string(),
+            }),
+        };
+        assert!(recoverable_action_available(Some(&continue_action)));
+        assert!(!safe_boundary_action(Some(&continue_action)));
+
+        let safe_stop = ArtifactRecoveryAction::SafeStop {
+            reason: SafeStopReason::VerifierMissing,
+        };
+        assert!(!recoverable_action_available(Some(&safe_stop)));
+        assert!(safe_boundary_action(Some(&safe_stop)));
+    }
+
+    #[test]
+    fn three_distinct_strategies_are_required_before_persistent_failure() {
+        let mut ledger = ControllerPolicyLedger::default();
+        ledger.record(ControllerRecoveryStrategy::ToolFirstRetry);
+        ledger.record(ControllerRecoveryStrategy::ToolFirstRetry);
+        assert_eq!(ledger.distinct_strategy_count(), 1);
+        assert!(!ledger.persistent_failure_allowed());
+
+        ledger.record(ControllerRecoveryStrategy::TargetedArtifactRetry);
+        assert_eq!(ledger.distinct_strategy_count(), 2);
+        assert!(!ledger.persistent_failure_allowed());
+
+        ledger.record(ControllerRecoveryStrategy::EvidenceAction);
+        assert_eq!(ledger.distinct_strategy_count(), 3);
+        assert!(ledger.persistent_failure_allowed());
+    }
+
+    #[test]
+    fn recoverable_prose_only_terminal_is_blocked_until_three_strategies() {
+        let action = ArtifactRecoveryAction::RepairArtifact { target_hint: None };
+        let mut ledger = ControllerPolicyLedger::default();
+
+        assert_eq!(
+            prose_only_terminal_decision(Some(&action), &ledger),
+            ProseOnlyTerminalDecision::BlockForRecovery
+        );
+
+        ledger.record(ControllerRecoveryStrategy::ToolFirstRetry);
+        ledger.record(ControllerRecoveryStrategy::TargetedArtifactRetry);
+        assert_eq!(
+            prose_only_terminal_decision(Some(&action), &ledger),
+            ProseOnlyTerminalDecision::BlockForRecovery
+        );
+
+        ledger.record(ControllerRecoveryStrategy::EvidenceAction);
+        assert_eq!(
+            prose_only_terminal_decision(Some(&action), &ledger),
+            ProseOnlyTerminalDecision::AllowTerminalReport
+        );
+    }
+
+    #[test]
+    fn safe_boundary_terminal_is_not_converted_into_recovery() {
+        let action = ArtifactRecoveryAction::SafeStop {
+            reason: SafeStopReason::VerifierWeak,
+        };
+        let ledger = ControllerPolicyLedger::default();
+        assert_eq!(
+            prose_only_terminal_decision(Some(&action), &ledger),
+            ProseOnlyTerminalDecision::BoundaryStop
+        );
+    }
+
+    #[test]
+    fn prose_block_recovery_note_exposes_strategy_count_without_paths_or_commands() {
+        let note = prose_block_recovery_note(ControllerRecoveryStrategy::EvidenceAction, 2);
+        assert!(note.contains("controller_recovery_strategy=evidence_action"));
+        assert!(note.contains("controller_recovery_strategy_count=2/3"));
+        assert!(note.contains("Preserve approval"));
+    }
+}

--- a/src/agent/loop_run/handle_user_message.rs
+++ b/src/agent/loop_run/handle_user_message.rs
@@ -103,6 +103,10 @@ pub(super) fn handle_user_message(
     // it gives a within-turn single-emit guarantee that does NOT bleed
     // across turn boundaries.
     agent.artifact_completion_failed_diagnostic_emitted_this_turn = false;
+    // Issue #950: turn-local delegated-persistence strategy ledger. Reset
+    // beside artifact completion / active-job state so recovery attempts never
+    // bleed across independent user turns.
+    agent.controller_policy_ledger.clear();
     // Issue #456: AnvilScore compute happens once per turn, post-loop.
     // The flag flips after the compute so the post-loop Reminder hook
     // sees `CurrentTurn` while the iteration-internal hook sees

--- a/src/agent/loop_run/prepare_actor_loop_state.rs
+++ b/src/agent/loop_run/prepare_actor_loop_state.rs
@@ -94,6 +94,10 @@ pub(super) fn prepare_actor_loop_turn_state(agent: &mut Agent) -> Option<TaskCon
     // current turn never observes a previous turn's edits.
     agent.task_contract_excerpts.clear();
     agent.current_artifact_recovery_target = None;
+    // Issue #950: the strategy ledger is actor-loop-local. Reset here as a
+    // defensive mirror for tests or future entry points that call the actor
+    // loop without passing through `handle_user_message`.
+    agent.controller_policy_ledger.clear();
     // Issue #652: per-turn reset of the artifact completion job state
     // (DR3-003 / per-turn cap pattern). A job is only reconstructed
     // through `set_artifact_recovery_target_from_hint`, so dropping it

--- a/src/session/eval_log.rs
+++ b/src/session/eval_log.rs
@@ -82,6 +82,13 @@ pub struct EvalRecord {
     /// intentionally unchanged.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub terminal_diagnostics: Option<TerminalDiagnosticsSummary>,
+    /// Issue #950: distinct controller recovery strategies attempted during
+    /// delegated local-LLM persistence. Labels are static controller-owned
+    /// strings, never raw commands, paths, tool args, or approval details.
+    #[serde(default, skip_serializing_if = "is_zero_usize")]
+    pub recovery_strategy_count: usize,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub recovery_strategies: Vec<String>,
     /// Issue #904: machine-readable evaluation taxonomy for no-PAM/PAM
     /// aggregation. External postcheck agreement is intentionally explicit:
     /// the in-process turn log cannot know the harness result unless a future
@@ -363,6 +370,10 @@ impl EvalRecord {
     }
 }
 
+fn is_zero_usize(value: &usize) -> bool {
+    *value == 0
+}
+
 // ---------------------------------------------------------------------------
 // OnceLock state
 // ---------------------------------------------------------------------------
@@ -557,6 +568,8 @@ pub fn build_eval_record_with_terminal_context(
         photon_canary: 0,
         auto_promote,
         terminal_diagnostics,
+        recovery_strategy_count: 0,
+        recovery_strategies: Vec::new(),
         evaluation_taxonomy,
         completion_reason,
         final_outcome: final_outcome.to_string(),
@@ -1082,6 +1095,8 @@ mod tests {
                 },
                 1,
             )),
+            recovery_strategy_count: 0,
+            recovery_strategies: Vec::new(),
             evaluation_taxonomy: build_evaluation_taxonomy(
                 "fix the bug",
                 "done",

--- a/tests/eval_log_smoke.rs
+++ b/tests/eval_log_smoke.rs
@@ -185,6 +185,40 @@ fn r1c_pam_eval_summary_serializes_unused_reason() {
     assert_eq!(json["pam_eval"]["completion_judgement_override"], false);
 }
 
+#[test]
+fn issue950_recovery_strategy_fields_serialize_when_present() {
+    let mut rec = build_eval_record(
+        "sess-950",
+        1_700_000_000_003,
+        "recover from a local test failure",
+        "qwen3:14b",
+        "Act",
+        "native",
+        &[],
+        None,
+        &[],
+        None,
+        make_classes(),
+        &[],
+        None,
+        None,
+        None,
+        "missing_evidence",
+    );
+    rec.recovery_strategy_count = 3;
+    rec.recovery_strategies = vec![
+        "tool_first_retry".to_string(),
+        "targeted_artifact_retry".to_string(),
+        "evidence_action".to_string(),
+    ];
+
+    let json = serde_json::to_value(&rec).unwrap();
+    assert_eq!(json["recovery_strategy_count"], 3);
+    assert_eq!(json["recovery_strategies"][0], "tool_first_retry");
+    assert_eq!(json["recovery_strategies"][1], "targeted_artifact_retry");
+    assert_eq!(json["recovery_strategies"][2], "evidence_action");
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // R2: task secret is masked
 // ─────────────────────────────────────────────────────────────────────────────
@@ -460,6 +494,8 @@ fn r9_oversized_record_is_dropped() {
             },
             0,
         )),
+        recovery_strategy_count: 0,
+        recovery_strategies: vec![],
         evaluation_taxonomy: EvaluationTaxonomySummary {
             pam_variant: "unknown".to_string(),
             task_kind: "coding".to_string(),


### PR DESCRIPTION
## Summary
- Add a controller policy ledger for delegated local-LLM persistence with static recovery strategy labels.
- Block prose-only terminal reporting while a recoverable action is available until three distinct local recovery strategies have been attempted.
- Record strategy count/labels in eval logs without capturing commands, paths, tool args, approval details, or secrets.

## Verification
- `cargo fmt --check`
- `cargo test controller_policy`
- `cargo test issue950_recovery_strategy_fields_serialize_when_present`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`

Closes #950