### PR TITLE
Route evidence failures to DiagnosticRepairWorker

### DIFF
--- a/src/agent/loop_run/active_job_arbiter.rs
+++ b/src/agent/loop_run/active_job_arbiter.rs
@@ -39,7 +39,7 @@ use super::task_contract::{
     VerifierPrerequisiteSignal, has_required_setup_artifact,
 };
 use super::tool_policy::EffectiveToolPolicy;
-use super::worker_contract::TestAuthorWorkerRequest;
+use super::worker_contract::{DiagnosticRepairWorkerRequest, TestAuthorWorkerRequest};
 use crate::logging::stable_path_hash;
 use crate::modes::plan_act::ExecutionMode;
 use crate::session::feedback::mask_secrets;
@@ -324,6 +324,8 @@ pub(super) enum DesiredAction {
         command: String,
         #[allow(dead_code)]
         target_hint: Option<RecoveryTargetHint>,
+        #[allow(dead_code)]
+        worker_request: Option<DiagnosticRepairWorkerRequest>,
     },
     /// Create missing evidence for the current task. For coding tasks this may
     /// carry a bounded TestAuthorWorker request; legacy missing-verifier setup
@@ -836,6 +838,7 @@ mod tests {
                 DesiredAction::VerifierRepair {
                     command: "cargo test".to_string(),
                     target_hint: None,
+                    worker_request: None,
                 },
             ),
             ActiveJobKind::ForcedSmallEditRecovery => (
@@ -1229,6 +1232,7 @@ mod tests {
         let a = DesiredAction::VerifierRepair {
             command: "cargo test".to_string(),
             target_hint: None,
+            worker_request: None,
         };
         assert_eq!(a.label(), "verifier_repair");
         let b = DesiredAction::MissingVerifierCreate {

--- a/src/agent/loop_run/effective_tool_policy_flow.rs
+++ b/src/agent/loop_run/effective_tool_policy_flow.rs
@@ -183,7 +183,11 @@ fn priority_one_arbiter_candidates(agent: &Agent) -> Option<Vec<JobCandidate>> {
                 kind: ActiveJobKind::VerifierRepair,
                 desired_action: DesiredAction::VerifierRepair {
                     command: String::new(),
-                    target_hint,
+                    target_hint: target_hint.clone(),
+                    worker_request: diagnostic_repair_worker_request_for_evidence_failed(
+                        agent,
+                        target_hint.as_ref(),
+                    ),
                 },
                 policy: verifier_repair_policy_for_next_action(agent, &next_action),
                 budget: Budget::Unbounded,
@@ -228,6 +232,45 @@ fn test_author_worker_request_for_missing_evidence(
         ),
         implementation_context,
     )
+}
+
+fn diagnostic_repair_worker_request_for_evidence_failed(
+    agent: &Agent,
+    next_action_target_hint: Option<&super::task_contract::RecoveryTargetHint>,
+) -> Option<super::worker_contract::DiagnosticRepairWorkerRequest> {
+    let contract = super::task_classification::task_contract_authority(agent)?;
+    let job = agent.repair_job.as_ref()?;
+    let target_hint = next_action_target_hint
+        .or(job.repair_target_hint.as_ref())
+        .or(job.target_hint.as_ref())?;
+    let allowed_change_kind = job
+        .correction_job
+        .as_ref()
+        .map(|correction| correction.kind.as_str())
+        .unwrap_or("bounded_target_repair");
+    let diagnostic = diagnostic_repair_diagnostic_for_job(job);
+    Some(
+        super::worker_contract::diagnostic_repair_worker_request_for_evidence_failed(
+            contract.as_ref(),
+            &diagnostic,
+            target_hint,
+            allowed_change_kind,
+            Some(job.command.as_str()),
+        ),
+    )
+}
+
+fn diagnostic_repair_diagnostic_for_job(job: &super::repair_job::RepairJob) -> String {
+    let error_kind = job
+        .error_kind
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or(job.failure_signature.as_str());
+    if job.output_excerpt.trim().is_empty() {
+        error_kind.to_string()
+    } else {
+        format!("{error_kind}\n{}", job.output_excerpt)
+    }
 }
 
 fn push_focused_edit_candidate(

--- a/src/agent/loop_run/progress_tests.rs
+++ b/src/agent/loop_run/progress_tests.rs
@@ -6495,6 +6495,9 @@ E   assert [{'id': 1}] == []\n";
             "def main():\n    return 1\n",
         )
         .unwrap();
+        agent.session.messages.push(ConversationMessage::user(
+            "Create a Python CLI and verify it with pytest.".to_string(),
+        ));
         agent.task_contract_verifier_repair_pending = true;
         agent.repair_job = Some(verifier_context_for("app/main.py"));
 
@@ -6506,17 +6509,34 @@ E   assert [{'id': 1}] == []\n";
             super::super::active_job_arbiter::ActiveJobKind::VerifierRepair
         );
         assert_eq!(
+            selected.recovery_job_kind(),
+            super::super::active_job_arbiter::RecoveryJobKind::EvidenceFailedJob
+        );
+        assert_eq!(
             selected.policy.allowed_tool_names_for_prompt().unwrap(),
             ["Read"]
         );
         match selected.desired_action {
             super::super::active_job_arbiter::DesiredAction::VerifierRepair {
-                target_hint, ..
+                target_hint,
+                worker_request,
+                ..
             } => {
                 assert_eq!(
                     target_hint.map(|hint| hint.path),
                     Some("app/main.py".to_string())
                 );
+                let worker_request = worker_request
+                    .expect("evidence failure should route to DiagnosticRepairWorker");
+                assert_eq!(
+                    worker_request.failure_kind(),
+                    super::super::worker_contract::EvidenceFailureKind::SignatureMismatch
+                );
+                assert_eq!(
+                    worker_request.target_role(),
+                    super::super::worker_contract::DiagnosticRepairTargetRole::Implementation
+                );
+                assert_eq!(worker_request.evidence_command(), "python3 -m pytest");
             }
             other => panic!("unexpected desired action: {other:?}"),
         }

--- a/src/agent/loop_run/recovery_messages.rs
+++ b/src/agent/loop_run/recovery_messages.rs
@@ -258,12 +258,72 @@ fn verifier_repair_request_patch_message(
     let target_display = verifier_repair_target_display(&target, &agent.work_root);
     let already_read =
         focused_edit_target_already_read(&agent.session.messages, &target, &agent.work_root);
+    if let Some(message) =
+        diagnostic_repair_worker_policy_message(agent, target_hint, target.is_file(), already_read)
+    {
+        return message;
+    }
     verifier_repair_request_patch_message_body(
         &target_display,
         diagnostics,
         target.is_file(),
         already_read,
     )
+}
+
+fn diagnostic_repair_worker_policy_message(
+    agent: &Agent,
+    target_hint: &super::task_contract::RecoveryTargetHint,
+    target_is_file: bool,
+    target_already_read: bool,
+) -> Option<String> {
+    let contract = super::task_classification::task_contract_authority(agent)?;
+    let job = agent.repair_job.as_ref()?;
+    let allowed_change_kind = job
+        .correction_job
+        .as_ref()
+        .map(|correction| correction.kind.as_str())
+        .unwrap_or("bounded_target_repair");
+    let diagnostic = diagnostic_repair_diagnostic_for_job(job);
+    let request = super::worker_contract::diagnostic_repair_worker_request_for_evidence_failed(
+        contract.as_ref(),
+        &diagnostic,
+        target_hint,
+        allowed_change_kind,
+        Some(job.command.as_str()),
+    );
+    Some(
+        request.policy_message(diagnostic_repair_next_required_action(
+            target_is_file,
+            target_already_read,
+        )),
+    )
+}
+
+fn diagnostic_repair_diagnostic_for_job(job: &super::repair_job::RepairJob) -> String {
+    let error_kind = job
+        .error_kind
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or(job.failure_signature.as_str());
+    if job.output_excerpt.trim().is_empty() {
+        error_kind.to_string()
+    } else {
+        format!("{error_kind}\n{}", job.output_excerpt)
+    }
+}
+
+fn diagnostic_repair_next_required_action(
+    target_is_file: bool,
+    target_already_read: bool,
+) -> &'static str {
+    if !target_is_file {
+        "exactly one Write on the declared target"
+    } else if target_already_read {
+        "exactly one compact Edit on the declared target"
+    } else {
+        "exactly one Read on the declared target; the next turn will request the bounded Edit"
+    }
 }
 
 /// Issue #931 (Choke B): pure render-point helper for the verifier-repair

--- a/src/agent/loop_run/turn_tests.rs
+++ b/src/agent/loop_run/turn_tests.rs
@@ -2875,6 +2875,7 @@ mod tests {
             desired_action: DesiredAction::VerifierRepair {
                 command: "cargo test -- --token=AKIAIOSFODNN7EXAMPLE".to_string(),
                 target_hint: None,
+                worker_request: None,
             },
             policy,
             budget: Budget::Unbounded,

--- a/src/agent/loop_run/worker_contract.rs
+++ b/src/agent/loop_run/worker_contract.rs
@@ -10,7 +10,8 @@
 use std::path::{Path, PathBuf};
 
 use super::task_contract::{
-    ObjectiveDeliverableKind, ObjectiveEvidenceKind, TaskContract, TaskKind,
+    ArtifactRole, ObjectiveDeliverableKind, ObjectiveEvidenceKind, RecoveryTargetHint,
+    TaskContract, TaskKind,
 };
 
 pub(super) const MAX_CONTEXT_PACK_ENTRIES: usize = 8;
@@ -222,6 +223,132 @@ pub(super) struct TestAuthorWorkerRequest {
     output_contract: &'static str,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum EvidenceFailureKind {
+    CompileError,
+    ImportNameMismatch,
+    SignatureMismatch,
+    AssertionMismatch,
+    SetupManifestMissing,
+    SchemaMismatch,
+    ContentSectionMissing,
+    SourceEvidenceMissing,
+    Unknown,
+}
+
+impl EvidenceFailureKind {
+    pub(super) fn label(self) -> &'static str {
+        match self {
+            EvidenceFailureKind::CompileError => "compile_error",
+            EvidenceFailureKind::ImportNameMismatch => "import_name_mismatch",
+            EvidenceFailureKind::SignatureMismatch => "signature_mismatch",
+            EvidenceFailureKind::AssertionMismatch => "assertion_mismatch",
+            EvidenceFailureKind::SetupManifestMissing => "setup_manifest_missing",
+            EvidenceFailureKind::SchemaMismatch => "schema_mismatch",
+            EvidenceFailureKind::ContentSectionMissing => "content_section_missing",
+            EvidenceFailureKind::SourceEvidenceMissing => "source_evidence_missing",
+            EvidenceFailureKind::Unknown => "unknown",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum DiagnosticRepairTargetRole {
+    Implementation,
+    TestArtifact,
+    Manifest,
+    Docs,
+    Data,
+    ResearchEvidence,
+    OpsProcedure,
+    Unknown,
+}
+
+impl DiagnosticRepairTargetRole {
+    pub(super) fn label(self) -> &'static str {
+        match self {
+            DiagnosticRepairTargetRole::Implementation => "implementation",
+            DiagnosticRepairTargetRole::TestArtifact => "test_artifact",
+            DiagnosticRepairTargetRole::Manifest => "manifest",
+            DiagnosticRepairTargetRole::Docs => "docs",
+            DiagnosticRepairTargetRole::Data => "data",
+            DiagnosticRepairTargetRole::ResearchEvidence => "research_evidence",
+            DiagnosticRepairTargetRole::OpsProcedure => "ops_procedure",
+            DiagnosticRepairTargetRole::Unknown => "unknown",
+        }
+    }
+
+    fn from_artifact_role(role: ArtifactRole, task_kind: TaskKind) -> Self {
+        match role {
+            ArtifactRole::Implementation => DiagnosticRepairTargetRole::Implementation,
+            ArtifactRole::Test => DiagnosticRepairTargetRole::TestArtifact,
+            ArtifactRole::Setup => DiagnosticRepairTargetRole::Manifest,
+            ArtifactRole::UsageDocs => match task_kind {
+                TaskKind::Research => DiagnosticRepairTargetRole::ResearchEvidence,
+                TaskKind::Ops => DiagnosticRepairTargetRole::OpsProcedure,
+                _ => DiagnosticRepairTargetRole::Docs,
+            },
+            ArtifactRole::DataOutput => DiagnosticRepairTargetRole::Data,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct DiagnosticRepairWorkerRequest {
+    pub(super) worker_contract: WorkerContract,
+    failure_kind: EvidenceFailureKind,
+    target_role: DiagnosticRepairTargetRole,
+    target_path: PathBuf,
+    allowed_change_kind: String,
+    evidence_command: String,
+    diagnostic: String,
+    output_contract: &'static str,
+}
+
+impl DiagnosticRepairWorkerRequest {
+    pub(super) fn failure_kind(&self) -> EvidenceFailureKind {
+        self.failure_kind
+    }
+
+    pub(super) fn target_role(&self) -> DiagnosticRepairTargetRole {
+        self.target_role
+    }
+
+    pub(super) fn target_path(&self) -> &Path {
+        &self.target_path
+    }
+
+    pub(super) fn allowed_change_kind(&self) -> &str {
+        &self.allowed_change_kind
+    }
+
+    pub(super) fn evidence_command(&self) -> &str {
+        &self.evidence_command
+    }
+
+    pub(super) fn diagnostic(&self) -> &str {
+        &self.diagnostic
+    }
+
+    pub(super) fn output_contract(&self) -> &'static str {
+        self.output_contract
+    }
+
+    pub(super) fn policy_message(&self, next_required_action: &str) -> String {
+        let target =
+            super::task_contract::mask_and_cap_recovery_field(&self.target_path.to_string_lossy());
+        let diagnostic = super::task_contract::mask_and_cap_recovery_field(&self.diagnostic);
+        let evidence_command =
+            super::task_contract::mask_and_cap_recovery_field(&self.evidence_command);
+        format!(
+            "[DiagnosticRepairWorker] EvidenceFailedJob owns this turn. failure_kind={failure_kind}; target_role={target_role}; target={target}; allowed_change_kind={allowed_change_kind}; evidence_command={evidence_command}. Diagnostic: {diagnostic}. Next required action: {next_required_action}. Keep the change bounded to that target and failure. Do not switch files, run verification, or finish with prose.",
+            failure_kind = self.failure_kind.label(),
+            target_role = self.target_role.label(),
+            allowed_change_kind = self.allowed_change_kind,
+        )
+    }
+}
+
 impl TestAuthorWorkerRequest {
     pub(super) fn target_test_path(&self) -> &Path {
         &self.target_test_path
@@ -309,6 +436,209 @@ pub(super) fn test_author_evidence_command_for_stack(
         "typescript" => "npm test".to_string(),
         _ => "npm test".to_string(),
     }
+}
+
+pub(super) fn diagnostic_repair_worker_request_for_evidence_failed(
+    contract: &TaskContract,
+    diagnostic: &str,
+    target_hint: &RecoveryTargetHint,
+    allowed_change_kind: &str,
+    evidence_command: Option<&str>,
+) -> DiagnosticRepairWorkerRequest {
+    let objective = contract.objective_contract();
+    let failure_kind = classify_evidence_failure_kind(diagnostic);
+    let target_role =
+        DiagnosticRepairTargetRole::from_artifact_role(target_hint.role, objective.task_kind);
+    let target_path = PathBuf::from(target_hint.path.as_str());
+    let evidence_command = evidence_command
+        .filter(|command| !command.trim().is_empty())
+        .unwrap_or("rerun configured evidence command")
+        .to_string();
+    let allowed_change_kind = if allowed_change_kind.trim().is_empty() {
+        default_allowed_change_kind_for_target_role(target_role)
+    } else {
+        allowed_change_kind.trim().to_string()
+    };
+    let mut context_pack =
+        WorkerContract::from_task_contract(contract, WorkerKind::DiagnosticRepair).context_pack;
+    context_pack.push(ContextPackEntry::new(
+        ContextPackKind::Target,
+        "target_role",
+        target_role.label(),
+    ));
+    context_pack.push(ContextPackEntry::new(
+        ContextPackKind::Target,
+        "target_path",
+        target_path.to_string_lossy(),
+    ));
+    context_pack.push(ContextPackEntry::new(
+        ContextPackKind::Repair,
+        "allowed_change_kind",
+        allowed_change_kind.as_str(),
+    ));
+    context_pack.push(ContextPackEntry::new(
+        ContextPackKind::Evidence,
+        "evidence_command",
+        evidence_command.as_str(),
+    ));
+    context_pack.push(ContextPackEntry::new(
+        ContextPackKind::Diagnostic,
+        "diagnostic",
+        format!("failure_kind={}; {diagnostic}", failure_kind.label()),
+    ));
+    DiagnosticRepairWorkerRequest {
+        worker_contract: WorkerContract::from_task_contract(contract, WorkerKind::DiagnosticRepair)
+            .with_context_pack(context_pack),
+        failure_kind,
+        target_role,
+        target_path,
+        allowed_change_kind,
+        evidence_command,
+        diagnostic: diagnostic.to_string(),
+        output_contract: "single_bounded_repair_tool_action_for_the_declared_target_and_failure",
+    }
+}
+
+pub(super) fn classify_evidence_failure_kind(diagnostic: &str) -> EvidenceFailureKind {
+    let normalized = diagnostic.to_ascii_lowercase();
+    if contains_any(
+        &normalized,
+        &[
+            "cargo.toml",
+            "package.json",
+            "pyproject.toml",
+            "requirements.txt",
+            "module not found",
+            "no such file or directory",
+            "could not find manifest",
+            "could not find `cargo.toml`",
+            "missing manifest",
+        ],
+    ) {
+        return EvidenceFailureKind::SetupManifestMissing;
+    }
+    if contains_any(
+        &normalized,
+        &[
+            "importerror",
+            "modulenotfounderror",
+            "cannot find module",
+            "does not provide an export",
+            "has no exported member",
+            "unresolved import",
+            "unresolved imports",
+            "cannot import name",
+            "no named exports",
+            "not exported",
+        ],
+    ) {
+        return EvidenceFailureKind::ImportNameMismatch;
+    }
+    if contains_any(
+        &normalized,
+        &[
+            "wrong number of arguments",
+            "takes 0 positional arguments",
+            "takes 1 argument",
+            "expected function",
+            "mismatched types",
+            "expected signature",
+            "signature mismatch",
+            "typeerror:",
+            "typeerror",
+        ],
+    ) {
+        return EvidenceFailureKind::SignatureMismatch;
+    }
+    if contains_any(
+        &normalized,
+        &[
+            "assertionerror",
+            "assertion failed",
+            "assert_eq!",
+            "assert_ne!",
+            "expected:",
+            "actual:",
+            "left:",
+            "right:",
+            "snapshot mismatch",
+            "test failed",
+        ],
+    ) {
+        return EvidenceFailureKind::AssertionMismatch;
+    }
+    if contains_any(
+        &normalized,
+        &[
+            "schema",
+            "jsonschema",
+            "csv",
+            "missing column",
+            "unexpected column",
+            "invalid field",
+            "invalid record",
+        ],
+    ) {
+        return EvidenceFailureKind::SchemaMismatch;
+    }
+    if contains_any(
+        &normalized,
+        &[
+            "missing heading",
+            "required heading",
+            "missing section",
+            "required section",
+            "content check failed",
+        ],
+    ) {
+        return EvidenceFailureKind::ContentSectionMissing;
+    }
+    if contains_any(
+        &normalized,
+        &[
+            "source fetch",
+            "citation",
+            "reference not found",
+            "missing source",
+            "source evidence",
+        ],
+    ) {
+        return EvidenceFailureKind::SourceEvidenceMissing;
+    }
+    if contains_any(
+        &normalized,
+        &[
+            "error[e",
+            "failed to compile",
+            "compilation failed",
+            "syntaxerror",
+            "tsc",
+            "cannot find symbol",
+            "expected one of",
+            "unterminated",
+            "parse error",
+        ],
+    ) {
+        return EvidenceFailureKind::CompileError;
+    }
+    EvidenceFailureKind::Unknown
+}
+
+fn default_allowed_change_kind_for_target_role(role: DiagnosticRepairTargetRole) -> String {
+    match role {
+        DiagnosticRepairTargetRole::Implementation => "implementation".to_string(),
+        DiagnosticRepairTargetRole::TestArtifact => "test".to_string(),
+        DiagnosticRepairTargetRole::Manifest => "manifest".to_string(),
+        DiagnosticRepairTargetRole::Docs => "docs".to_string(),
+        DiagnosticRepairTargetRole::Data => "data_schema".to_string(),
+        DiagnosticRepairTargetRole::ResearchEvidence => "research_evidence".to_string(),
+        DiagnosticRepairTargetRole::OpsProcedure => "ops_procedure".to_string(),
+        DiagnosticRepairTargetRole::Unknown => "bounded_target_repair".to_string(),
+    }
+}
+
+fn contains_any(haystack: &str, needles: &[&str]) -> bool {
+    needles.iter().any(|needle| haystack.contains(needle))
 }
 
 fn truncate_utf8(value: String, max_bytes: usize) -> (String, bool) {
@@ -538,5 +868,185 @@ mod tests {
         );
 
         assert!(request.is_none());
+    }
+
+    #[test]
+    fn evidence_failure_classifier_covers_coding_and_non_coding_runner_failures() {
+        let cases = [
+            (
+                "error[E0425]: cannot find function `slugify` in this scope",
+                EvidenceFailureKind::CompileError,
+            ),
+            (
+                "ImportError: cannot import name 'slugify' from 'app'",
+                EvidenceFailureKind::ImportNameMismatch,
+            ),
+            (
+                "SyntaxError: The requested module './main.js' does not provide an export named 'formatJson'",
+                EvidenceFailureKind::ImportNameMismatch,
+            ),
+            (
+                "TypeError: slugify() takes 1 argument but 2 were given",
+                EvidenceFailureKind::SignatureMismatch,
+            ),
+            (
+                "AssertionError: expected: clean-slug actual: clean_slug",
+                EvidenceFailureKind::AssertionMismatch,
+            ),
+            (
+                "CSV schema check failed: missing column total",
+                EvidenceFailureKind::SchemaMismatch,
+            ),
+            (
+                "Content check failed: missing section Rollback",
+                EvidenceFailureKind::ContentSectionMissing,
+            ),
+            (
+                "Source evidence missing: citation reference not found",
+                EvidenceFailureKind::SourceEvidenceMissing,
+            ),
+            (
+                "could not find `Cargo.toml` in `/tmp/project`",
+                EvidenceFailureKind::SetupManifestMissing,
+            ),
+        ];
+
+        for (diagnostic, expected) in cases {
+            assert_eq!(
+                classify_evidence_failure_kind(diagnostic),
+                expected,
+                "{diagnostic}"
+            );
+        }
+    }
+
+    #[test]
+    fn diagnostic_repair_worker_request_focuses_rust_compile_failure_on_impl_target() {
+        let contract = TaskContract::from_request(
+            "Create a Rust slugify library and verify it with cargo test.",
+        );
+        let target_hint = RecoveryTargetHint {
+            role: ArtifactRole::Implementation,
+            path: "src/lib.rs".to_string(),
+            reason: "compiler points at missing public function".to_string(),
+        };
+        let request = diagnostic_repair_worker_request_for_evidence_failed(
+            &contract,
+            "error[E0425]: cannot find function `slugify` in this scope",
+            &target_hint,
+            "implementation",
+            Some("cargo test"),
+        );
+
+        assert_eq!(
+            request.worker_contract.worker_kind,
+            WorkerKind::DiagnosticRepair
+        );
+        assert_eq!(request.failure_kind(), EvidenceFailureKind::CompileError);
+        assert_eq!(
+            request.target_role(),
+            DiagnosticRepairTargetRole::Implementation
+        );
+        assert_eq!(request.target_path(), Path::new("src/lib.rs"));
+        assert_eq!(request.allowed_change_kind(), "implementation");
+        assert_eq!(request.evidence_command(), "cargo test");
+        assert_eq!(
+            request.output_contract(),
+            "single_bounded_repair_tool_action_for_the_declared_target_and_failure"
+        );
+        assert!(
+            request
+                .policy_message("exactly one compact Edit on the declared target")
+                .contains("DiagnosticRepairWorker")
+        );
+        let diagnostic_entries = request
+            .worker_contract
+            .context_pack
+            .entries_for_kind(ContextPackKind::Diagnostic);
+        assert_eq!(diagnostic_entries.len(), 1);
+        assert!(
+            diagnostic_entries[0]
+                .content()
+                .contains("failure_kind=compile_error")
+        );
+    }
+
+    #[test]
+    fn diagnostic_repair_worker_request_distinguishes_test_artifact_self_failure() {
+        let contract = TaskContract::from_request(
+            "Create a Node JSON formatter CLI and verify it with node --test.",
+        );
+        let target_hint = RecoveryTargetHint {
+            role: ArtifactRole::Test,
+            path: "tests/main.test.js".to_string(),
+            reason: "test imports the wrong export name".to_string(),
+        };
+        let request = diagnostic_repair_worker_request_for_evidence_failed(
+            &contract,
+            "SyntaxError: The requested module '../src/main.js' does not provide an export named 'formatJson'",
+            &target_hint,
+            "test",
+            Some("node --test tests/main.test.js"),
+        );
+
+        assert_eq!(
+            request.failure_kind(),
+            EvidenceFailureKind::ImportNameMismatch
+        );
+        assert_eq!(
+            request.target_role(),
+            DiagnosticRepairTargetRole::TestArtifact
+        );
+        assert_eq!(request.allowed_change_kind(), "test");
+        assert_eq!(request.evidence_command(), "node --test tests/main.test.js");
+    }
+
+    #[test]
+    fn diagnostic_repair_worker_request_projects_non_coding_target_roles() {
+        let docs = TaskContract::from_request(
+            "Write README.md with prerequisites, rollback, and validation sections.",
+        );
+        let docs_hint = RecoveryTargetHint {
+            role: ArtifactRole::UsageDocs,
+            path: "README.md".to_string(),
+            reason: "content check found a missing section".to_string(),
+        };
+        let docs_request = diagnostic_repair_worker_request_for_evidence_failed(
+            &docs,
+            "Content check failed: missing heading Rollback",
+            &docs_hint,
+            "",
+            Some("content-check README.md"),
+        );
+
+        assert_eq!(
+            docs_request.failure_kind(),
+            EvidenceFailureKind::ContentSectionMissing
+        );
+        assert_eq!(docs_request.target_role(), DiagnosticRepairTargetRole::Docs);
+        assert_eq!(docs_request.allowed_change_kind(), "docs");
+
+        let data = TaskContract::from_request(
+            "Transform orders.csv into output.csv with id,total columns.",
+        );
+        let data_hint = RecoveryTargetHint {
+            role: ArtifactRole::DataOutput,
+            path: "output.csv".to_string(),
+            reason: "schema check found missing total column".to_string(),
+        };
+        let data_request = diagnostic_repair_worker_request_for_evidence_failed(
+            &data,
+            "CSV schema check failed: missing column total",
+            &data_hint,
+            "",
+            Some("schema-check output.csv"),
+        );
+
+        assert_eq!(
+            data_request.failure_kind(),
+            EvidenceFailureKind::SchemaMismatch
+        );
+        assert_eq!(data_request.target_role(), DiagnosticRepairTargetRole::Data);
+        assert_eq!(data_request.allowed_change_kind(), "data_schema");
     }
 }


### PR DESCRIPTION
## Summary

Closes #963. Part of parent #960, after #961 and #962.

This routes runner-present verifier failures through a focused DiagnosticRepairWorker request instead of letting them collapse into missing evidence / broad verifier repair prose.

- Added `DiagnosticRepairWorkerRequest` on top of the WorkerContract/ContextPack foundation.
- Added stable evidence failure categories for compile, import/export, signature, assertion, setup manifest, schema, content section, and source-evidence failures.
- Added target-role projection for implementation, test artifact, manifest, docs, data, research evidence, and ops procedure repairs.
- Attached the request to `DesiredAction::VerifierRepair` while keeping active-job logging redacted/static.
- Updated verifier repair policy messages to prefer DiagnosticRepairWorker wording when a bounded EvidenceFailedJob target exists.
- Added focused worker-contract and active-job tests, including EvidenceFailedJob routing and DiagnosticRepairWorker classification.

## Verification

- `cargo fmt --all -- --check`
- `cargo test worker_contract --lib -q`
- `cargo test desired_action_labels_are_stable --lib -q`
- `cargo test active_job_candidates_project_generic_recovery_jobs --lib -q`
- `cargo test active_job_verifier_repair_branch_reads_repair_job_next_action_directly --lib -q`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --lib -q` (escalated due mockito local bind)
- `cargo test` (escalated due mockito local bind)

Orchestration run: `20260605-024707-orchestrate`.

## Risk

The main behavior change is prompt/policy wording for verifier repair request-patch turns when a task contract is available. The active job label and redacted structured logging remain stable.