### PR TITLE
#1004 feature: Validate EvidenceBindingPlan after scaffold materialization

### DIFF
--- a/src/agent/loop_run/evidence_binding.rs
+++ b/src/agent/loop_run/evidence_binding.rs
@@ -9,9 +9,20 @@
 //! The core types (`EvidenceBindingPlan` / `BindingCheck` /
 //! `EvidenceBindingStatus` / `BindingCheckKind`) are runtime-neutral so the same
 //! shape extends to Node manifest/test ordering, docs content, data schema, and
-//! research citation binding. Runtime differences live in adapters (`rust_*`
-//! free functions) and the generic [`BindingFailureCheck`] recovery routing
-//! axis, not in provider-specific control flow.
+//! research citation binding. Runtime differences live in adapters (`rust_*` /
+//! `node_*` / `docs_*` / `data_*` / `research_*` free functions) and the generic
+//! [`BindingFailureCheck`] recovery routing axis, not in provider-specific
+//! control flow.
+//!
+//! Issue #1004 adds the controller hook [`evidence_binding_plan_after_scaffold`]:
+//! the lifecycle runs it *after scaffold materialization* and *before* the
+//! EvidenceRunner so a binding gap is classified as a structured
+//! `evidence_binding_failed` observation (routed to `EvidenceBindingFailedJob`
+//! via [`EvidenceBindingPlan::recovery_job_kind`]) instead of a generic evidence
+//! failure. The dispatch is runtime-neutral: it unions the per-runtime adapters
+//! so the Rust/Node branches never leak into the lifecycle center. The structured
+//! `BindingCheck` vocabulary covers manifest / public-API import / executable
+//! handle / test script / required sections / schema / citation / file layout.
 //!
 //! Like `evidence_runner.rs`, this module is an extension seam: the focused
 //! in-crate tests pin the shape before broad callers are wired, so the
@@ -26,6 +37,7 @@ use std::path::{Path, PathBuf};
 use super::active_job_arbiter::RecoveryJobKind;
 use super::evidence_runner::{EvidenceRunnerError, EvidenceRunnerKind};
 use super::generated_test_guard::{parse_toml_string_value, strip_toml_comment};
+use super::node_runner_manifest::complete_node_test_runner_manifest;
 use super::summary::GenericTerminalState;
 use super::task_contract::TaskKind;
 
@@ -59,6 +71,7 @@ impl EvidenceBindingStatus {
 pub(super) enum BindingCheckKind {
     /// The project descriptor declares a usable identity.
     /// Rust: `Cargo.toml` has a non-empty `[package] name`.
+    /// Node: `package.json` exists.
     ManifestIdentity,
     /// A referenced import/symbol resolves to a declared identity.
     /// Rust: `use <crate>::…` ↔ `[lib] name` (default lib = package name).
@@ -67,6 +80,21 @@ pub(super) enum BindingCheckKind {
     /// Rust: `env!("CARGO_BIN_EXE_<name>")` / `cargo_bin("<name>")` ↔ `[[bin]] name`
     /// (default bin = package name).
     ExecutableHandle,
+    /// A runnable test command binds.
+    /// Node: `package.json` declares a usable `scripts.test`.
+    TestScript,
+    /// A required document section binds to the produced document.
+    /// Docs: `## Setup` ↔ a section observed in the rendered document.
+    RequiredSection,
+    /// A declared schema column binds to the produced output.
+    /// Data: a `[schema] columns` entry ↔ a column observed in the output.
+    SchemaColumn,
+    /// A citation binds to an available source.
+    /// Research: a cited reference ↔ a fetched/declared source.
+    Citation,
+    /// A required file/path the evidence runner depends on exists.
+    /// Generic: the document / output / notes the non-coding runner binds to.
+    FileLayout,
 }
 
 impl BindingCheckKind {
@@ -75,6 +103,11 @@ impl BindingCheckKind {
             BindingCheckKind::ManifestIdentity => "manifest_identity",
             BindingCheckKind::ImportSymbol => "import_symbol",
             BindingCheckKind::ExecutableHandle => "executable_handle",
+            BindingCheckKind::TestScript => "test_script",
+            BindingCheckKind::RequiredSection => "required_section",
+            BindingCheckKind::SchemaColumn => "schema_column",
+            BindingCheckKind::Citation => "citation",
+            BindingCheckKind::FileLayout => "file_layout",
         }
     }
 }
@@ -313,6 +346,19 @@ impl EvidenceBindingPlan {
     pub(super) fn generic_terminal_state(&self) -> Option<GenericTerminalState> {
         self.binding_error()
             .map(EvidenceRunnerError::generic_terminal_state)
+    }
+
+    /// Route a binding gap to the dedicated recovery job kind
+    /// (`EvidenceBindingFailedJob`), keeping it distinct from a bound runner that
+    /// failed (`EvidenceFailedJob`). `Bound` / `Indeterminate` return `None`.
+    ///
+    /// This is runtime-neutral: every adapter (Rust / Node / docs / data /
+    /// research) routes through the same single job kind, so no new job type is
+    /// introduced. The structured per-check detail (`failed_checks`) selects the
+    /// concrete repair operator; this projection is only the job-kind routing.
+    pub(super) fn recovery_job_kind(&self) -> Option<RecoveryJobKind> {
+        (self.status() == EvidenceBindingStatus::Unbound)
+            .then_some(RecoveryJobKind::EvidenceBindingFailedJob)
     }
 }
 
@@ -691,6 +737,207 @@ pub(super) fn rust_evidence_binding_plan_from_work_root(work_root: &Path) -> Evi
     rust_evidence_binding_plan(manifest.as_deref(), &references)
 }
 
+// ---------------------------------------------------------------------------
+// Node adapter
+// ---------------------------------------------------------------------------
+
+/// Build the Node evidence binding plan from a `package.json` source and whether
+/// a Node test deliverable exists. Pure (no filesystem) so focused tests drive
+/// it directly.
+///
+/// - No Node test file → an empty (`Indeterminate`) plan, so non-Node evidence
+///   paths (Rust/Python/docs) are never affected.
+/// - Test file present + missing `package.json` → a `ManifestIdentity` `Unbound`
+///   check (the runner cannot bind without a manifest).
+/// - Test file present + manifest without a usable `scripts.test` → a
+///   `TestScript` `Unbound` check. Bindability reuses
+///   [`complete_node_test_runner_manifest`] so the plan and the deterministic
+///   recovery operator agree (a malformed manifest is conservatively treated as
+///   bound — a false negative, never a false positive).
+pub(super) fn node_evidence_binding_plan(
+    manifest_source: Option<&str>,
+    test_file_present: bool,
+) -> EvidenceBindingPlan {
+    let mut plan = EvidenceBindingPlan::default();
+    if !test_file_present {
+        return plan; // Indeterminate: no test deliverable to bind.
+    }
+    match manifest_source {
+        None => plan.checks.push(BindingCheck::unbound(
+            BindingCheckKind::ManifestIdentity,
+            "package.json".to_string(),
+            Vec::new(),
+        )),
+        Some(source) => {
+            plan.checks.push(BindingCheck::bound(
+                BindingCheckKind::ManifestIdentity,
+                "package.json".to_string(),
+                vec!["package.json".to_string()],
+            ));
+            // A `Some(completion)` means the runner cannot bind a usable
+            // `scripts.test` yet; `None` means it is already bindable (or the
+            // manifest is malformed and must not be clobbered → bound,
+            // conservatively).
+            let bound = complete_node_test_runner_manifest(Some(source)).is_none();
+            let candidates = if bound {
+                vec!["scripts.test".to_string()]
+            } else {
+                Vec::new()
+            };
+            plan.checks.push(BindingCheck::resolved(
+                BindingCheckKind::TestScript,
+                bound,
+                "scripts.test".to_string(),
+                candidates,
+            ));
+        }
+    }
+    plan
+}
+
+/// Build the Node evidence binding plan by reading `package.json` and probing for
+/// a conventional Node test file under `work_root`. Read-only. Reuses
+/// `node_request_helpers::workspace_has_node_test_file` so the Node test-file
+/// suffix list stays a single source of truth.
+pub(super) fn node_evidence_binding_plan_from_work_root(work_root: &Path) -> EvidenceBindingPlan {
+    let test_file_present = super::node_request_helpers::workspace_has_node_test_file(work_root);
+    let manifest = read_capped(&work_root.join("package.json"));
+    node_evidence_binding_plan(manifest.as_deref(), test_file_present)
+}
+
+// ---------------------------------------------------------------------------
+// Non-coding adapters (docs / data / research)
+// ---------------------------------------------------------------------------
+
+/// Generic membership binding plan shared by the docs/data/research adapters:
+/// each `reference` must resolve to one of `candidates`, expressing the binding
+/// through the same `BindingCheck` vocabulary as the Rust/Node adapters.
+///
+/// - No references → an empty (`Indeterminate`) plan (nothing to bind).
+/// - Deliverable absent → a single `FileLayout` `Unbound` check (the document /
+///   output / notes the runner binds to does not exist).
+/// - Otherwise each reference resolves iff present in the candidate set.
+fn membership_binding_plan(
+    kind: BindingCheckKind,
+    deliverable_present: bool,
+    deliverable_label: &str,
+    references: &[String],
+    candidates: &[String],
+) -> EvidenceBindingPlan {
+    let mut plan = EvidenceBindingPlan::default();
+    if references.is_empty() {
+        return plan; // Indeterminate: nothing to bind.
+    }
+    if !deliverable_present {
+        plan.checks.push(BindingCheck::unbound(
+            BindingCheckKind::FileLayout,
+            deliverable_label.to_string(),
+            Vec::new(),
+        ));
+        return plan;
+    }
+    let available: BTreeSet<&str> = candidates.iter().map(String::as_str).collect();
+    let candidate_list: Vec<String> = candidates.to_vec();
+    for reference in references {
+        let bound = available.contains(reference.as_str());
+        plan.checks.push(BindingCheck::resolved(
+            kind,
+            bound,
+            reference.clone(),
+            candidate_list.clone(),
+        ));
+    }
+    plan
+}
+
+/// Docs adapter: each required section must bind to the produced document.
+pub(super) fn docs_evidence_binding_plan(
+    document_present: bool,
+    required_sections: &[String],
+    present_sections: &[String],
+) -> EvidenceBindingPlan {
+    membership_binding_plan(
+        BindingCheckKind::RequiredSection,
+        document_present,
+        "document",
+        required_sections,
+        present_sections,
+    )
+}
+
+/// Data adapter: each declared schema column must bind to the produced output.
+pub(super) fn data_evidence_binding_plan(
+    output_present: bool,
+    required_columns: &[String],
+    observed_columns: &[String],
+) -> EvidenceBindingPlan {
+    membership_binding_plan(
+        BindingCheckKind::SchemaColumn,
+        output_present,
+        "output",
+        required_columns,
+        observed_columns,
+    )
+}
+
+/// Research adapter: each citation must bind to an available source.
+pub(super) fn research_evidence_binding_plan(
+    notes_present: bool,
+    citations: &[String],
+    available_sources: &[String],
+) -> EvidenceBindingPlan {
+    membership_binding_plan(
+        BindingCheckKind::Citation,
+        notes_present,
+        "notes",
+        citations,
+        available_sources,
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Controller hook
+// ---------------------------------------------------------------------------
+
+/// The controller hook the lifecycle runs *after scaffold materialization* and
+/// *before* the EvidenceRunner executes: build the structured
+/// `EvidenceBindingPlan` for the active task kind so a binding gap is classified
+/// as a structured `evidence_binding_failed` observation
+/// ([`EvidenceBindingPlan::recovery_job_kind`] → `EvidenceBindingFailedJob`)
+/// instead of being rolled into a generic evidence failure or `repair_exhausted`.
+///
+/// The dispatch stays runtime-neutral; the Rust/Node specifics live in the
+/// per-runtime adapters so they never leak into the lifecycle center (Issue #1004
+/// maintainability requirement).
+///
+/// - `Coding` → the union of the Rust (cargo/test) and Node (manifest/test-script)
+///   work-root plans. A coding workspace is usually one runtime or the other; the
+///   union is `Unbound` if either runtime is unbound and `Indeterminate` when
+///   neither declares references (so Python-only / non-coding workspaces are
+///   never flagged).
+/// - `Docs | Data | Research | Ops | Authoring` → `Indeterminate`. Their binding
+///   is driven by contract evidence (required sections / schema columns /
+///   citations) via [`docs_evidence_binding_plan`] / [`data_evidence_binding_plan`]
+///   / [`research_evidence_binding_plan`], not by a post-scaffold workspace scan.
+pub(super) fn evidence_binding_plan_after_scaffold(
+    task_kind: TaskKind,
+    work_root: &Path,
+) -> EvidenceBindingPlan {
+    match task_kind {
+        TaskKind::Coding => {
+            let mut plan = rust_evidence_binding_plan_from_work_root(work_root);
+            let node = node_evidence_binding_plan_from_work_root(work_root);
+            plan.checks.extend(node.checks);
+            plan
+        }
+        TaskKind::Docs
+        | TaskKind::Data
+        | TaskKind::Research
+        | TaskKind::Ops
+        | TaskKind::Authoring => EvidenceBindingPlan::default(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -721,6 +968,15 @@ mod tests {
             BindingCheckKind::ExecutableHandle.as_str(),
             "executable_handle"
         );
+        // Issue #1004: generic vocabulary additions (labels must stay stable).
+        assert_eq!(BindingCheckKind::TestScript.as_str(), "test_script");
+        assert_eq!(
+            BindingCheckKind::RequiredSection.as_str(),
+            "required_section"
+        );
+        assert_eq!(BindingCheckKind::SchemaColumn.as_str(), "schema_column");
+        assert_eq!(BindingCheckKind::Citation.as_str(), "citation");
+        assert_eq!(BindingCheckKind::FileLayout.as_str(), "file_layout");
     }
 
     #[test]
@@ -1040,6 +1296,281 @@ mod generic_binding_failure_tests {
         assert_eq!(
             BindingRecovery::RecoverSourceCitation.as_str(),
             "recover_source_citation"
+        );
+    }
+}
+
+/// Issue #1004: the controller hook that validates the `EvidenceBindingPlan`
+/// after scaffold materialization, plus the Node / docs / data / research
+/// adapters that express their bindings through the same `EvidenceBindingPlan`
+/// abstraction.
+#[cfg(test)]
+mod after_scaffold_tests {
+    use super::*;
+
+    fn strings(values: &[&str]) -> Vec<String> {
+        values.iter().map(|s| s.to_string()).collect()
+    }
+
+    // --- Node adapter (AC1) -------------------------------------------------
+
+    #[test]
+    fn node_test_without_manifest_is_a_binding_failure() {
+        // A Node test deliverable exists but `package.json` is missing — a
+        // binding-order failure routed to `EvidenceBindingFailedJob`, not a
+        // missing/failed-evidence terminal.
+        let plan = node_evidence_binding_plan(None, true);
+        assert_eq!(plan.status(), EvidenceBindingStatus::Unbound);
+        assert_eq!(
+            plan.recovery_job_kind(),
+            Some(RecoveryJobKind::EvidenceBindingFailedJob)
+        );
+        assert_eq!(
+            plan.generic_terminal_state(),
+            Some(GenericTerminalState::EvidenceBindingFailed)
+        );
+        let failure = plan
+            .failed_checks()
+            .next()
+            .expect("manifest binding failure");
+        assert_eq!(failure.kind, BindingCheckKind::ManifestIdentity);
+        assert_eq!(failure.reference, "package.json");
+    }
+
+    #[test]
+    fn node_manifest_without_test_script_is_a_test_script_binding_failure() {
+        let manifest = r#"{"name":"app","version":"1.0.0","type":"module"}"#;
+        let plan = node_evidence_binding_plan(Some(manifest), true);
+        assert_eq!(plan.status(), EvidenceBindingStatus::Unbound);
+        assert_eq!(
+            plan.recovery_job_kind(),
+            Some(RecoveryJobKind::EvidenceBindingFailedJob)
+        );
+        let failure = plan
+            .failed_checks()
+            .find(|check| check.kind == BindingCheckKind::TestScript)
+            .expect("test script binding failure");
+        assert_eq!(failure.reference, "scripts.test");
+        // The manifest itself binds; only the runnable test command does not.
+        assert!(
+            plan.checks
+                .iter()
+                .any(|check| check.kind == BindingCheckKind::ManifestIdentity
+                    && check.status == EvidenceBindingStatus::Bound)
+        );
+    }
+
+    #[test]
+    fn node_manifest_with_bound_test_script_is_not_a_binding_failure() {
+        let manifest = r#"{"name":"app","scripts":{"test":"node --test"}}"#;
+        let plan = node_evidence_binding_plan(Some(manifest), true);
+        assert_eq!(plan.status(), EvidenceBindingStatus::Bound);
+        assert!(plan.is_bound());
+        assert_eq!(plan.recovery_job_kind(), None);
+        assert!(plan.failed_checks().next().is_none());
+    }
+
+    #[test]
+    fn node_without_test_file_is_indeterminate() {
+        // No Node test deliverable -> nothing to bind, so the plan never routes
+        // a failure (a Rust/Python workspace is unaffected).
+        let plan = node_evidence_binding_plan(None, false);
+        assert!(plan.checks.is_empty());
+        assert_eq!(plan.status(), EvidenceBindingStatus::Indeterminate);
+        assert_eq!(plan.recovery_job_kind(), None);
+    }
+
+    #[test]
+    fn node_malformed_manifest_is_conservatively_bound() {
+        // A malformed manifest must not be clobbered; the binding scan treats it
+        // as bound (false negative, never a false positive).
+        let plan = node_evidence_binding_plan(Some("{not json"), true);
+        assert_eq!(plan.status(), EvidenceBindingStatus::Bound);
+        assert_eq!(plan.recovery_job_kind(), None);
+    }
+
+    // --- Controller hook (AC1 / AC2 end-to-end) -----------------------------
+
+    #[test]
+    fn after_scaffold_node_missing_manifest_routes_to_binding_failed_job() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        std::fs::create_dir_all(root.join("tests")).unwrap();
+        std::fs::write(
+            root.join("tests").join("main.test.js"),
+            "import { test } from 'node:test';\ntest('ok', () => {});\n",
+        )
+        .unwrap();
+
+        let plan = evidence_binding_plan_after_scaffold(TaskKind::Coding, root);
+        assert_eq!(plan.status(), EvidenceBindingStatus::Unbound);
+        assert_eq!(
+            plan.recovery_job_kind(),
+            Some(RecoveryJobKind::EvidenceBindingFailedJob)
+        );
+        assert!(
+            plan.failed_checks()
+                .any(|check| check.kind == BindingCheckKind::ManifestIdentity)
+        );
+    }
+
+    #[test]
+    fn after_scaffold_rust_crate_mismatch_routes_to_binding_failed_job() {
+        // AC2: a Rust integration test crate/bin/lib mismatch surfaces through
+        // the controller hook as a binding failure.
+        let root = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests")
+            .join("fixtures")
+            .join("evidence_binding")
+            .join("rust")
+            .join("slug");
+        let plan = evidence_binding_plan_after_scaffold(TaskKind::Coding, &root);
+        assert_eq!(plan.status(), EvidenceBindingStatus::Unbound);
+        assert_eq!(
+            plan.recovery_job_kind(),
+            Some(RecoveryJobKind::EvidenceBindingFailedJob)
+        );
+        assert!(
+            plan.failed_checks()
+                .any(|check| check.kind == BindingCheckKind::ImportSymbol)
+        );
+    }
+
+    #[test]
+    fn after_scaffold_empty_workspace_is_indeterminate() {
+        let temp = tempfile::tempdir().unwrap();
+        let plan = evidence_binding_plan_after_scaffold(TaskKind::Coding, temp.path());
+        assert_eq!(plan.status(), EvidenceBindingStatus::Indeterminate);
+        assert_eq!(plan.recovery_job_kind(), None);
+    }
+
+    #[test]
+    fn after_scaffold_non_coding_kinds_are_indeterminate() {
+        let temp = tempfile::tempdir().unwrap();
+        for kind in [
+            TaskKind::Docs,
+            TaskKind::Data,
+            TaskKind::Research,
+            TaskKind::Ops,
+            TaskKind::Authoring,
+        ] {
+            let plan = evidence_binding_plan_after_scaffold(kind, temp.path());
+            assert!(plan.checks.is_empty());
+            assert_eq!(plan.status(), EvidenceBindingStatus::Indeterminate);
+            assert_eq!(plan.recovery_job_kind(), None);
+        }
+    }
+
+    // --- docs / data / research adapters (AC3) ------------------------------
+
+    #[test]
+    fn docs_missing_required_section_is_a_binding_failure() {
+        let plan =
+            docs_evidence_binding_plan(true, &strings(&["Setup", "Usage"]), &strings(&["Setup"]));
+        assert_eq!(plan.status(), EvidenceBindingStatus::Unbound);
+        assert_eq!(
+            plan.recovery_job_kind(),
+            Some(RecoveryJobKind::EvidenceBindingFailedJob)
+        );
+        let failure = plan
+            .failed_checks()
+            .find(|check| check.kind == BindingCheckKind::RequiredSection)
+            .expect("required section binding failure");
+        assert_eq!(failure.reference, "Usage");
+
+        // All sections present -> bound.
+        let bound = docs_evidence_binding_plan(
+            true,
+            &strings(&["Setup", "Usage"]),
+            &strings(&["Setup", "Usage"]),
+        );
+        assert_eq!(bound.status(), EvidenceBindingStatus::Bound);
+        assert_eq!(bound.recovery_job_kind(), None);
+    }
+
+    #[test]
+    fn docs_missing_document_is_a_file_layout_binding_failure() {
+        let plan = docs_evidence_binding_plan(false, &strings(&["Setup"]), &[]);
+        assert_eq!(plan.status(), EvidenceBindingStatus::Unbound);
+        let failure = plan.failed_checks().next().expect("file layout failure");
+        assert_eq!(failure.kind, BindingCheckKind::FileLayout);
+        assert_eq!(failure.reference, "document");
+    }
+
+    #[test]
+    fn data_schema_output_mismatch_is_a_binding_failure() {
+        let plan = data_evidence_binding_plan(
+            true,
+            &strings(&["Category", "Total"]),
+            &strings(&["Category"]),
+        );
+        assert_eq!(plan.status(), EvidenceBindingStatus::Unbound);
+        assert_eq!(
+            plan.recovery_job_kind(),
+            Some(RecoveryJobKind::EvidenceBindingFailedJob)
+        );
+        let failure = plan
+            .failed_checks()
+            .find(|check| check.kind == BindingCheckKind::SchemaColumn)
+            .expect("schema column binding failure");
+        assert_eq!(failure.reference, "Total");
+    }
+
+    #[test]
+    fn research_citation_source_mismatch_is_a_binding_failure() {
+        let plan = research_evidence_binding_plan(
+            true,
+            &strings(&["https://example.test/a", "https://example.test/missing"]),
+            &strings(&["https://example.test/a"]),
+        );
+        assert_eq!(plan.status(), EvidenceBindingStatus::Unbound);
+        assert_eq!(
+            plan.recovery_job_kind(),
+            Some(RecoveryJobKind::EvidenceBindingFailedJob)
+        );
+        let failure = plan
+            .failed_checks()
+            .find(|check| check.kind == BindingCheckKind::Citation)
+            .expect("citation binding failure");
+        assert_eq!(failure.reference, "https://example.test/missing");
+    }
+
+    #[test]
+    fn non_coding_adapters_with_no_references_are_indeterminate() {
+        // Empty reference sets never route a failure (no false positives on a
+        // task with no declared sections / columns / citations).
+        assert_eq!(
+            docs_evidence_binding_plan(true, &[], &[]).status(),
+            EvidenceBindingStatus::Indeterminate
+        );
+        assert_eq!(
+            data_evidence_binding_plan(true, &[], &[]).status(),
+            EvidenceBindingStatus::Indeterminate
+        );
+        assert_eq!(
+            research_evidence_binding_plan(true, &[], &[]).status(),
+            EvidenceBindingStatus::Indeterminate
+        );
+    }
+
+    // --- Legacy projection compatibility (AC4) ------------------------------
+
+    #[test]
+    fn unbound_plan_routes_to_binding_failed_not_evidence_failed() {
+        // Every adapter's binding gap routes to the dedicated
+        // `EvidenceBindingFailedJob`, never the generic `EvidenceFailedJob`.
+        let plan = node_evidence_binding_plan(None, true);
+        assert_eq!(
+            plan.recovery_job_kind(),
+            Some(RecoveryJobKind::EvidenceBindingFailedJob)
+        );
+        assert_ne!(
+            plan.recovery_job_kind(),
+            Some(RecoveryJobKind::EvidenceFailedJob)
+        );
+        assert_eq!(
+            plan.binding_error(),
+            Some(EvidenceRunnerError::BindingFailed)
         );
     }
 }

--- a/src/agent/loop_run/node_request_helpers.rs
+++ b/src/agent/loop_run/node_request_helpers.rs
@@ -99,7 +99,11 @@ fn is_node_test_filename(name: &str) -> bool {
         .any(|suffix| lower.ends_with(suffix))
 }
 
-fn workspace_has_node_test_file(work_root: &Path) -> bool {
+/// True when a conventional Node test file exists at the workspace top level or
+/// under `tests` / `test` / `__tests__`. Shared with the `evidence_binding`
+/// adapter (`node_evidence_binding_plan_from_work_root`) so the Node test-file
+/// suffix list stays a single source of truth (DR3-001 / DRY).
+pub(super) fn workspace_has_node_test_file(work_root: &Path) -> bool {
     if dir_has_node_test_file(work_root) {
         return true;
     }


### PR DESCRIPTION
Closes #1004

## Summary

- Scaffold materialization 後、EvidenceRunner 実行前に `EvidenceBindingPlan` を必ず検査し、manifest / runner / test script / crate/bin/lib 名 / required sections / schema などの binding failure を構造化して route する。

## Changed Files

- `src/agent/loop_run/evidence_binding.rs`
- `src/agent/loop_run/evidence_runner.rs`
- `src/agent/loop_run/summary.rs`
- `src/agent/loop_run/active_job_arbiter.rs`
- `package.json`
- `workspace/v0.6.5/general-purpose-countermeasures-20260606.md`
- `src/session/sessions_cli.rs`
- `src/session/feedback.rs`

## Tests Run

- `cargo test`
- `cargo clippy`
- `cargo fmt`

## Known Risks

- None recorded by orchestration planner.

## Orchestration

- Run ID: `20260606-032310-orchestrate`
