### PR TITLE
Route missing evidence to TestAuthorWorker (#962)

### DIFF
--- a/src/agent/loop_run/active_job_arbiter.rs
+++ b/src/agent/loop_run/active_job_arbiter.rs
@@ -27,7 +27,7 @@
 //!   `redact_verifier_command_for_storage` before logging (never `Debug`).
 
 use std::num::NonZeroU32;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use super::artifact_completion_job::{AllowedReadScope, AllowedWriteActions};
 use super::repair_job::{RepairNextAction, StopReason, VerifierBootstrapNextAction};
@@ -39,6 +39,7 @@ use super::task_contract::{
     VerifierPrerequisiteSignal, has_required_setup_artifact,
 };
 use super::tool_policy::EffectiveToolPolicy;
+use super::worker_contract::TestAuthorWorkerRequest;
 use crate::logging::stable_path_hash;
 use crate::modes::plan_act::ExecutionMode;
 use crate::session::feedback::mask_secrets;
@@ -324,8 +325,12 @@ pub(super) enum DesiredAction {
         #[allow(dead_code)]
         target_hint: Option<RecoveryTargetHint>,
     },
-    /// Create the missing verifier file (no diagnostic command yet).
-    MissingVerifierCreate,
+    /// Create missing evidence for the current task. For coding tasks this may
+    /// carry a bounded TestAuthorWorker request; legacy missing-verifier setup
+    /// keeps `None` for back-compat projections.
+    MissingVerifierCreate {
+        worker_request: Option<TestAuthorWorkerRequest>,
+    },
     /// Focused-edit recovery: model should Read (if not yet) and Edit/Write
     /// the named target.
     FocusedEdit {
@@ -361,7 +366,7 @@ impl DesiredAction {
     pub(super) fn label(&self) -> &'static str {
         match self {
             DesiredAction::VerifierRepair { .. } => "verifier_repair",
-            DesiredAction::MissingVerifierCreate => "missing_verifier_create",
+            DesiredAction::MissingVerifierCreate { .. } => "missing_verifier_create",
             DesiredAction::FocusedEdit { .. } => "focused_edit",
             DesiredAction::ArtifactDirected { .. } => "artifact_directed",
             DesiredAction::SetupBash => "setup_bash",
@@ -369,18 +374,19 @@ impl DesiredAction {
     }
 
     /// Optional workspace-relative target path. `None` for action variants
-    /// with no path semantic (`VerifierRepair` / `MissingVerifierCreate` /
-    /// `SetupBash`). Consumed by the Phase C `agent.active_job.selected`
+    /// with no path semantic (`VerifierRepair` / `SetupBash`). Consumed by the
+    /// Phase C `agent.active_job.selected`
     /// payload builder to derive `target_path_hash` via
     /// `stable_path_hash(mask_secrets(...))`. The raw path MUST NOT be
     /// logged — callers route through the redaction pipeline.
-    pub(super) fn target_path(&self) -> Option<&PathBuf> {
+    pub(super) fn target_path(&self) -> Option<&Path> {
         match self {
-            DesiredAction::VerifierRepair { .. }
-            | DesiredAction::MissingVerifierCreate
-            | DesiredAction::SetupBash => None,
-            DesiredAction::FocusedEdit { target, .. } => Some(target),
-            DesiredAction::ArtifactDirected { target, .. } => Some(target),
+            DesiredAction::VerifierRepair { .. } | DesiredAction::SetupBash => None,
+            DesiredAction::MissingVerifierCreate { worker_request } => worker_request
+                .as_ref()
+                .map(|request| request.target_test_path()),
+            DesiredAction::FocusedEdit { target, .. } => Some(target.as_path()),
+            DesiredAction::ArtifactDirected { target, .. } => Some(target.as_path()),
         }
     }
 }
@@ -468,7 +474,7 @@ pub(super) struct JobCandidate {
 impl JobCandidate {
     pub(super) fn recovery_job_kind(&self) -> RecoveryJobKind {
         match &self.desired_action {
-            DesiredAction::MissingVerifierCreate => RecoveryJobKind::MissingEvidenceJob,
+            DesiredAction::MissingVerifierCreate { .. } => RecoveryJobKind::MissingEvidenceJob,
             DesiredAction::SetupBash => RecoveryJobKind::ToolFailureJob,
             _ => self.kind.default_recovery_job_kind(),
         }
@@ -1194,7 +1200,9 @@ mod tests {
 
         let missing_verifier = JobCandidate {
             kind: ActiveJobKind::VerifierRepair,
-            desired_action: DesiredAction::MissingVerifierCreate,
+            desired_action: DesiredAction::MissingVerifierCreate {
+                worker_request: None,
+            },
             policy: EffectiveToolPolicy::restricted(
                 EffectiveToolPolicyReason::VerifierRepair,
                 vec!["Read", "Edit"],
@@ -1223,7 +1231,9 @@ mod tests {
             target_hint: None,
         };
         assert_eq!(a.label(), "verifier_repair");
-        let b = DesiredAction::MissingVerifierCreate;
+        let b = DesiredAction::MissingVerifierCreate {
+            worker_request: None,
+        };
         assert_eq!(b.label(), "missing_verifier_create");
         let c = DesiredAction::FocusedEdit {
             target: PathBuf::from("x"),
@@ -1258,7 +1268,9 @@ mod tests {
     fn missing_verifier_create_variant_constructs_and_labels() {
         let c = JobCandidate {
             kind: ActiveJobKind::VerifierRepair,
-            desired_action: DesiredAction::MissingVerifierCreate,
+            desired_action: DesiredAction::MissingVerifierCreate {
+                worker_request: None,
+            },
             policy: EffectiveToolPolicy::restricted(
                 EffectiveToolPolicyReason::VerifierRepair,
                 vec!["Write"],

--- a/src/agent/loop_run/effective_tool_policy_flow.rs
+++ b/src/agent/loop_run/effective_tool_policy_flow.rs
@@ -195,9 +195,10 @@ fn priority_one_arbiter_candidates(agent: &Agent) -> Option<Vec<JobCandidate>> {
                 super::repair_job::VerifierBootstrapNextAction::RequestSetupEdit
             ) && let Some(job) = agent.missing_verifier_job.as_ref()
             {
+                let worker_request = test_author_worker_request_for_missing_evidence(agent);
                 return Some(vec![JobCandidate {
                     kind: ActiveJobKind::VerifierRepair,
-                    desired_action: DesiredAction::MissingVerifierCreate,
+                    desired_action: DesiredAction::MissingVerifierCreate { worker_request },
                     policy: EffectiveToolPolicy::restricted(
                         EffectiveToolPolicyReason::VerifierRepair,
                         job.allowed_tool_names().to_vec(),
@@ -209,6 +210,24 @@ fn priority_one_arbiter_candidates(agent: &Agent) -> Option<Vec<JobCandidate>> {
         }
         LoopControlAction::RunVerifier | LoopControlAction::RequestModelTurn => None,
     }
+}
+
+fn test_author_worker_request_for_missing_evidence(
+    agent: &Agent,
+) -> Option<super::worker_contract::TestAuthorWorkerRequest> {
+    let contract = super::task_classification::task_contract_authority(agent)?;
+    let active_request = super::workspace_access::active_request_text(agent).unwrap_or_default();
+    let implementation_context = agent
+        .task_contract_excerpts
+        .get(&super::task_contract::ArtifactRole::Implementation)
+        .map(String::as_str);
+    super::worker_contract::test_author_worker_request_for_missing_evidence(
+        contract.as_ref(),
+        super::verifier_orchestration::synthesized_missing_test_target_path_for_request(
+            &active_request,
+        ),
+        implementation_context,
+    )
 }
 
 fn push_focused_edit_candidate(

--- a/src/agent/loop_run/recovery_messages.rs
+++ b/src/agent/loop_run/recovery_messages.rs
@@ -202,12 +202,31 @@ pub(super) fn verifier_repair_policy_message(
                 super::repair_job::RepairNextAction::RerunVerifier
                 | super::repair_job::RepairNextAction::VerifiedDone,
             ) => verifier_repair_transition_message(),
-            None if agent.missing_verifier_job.is_some() => verifier_setup_policy_message(
-                &super::workspace_access::active_request_text(agent).unwrap_or_default(),
-            ),
+            None if agent.missing_verifier_job.is_some() => {
+                let active_request =
+                    super::workspace_access::active_request_text(agent).unwrap_or_default();
+                test_author_worker_policy_message(agent, &active_request)
+                    .unwrap_or_else(|| verifier_setup_policy_message(&active_request))
+            }
             None => verifier_repair_transition_message(),
         }
     })
+}
+
+fn test_author_worker_policy_message(agent: &Agent, active_request: &str) -> Option<String> {
+    let contract = super::task_classification::task_contract_authority(agent)?;
+    let implementation_context = agent
+        .task_contract_excerpts
+        .get(&super::task_contract::ArtifactRole::Implementation)
+        .map(String::as_str);
+    super::worker_contract::test_author_worker_request_for_missing_evidence(
+        contract.as_ref(),
+        super::verifier_orchestration::synthesized_missing_test_target_path_for_request(
+            active_request,
+        ),
+        implementation_context,
+    )
+    .map(|request| request.policy_message())
 }
 
 fn verifier_repair_diagnostic_policy_message(agent: &Agent) -> String {

--- a/src/agent/loop_run/verifier_orchestration.rs
+++ b/src/agent/loop_run/verifier_orchestration.rs
@@ -264,11 +264,14 @@ pub(super) fn verifier_framework_signal_for_context(context: &RepairJob) -> Stri
 }
 
 pub(super) fn verifier_setup_policy_message(active_request: &str) -> String {
-    let hint = missing_verifier_setup_hint_for_request(active_request)
+    let setup_hint = missing_verifier_setup_hint_for_request(active_request)
+        .map(|hint| format!(" {hint}"))
+        .unwrap_or_default();
+    let author_hint = missing_evidence_test_author_hint_for_request(active_request)
         .map(|hint| format!(" {hint}"))
         .unwrap_or_default();
     format!(
-        "[Verifier Setup Policy] A runnable verifier is required but missing. Emit exactly one Write or Edit for project-local verifier metadata now.{hint} Do not call Bash, do not switch tasks, and do not answer in prose."
+        "[Verifier Setup Policy] A runnable verifier is required but missing. MissingEvidenceJob selected TestAuthorWorker for coding evidence authoring. Emit exactly one Write or Edit for project-local verifier metadata or the owned test artifact now.{author_hint}{setup_hint} Do not call Bash, do not switch tasks, and do not answer in prose."
     )
 }
 
@@ -1394,11 +1397,14 @@ pub(super) fn task_contract_no_verifier_note(
     attempt_limit: usize,
     active_request: &str,
 ) -> String {
-    let hint = missing_verifier_setup_hint_for_request(active_request)
+    let setup_hint = missing_verifier_setup_hint_for_request(active_request)
+        .map(|hint| format!(" {hint}"))
+        .unwrap_or_default();
+    let author_hint = missing_evidence_test_author_hint_for_request(active_request)
         .map(|hint| format!(" {hint}"))
         .unwrap_or_default();
     format!(
-        "[Task Contract Verification] Required artifacts are present, but no runnable verifier was detected for this workspace. Emit exactly one Write or Edit now for project-local verifier metadata, then Anvil will rerun verification.{hint} Do not call Bash, do not switch tasks, and do not answer in prose. task_contract_verify_attempt={attempt}/{attempt_limit}"
+        "[Task Contract Verification] Required artifacts are present, but no runnable verifier evidence was detected for this workspace. MissingEvidenceJob selected TestAuthorWorker for coding evidence authoring. Emit exactly one Write or Edit now for project-local verifier metadata or the owned test artifact, then Anvil will rerun verification.{author_hint}{setup_hint} Do not call Bash, do not switch tasks, and do not answer in prose. task_contract_verify_attempt={attempt}/{attempt_limit}"
     )
 }
 
@@ -2165,6 +2171,15 @@ pub(super) fn missing_verifier_setup_hint_for_request(request: &str) -> Option<&
         return Some("For Node/npm workspaces, create or update package.json with a test script.");
     }
     None
+}
+
+fn missing_evidence_test_author_hint_for_request(request: &str) -> Option<String> {
+    let (target_path, stack_label) = synthesized_missing_test_target_path_for_request(request)?;
+    let evidence_command =
+        super::worker_contract::test_author_evidence_command_for_stack(stack_label, target_path);
+    Some(format!(
+        "TestAuthorWorker target `{target_path}`; required evidence command `{evidence_command}`."
+    ))
 }
 
 pub(super) fn apply_verifier_repair_pass_edit(

--- a/src/agent/loop_run/worker_contract.rs
+++ b/src/agent/loop_run/worker_contract.rs
@@ -7,6 +7,8 @@
 
 #![allow(dead_code)] // Foundation seam; focused tests pin the shape before broad callers are wired.
 
+use std::path::{Path, PathBuf};
+
 use super::task_contract::{
     ObjectiveDeliverableKind, ObjectiveEvidenceKind, TaskContract, TaskKind,
 };
@@ -211,6 +213,104 @@ impl WorkerContract {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct TestAuthorWorkerRequest {
+    pub(super) worker_contract: WorkerContract,
+    target_test_path: PathBuf,
+    allowed_write_scope: Vec<PathBuf>,
+    evidence_command: String,
+    output_contract: &'static str,
+}
+
+impl TestAuthorWorkerRequest {
+    pub(super) fn target_test_path(&self) -> &Path {
+        &self.target_test_path
+    }
+
+    pub(super) fn allowed_write_scope(&self) -> &[PathBuf] {
+        &self.allowed_write_scope
+    }
+
+    pub(super) fn evidence_command(&self) -> &str {
+        &self.evidence_command
+    }
+
+    pub(super) fn output_contract(&self) -> &'static str {
+        self.output_contract
+    }
+
+    pub(super) fn policy_message(&self) -> String {
+        let target = self.target_test_path.to_string_lossy();
+        format!(
+            "[TestAuthorWorker] MissingEvidenceJob owns this turn. Create or update `{target}` only, using exactly one Write or Edit tool call. The required evidence command is `{}`. Output runnable tests; do not answer in prose, do not call Bash, and do not change unrelated files.",
+            self.evidence_command
+        )
+    }
+}
+
+pub(super) fn test_author_worker_request_for_missing_evidence(
+    contract: &TaskContract,
+    target_and_stack: Option<(&str, &str)>,
+    implementation_context: Option<&str>,
+) -> Option<TestAuthorWorkerRequest> {
+    let objective = contract.objective_contract();
+    if objective.task_kind != TaskKind::Coding
+        || objective.deliverable_kind != ObjectiveDeliverableKind::SourceFiles
+        || objective.evidence_kind != ObjectiveEvidenceKind::TestRun
+    {
+        return None;
+    }
+    let (target_test_path, stack_label) = target_and_stack?;
+    let target_test_path = PathBuf::from(target_test_path);
+    let evidence_command =
+        test_author_evidence_command_for_stack(stack_label, &target_test_path.to_string_lossy());
+    let mut context_pack =
+        WorkerContract::from_task_contract(contract, WorkerKind::TestAuthor).context_pack;
+    context_pack.push(ContextPackEntry::new(
+        ContextPackKind::Target,
+        "target_test_path",
+        target_test_path.to_string_lossy(),
+    ));
+    context_pack.push(ContextPackEntry::new(
+        ContextPackKind::Target,
+        "allowed_write_scope",
+        target_test_path.to_string_lossy(),
+    ));
+    context_pack.push(ContextPackEntry::new(
+        ContextPackKind::Evidence,
+        "evidence_command",
+        evidence_command.as_str(),
+    ));
+    context_pack.push(ContextPackEntry::new(
+        ContextPackKind::Target,
+        "implementation_context",
+        implementation_context.unwrap_or(
+            "implementation excerpt unavailable; infer public behavior from the active request and project files",
+        ),
+    ));
+    Some(TestAuthorWorkerRequest {
+        worker_contract: WorkerContract::from_task_contract(contract, WorkerKind::TestAuthor)
+            .with_context_pack(context_pack),
+        target_test_path: target_test_path.clone(),
+        allowed_write_scope: vec![target_test_path],
+        evidence_command,
+        output_contract: "exactly_one_write_or_edit_tool_call_creating_or_updating_the_owned_test_artifact",
+    })
+}
+
+pub(super) fn test_author_evidence_command_for_stack(
+    stack_label: &str,
+    target_test_path: &str,
+) -> String {
+    match stack_label {
+        "rust" => "cargo test".to_string(),
+        "python" => format!("pytest {target_test_path}"),
+        "javascript" => format!("node --test {target_test_path}"),
+        "typescript" => "npm test".to_string(),
+        _ => "npm test".to_string(),
+    }
+}
+
 fn truncate_utf8(value: String, max_bytes: usize) -> (String, bool) {
     if value.len() <= max_bytes {
         return (value, false);
@@ -347,5 +447,96 @@ mod tests {
             MAX_CONTEXT_PACK_ENTRIES / 2
         );
         assert!(pack.approximate_token_count() > 0);
+    }
+
+    #[test]
+    fn test_author_worker_request_uses_coding_objective_and_bounded_context() {
+        let contract = TaskContract::from_request(
+            "Create a Rust library crate and verify it with cargo test.",
+        );
+        let request = test_author_worker_request_for_missing_evidence(
+            &contract,
+            Some(("tests/lib.rs", "rust")),
+            Some("pub fn slugify(input: &str) -> String"),
+        )
+        .expect("coding request should create test author request");
+
+        assert_eq!(request.worker_contract.worker_kind, WorkerKind::TestAuthor);
+        assert_eq!(request.worker_contract.task_kind, TaskKind::Coding);
+        assert_eq!(
+            request.worker_contract.deliverable_kind,
+            ObjectiveDeliverableKind::SourceFiles
+        );
+        assert_eq!(
+            request.worker_contract.evidence_kind,
+            ObjectiveEvidenceKind::TestRun
+        );
+        assert_eq!(request.target_test_path(), Path::new("tests/lib.rs"));
+        assert_eq!(
+            request.allowed_write_scope(),
+            &[PathBuf::from("tests/lib.rs")]
+        );
+        assert_eq!(request.evidence_command(), "cargo test");
+        assert!(request.policy_message().contains("TestAuthorWorker"));
+        assert!(
+            request
+                .worker_contract
+                .context_pack
+                .entries_for_kind(ContextPackKind::Target)
+                .len()
+                >= 3
+        );
+    }
+
+    #[test]
+    fn test_author_worker_request_covers_rust_node_and_python_target_synthesis() {
+        let cases = [
+            (
+                "Create a Rust library and verify behavior with cargo test.",
+                "tests/lib.rs",
+                "cargo test",
+            ),
+            (
+                "Build a Node JSON formatter CLI and add npm test coverage.",
+                "tests/main.test.js",
+                "node --test tests/main.test.js",
+            ),
+            (
+                "Create a Python sales CLI and verify it with pytest.",
+                "tests/test_main.py",
+                "pytest tests/test_main.py",
+            ),
+        ];
+
+        for (active_request, expected_target, expected_command) in cases {
+            let contract = TaskContract::from_request(active_request);
+            let target_and_stack =
+                super::super::verifier_orchestration::synthesized_missing_test_target_path_for_request(
+                    active_request,
+                );
+            let request =
+                test_author_worker_request_for_missing_evidence(&contract, target_and_stack, None)
+                    .expect(active_request);
+
+            assert_eq!(request.target_test_path(), Path::new(expected_target));
+            assert_eq!(request.evidence_command(), expected_command);
+            assert_eq!(
+                request.output_contract(),
+                "exactly_one_write_or_edit_tool_call_creating_or_updating_the_owned_test_artifact"
+            );
+        }
+    }
+
+    #[test]
+    fn test_author_worker_request_keeps_non_coding_tasks_out_of_coding_verifier_vocabulary() {
+        let docs =
+            TaskContract::from_request("Write README.md with install and rollback sections.");
+        let request = test_author_worker_request_for_missing_evidence(
+            &docs,
+            Some(("tests/main.test.js", "javascript")),
+            None,
+        );
+
+        assert!(request.is_none());
     }
 }


### PR DESCRIPTION
Closes #962

## Summary
- Add `TestAuthorWorkerRequest` on top of the existing `WorkerContract` foundation.
- Route `MissingVerifierCreate` / `MissingEvidenceJob` candidate projection to carry an optional TestAuthorWorker request for coding tasks.
- Include synthesized test target, allowed write scope, evidence command, and bounded context pack entries.
- Update missing-verifier policy/system notes to explicitly direct TestAuthorWorker evidence authoring while keeping the existing Write/Edit-only safety boundary.

## Changed Files
- `src/agent/loop_run/worker_contract.rs`
- `src/agent/loop_run/active_job_arbiter.rs`
- `src/agent/loop_run/effective_tool_policy_flow.rs`
- `src/agent/loop_run/recovery_messages.rs`
- `src/agent/loop_run/verifier_orchestration.rs`

## Tests Run
- `cargo test worker_contract --lib -q`
- `cargo test desired_action_labels_are_stable --lib -q`
- `cargo test missing_verifier_create_variant_constructs_and_labels --lib -q`
- `cargo test active_job_candidates_project_generic_recovery_jobs --lib -q`
- `cargo test missing_verifier_note_for_rust_requires_single_cargo_metadata_edit --lib -q`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --lib -q` (passed with escalation because localhost mock servers cannot bind inside the sandbox)
- `cargo test` (passed with escalation for the same localhost-binding reason)

## Known Risks
- This wires the request and prompt/control projection; it does not add a separate provider or autonomous worker process.
- Non-coding tasks intentionally return no TestAuthorWorker request and remain available for the #965 capability lifecycle.
- `dev-reports/issue-962/*` were kept local because repo hygiene rejects transient artifacts in PRs.

## Orchestration
- Parent: #960
- Depends on merged #961
- Run ID: `20260605-024707-orchestrate`