### PR TITLE
Add worker lifecycle eval reporting

### DIFF
--- a/scripts/analyze_run.py
+++ b/scripts/analyze_run.py
@@ -90,6 +90,17 @@ GENERIC_TERMINAL_BY_FINAL_OUTCOME = {
 KNOWN_GENERIC_TERMINAL_STATES = set(GENERIC_TERMINAL_BY_FINAL_OUTCOME.values()) | {
     "unknown",
 }
+KNOWN_LIFECYCLE_FAILURE_STAGES = {
+    "classification",
+    "deliverable",
+    "evidence_authoring",
+    "runner_binding",
+    "diagnostic_classification",
+    "repair",
+    "rerun",
+    "completed",
+    "unknown",
+}
 RECOVERY_JOB_BY_GENERIC_TERMINAL = {
     "completed": "none",
     "missing_deliverable": "MissingDeliverableJob",
@@ -114,6 +125,24 @@ KNOWN_FAILURE_AUTHORITIES = {
     "repair_routing",
     "success",
     "unknown",
+}
+WORKER_LIFECYCLE_STRING_FIELDS = {
+    "worker_kind",
+    "context_pack_kind",
+    "diagnostic_class",
+    "lifecycle_failure_stage",
+}
+WORKER_LIFECYCLE_BOOL_FIELDS = {
+    "deliverable_created",
+    "evidence_created",
+    "runner_bound",
+    "diagnostic_classified",
+    "repair_applied",
+    "rerun_passed",
+}
+WORKER_LIFECYCLE_INT_FIELDS = {
+    "context_token_estimate",
+    "context_entry_count",
 }
 
 GAME_KEYWORDS_V1 = [
@@ -862,12 +891,78 @@ def _read_eval_objective_projection(run_dir: Path) -> dict[str, Any]:
                 if recovery_strategies:
                     parsed["recovery_strategies"] = recovery_strategies
 
+                worker_lifecycle = rec.get("worker_lifecycle")
+                if isinstance(worker_lifecycle, dict):
+                    for key in WORKER_LIFECYCLE_STRING_FIELDS:
+                        value = _bounded_string(worker_lifecycle.get(key))
+                        if value is not None:
+                            parsed[key] = value
+                    for key in WORKER_LIFECYCLE_BOOL_FIELDS:
+                        value = worker_lifecycle.get(key)
+                        if isinstance(value, bool):
+                            parsed[key] = value
+                    for key in WORKER_LIFECYCLE_INT_FIELDS:
+                        value = worker_lifecycle.get(key)
+                        if isinstance(value, int) and not isinstance(value, bool):
+                            parsed[key] = max(0, value)
+
                 if parsed:
                     last = parsed
     except OSError as e:
         _warn(f"eval.jsonl read error: {e}")
         return {}
     return last
+
+
+def _has_worker_lifecycle_projection(projection: dict[str, Any]) -> bool:
+    return any(
+        key in projection
+        for key in (
+            *WORKER_LIFECYCLE_STRING_FIELDS,
+            *WORKER_LIFECYCLE_BOOL_FIELDS,
+            *WORKER_LIFECYCLE_INT_FIELDS,
+        )
+    )
+
+
+def _derive_lifecycle_failure_stage(
+    *,
+    task_kind_misroute: bool,
+    projection: dict[str, Any],
+    generic_terminal_state: str,
+    postcheck_success: bool | None,
+) -> str:
+    explicit = projection.get("lifecycle_failure_stage")
+    if isinstance(explicit, str) and explicit in KNOWN_LIFECYCLE_FAILURE_STAGES:
+        return explicit
+    if task_kind_misroute:
+        return "classification"
+    if projection.get("deliverable_created") is False:
+        return "deliverable"
+    if projection.get("evidence_created") is False:
+        return "evidence_authoring"
+    if projection.get("runner_bound") is False:
+        return "runner_binding"
+    if projection.get("diagnostic_classified") is False:
+        return "diagnostic_classification"
+    if generic_terminal_state == "missing_deliverable":
+        return "deliverable"
+    if generic_terminal_state == "missing_evidence":
+        return "evidence_authoring"
+    if generic_terminal_state in {"evidence_runner_missing", "evidence_binding_failed"}:
+        return "runner_binding"
+    if generic_terminal_state in {
+        "evidence_repair_exhausted",
+        "evidence_repair_safe_stop",
+    }:
+        return "repair"
+    if projection.get("rerun_passed") is False:
+        return "rerun"
+    if generic_terminal_state == "evidence_failed":
+        return "rerun"
+    if generic_terminal_state == "completed" and postcheck_success is True:
+        return "completed"
+    return "unknown"
 
 
 def _read_classified_task_kind(run_dir: Path) -> str | None:
@@ -1378,6 +1473,27 @@ def main(argv: list[str]) -> int:
     page_tsx_touched = "src/app/page.tsx" in files_modified
     tool_calls = session_metrics["tool_calls"]
     tool_call_total = sum(tool_calls.values())
+    worker_lifecycle_available = _has_worker_lifecycle_projection(
+        eval_objective_projection
+    )
+    worker_lifecycle_fields = {
+        key: eval_objective_projection[key]
+        for key in (
+            *WORKER_LIFECYCLE_STRING_FIELDS,
+            *WORKER_LIFECYCLE_BOOL_FIELDS,
+            *WORKER_LIFECYCLE_INT_FIELDS,
+        )
+        if key in eval_objective_projection
+    }
+    if worker_lifecycle_available or task_kind_misroute:
+        worker_lifecycle_fields["lifecycle_failure_stage"] = (
+            _derive_lifecycle_failure_stage(
+                task_kind_misroute=task_kind_misroute,
+                projection=eval_objective_projection,
+                generic_terminal_state=generic_terminal_state,
+                postcheck_success=postcheck_success,
+            )
+        )
 
     out: dict[str, Any] = {
         "anvil_score": anvil_score,
@@ -1432,6 +1548,7 @@ def main(argv: list[str]) -> int:
         "tool_call_total": tool_call_total,
         "tool_calls": tool_calls,
         "we_total": session_metrics["we_total"],
+        **worker_lifecycle_fields,
         "xml_parser_errors": None,
     }
 

--- a/scripts/report.py
+++ b/scripts/report.py
@@ -839,6 +839,39 @@ def _render_recovery_job_summary(rows: list[dict]) -> list[str]:
     )
 
 
+def _worker_lifecycle_rows(rows: list[dict]) -> list[dict]:
+    lifecycle_keys = {
+        "worker_kind",
+        "context_pack_kind",
+        "lifecycle_failure_stage",
+        "deliverable_created",
+        "evidence_created",
+        "runner_bound",
+        "diagnostic_classified",
+        "repair_applied",
+        "rerun_passed",
+    }
+    return [
+        row
+        for row in rows
+        if not row.get("_failed") and any(key in row for key in lifecycle_keys)
+    ]
+
+
+def _render_worker_lifecycle_summary(rows: list[dict]) -> list[str]:
+    lifecycle_rows = _worker_lifecycle_rows(rows)
+    return _render_quality_group_summary(
+        "Worker Lifecycle Summary",
+        [
+            "worker_kind",
+            "context_pack_kind",
+            "lifecycle_failure_stage",
+            "recovery_job_kind",
+        ],
+        rows=lifecycle_rows,
+    )
+
+
 def _render_report(bench_root: Path, rows: list[dict]) -> str:
     parts: list[str] = []
     parts.append(f"# Benchmark Report: {bench_root.name}")
@@ -879,12 +912,16 @@ def _render_report(bench_root: Path, rows: list[dict]) -> str:
         parts.append("")
         parts.extend(_render_recovery_job_summary(rows))
         parts.append("")
+        if _worker_lifecycle_rows(rows):
+            parts.extend(_render_worker_lifecycle_summary(rows))
+            parts.append("")
     return "\n".join(parts)
 
 
 def _render_json_report(bench_root: Path, rows: list[dict]) -> str:
     analyzed = [r for r in rows if not r.get("_failed")]
     failed = [r for r in rows if r.get("_failed")]
+    lifecycle_rows = _worker_lifecycle_rows(analyzed)
     out = {
         "schema_version": 1,
         "bench_root": str(bench_root),
@@ -904,6 +941,20 @@ def _render_json_report(bench_root: Path, rows: list[dict]) -> str:
             analyzed, ["generic_terminal_state"]
         ),
         "by_recovery_job_kind": _grouped_quality(analyzed, ["recovery_job_kind"]),
+        "by_worker_kind": _grouped_quality(lifecycle_rows, ["worker_kind"]),
+        "by_context_pack_kind": _grouped_quality(lifecycle_rows, ["context_pack_kind"]),
+        "by_lifecycle_failure_stage": _grouped_quality(
+            lifecycle_rows, ["lifecycle_failure_stage"]
+        ),
+        "by_worker_lifecycle": _grouped_quality(
+            lifecycle_rows,
+            [
+                "worker_kind",
+                "context_pack_kind",
+                "lifecycle_failure_stage",
+                "recovery_job_kind",
+            ],
+        ),
         "by_objective_matrix": _grouped_quality(
             analyzed,
             [

--- a/tests/test_eval_task_kind.py
+++ b/tests/test_eval_task_kind.py
@@ -41,6 +41,7 @@ def _make_run(
     classified_task_kind: object = _MATCH_TASK_KIND,
     recovery_strategy_count: int | None = None,
     recovery_strategies: list[str] | None = None,
+    worker_lifecycle: dict[str, object] | None = None,
 ) -> None:
     session: dict[str, object] = {
         "id": f"{task_kind}-{pam_variant}",
@@ -103,6 +104,8 @@ def _make_run(
         eval_record["recovery_strategy_count"] = recovery_strategy_count
     if recovery_strategies is not None:
         eval_record["recovery_strategies"] = recovery_strategies
+    if worker_lifecycle is not None:
+        eval_record["worker_lifecycle"] = worker_lifecycle
     if eval_record:
         logs_dir = run_dir / "logs"
         logs_dir.mkdir(parents=True, exist_ok=True)
@@ -475,6 +478,262 @@ class TestTaskKindEvalReporting(unittest.TestCase):
         )
         self.assertEqual(completed["terminal_success"]["ok"], 6)
         self.assertEqual(data["by_recovery_job_kind"][0]["recovery_job_kind"], "none")
+
+    def test_analyze_emits_worker_lifecycle_metrics_from_eval_log(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            run_dir = pathlib.Path(raw) / "run-1"
+            _make_run(
+                run_dir,
+                task_kind="coding",
+                pam_variant="pam_off",
+                modified_path="tests/test_sales_cli.py",
+                final_outcome="missing_evidence",
+                worker_lifecycle={
+                    "worker_kind": "test_author",
+                    "context_pack_kind": "evidence",
+                    "context_token_estimate": 384,
+                    "context_entry_count": 5,
+                    "deliverable_created": True,
+                    "evidence_created": False,
+                    "runner_bound": False,
+                    "diagnostic_class": "missing_test",
+                    "diagnostic_classified": True,
+                    "repair_applied": False,
+                    "rerun_passed": False,
+                },
+            )
+            data = self._analyze(run_dir)
+
+        self.assertEqual(data["worker_kind"], "test_author")
+        self.assertEqual(data["context_pack_kind"], "evidence")
+        self.assertEqual(data["context_token_estimate"], 384)
+        self.assertEqual(data["context_entry_count"], 5)
+        self.assertTrue(data["deliverable_created"])
+        self.assertFalse(data["evidence_created"])
+        self.assertFalse(data["runner_bound"])
+        self.assertEqual(data["diagnostic_class"], "missing_test")
+        self.assertTrue(data["diagnostic_classified"])
+        self.assertFalse(data["repair_applied"])
+        self.assertFalse(data["rerun_passed"])
+        self.assertEqual(data["lifecycle_failure_stage"], "evidence_authoring")
+
+    def test_report_worker_lifecycle_summary_and_json_groupings(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            bench_root = pathlib.Path(raw) / "bench-root"
+            _make_run(
+                bench_root / "qwen3" / "coding" / "pam_off" / "run-1",
+                task_kind="coding",
+                pam_variant="pam_off",
+                modified_path="tests/test_sales_cli.py",
+                final_outcome="missing_evidence",
+                worker_lifecycle={
+                    "worker_kind": "test_author",
+                    "context_pack_kind": "evidence",
+                    "deliverable_created": True,
+                    "evidence_created": False,
+                    "runner_bound": False,
+                    "diagnostic_classified": True,
+                    "repair_applied": False,
+                    "rerun_passed": False,
+                },
+            )
+            _make_run(
+                bench_root / "qwen3" / "docs" / "pam_on" / "run-1",
+                task_kind="docs",
+                pam_variant="pam_on",
+                modified_path="README.md",
+                final_outcome="done",
+                worker_lifecycle={
+                    "worker_kind": "docs",
+                    "context_pack_kind": "contract",
+                    "deliverable_created": True,
+                    "evidence_created": True,
+                    "runner_bound": True,
+                    "diagnostic_classified": True,
+                    "repair_applied": False,
+                    "rerun_passed": True,
+                },
+            )
+
+            markdown = subprocess.run(
+                [sys.executable, str(REPORT), str(bench_root)],
+                capture_output=True,
+                text=True,
+                cwd=str(REPO_ROOT),
+                check=True,
+            ).stdout
+            self.assertIn("## Worker Lifecycle Summary", markdown)
+            self.assertIn(
+                "| test_author | evidence | evidence_authoring | MissingEvidenceJob | 1 | 100% (1/1) | 100% (1/1) | 100% (1/1) | 1 | 0 | 0 | 0 |",
+                markdown,
+            )
+            self.assertIn(
+                "| docs | contract | completed | none | 1 | 100% (1/1) | 100% (1/1) | 100% (1/1) | 1 | 0 | 0 | 0 |",
+                markdown,
+            )
+
+            json_result = subprocess.run(
+                [sys.executable, str(REPORT), "--format", "json", str(bench_root)],
+                capture_output=True,
+                text=True,
+                cwd=str(REPO_ROOT),
+                check=True,
+            )
+            data = json.loads(json_result.stdout)
+
+        def by_keys(items: list[dict[str, object]], **criteria: str) -> dict[str, object]:
+            for item in items:
+                if all(item.get(key) == value for key, value in criteria.items()):
+                    return item
+            raise AssertionError(f"missing {criteria}: {items}")
+
+        by_keys(data["by_worker_kind"], worker_kind="test_author")
+        by_keys(data["by_context_pack_kind"], context_pack_kind="evidence")
+        by_keys(
+            data["by_lifecycle_failure_stage"],
+            lifecycle_failure_stage="evidence_authoring",
+        )
+        by_keys(
+            data["by_worker_lifecycle"],
+            worker_kind="docs",
+            context_pack_kind="contract",
+            lifecycle_failure_stage="completed",
+            recovery_job_kind="none",
+        )
+
+    def test_v062_successor_regression_matrix_has_worker_lifecycle_expectations(self) -> None:
+        cases = [
+            (
+                "python_sales_cli_missing_tests",
+                "tests/test_sales_cli.py",
+                "missing_evidence",
+                {
+                    "worker_kind": "test_author",
+                    "context_pack_kind": "evidence",
+                    "deliverable_created": True,
+                    "evidence_created": False,
+                    "runner_bound": False,
+                    "diagnostic_class": "missing_test",
+                    "diagnostic_classified": True,
+                    "repair_applied": False,
+                    "rerun_passed": False,
+                },
+                "evidence_authoring",
+            ),
+            (
+                "node_json_formatter_missing_tests",
+                "tests/main.test.js",
+                "missing_evidence",
+                {
+                    "worker_kind": "test_author",
+                    "context_pack_kind": "evidence",
+                    "deliverable_created": True,
+                    "evidence_created": False,
+                    "runner_bound": False,
+                    "diagnostic_class": "missing_test",
+                    "diagnostic_classified": True,
+                    "repair_applied": False,
+                    "rerun_passed": False,
+                },
+                "evidence_authoring",
+            ),
+            (
+                "node_csv_to_json_package_only_partial_state",
+                "package.json",
+                "missing_deliverable",
+                {
+                    "worker_kind": "implement",
+                    "context_pack_kind": "target",
+                    "deliverable_created": False,
+                    "evidence_created": False,
+                    "runner_bound": False,
+                    "diagnostic_class": "partial_scaffold",
+                    "diagnostic_classified": True,
+                    "repair_applied": False,
+                    "rerun_passed": False,
+                },
+                "deliverable",
+            ),
+            (
+                "rust_slug_compile_failure",
+                "src/lib.rs",
+                "evidence_failed",
+                {
+                    "worker_kind": "diagnostic_repair",
+                    "context_pack_kind": "diagnostic",
+                    "deliverable_created": True,
+                    "evidence_created": True,
+                    "runner_bound": True,
+                    "diagnostic_class": "compile_error",
+                    "diagnostic_classified": True,
+                    "repair_applied": False,
+                    "rerun_passed": False,
+                },
+                "rerun",
+            ),
+            (
+                "rust_ndjson_trivial_compile_repair",
+                "tests/ndjson.rs",
+                "done",
+                {
+                    "worker_kind": "diagnostic_repair",
+                    "context_pack_kind": "repair",
+                    "deliverable_created": True,
+                    "evidence_created": True,
+                    "runner_bound": True,
+                    "diagnostic_class": "compile_error",
+                    "diagnostic_classified": True,
+                    "repair_applied": True,
+                    "rerun_passed": True,
+                },
+                "completed",
+            ),
+        ]
+
+        with tempfile.TemporaryDirectory() as raw:
+            root = pathlib.Path(raw)
+            analyzed: list[dict[str, object]] = []
+            for idx, (
+                case_name,
+                modified_path,
+                final_outcome,
+                worker_lifecycle,
+                expected_stage,
+            ) in enumerate(cases, start=1):
+                run_dir = root / f"run-{idx}"
+                _make_run(
+                    run_dir,
+                    task_kind="coding",
+                    pam_variant="pam_off",
+                    modified_path=modified_path,
+                    final_outcome=final_outcome,
+                    worker_lifecycle=worker_lifecycle,
+                )
+                data = self._analyze(run_dir)
+                analyzed.append(data)
+                self.assertEqual(data["case"], "coding-case")
+                self.assertEqual(
+                    data["lifecycle_failure_stage"],
+                    expected_stage,
+                    case_name,
+                )
+
+        legacy_states = [row["legacy_terminal_state"] for row in analyzed]
+        self.assertNotIn("missing_verification", legacy_states)
+        self.assertEqual(
+            sum(row["generic_terminal_state"] == "missing_evidence" for row in analyzed),
+            2,
+        )
+        for row in analyzed:
+            if row.get("runner_bound") is True and row.get("diagnostic_class") == "compile_error":
+                self.assertNotEqual(
+                    row["legacy_terminal_state"],
+                    "safe_stop_verifier_missing",
+                )
+                self.assertNotEqual(
+                    row["generic_terminal_state"],
+                    "evidence_runner_missing",
+                )
 
     # ---- Issue #925 (P8): R5 misroute fail-closed gate ---------------------
 


### PR DESCRIPTION
## Summary
- Extend `scripts/analyze_run.py` to project `worker_lifecycle` eval.jsonl metrics into analyzed run rows, including worker/context pack, context size, deliverable/evidence/runner/diagnostic/repair/rerun booleans, diagnostic class, and derived lifecycle failure stage.
- Add Worker Lifecycle Summary sections and JSON groupings in `scripts/report.py` while preserving existing legacy objective and generic terminal labels when lifecycle fields are absent.
- Add a v0.6.2 successor regression matrix covering Python sales CLI, Node JSON formatter, Node CSV-to-JSON package-only partial state, Rust slug compile failure, and Rust NDJSON trivial compile repair.

## Verification
- `python3 -m unittest tests.test_eval_task_kind -v`
- `python3 -m unittest tests.golden.test_analyze_run tests.test_report -v`
- `PYTHONPYCACHEPREFIX=/private/tmp/anvil-pycache-966 python3 -m py_compile scripts/analyze_run.py scripts/report.py tests/test_eval_task_kind.py`
- `PYTHONPYCACHEPREFIX=/private/tmp/anvil-pycache-966 python3 -m unittest tests.test_eval_task_kind tests.golden.test_analyze_run tests.test_report tests.test_report_security tests.test_analyze_run_security -v`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`

Note: local `python3 -m ruff ...` is unavailable in this environment (`No module named ruff`); CI's Python job runs ruff.

Closes #966
Part of #960
Depends on #961, #962, #963, #964, #965