### PR TITLE
feature: Add deterministic Node test-runner manifest recovery

### DIFF
--- a/src/agent/loop_run.rs
+++ b/src/agent/loop_run.rs
@@ -318,6 +318,15 @@ mod tool_policy_decisions;
 // `tests.py` scan). Free fns over `&Agent`. `pub(super)` limited / no
 // facade re-export (DR3-001).
 mod python_request_helpers;
+// Issue #977 (parent #974, Issue C): Node request / workspace-state
+// inspection helpers (`active_node_request_requires_tests`,
+// `node_test_artifact_exists`, `node_test_runner_completion`,
+// `node_test_runner_bindable`) that gate the deterministic Node
+// test-runner manifest completion, plus the pure operator that produces
+// the completed `package.json` contents. `pub(super)` limited / no facade
+// re-export (DR3-001).
+mod node_request_helpers;
+mod node_runner_manifest;
 // Per-Agent `#[cfg(test)]` test seams extracted from `turn.rs` (parent
 // #680). Hosts the test-only `pub(super)` seams that drive the
 // production wiring without widening visibility (Issue #664 / CB2-003):

--- a/src/agent/loop_run/actor_loop_flow.rs
+++ b/src/agent/loop_run/actor_loop_flow.rs
@@ -127,6 +127,9 @@ pub(super) struct PostReplyRecoveryArgs<'a, 'b> {
     pub(super) interrupt_flag: &'a InterruptFlag,
     pub(super) repo_change_retries: &'b mut usize,
     pub(super) python_test_retries: &'b mut usize,
+    // Issue #977 (parent #974, Issue C): per-actor-loop counter for the Node
+    // test-runner manifest recovery (mirrors `python_test_retries`).
+    pub(super) node_runner_retries: &'b mut usize,
     pub(super) no_tool_retries: &'b mut usize,
     pub(super) framework_app_fallback_materialized: &'b mut bool,
 }
@@ -664,6 +667,83 @@ pub(super) fn maybe_handle_python_test_artifact_recovery(
     );
     super::message_push::push_system_note(agent,
         "[Python Test Policy] The user explicitly requested tests. Add a concrete Python test artifact now, such as test_*.py, *_test.py, or a clearly runnable self-test command. Keep the edit small and verify it if possible."
+            .to_string(),
+    );
+    Some(PostReplyRecoveryOutcome::Continue)
+}
+
+/// Issue #977 (parent #974, Issue C): MissingEvidence recovery for a Node
+/// task whose test artifacts already exist but cannot be run because no test
+/// runner can be bound (`package.json` missing, or present without a usable
+/// `scripts.test`). After a couple of nudges the manifest is completed
+/// deterministically (not LLM free regeneration) and the loop continues so
+/// the EvidenceRunner reruns against the now-bound `npm test` command.
+///
+/// Disjoint from `maybe_handle_python_test_artifact_recovery`, which fires
+/// only when a test artifact is *missing*; this fires only when one *exists*
+/// but the runner is unbindable.
+pub(super) fn maybe_handle_node_test_runner_recovery(
+    agent: &mut Agent,
+    args: &mut PostReplyRecoveryArgs<'_, '_>,
+) -> Option<PostReplyRecoveryOutcome> {
+    if args.repo_edit_calls_made_this_turn == 0
+        || !super::node_request_helpers::active_node_request_requires_tests(agent)
+        || !super::node_request_helpers::node_test_artifact_exists(agent)
+        || super::node_request_helpers::node_test_runner_bindable(agent)
+    {
+        return None;
+    }
+    *args.node_runner_retries += 1;
+    agent
+        .controller_policy_ledger
+        .record(ControllerRecoveryStrategy::TargetedArtifactRetry);
+    if *args.node_runner_retries >= 2 {
+        return Some(
+            match super::scaffold_pipeline::maybe_materialize_node_test_runner_manifest(agent) {
+                Ok(Some(path)) => {
+                    agent
+                        .controller_policy_ledger
+                        .record(ControllerRecoveryStrategy::DeterministicFallback);
+                    super::message_push::push_system_note(
+                        agent,
+                        format!(
+                            "[Node Evidence Policy] Completed the missing Node test runner manifest deterministically: {path}. The bound `npm test` command will run the existing tests on the next verification pass."
+                        ),
+                    );
+                    // Issue #977: completion always proceeds to an EvidenceRunner
+                    // rerun. `Continue` re-enters the actor loop, where the verifier
+                    // orchestration now binds `npm test` via the completed manifest.
+                    // The `node_test_runner_bindable` predicate short-circuits a
+                    // second materialization, so this cannot loop.
+                    PostReplyRecoveryOutcome::Continue
+                }
+                Ok(None) => PostReplyRecoveryOutcome::Finalize {
+                    final_prose: String::new(),
+                    exit_reason: ExitReason::MissingRepoEdits,
+                    error_text:
+                        "Node test runner manifest could not be completed deterministically"
+                            .to_string(),
+                },
+                Err(err) => PostReplyRecoveryOutcome::Finalize {
+                    final_prose: String::new(),
+                    exit_reason: ExitReason::TransportError,
+                    error_text: err,
+                },
+            },
+        );
+    }
+    super::turn_helpers::write_stdout_rendered(
+        &format_iteration_status(
+            args.last_iter,
+            agent.config.max_iterations,
+            "Evidence gate",
+            "Asked the model to add a Node test runner manifest (package.json test script) so the existing tests can run.",
+            agent.footer.current_cols(),
+        ),
+        true,
+    );
+    super::message_push::push_system_note(agent,
+        "[Node Evidence Policy] Test files exist but no runnable test command is bound. Create or update package.json with a `scripts.test` entry (for example `node --test`) so `npm test` can run the existing tests."
             .to_string(),
     );
     Some(PostReplyRecoveryOutcome::Continue)
@@ -2903,6 +2983,9 @@ pub(super) fn handle_post_reply_recovery(
     if let Some(outcome) = maybe_handle_python_test_artifact_recovery(agent, &mut args) {
         return Some(outcome);
     }
+    if let Some(outcome) = maybe_handle_node_test_runner_recovery(agent, &mut args) {
+        return Some(outcome);
+    }
     if let Some(outcome) = maybe_handle_answer_only_inadequate_recovery(agent, &mut args) {
         return Some(outcome);
     }
@@ -3078,6 +3161,7 @@ pub(super) fn run_actor_loop(
     let mut task_contract_verifier_passed_in_loop = false;
     let mut task_contract_verify_commands_collected = Vec::<String>::new();
     let mut python_test_retries = 0usize;
+    let mut node_runner_retries = 0usize;
     let mut plan_progress_retries = 0usize;
     let mut plan_exploration_only_turns = 0usize;
     let mut plan_exploration_counts = HashMap::<PlanExplorationKey, usize>::new();
@@ -3879,6 +3963,7 @@ pub(super) fn run_actor_loop(
                 interrupt_flag: &interrupt_flag,
                 repo_change_retries: &mut repo_change_retries,
                 python_test_retries: &mut python_test_retries,
+                node_runner_retries: &mut node_runner_retries,
                 no_tool_retries: &mut no_tool_retries,
                 framework_app_fallback_materialized: &mut framework_app_fallback_materialized,
             },

--- a/src/agent/loop_run/node_request_helpers.rs
+++ b/src/agent/loop_run/node_request_helpers.rs
@@ -1,0 +1,144 @@
+//! Issue #977 (parent #974, Issue C): Node request / workspace-state
+//! inspection helpers for the MissingDeliverable / MissingEvidence recovery
+//! lifecycle.
+//!
+//! Mirrors `python_request_helpers`: small, side-effect-free signals that
+//! gate the deterministic Node test-runner manifest completion. The Node
+//! recovery fires when the request targets a Node/JS/TS stack that requires
+//! tests, test artifacts already exist, but no runnable test command can be
+//! bound (`package.json` missing, or present without a usable `scripts.test`).
+//!
+//! `pub(super)` limited / no facade re-export (DR3-001).
+
+use std::path::Path;
+
+use super::Agent;
+use super::node_runner_manifest::{NodeManifestCompletion, complete_node_test_runner_manifest};
+
+/// True when the active request targets a Node/JS/TS coding stack and the
+/// task contract requires test execution. Reuses the request-family
+/// classifier (`synthesized_missing_test_target_path_for_request`) so the
+/// stack gate stays consistent with the rest of the verifier orchestration.
+pub(super) fn active_node_request_requires_tests(agent: &Agent) -> bool {
+    let Some(request) = super::workspace_access::active_request_text(agent) else {
+        return false;
+    };
+    if !request_targets_node_stack(&request) {
+        return false;
+    }
+    super::task_classification::task_contract_authority(agent)
+        .is_some_and(|contract| contract.completion_policy.test_execution_required())
+}
+
+fn request_targets_node_stack(request: &str) -> bool {
+    matches!(
+        super::verifier_orchestration::synthesized_missing_test_target_path_for_request(request),
+        Some((_, "javascript" | "typescript"))
+    )
+}
+
+/// True when a Node test artifact already exists in the workspace (top-level
+/// or in a conventional `tests` / `test` / `__tests__` directory).
+pub(super) fn node_test_artifact_exists(agent: &Agent) -> bool {
+    workspace_has_node_test_file(&agent.work_root)
+}
+
+/// The deterministic manifest completion for the current workspace, if any.
+/// `None` means the runner is already bindable (a usable `scripts.test`
+/// exists) or the manifest is malformed and must not be clobbered.
+pub(super) fn node_test_runner_completion(agent: &Agent) -> Option<NodeManifestCompletion> {
+    let existing = std::fs::read_to_string(agent.work_root.join("package.json")).ok();
+    complete_node_test_runner_manifest(existing.as_deref())
+}
+
+/// True when a runnable Node test command can already be bound from the
+/// current `package.json` (so no deterministic completion is needed).
+pub(super) fn node_test_runner_bindable(agent: &Agent) -> bool {
+    node_test_runner_completion(agent).is_none()
+}
+
+const NODE_TEST_FILE_SUFFIXES: &[&str] = &[
+    ".test.js",
+    ".test.mjs",
+    ".test.cjs",
+    ".test.jsx",
+    ".test.ts",
+    ".test.mts",
+    ".test.cts",
+    ".test.tsx",
+    ".spec.js",
+    ".spec.mjs",
+    ".spec.cjs",
+    ".spec.jsx",
+    ".spec.ts",
+    ".spec.mts",
+    ".spec.cts",
+    ".spec.tsx",
+];
+
+fn is_node_test_filename(name: &str) -> bool {
+    let lower = name.to_ascii_lowercase();
+    NODE_TEST_FILE_SUFFIXES
+        .iter()
+        .any(|suffix| lower.ends_with(suffix))
+}
+
+fn workspace_has_node_test_file(work_root: &Path) -> bool {
+    if dir_has_node_test_file(work_root) {
+        return true;
+    }
+    ["tests", "test", "__tests__"]
+        .iter()
+        .any(|sub| dir_has_node_test_file(&work_root.join(sub)))
+}
+
+fn dir_has_node_test_file(dir: &Path) -> bool {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return false;
+    };
+    entries.flatten().any(|entry| {
+        entry.path().is_file()
+            && entry
+                .file_name()
+                .to_str()
+                .is_some_and(is_node_test_filename)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn node_test_filename_predicate_matches_common_shapes() {
+        assert!(is_node_test_filename("index.test.js"));
+        assert!(is_node_test_filename("main.test.ts"));
+        assert!(is_node_test_filename("App.spec.jsx"));
+        assert!(is_node_test_filename("cli.test.mjs"));
+        assert!(!is_node_test_filename("index.js"));
+        assert!(!is_node_test_filename("test_main.py"));
+        assert!(!is_node_test_filename("README.md"));
+    }
+
+    #[test]
+    fn workspace_test_file_detected_top_level_and_in_tests_dir() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        assert!(!workspace_has_node_test_file(root));
+
+        std::fs::write(root.join("index.js"), "export const x = 1;\n").unwrap();
+        assert!(!workspace_has_node_test_file(root));
+
+        std::fs::create_dir_all(root.join("tests")).unwrap();
+        std::fs::write(root.join("tests").join("index.test.js"), "// test\n").unwrap();
+        assert!(workspace_has_node_test_file(root));
+    }
+
+    #[test]
+    fn workspace_test_file_detected_at_top_level() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        std::fs::write(root.join("main.spec.ts"), "// test\n").unwrap();
+        assert!(workspace_has_node_test_file(root));
+    }
+}

--- a/src/agent/loop_run/node_runner_manifest.rs
+++ b/src/agent/loop_run/node_runner_manifest.rs
@@ -1,0 +1,229 @@
+//! Issue #977 (parent #974, Issue C): deterministic Node test-runner
+//! manifest completion operator.
+//!
+//! Pure operator for the MissingDeliverable / MissingEvidence recovery
+//! lifecycle. When a Node coding task already produced test artifacts but
+//! the workspace cannot bind a test runner — `package.json` is missing, or
+//! present without a usable `scripts.test` — this operator deterministically
+//! completes the manifest so the existing `auto_test::detect_node_scripts`
+//! evidence binding picks up `npm test` on the next EvidenceRunner pass.
+//!
+//! This is a deterministic operator, not LLM free regeneration. It mirrors
+//! the replay-fixture shapes named in the issue:
+//! - `043`: `package.json` exists but `scripts.test` is missing.
+//! - `048` / `058`: tests exist but `package.json` is missing.
+//!
+//! `pub(super)` limited / no facade re-export (DR3-001). The pure entry
+//! point takes the raw manifest text (or its absence) and returns the
+//! completion content; all filesystem / `Agent` access lives in the
+//! `node_request_helpers` + `scaffold_pipeline` callers.
+
+use serde_json::{Map, Value};
+
+/// The deterministic test command bound into a completed manifest. Matches
+/// the empty-workspace Node scaffold (`scaffold_pipeline::node_skeleton_files`)
+/// so the two deterministic paths agree.
+pub(super) const NODE_TEST_SCRIPT: &str = "node --test";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum NodeManifestAction {
+    /// `package.json` was absent — a minimal manifest is created.
+    CreateManifest,
+    /// `package.json` existed but lacked a usable `scripts.test` — the
+    /// script is inserted, preserving the remaining declared fields.
+    AddTestScript,
+}
+
+impl NodeManifestAction {
+    pub(super) fn as_str(self) -> &'static str {
+        match self {
+            NodeManifestAction::CreateManifest => "create_manifest",
+            NodeManifestAction::AddTestScript => "add_test_script",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct NodeManifestCompletion {
+    pub(super) action: NodeManifestAction,
+    pub(super) contents: String,
+}
+
+/// Minimal `package.json` written when none exists. Mirrors the
+/// empty-workspace Node skeleton manifest (library shape — no `bin`), which
+/// is enough for `detect_node_scripts` to bind `npm test` -> `node --test`.
+fn created_manifest_contents() -> String {
+    format!(
+        r#"{{
+  "name": "app",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {{
+    "test": "{NODE_TEST_SCRIPT}"
+  }}
+}}
+"#
+    )
+}
+
+/// Deterministically complete a Node test-runner manifest.
+///
+/// - `existing == None` (no `package.json`) -> [`NodeManifestAction::CreateManifest`].
+/// - `existing == Some(raw)` with no usable `scripts.test` ->
+///   [`NodeManifestAction::AddTestScript`], preserving the other declared
+///   fields.
+/// - Already bindable (`scripts.test` present and non-empty) -> `None`.
+/// - Malformed (unparseable JSON, non-object root, or a non-object
+///   `scripts` field) -> `None`. Clobbering a malformed user file is never
+///   deterministically safe; the LLM repair path owns that case.
+pub(super) fn complete_node_test_runner_manifest(
+    existing: Option<&str>,
+) -> Option<NodeManifestCompletion> {
+    let Some(raw) = existing else {
+        return Some(NodeManifestCompletion {
+            action: NodeManifestAction::CreateManifest,
+            contents: created_manifest_contents(),
+        });
+    };
+    let value = serde_json::from_str::<Value>(raw).ok()?;
+    let Value::Object(mut object) = value else {
+        return None;
+    };
+    if manifest_has_usable_test_script(&object) {
+        return None;
+    }
+    let scripts = object
+        .entry("scripts".to_string())
+        .or_insert_with(|| Value::Object(Map::new()));
+    let Value::Object(scripts) = scripts else {
+        // A non-object `scripts` field is malformed; do not overwrite it.
+        return None;
+    };
+    scripts.insert(
+        "test".to_string(),
+        Value::String(NODE_TEST_SCRIPT.to_string()),
+    );
+    let mut contents = serde_json::to_string_pretty(&Value::Object(object)).ok()?;
+    contents.push('\n');
+    Some(NodeManifestCompletion {
+        action: NodeManifestAction::AddTestScript,
+        contents,
+    })
+}
+
+/// True when the manifest already declares a non-empty `test` script. The
+/// key match is case-insensitive so an existing `"Test"` is not duplicated;
+/// `detect_node_scripts` normalizes script names the same way.
+fn manifest_has_usable_test_script(object: &Map<String, Value>) -> bool {
+    let Some(scripts) = object.get("scripts").and_then(Value::as_object) else {
+        return false;
+    };
+    scripts.iter().any(|(name, value)| {
+        name.eq_ignore_ascii_case("test")
+            && value
+                .as_str()
+                .is_some_and(|script| !script.trim().is_empty())
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_script(contents: &str) -> Option<String> {
+        let json = serde_json::from_str::<Value>(contents).expect("completion is valid json");
+        json.get("scripts")?
+            .get("test")?
+            .as_str()
+            .map(str::to_string)
+    }
+
+    #[test]
+    fn missing_manifest_is_created_with_test_script() {
+        let completion = complete_node_test_runner_manifest(None).expect("creates a manifest");
+        assert_eq!(completion.action, NodeManifestAction::CreateManifest);
+        assert_eq!(
+            test_script(&completion.contents).as_deref(),
+            Some("node --test")
+        );
+        // The created manifest must be re-completable into a no-op (it is
+        // already bindable).
+        assert!(complete_node_test_runner_manifest(Some(&completion.contents)).is_none());
+    }
+
+    #[test]
+    fn manifest_without_scripts_gets_a_scripts_test() {
+        let existing = r#"{"name":"app","version":"1.2.3","type":"module"}"#;
+        let completion =
+            complete_node_test_runner_manifest(Some(existing)).expect("adds a test script");
+        assert_eq!(completion.action, NodeManifestAction::AddTestScript);
+        assert_eq!(
+            test_script(&completion.contents).as_deref(),
+            Some("node --test")
+        );
+        // Preserves the previously declared fields.
+        let json = serde_json::from_str::<Value>(&completion.contents).unwrap();
+        assert_eq!(json.get("name").and_then(Value::as_str), Some("app"));
+        assert_eq!(json.get("version").and_then(Value::as_str), Some("1.2.3"));
+        assert_eq!(json.get("type").and_then(Value::as_str), Some("module"));
+    }
+
+    #[test]
+    fn manifest_with_other_scripts_keeps_them_and_adds_test() {
+        let existing = r#"{"scripts":{"build":"node build.js"}}"#;
+        let completion =
+            complete_node_test_runner_manifest(Some(existing)).expect("adds a test script");
+        assert_eq!(completion.action, NodeManifestAction::AddTestScript);
+        let json = serde_json::from_str::<Value>(&completion.contents).unwrap();
+        let scripts = json.get("scripts").and_then(Value::as_object).unwrap();
+        assert_eq!(
+            scripts.get("build").and_then(Value::as_str),
+            Some("node build.js")
+        );
+        assert_eq!(
+            scripts.get("test").and_then(Value::as_str),
+            Some("node --test")
+        );
+    }
+
+    #[test]
+    fn manifest_with_existing_test_script_is_left_alone() {
+        let existing = r#"{"scripts":{"test":"vitest run"}}"#;
+        assert!(complete_node_test_runner_manifest(Some(existing)).is_none());
+    }
+
+    #[test]
+    fn manifest_with_case_insensitive_test_script_is_left_alone() {
+        let existing = r#"{"scripts":{"Test":"vitest run"}}"#;
+        assert!(complete_node_test_runner_manifest(Some(existing)).is_none());
+    }
+
+    #[test]
+    fn manifest_with_empty_test_script_is_completed() {
+        let existing = r#"{"scripts":{"test":"   "}}"#;
+        let completion =
+            complete_node_test_runner_manifest(Some(existing)).expect("blank script is unusable");
+        assert_eq!(completion.action, NodeManifestAction::AddTestScript);
+        assert_eq!(
+            test_script(&completion.contents).as_deref(),
+            Some("node --test")
+        );
+    }
+
+    #[test]
+    fn malformed_manifest_is_not_clobbered() {
+        assert!(complete_node_test_runner_manifest(Some("{not json")).is_none());
+    }
+
+    #[test]
+    fn non_object_root_manifest_is_not_clobbered() {
+        assert!(complete_node_test_runner_manifest(Some("[1, 2, 3]")).is_none());
+    }
+
+    #[test]
+    fn non_object_scripts_field_is_not_clobbered() {
+        let existing = r#"{"scripts":"oops"}"#;
+        assert!(complete_node_test_runner_manifest(Some(existing)).is_none());
+    }
+}

--- a/src/agent/loop_run/progress_tests.rs
+++ b/src/agent/loop_run/progress_tests.rs
@@ -7729,6 +7729,7 @@ export default function App() {
         let interrupt = super::InterruptFlag::new_preset(false);
         let mut repo_change_retries = 0;
         let mut python_test_retries = 0;
+        let mut node_runner_retries = 0;
         let mut no_tool_retries = 0;
         let mut framework_app_fallback_materialized = false;
 
@@ -7746,6 +7747,7 @@ export default function App() {
                 interrupt_flag: &interrupt,
                 repo_change_retries: &mut repo_change_retries,
                 python_test_retries: &mut python_test_retries,
+                node_runner_retries: &mut node_runner_retries,
                 no_tool_retries: &mut no_tool_retries,
                 framework_app_fallback_materialized: &mut framework_app_fallback_materialized,
             };
@@ -7766,10 +7768,183 @@ export default function App() {
                 interrupt_flag: &interrupt,
                 repo_change_retries: &mut repo_change_retries,
                 python_test_retries: &mut python_test_retries,
+                node_runner_retries: &mut node_runner_retries,
                 no_tool_retries: &mut no_tool_retries,
                 framework_app_fallback_materialized: &mut framework_app_fallback_materialized,
             };
             assert!(!super::missing_repo_edit_recovery_allowed(&blocked_args));
+        }
+    }
+
+    /// Issue #977: the deterministic Node manifest applier creates a
+    /// `package.json` with a `node --test` script when none exists (replay
+    /// fixtures 048 / 058: tests exist but the manifest is missing), and is a
+    /// no-op once the runner is bindable.
+    #[test]
+    fn node_runner_manifest_applier_creates_missing_package_json() {
+        use crate::agent::loop_run::commands::test_agent_with_config;
+        use crate::config::Config;
+
+        let (mut agent, temp) = test_agent_with_config(Config::default());
+        let result = super::super::scaffold_pipeline::maybe_materialize_node_test_runner_manifest(
+            &mut agent,
+        )
+        .expect("applier does not error");
+        assert_eq!(result.as_deref(), Some("package.json"));
+
+        let written = std::fs::read_to_string(temp.path().join("package.json")).unwrap();
+        let json: serde_json::Value = serde_json::from_str(&written).unwrap();
+        assert_eq!(json["scripts"]["test"].as_str(), Some("node --test"));
+        assert!(
+            agent
+                .session
+                .working_memory
+                .touched_files
+                .iter()
+                .any(|path| path.ends_with("package.json")),
+            "materialized manifest must be recorded as a touched file"
+        );
+
+        // Runner is now bindable -> second call is a no-op.
+        let second = super::super::scaffold_pipeline::maybe_materialize_node_test_runner_manifest(
+            &mut agent,
+        )
+        .expect("applier does not error");
+        assert_eq!(second, None);
+    }
+
+    /// Issue #977: the deterministic Node manifest applier adds a missing
+    /// `scripts.test` while preserving existing fields (replay fixture 043:
+    /// `package.json` exists but the test script is missing).
+    #[test]
+    fn node_runner_manifest_applier_adds_missing_test_script() {
+        use crate::agent::loop_run::commands::test_agent_with_config;
+        use crate::config::Config;
+
+        let (mut agent, temp) = test_agent_with_config(Config::default());
+        std::fs::write(
+            temp.path().join("package.json"),
+            r#"{"name":"app","version":"2.0.0","type":"module"}"#,
+        )
+        .unwrap();
+
+        let result = super::super::scaffold_pipeline::maybe_materialize_node_test_runner_manifest(
+            &mut agent,
+        )
+        .expect("applier does not error");
+        assert_eq!(result.as_deref(), Some("package.json"));
+
+        let written = std::fs::read_to_string(temp.path().join("package.json")).unwrap();
+        let json: serde_json::Value = serde_json::from_str(&written).unwrap();
+        assert_eq!(json["scripts"]["test"].as_str(), Some("node --test"));
+        assert_eq!(json["name"].as_str(), Some("app"));
+        assert_eq!(json["version"].as_str(), Some("2.0.0"));
+    }
+
+    /// Issue #977: end-to-end MissingEvidence recovery. A Node task with an
+    /// existing test artifact but no bindable runner is nudged once, then the
+    /// manifest is deterministically completed and the loop continues so the
+    /// EvidenceRunner reruns against the bound `npm test`.
+    #[test]
+    fn node_runner_recovery_completes_manifest_then_continues() {
+        use crate::agent::loop_run::commands::test_agent_with_config;
+        use crate::config::Config;
+
+        let (mut agent, temp) = test_agent_with_config(Config::default());
+        agent.session.working_memory.active_task = Some(
+            "Create a JavaScript CLI word counter in src/index.js with node --test tests."
+                .to_string(),
+        );
+        std::fs::create_dir_all(temp.path().join("tests")).unwrap();
+        std::fs::write(
+            temp.path().join("tests").join("index.test.js"),
+            "import test from 'node:test';\ntest('noop', () => {});\n",
+        )
+        .unwrap();
+
+        // Precondition: the recovery gate signals fire for this Node request.
+        assert!(
+            super::super::node_request_helpers::active_node_request_requires_tests(&agent),
+            "node request requiring tests must be recognized"
+        );
+        assert!(super::super::node_request_helpers::node_test_artifact_exists(&agent));
+        assert!(
+            !super::super::node_request_helpers::node_test_runner_bindable(&agent),
+            "no package.json yet -> runner not bindable"
+        );
+
+        let interrupt = super::InterruptFlag::new_preset(false);
+        let mut repo_change_retries = 0;
+        let mut python_test_retries = 0;
+        let mut node_runner_retries = 0;
+        let mut no_tool_retries = 0;
+        let mut framework_app_fallback_materialized = false;
+
+        // Construct fresh `PostReplyRecoveryArgs` for each pass; borrows are
+        // confined to the macro expansion so the counters can be reborrowed.
+        macro_rules! node_recovery_args {
+            () => {
+                super::PostReplyRecoveryArgs {
+                    last_iter: 0,
+                    action_expectation: super::recovery::ActionExpectation::RepoChange,
+                    requires_action: true,
+                    recovery_dispatch_gate: super::RecoveryDispatchGate::from_owner(
+                        super::RecoveryOwner::None,
+                    ),
+                    repo_edit_calls_made_this_turn: 1,
+                    final_reply: "",
+                    task_contract_action: None,
+                    interrupt_flag: &interrupt,
+                    repo_change_retries: &mut repo_change_retries,
+                    python_test_retries: &mut python_test_retries,
+                    node_runner_retries: &mut node_runner_retries,
+                    no_tool_retries: &mut no_tool_retries,
+                    framework_app_fallback_materialized: &mut framework_app_fallback_materialized,
+                }
+            };
+        }
+
+        // First pass: nudge only, no manifest yet.
+        {
+            let mut args = node_recovery_args!();
+            let outcome = super::super::actor_loop_flow::maybe_handle_node_test_runner_recovery(
+                &mut agent, &mut args,
+            );
+            assert!(matches!(
+                outcome,
+                Some(super::PostReplyRecoveryOutcome::Continue)
+            ));
+        }
+        assert!(
+            !temp.path().join("package.json").exists(),
+            "first pass must not materialize the manifest yet"
+        );
+
+        // Second pass: deterministic completion + Continue (forces rerun).
+        {
+            let mut args = node_recovery_args!();
+            let outcome = super::super::actor_loop_flow::maybe_handle_node_test_runner_recovery(
+                &mut agent, &mut args,
+            );
+            assert!(matches!(
+                outcome,
+                Some(super::PostReplyRecoveryOutcome::Continue)
+            ));
+        }
+        let written = std::fs::read_to_string(temp.path().join("package.json")).unwrap();
+        let json: serde_json::Value = serde_json::from_str(&written).unwrap();
+        assert_eq!(json["scripts"]["test"].as_str(), Some("node --test"));
+
+        // Now bindable -> the handler steps aside on subsequent passes.
+        {
+            let mut args = node_recovery_args!();
+            let outcome = super::super::actor_loop_flow::maybe_handle_node_test_runner_recovery(
+                &mut agent, &mut args,
+            );
+            assert!(
+                outcome.is_none(),
+                "bound runner must not re-trigger recovery"
+            );
         }
     }
 

--- a/src/agent/loop_run/scaffold_pipeline.rs
+++ b/src/agent/loop_run/scaffold_pipeline.rs
@@ -585,6 +585,11 @@ pub(super) const EVENT_DETERMINISTIC_FORMAT_ERROR_SMALL_EDIT: &str =
     "agent.deterministic_format_error_small_edit";
 pub(super) const EVENT_DETERMINISTIC_PYTHON_TEST_FALLBACK: &str =
     "agent.empty_workspace.deterministic_python_test_fallback";
+// Issue #977 (parent #974, Issue C): MissingEvidence runner-manifest
+// completion. Distinct from the empty-workspace scaffold events — this fires
+// when test artifacts already exist but no runnable test command is bound.
+pub(super) const EVENT_DETERMINISTIC_NODE_TEST_RUNNER_MANIFEST: &str =
+    "agent.deterministic_node_test_runner_manifest";
 pub(super) const CREATE_NEXT_APP_PACKAGE_VERSION: &str = "16.2.4";
 
 pub(super) fn task_requires_nextjs_scaffold(task: &str) -> bool {
@@ -1868,6 +1873,56 @@ if __name__ == "__main__":
         }),
     );
     Ok(Some(test_name))
+}
+
+/// Issue #977 (parent #974, Issue C): deterministically complete the Node
+/// test-runner manifest (`package.json`) when the workspace has Node test
+/// artifacts but no runnable test command can be bound. This is the
+/// MissingEvidence "runner manifest/script missing" recovery — it materializes
+/// the manifest from the deterministic `node_runner_manifest` operator (no LLM
+/// free regeneration) so the existing `auto_test::detect_node_scripts` binding
+/// can run `npm test` on the next EvidenceRunner pass.
+///
+/// Returns `Ok(Some(relative_path))` when the manifest was written,
+/// `Ok(None)` when no completion applies (non-coding task, support recovery
+/// disabled, runner already bindable, or a malformed manifest that must not be
+/// clobbered), and `Err` on a filesystem write failure.
+pub(super) fn maybe_materialize_node_test_runner_manifest(
+    agent: &mut Agent,
+) -> Result<Option<String>, String> {
+    if !scaffold_allowed_for_active_task(agent) {
+        return Ok(None);
+    }
+    if !agent
+        .config
+        .deterministic_fallback
+        .allows_support_recovery()
+    {
+        return Ok(None);
+    }
+    let Some(completion) = super::node_request_helpers::node_test_runner_completion(agent) else {
+        return Ok(None);
+    };
+    let relative = "package.json";
+    let target = agent.work_root.join(relative);
+    std::fs::write(&target, &completion.contents)
+        .map_err(|err| format!("failed to write {}: {err}", target.display()))?;
+    agent
+        .session
+        .working_memory
+        .note_touched_file(normalize_memory_path(relative, &agent.work_root));
+    log_llm_event(
+        EVENT_DETERMINISTIC_NODE_TEST_RUNNER_MANIFEST,
+        serde_json::json!({
+            "session_id": agent.session_store.session_id(),
+            "work_root": agent.work_root.display().to_string(),
+            "work_mode": agent.session.mode_state.work_mode.as_str(),
+            "fallback_level": agent.config.deterministic_fallback.fallback_level(),
+            "fallback_action": completion.action.as_str(),
+            "target": relative,
+        }),
+    );
+    Ok(Some(relative.to_string()))
 }
 
 pub(super) fn maybe_apply_deterministic_polish_fallback(


### PR DESCRIPTION
Closes #977
Part of #974

## Summary
- Adds deterministic Node test-runner manifest completion for MissingDeliverable/MissingEvidence recovery.
- Creates/repairs `package.json` test script when Node test artifacts exist but no runner is bindable.
- Integrates the recovery into post-reply flow with retry accounting and focused progress tests.

## Changed files
- `src/agent/loop_run.rs`
- `src/agent/loop_run/actor_loop_flow.rs`
- `src/agent/loop_run/node_request_helpers.rs`
- `src/agent/loop_run/node_runner_manifest.rs`
- `src/agent/loop_run/progress_tests.rs`
- `src/agent/loop_run/scaffold_pipeline.rs`

## Tests run
- `cargo fmt --check`
- `cargo test --lib node_runner`
- `cargo test --lib node_request_helpers`
- `cargo clippy --all-targets -- -D warnings`
- Worker also ran full `cargo test --lib` and `cargo test --tests` before final rebase, recorded in local `dev-reports/issue-977/verification.md`.

## Known risks
- This issue intentionally handles a narrow Node test-runner binding case first; broader partial deliverable completion remains in later child issues.
- Recovery depends on existing Node test-artifact detection heuristics, so unusual test filenames may still miss the deterministic operator.

## Orchestration
- Run ID: `workspace/management/runs/20260605-070304-orchestrate`