### PR TITLE
feature: Add ToolFailure protocol recovery guard

### DIFF
--- a/src/agent/loop_run.rs
+++ b/src/agent/loop_run.rs
@@ -292,6 +292,14 @@ mod repo_edit_observation;
 // RequestPatch branches). Free fns over `&mut Agent` / `&Agent`.
 // `pub(super)` limited / no facade re-export (DR3-001).
 mod recovery_targets;
+// Issue #979 (parent #974, Issue E): controller-side ToolFailure recovery.
+// Pure decision logic — `is_tool_protocol_failure` classifier +
+// `decide_tool_protocol_recovery` zero-file escalation guard — that keeps a
+// tool *protocol* failure (malformed/truncated/unparseable tool call) with no
+// deliverable from terminating on assistant prose, escalating one bounded round
+// into the normal tool/action path instead. `pub(super)` limited / no facade
+// re-export (DR3-001).
+mod tool_failure_recovery;
 // Playable-UI quality gate decision helpers extracted from `turn.rs`
 // (parent #680). Hosts `current_request_needs_playable_ui_quality_gate`
 // (Act + policy + request gate), `accepted_repo_change_quality_issue`
@@ -2400,6 +2408,14 @@ pub struct Agent {
     #[allow(dead_code)]
     // Iteration-3 wires the production producer (external_import detection in run_structured); until then only the per-turn reset semantics are exercised.
     pub(in crate::agent::loop_run) external_import_rejected_emitted_this_turn: bool,
+    /// Issue #979 (parent #974, Issue E): per-turn budget for the zero-file
+    /// tool-protocol-failure escalation. Set the first time
+    /// `actor_loop_pre_reply_request_error` escalates a protocol failure back
+    /// into the tool/action path (instead of a 0-file terminal); a second
+    /// protocol failure in the same turn then takes the terminal path so the
+    /// protocol classification is preserved and the loop cannot churn. Reset at
+    /// the actor-loop head in `prepare_actor_loop_state`.
+    pub(in crate::agent::loop_run) tool_protocol_recovery_escalated_this_turn: bool,
     /// Issue #664 iteration-2 (CB-001): per-turn observation flag set when
     /// `run_task_contract_verifier_once` observes
     /// `OwnedTestVerifierPlan::Missing`. Read by
@@ -2729,6 +2745,9 @@ impl Agent {
             // Reset at handle_user_message head; producers land in iteration-3.
             last_verifier_invoked_payload_digest: None,
             external_import_rejected_emitted_this_turn: false,
+            // Issue #979 (parent #974, Issue E): per-turn zero-file
+            // tool-protocol-failure escalation budget. Reset at actor-loop head.
+            tool_protocol_recovery_escalated_this_turn: false,
             // Issue #664 iteration-2 (CB-001): per-turn Stage A observation.
             owned_test_verifier_missing_observed_this_turn: false,
             // Issue #664 iteration-4 (CB3-001): request-bound carryover.

--- a/src/agent/loop_run/actor_loop_flow.rs
+++ b/src/agent/loop_run/actor_loop_flow.rs
@@ -888,22 +888,63 @@ pub(super) fn actor_loop_pre_reply_repo_change_fallback_allowed(
 pub(super) fn actor_loop_pre_reply_request_error(
     agent: &mut Agent,
     err: String,
+    action_expectation: recovery::ActionExpectation,
 ) -> ActorLoopPreReplyOutcome {
-    let reason = if err == super::turn_constants::USER_INTERRUPT_ERROR {
-        ExitReason::Interrupted
-    } else if super::lifecycle::is_tool_call_format_error(&err) {
-        ExitReason::ToolCallFormatError
-    } else {
-        ExitReason::TransportError
-    };
-    if err != super::turn_constants::USER_INTERRUPT_ERROR
-        && (super::lifecycle::is_native_tool_parser_failure(&err)
-            || super::lifecycle::is_tool_call_format_error(&err)
-            || super::lifecycle::is_native_tool_transport_failure(&err))
+    if err == super::turn_constants::USER_INTERRUPT_ERROR {
+        return ActorLoopPreReplyOutcome::Exit {
+            reason: ExitReason::Interrupted,
+            error_text: err,
+        };
+    }
+    // Preserve the tool-protocol-failure diagnosis up front so the failure is
+    // never silently re-classified as a deliverable/evidence failure, whether or
+    // not we escalate below (Issue #979).
+    if super::lifecycle::is_native_tool_parser_failure(&err)
+        || super::lifecycle::is_tool_call_format_error(&err)
+        || super::lifecycle::is_native_tool_transport_failure(&err)
     {
         let frame = build_feedback_for_tool_protocol_failure(&err, &agent.work_root);
         agent.session.record_feedback(frame);
     }
+    // Issue #979 (parent #974, Issue E): a zero-file tool *protocol* failure
+    // (malformed/truncated/unparseable tool call) on a task that still owes a
+    // deliverable must not terminal on assistant prose. Escalate one bounded
+    // round back into the normal tool/action path so the controller's
+    // deterministic deliverable recovery / MissingDeliverable path (step 2) gets
+    // a chance. Bounded by `tool_protocol_recovery_escalated_this_turn` so a
+    // persistent protocol failure still reaches the protocol-failure terminal
+    // and the loop cannot churn.
+    let repo_edits_this_session = super::tool_history::successful_non_plan_repo_edit_count(
+        &agent.session.messages,
+        &agent.work_root,
+        agent.session.mode_state.active_plan_path.as_deref(),
+    );
+    let decision = super::tool_failure_recovery::decide_tool_protocol_recovery(
+        super::tool_failure_recovery::ToolProtocolRecoveryInputs {
+            is_tool_protocol_failure: super::tool_failure_recovery::is_tool_protocol_failure(&err),
+            action_expectation,
+            repo_edits_this_session,
+            already_escalated_this_turn: agent.tool_protocol_recovery_escalated_this_turn,
+        },
+    );
+    if decision
+        == super::tool_failure_recovery::ToolProtocolRecoveryDecision::EscalateToDeliverableRecovery
+    {
+        agent.tool_protocol_recovery_escalated_this_turn = true;
+        agent
+            .controller_policy_ledger
+            .record(ControllerRecoveryStrategy::ToolFirstRetry);
+        super::message_push::push_system_note(
+            agent,
+            recovery::tool_protocol_deliverable_recovery_note(),
+        );
+        return ActorLoopPreReplyOutcome::Continue;
+    }
+    let reason = if super::lifecycle::is_tool_call_format_error(&err) {
+        ExitReason::ToolCallFormatError
+    } else {
+        ExitReason::TransportError
+    };
     ActorLoopPreReplyOutcome::Exit {
         reason,
         error_text: err,
@@ -2279,7 +2320,7 @@ pub(super) fn request_actor_loop_pre_reply_model_turn(
             missing_verifier_setup_turn: control_state.missing_verifier_setup_turn,
             recovery_owner: control_state.recovery_owner,
         },
-        Err(err) => actor_loop_pre_reply_request_error(agent, err),
+        Err(err) => actor_loop_pre_reply_request_error(agent, err, args.action_expectation),
     }
 }
 

--- a/src/agent/loop_run/prepare_actor_loop_state.rs
+++ b/src/agent/loop_run/prepare_actor_loop_state.rs
@@ -64,6 +64,10 @@ pub(super) fn prepare_actor_loop_turn_state(agent: &mut Agent) -> Option<TaskCon
     // so the next user turn can emit `agent.verifier.weak` /
     // `agent.verifier.missing` again if the failure mode repeats.
     agent.session.verifier_safe_stop_emitted_this_turn = false;
+    // Issue #979 (parent #974, Issue E): reset the per-turn zero-file
+    // tool-protocol-failure escalation budget so the next user turn can again
+    // escalate one protocol failure into the tool/action path.
+    agent.tool_protocol_recovery_escalated_this_turn = false;
     // Issue #664 iteration-2 (CB-001) / iteration-3 (CB2-001) /
     // iteration-4 (CB3-001): consume the cross-turn carryover bound to
     // the current request key, then clear the per-turn flag.

--- a/src/agent/loop_run/summary.rs
+++ b/src/agent/loop_run/summary.rs
@@ -727,6 +727,32 @@ mod tests {
     }
 
     #[test]
+    fn tool_protocol_failure_is_not_confused_with_deliverable_or_evidence_failure() {
+        // Issue #979 acceptance: a tool *protocol* failure must classify as a
+        // ToolFailure / model_output_failure, never as a missing-deliverable or
+        // evidence failure. The legacy `tool_call_format_error` eval label is
+        // also preserved as the compatibility projection.
+        let outcome = RunTerminalOutcome::from_exit_reason(ExitReason::ToolCallFormatError);
+        assert_eq!(
+            outcome.generic_state,
+            GenericTerminalState::ModelOutputFailure
+        );
+        assert_eq!(
+            outcome.recovery_job_kind(),
+            Some(RecoveryJobKind::ToolFailureJob)
+        );
+        assert_ne!(
+            outcome.recovery_job_kind(),
+            Some(RecoveryJobKind::MissingDeliverableJob)
+        );
+        assert_ne!(
+            outcome.recovery_job_kind(),
+            Some(RecoveryJobKind::EvidenceFailedJob)
+        );
+        assert_eq!(outcome.legacy_label_for_eval(), "tool_call_format_error");
+    }
+
+    #[test]
     fn run_state_projects_existing_controller_actions() {
         let continue_action = ArtifactRecoveryAction::Continue {
             missing: vec![ArtifactRole::UsageDocs],

--- a/src/agent/loop_run/tool_failure_recovery.rs
+++ b/src/agent/loop_run/tool_failure_recovery.rs
@@ -1,0 +1,197 @@
+//! Issue #979 (parent #974, Issue E): controller-side ToolFailure recovery.
+//!
+//! A tool *protocol* failure — a malformed / truncated / unparseable tool call,
+//! or a native-tool parser failure — is a controller/protocol problem, distinct
+//! from a missing-deliverable or evidence failure. The summary projection
+//! already routes `ExitReason::ToolCallFormatError` to
+//! `GenericTerminalState::ModelOutputFailure` / `RecoveryJobKind::ToolFailureJob`
+//! (see `summary.rs`), so the *classification* never confuses a protocol failure
+//! with a deliverable/evidence failure.
+//!
+//! This module adds the *behavioral* guard that keeps a zero-file protocol
+//! failure from terminating on assistant prose. When the reply-retry budget is
+//! exhausted but no deliverable has been produced and the task still owes one,
+//! the controller escalates one bounded round back into the normal tool/action
+//! path. That re-entry is the second step of the two-step protocol recovery
+//! (step 1 = the stricter minimal tool-call retry / native→tagged downgrade in
+//! `reply_retry.rs`; step 2 = the no-tool deliverable fallback reached here), so
+//! the deterministic deliverable recovery / MissingDeliverable path gets a
+//! chance before any terminal.
+//!
+//! Pure decision logic only — no `Agent` access — so it is unit-testable
+//! without Ollama. `pub(super)` / no facade re-export (DR3-001).
+
+use crate::agent::recovery::ActionExpectation;
+
+/// True when `error` is a *tool protocol* failure the controller can recover by
+/// forcing a cleaner tool call: a malformed/truncated tool-call parse error or a
+/// native-tool parser failure. Native-tool *transport* (5xx) and generic
+/// transport errors are deliberately excluded — they are not fixed by
+/// reformatting a tool call and keep the existing transport-retry path.
+pub(super) fn is_tool_protocol_failure(error: &str) -> bool {
+    super::lifecycle::is_tool_call_format_error(error)
+        || super::lifecycle::is_native_tool_parser_failure(error)
+}
+
+/// Decision for a tool protocol failure surfaced at the pre-reply boundary after
+/// the reply-retry budget is exhausted.
+///
+/// This is the *second* step of the two-step protocol recovery. Step 1 — the
+/// stricter minimal tool-call retry / native→tagged protocol downgrade — runs
+/// inside `reply_retry.rs` while retry budget remains; only once that is
+/// exhausted does the error surface here for the step-2 decision.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ToolProtocolRecoveryDecision {
+    /// Re-enter the actor loop one bounded round (step 2: no-tool deliverable
+    /// fallback), forcing the next tool/action path instead of a zero-file
+    /// terminal on assistant prose.
+    EscalateToDeliverableRecovery,
+    /// No escalation available — terminate with the protocol-failure terminal
+    /// (`ExitReason::ToolCallFormatError` → `model_output_failure`) so a genuine
+    /// protocol failure is never re-classified as a deliverable/evidence
+    /// failure.
+    Terminal,
+}
+
+/// Inputs for the zero-file protocol-failure escalation guard. Every field is
+/// derived deterministically by the caller (no LLM).
+#[derive(Debug, Clone, Copy)]
+pub(super) struct ToolProtocolRecoveryInputs {
+    /// `is_tool_protocol_failure(err)` for the surfaced error.
+    pub(super) is_tool_protocol_failure: bool,
+    /// What the active request expects the agent to do this turn.
+    pub(super) action_expectation: ActionExpectation,
+    /// Count of successful non-plan repo edits observed this session.
+    pub(super) repo_edits_this_session: usize,
+    /// Whether the per-turn escalation budget was already spent.
+    pub(super) already_escalated_this_turn: bool,
+}
+
+impl ToolProtocolRecoveryInputs {
+    /// The active request still owes a repository deliverable.
+    fn deliverable_expected(self) -> bool {
+        matches!(self.action_expectation, ActionExpectation::RepoChange)
+    }
+
+    /// No deliverable has been produced yet — a terminal here would be a
+    /// zero-file terminal.
+    fn zero_file(self) -> bool {
+        self.repo_edits_this_session == 0
+    }
+}
+
+/// Issue #979: a tool protocol failure that has produced zero deliverable edits
+/// and still owes a deliverable must not terminal on assistant prose. Escalate
+/// once per turn into the normal tool/action path so the controller's
+/// deterministic deliverable recovery (or a stricter minimal tool-call retry)
+/// gets a chance — avoiding the 0-file terminal. Every other case keeps the
+/// existing terminal so the protocol-failure classification is preserved.
+pub(super) fn decide_tool_protocol_recovery(
+    inputs: ToolProtocolRecoveryInputs,
+) -> ToolProtocolRecoveryDecision {
+    if inputs.is_tool_protocol_failure
+        && inputs.deliverable_expected()
+        && inputs.zero_file()
+        && !inputs.already_escalated_this_turn
+    {
+        ToolProtocolRecoveryDecision::EscalateToDeliverableRecovery
+    } else {
+        ToolProtocolRecoveryDecision::Terminal
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const FORMAT_ERR: &str = "tool call parser failed: malformed tool call markup";
+    const TRUNCATED_ERR: &str =
+        "tool call parser failed: truncated tool call (generate response hit length limit)";
+    const NATIVE_PARSER_ERR: &str = "native tool parser failed: unexpected end element";
+    const TRANSPORT_ERR: &str = "failed to contact ollama chat api: connection refused";
+
+    fn inputs(
+        is_protocol: bool,
+        expectation: ActionExpectation,
+        edits: usize,
+        escalated: bool,
+    ) -> ToolProtocolRecoveryInputs {
+        ToolProtocolRecoveryInputs {
+            is_tool_protocol_failure: is_protocol,
+            action_expectation: expectation,
+            repo_edits_this_session: edits,
+            already_escalated_this_turn: escalated,
+        }
+    }
+
+    #[test]
+    fn classifies_format_and_native_parser_as_protocol_failure() {
+        assert!(is_tool_protocol_failure(FORMAT_ERR));
+        assert!(is_tool_protocol_failure(TRUNCATED_ERR));
+        assert!(is_tool_protocol_failure(NATIVE_PARSER_ERR));
+    }
+
+    #[test]
+    fn transport_error_is_not_a_protocol_failure() {
+        // Transport failures keep the transport-retry path; reformatting a tool
+        // call cannot fix them.
+        assert!(!is_tool_protocol_failure(TRANSPORT_ERR));
+    }
+
+    #[test]
+    fn escalates_zero_file_repo_change_protocol_failure() {
+        // The core regression: a malformed-tool-call failure that produced no
+        // deliverable, on a task that owes one, escalates instead of going
+        // terminal on prose.
+        let decision =
+            decide_tool_protocol_recovery(inputs(true, ActionExpectation::RepoChange, 0, false));
+        assert_eq!(
+            decision,
+            ToolProtocolRecoveryDecision::EscalateToDeliverableRecovery
+        );
+    }
+
+    #[test]
+    fn does_not_escalate_twice_in_one_turn() {
+        // Bounded: once the per-turn escalation budget is spent, the next
+        // protocol failure terminates (preserving the protocol classification).
+        assert_eq!(
+            decide_tool_protocol_recovery(inputs(true, ActionExpectation::RepoChange, 0, true)),
+            ToolProtocolRecoveryDecision::Terminal
+        );
+    }
+
+    #[test]
+    fn does_not_escalate_when_a_deliverable_already_landed() {
+        // Files already produced — not a zero-file terminal, so no escalation.
+        assert_eq!(
+            decide_tool_protocol_recovery(inputs(true, ActionExpectation::RepoChange, 1, false)),
+            ToolProtocolRecoveryDecision::Terminal
+        );
+    }
+
+    #[test]
+    fn does_not_escalate_when_no_deliverable_is_expected() {
+        // Answer-only / non-repo-change turns have no deliverable to protect.
+        for expectation in [
+            ActionExpectation::None,
+            ActionExpectation::ToolAction,
+            ActionExpectation::PlanProgress,
+        ] {
+            assert_eq!(
+                decide_tool_protocol_recovery(inputs(true, expectation, 0, false)),
+                ToolProtocolRecoveryDecision::Terminal,
+                "expectation {expectation:?} must not escalate"
+            );
+        }
+    }
+
+    #[test]
+    fn does_not_escalate_a_non_protocol_failure() {
+        // Transport / non-protocol errors keep their own terminal/retry path.
+        assert_eq!(
+            decide_tool_protocol_recovery(inputs(false, ActionExpectation::RepoChange, 0, false)),
+            ToolProtocolRecoveryDecision::Terminal
+        );
+    }
+}

--- a/src/agent/recovery.rs
+++ b/src/agent/recovery.rs
@@ -227,6 +227,18 @@ pub fn tool_call_format_recovery_note(error: &str, attempt: usize) -> String {
     )
 }
 
+/// Issue #979 (parent #974, Issue E): step-2 escalation note for a zero-file
+/// tool *protocol* failure. The reply-retry budget (step 1: stricter minimal
+/// tool-call retry / native→tagged downgrade) is exhausted, no deliverable has
+/// landed, and the task still owes one. Instead of a terminal on assistant
+/// prose, force the next turn back onto the tool/action path so the controller's
+/// deterministic deliverable recovery can run. Carries no caller-supplied path
+/// or reason, so it needs no masking (it never reaches a path-interpolation
+/// site of the recovery-prompt masking convention).
+pub fn tool_protocol_deliverable_recovery_note() -> String {
+    "Repeated tool-call protocol failures stopped earlier turns before any file was produced, but the task still needs a deliverable. Do not answer in prose and do not describe what you will do. Emit exactly one valid <anvil_tool_call>{\"name\":\"Tool\",\"arguments\":{...}}</anvil_tool_call> block now that creates the first required file with a small, complete Write. Keep the JSON complete and the body short.".to_string()
+}
+
 pub fn forced_small_edit_recovery_note(path: &str, attempt: usize) -> String {
     let path = mask_recovery_path(path);
     format!(


### PR DESCRIPTION
Closes #979
Part of #974

## Summary
- Add a pure ToolFailure recovery decision module for protocol-format failures.
- Escalate zero-file tool protocol failures into one bounded deliverable-recovery path instead of ending with assistant prose.
- Add summary projection coverage so tool protocol failures are not confused with missing deliverable/evidence failures.

## Changed Files
- `src/agent/loop_run.rs`
- `src/agent/loop_run/actor_loop_flow.rs`
- `src/agent/loop_run/prepare_actor_loop_state.rs`
- `src/agent/loop_run/summary.rs`
- `src/agent/loop_run/tool_failure_recovery.rs`
- `src/agent/recovery.rs`

## Tests
- `cargo test --lib tool_failure_recovery -- --nocapture`
- `cargo test --lib summary::tests`
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --lib`
- `cargo test`

## Known Risks
- Scope is intentionally limited to tool protocol / no-tool fallback behavior; transport errors remain on the existing retry path.
- The recovery escalation is bounded per turn to avoid unbounded loops.

## Orchestration
- Run ID: `workspace/management/runs/20260605-070304-orchestrate`