### PR TITLE
#1006 feature: Extend NoProgressRecovery with deterministic strategy switching

### DIFF
--- a/src/agent/loop_run/no_progress_recovery.rs
+++ b/src/agent/loop_run/no_progress_recovery.rs
@@ -62,6 +62,51 @@ impl NoProgressExhaustionReason {
     }
 }
 
+/// Issue #1006: the deterministic *forward* strategy the controller should
+/// switch to when the same failure key keeps recurring. Where
+/// [`NoProgressExhaustionReason`] explains *why convergence failed*, this enum
+/// decides *what to try next* — turning the policy from fail-fast into
+/// strategy-switching. Closed, `Copy`, and generic over [`ArtifactRole`] (no
+/// runtime-specific branches): the only inputs are the same-failure-key
+/// repetition count, the failing role, the alternate roles, and whether the
+/// failure is an inter-artifact contract conflict.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum RecoveryStrategy {
+    /// `same_failure_once`: try the deterministic operator again (no ban yet).
+    RetryDeterministicOperator,
+    /// `same_failure_twice`: the previous target role is banned — switch to an
+    /// alternate role rather than repeating the same role's repair.
+    SwitchTargetRole,
+    /// A setup-role no-progress never loops back into implementation repair; it
+    /// routes to the evidence-binding / scaffold-rebuild side (AC2). Role-driven,
+    /// not runtime-specific.
+    RouteToEvidenceBinding,
+    /// `same_failure_three_times` with an inter-artifact (e.g. test/impl)
+    /// disagreement: escalate to contract arbitration (AC3).
+    EscalateToContractConflict,
+    /// `same_failure_three_times` with no inter-artifact conflict and an
+    /// alternate role still available: rebuild via scaffold rather than keep
+    /// patching.
+    EscalateToScaffoldRebuild,
+    /// No alternate role / operator remains for the cluster — the structured
+    /// terminal reason (AC4). Keeps the `repair_exhausted` projection but records
+    /// *why* no further strategy exists.
+    OperatorMissing,
+}
+
+impl RecoveryStrategy {
+    pub(super) fn as_str(self) -> &'static str {
+        match self {
+            Self::RetryDeterministicOperator => "retry_deterministic_operator",
+            Self::SwitchTargetRole => "switch_target_role",
+            Self::RouteToEvidenceBinding => "route_to_evidence_binding",
+            Self::EscalateToContractConflict => "escalate_to_contract_conflict",
+            Self::EscalateToScaffoldRebuild => "escalate_to_scaffold_rebuild",
+            Self::OperatorMissing => "operator_missing",
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct NoProgressObservation {
     scope: String,
@@ -291,6 +336,76 @@ impl NoProgressRecoveryPolicy {
             Some(NoProgressExhaustionReason::SameTargetSameDiagnostic)
         }
     }
+
+    /// Issue #1006: how many no-progress observations have accrued for `scope`,
+    /// across all roles. This is the repetition count of the *same failure key*
+    /// (the cluster scope) and drives the strategy-switch escalation tier.
+    pub(super) fn scope_no_progress_count(&self, scope: &str) -> usize {
+        let scope = Self::sanitize_scope(scope);
+        self.observations
+            .iter()
+            .filter(|obs| obs.scope == scope)
+            .count()
+    }
+
+    /// Issue #1006: the role of the most recent no-progress observation for
+    /// `scope`. Used to decide the role-driven strategy (e.g. a setup failure
+    /// routes to evidence binding). `None` when no observation exists.
+    pub(super) fn latest_no_progress_role(&self, scope: &str) -> Option<ArtifactRole> {
+        let scope = Self::sanitize_scope(scope);
+        self.observations
+            .iter()
+            .rev()
+            .find(|obs| obs.scope == scope)
+            .map(|obs| obs.role)
+    }
+
+    /// Issue #1006: the deterministic forward strategy for `scope`, given the
+    /// failing `role`, the cluster's `candidate_roles`, and whether the failure
+    /// is an inter-artifact contract conflict.
+    ///
+    /// The decision is keyed purely on the same-failure-key repetition count and
+    /// the closed role/conflict signals — there are no runtime-specific
+    /// branches. The `OperatorMissing` arm stays coherent with
+    /// [`Self::classify_exhaustion`] (both fire when no alternate role remains).
+    pub(super) fn classify_strategy(
+        &self,
+        scope: &str,
+        role: ArtifactRole,
+        candidate_roles: &[ArtifactRole],
+        has_contract_conflict: bool,
+    ) -> RecoveryStrategy {
+        let count = self.scope_no_progress_count(scope);
+        if count == 0 {
+            // No no-progress recorded yet: a deterministic operator attempt is
+            // the first strategy (same_failure_once is the next tier).
+            return RecoveryStrategy::RetryDeterministicOperator;
+        }
+        // AC2: a setup failure never loops back into implementation repair; it
+        // routes to the evidence-binding / scaffold-rebuild side. Role-driven so
+        // it stays runtime-agnostic.
+        if role == ArtifactRole::Setup {
+            return RecoveryStrategy::RouteToEvidenceBinding;
+        }
+        // AC4: no alternate role / operator remains — the structured terminal
+        // reason, regardless of how many times we have retried.
+        if self.required_next_roles(scope, candidate_roles).is_empty() {
+            return RecoveryStrategy::OperatorMissing;
+        }
+        match count {
+            1 => RecoveryStrategy::RetryDeterministicOperator,
+            2 => RecoveryStrategy::SwitchTargetRole,
+            _ => {
+                if has_contract_conflict {
+                    // AC3: an inter-artifact (test/impl) disagreement escalates
+                    // to contract arbitration.
+                    RecoveryStrategy::EscalateToContractConflict
+                } else {
+                    RecoveryStrategy::EscalateToScaffoldRebuild
+                }
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -428,5 +543,164 @@ mod tests {
         assert_eq!(policy.banned_targets_for(SCOPE_A).len(), 1);
         // ... but two observations under the same role still ban the role.
         assert!(policy.is_role_banned(SCOPE_A, ArtifactRole::Implementation));
+    }
+
+    // --- Issue #1006: deterministic strategy-switch decision table -----------
+
+    #[test]
+    fn scope_count_and_latest_role_track_observations() {
+        let mut policy = NoProgressRecoveryPolicy::new();
+        assert_eq!(policy.scope_no_progress_count(SCOPE_A), 0);
+        assert_eq!(policy.latest_no_progress_role(SCOPE_A), None);
+
+        policy.record_no_progress(SCOPE_A, ArtifactRole::Implementation, "src/lib.rs");
+        policy.record_no_progress(SCOPE_A, ArtifactRole::Test, "tests/a.rs");
+        assert_eq!(policy.scope_no_progress_count(SCOPE_A), 2);
+        // The most recent observation's role.
+        assert_eq!(
+            policy.latest_no_progress_role(SCOPE_A),
+            Some(ArtifactRole::Test)
+        );
+        // A different cluster scope is unaffected.
+        assert_eq!(policy.scope_no_progress_count(SCOPE_B), 0);
+    }
+
+    #[test]
+    fn strategy_same_failure_once_retries_deterministic_operator() {
+        let mut policy = NoProgressRecoveryPolicy::new();
+        policy.record_no_progress(SCOPE_A, ArtifactRole::Implementation, "src/lib.rs");
+        assert_eq!(
+            policy.classify_strategy(
+                SCOPE_A,
+                ArtifactRole::Implementation,
+                &[ArtifactRole::Implementation, ArtifactRole::Test],
+                false,
+            ),
+            RecoveryStrategy::RetryDeterministicOperator
+        );
+    }
+
+    #[test]
+    fn strategy_same_failure_twice_switches_target_role() {
+        // AC1: a second no-progress under the same role bans the role and the
+        // strategy switches off it.
+        let mut policy = NoProgressRecoveryPolicy::new();
+        policy.record_no_progress(SCOPE_A, ArtifactRole::Implementation, "src/lib.rs");
+        policy.record_no_progress(SCOPE_A, ArtifactRole::Implementation, "src/other.rs");
+        assert!(policy.is_role_banned(SCOPE_A, ArtifactRole::Implementation));
+        assert_eq!(
+            policy.classify_strategy(
+                SCOPE_A,
+                ArtifactRole::Implementation,
+                &[ArtifactRole::Implementation, ArtifactRole::Test],
+                false,
+            ),
+            RecoveryStrategy::SwitchTargetRole
+        );
+    }
+
+    #[test]
+    fn strategy_setup_routes_to_evidence_binding() {
+        // AC2: a setup-role no-progress routes to evidence binding / scaffold,
+        // never back to implementation repair — even when implementation is an
+        // available candidate role.
+        let mut policy = NoProgressRecoveryPolicy::new();
+        policy.record_no_progress(SCOPE_A, ArtifactRole::Setup, "Cargo.toml");
+        let strategy = policy.classify_strategy(
+            SCOPE_A,
+            ArtifactRole::Setup,
+            &[ArtifactRole::Setup, ArtifactRole::Implementation],
+            false,
+        );
+        assert_eq!(strategy, RecoveryStrategy::RouteToEvidenceBinding);
+        assert_ne!(strategy, RecoveryStrategy::SwitchTargetRole);
+    }
+
+    #[test]
+    fn strategy_three_times_with_conflict_escalates_to_contract() {
+        // AC3: a recurring inter-artifact (test/impl) conflict escalates to
+        // contract arbitration.
+        let mut policy = NoProgressRecoveryPolicy::new();
+        policy.record_no_progress(SCOPE_A, ArtifactRole::Implementation, "src/lib.rs");
+        policy.record_no_progress(SCOPE_A, ArtifactRole::Implementation, "src/lib.rs");
+        policy.record_no_progress(SCOPE_A, ArtifactRole::Implementation, "src/lib.rs");
+        assert_eq!(
+            policy.classify_strategy(
+                SCOPE_A,
+                ArtifactRole::Implementation,
+                &[ArtifactRole::Implementation, ArtifactRole::Test],
+                true,
+            ),
+            RecoveryStrategy::EscalateToContractConflict
+        );
+    }
+
+    #[test]
+    fn strategy_three_times_without_conflict_rebuilds_scaffold() {
+        let mut policy = NoProgressRecoveryPolicy::new();
+        policy.record_no_progress(SCOPE_A, ArtifactRole::Implementation, "src/lib.rs");
+        policy.record_no_progress(SCOPE_A, ArtifactRole::Implementation, "src/lib.rs");
+        policy.record_no_progress(SCOPE_A, ArtifactRole::Implementation, "src/lib.rs");
+        assert_eq!(
+            policy.classify_strategy(
+                SCOPE_A,
+                ArtifactRole::Implementation,
+                &[ArtifactRole::Implementation, ArtifactRole::Test],
+                false,
+            ),
+            RecoveryStrategy::EscalateToScaffoldRebuild
+        );
+    }
+
+    #[test]
+    fn strategy_operator_missing_when_no_alternate_role() {
+        // AC4: a single-role cluster exhausting its only role yields the
+        // structured operator-missing strategy.
+        let mut policy = NoProgressRecoveryPolicy::new();
+        policy.record_no_progress(SCOPE_A, ArtifactRole::Implementation, "src/lib.rs");
+        policy.record_no_progress(SCOPE_A, ArtifactRole::Implementation, "src/lib.rs");
+        // Only Implementation is a candidate, and it is now role-banned.
+        assert_eq!(
+            policy.classify_strategy(
+                SCOPE_A,
+                ArtifactRole::Implementation,
+                &[ArtifactRole::Implementation],
+                false,
+            ),
+            RecoveryStrategy::OperatorMissing
+        );
+        // Coherent with the terminal classification.
+        assert_eq!(
+            policy.classify_exhaustion(SCOPE_A, &[ArtifactRole::Implementation]),
+            Some(NoProgressExhaustionReason::OperatorMissing)
+        );
+    }
+
+    #[test]
+    fn strategy_labels_are_stable() {
+        assert_eq!(
+            RecoveryStrategy::RetryDeterministicOperator.as_str(),
+            "retry_deterministic_operator"
+        );
+        assert_eq!(
+            RecoveryStrategy::SwitchTargetRole.as_str(),
+            "switch_target_role"
+        );
+        assert_eq!(
+            RecoveryStrategy::RouteToEvidenceBinding.as_str(),
+            "route_to_evidence_binding"
+        );
+        assert_eq!(
+            RecoveryStrategy::EscalateToContractConflict.as_str(),
+            "escalate_to_contract_conflict"
+        );
+        assert_eq!(
+            RecoveryStrategy::EscalateToScaffoldRebuild.as_str(),
+            "escalate_to_scaffold_rebuild"
+        );
+        assert_eq!(
+            RecoveryStrategy::OperatorMissing.as_str(),
+            "operator_missing"
+        );
     }
 }

--- a/src/agent/loop_run/repair_job.rs
+++ b/src/agent/loop_run/repair_job.rs
@@ -16,7 +16,9 @@
 
 use std::path::{Path, PathBuf};
 
-use super::no_progress_recovery::{NoProgressExhaustionReason, NoProgressRecoveryPolicy};
+use super::no_progress_recovery::{
+    NoProgressExhaustionReason, NoProgressRecoveryPolicy, RecoveryStrategy,
+};
 use super::repair_attempt_outcome::{
     MAX_REPAIR_ATTEMPT_OUTCOMES, RepairAttemptOutcome, RepairAttemptOutcomeKind,
     RepairRejectionKind, should_promote_to_exhausted_after_push,
@@ -1109,8 +1111,60 @@ impl RepairJob {
     pub(super) fn no_progress_diagnostic_payload(&self) -> serde_json::Value {
         let scope = self.no_progress_cluster_scope().unwrap_or_default();
         let candidate_roles = self.no_progress_candidate_roles();
-        self.no_progress_policy
-            .diagnostic_payload(&scope, &candidate_roles)
+        let mut payload = self
+            .no_progress_policy
+            .diagnostic_payload(&scope, &candidate_roles);
+        // Issue #1006: surface the deterministic forward strategy alongside the
+        // ban data so the diagnostic classifier (and the logs) see *which*
+        // strategy switch the controller has selected — a closed-enum label
+        // only, never raw paths or LLM prose.
+        if let Some(strategy) = self.no_progress_strategy()
+            && let Some(obj) = payload.as_object_mut()
+        {
+            obj.insert(
+                "strategy".to_string(),
+                serde_json::Value::String(strategy.as_str().to_string()),
+            );
+        }
+        payload
+    }
+
+    /// Issue #1006: the deterministic forward strategy for the active cluster's
+    /// no-progress state. `None` when no bans exist or no cluster scope is
+    /// available (the legacy fail-fast path is unaffected).
+    ///
+    /// The `role` is the most recent no-progress observation's role (falling
+    /// back to the plan's preferred role), and `has_contract_conflict` reuses
+    /// the #994 contract-conflict classifier so the test/impl escalation is tied
+    /// to the same inter-artifact signal that drives `ContractConflictJob`.
+    pub(super) fn no_progress_strategy(&self) -> Option<RecoveryStrategy> {
+        if self.no_progress_policy.is_empty() {
+            return None;
+        }
+        let scope = self.no_progress_cluster_scope()?;
+        let candidate_roles = self.no_progress_candidate_roles();
+        let role = self
+            .no_progress_policy
+            .latest_no_progress_role(&scope)
+            .or_else(|| {
+                self.semantic_plan
+                    .as_ref()
+                    .map(|plan| plan.preferred_repair_role)
+            })?;
+        let has_contract_conflict = self
+            .semantic_plan
+            .as_ref()
+            .map(|plan| {
+                super::contract_conflict_job::classify_contract_conflict(&plan.semantic_report)
+                    .is_some()
+            })
+            .unwrap_or(false);
+        Some(self.no_progress_policy.classify_strategy(
+            &scope,
+            role,
+            &candidate_roles,
+            has_contract_conflict,
+        ))
     }
 
     /// Issue #990: whether the diagnostic LLM's selected `(role, path)` is
@@ -4766,6 +4820,138 @@ mod tests {
             &vec![serde_json::json!("test")],
             "forced role switch to the cluster's alternate role"
         );
+    }
+
+    #[test]
+    fn strategy_switches_role_on_repeated_same_failure() {
+        // Issue #1006 (AC1): when the same failure key recurs, the previous
+        // target role is banned and the deterministic strategy switches off it.
+        // The strategy is also surfaced in the diagnostic payload.
+        let (mut job, targets) = semantic_repair_job_with_targets_for_test(
+            "A",
+            ArtifactRole::Implementation,
+            &["src/lib.rs", "src/other.rs"],
+        );
+        job.apply_event(RepairJobEvent::TargetReassessmentRequired {
+            key: RepairAttemptKey::from_target(&targets[0], None),
+        });
+        assert_eq!(
+            job.no_progress_strategy(),
+            Some(RecoveryStrategy::RetryDeterministicOperator),
+            "first no-progress retries the deterministic operator"
+        );
+        job.apply_event(RepairJobEvent::TargetReassessmentRequired {
+            key: RepairAttemptKey::from_target(&targets[1], None),
+        });
+        assert!(!job.no_progress_policy.is_empty());
+        assert_eq!(
+            job.no_progress_strategy(),
+            Some(RecoveryStrategy::SwitchTargetRole),
+            "second same-failure-key no-progress switches target role"
+        );
+        let payload = job.no_progress_diagnostic_payload();
+        assert_eq!(payload["strategy"], serde_json::json!("switch_target_role"));
+    }
+
+    #[test]
+    fn strategy_routes_setup_failure_to_evidence_binding() {
+        // Issue #1006 (AC2): a setup-role no-progress routes to evidence binding
+        // / scaffold, never back to implementation repair — even when
+        // implementation is an available candidate role for the cluster.
+        let (mut job, targets) =
+            semantic_repair_job_with_targets_for_test("S", ArtifactRole::Setup, &["Cargo.toml"]);
+        if let Some(plan) = job.semantic_plan.as_mut()
+            && let Some(cluster) = plan.semantic_report.failure_clusters.get_mut(0)
+        {
+            cluster.involved_artifacts = vec![ArtifactRole::Setup, ArtifactRole::Implementation];
+        }
+        job.apply_event(RepairJobEvent::TargetReassessmentRequired {
+            key: RepairAttemptKey::from_target(&targets[0], None),
+        });
+        let strategy = job.no_progress_strategy();
+        assert_eq!(strategy, Some(RecoveryStrategy::RouteToEvidenceBinding));
+        assert_ne!(strategy, Some(RecoveryStrategy::SwitchTargetRole));
+        let payload = job.no_progress_diagnostic_payload();
+        assert_eq!(
+            payload["strategy"],
+            serde_json::json!("route_to_evidence_binding")
+        );
+    }
+
+    #[test]
+    fn strategy_escalates_test_impl_conflict_to_contract() {
+        // Issue #1006 (AC3): a recurring inter-artifact (test/impl) conflict
+        // escalates to contract arbitration, tied to the #994 conflict
+        // classifier via the cluster's involved artifacts.
+        let (mut job, targets) = semantic_repair_job_with_targets_for_test(
+            "A",
+            ArtifactRole::Implementation,
+            &["src/lib.rs"],
+        );
+        if let Some(plan) = job.semantic_plan.as_mut()
+            && let Some(cluster) = plan.semantic_report.failure_clusters.get_mut(0)
+        {
+            // Make the cluster an impl-vs-test conflict so `classify_contract_conflict`
+            // reports >= 2 involved roles.
+            cluster.involved_artifacts = vec![ArtifactRole::Implementation, ArtifactRole::Test];
+        }
+        for _ in 0..3 {
+            job.apply_event(RepairJobEvent::TargetReassessmentRequired {
+                key: RepairAttemptKey::from_target(&targets[0], None),
+            });
+        }
+        assert_eq!(
+            job.no_progress_strategy(),
+            Some(RecoveryStrategy::EscalateToContractConflict)
+        );
+        let payload = job.no_progress_diagnostic_payload();
+        assert_eq!(
+            payload["strategy"],
+            serde_json::json!("escalate_to_contract_conflict")
+        );
+    }
+
+    #[test]
+    fn strategy_records_operator_missing_reason() {
+        // Issue #1006 (AC4): a single-role cluster that exhausts its only role
+        // yields the structured operator-missing strategy AND the matching
+        // terminal reason that is persisted via the safe-stop report.
+        let (mut job, targets) = semantic_repair_job_with_targets_for_test(
+            "A",
+            ArtifactRole::Implementation,
+            &["src/lib.rs"],
+        );
+        if let Some(plan) = job.semantic_plan.as_mut()
+            && let Some(cluster) = plan.semantic_report.failure_clusters.get_mut(0)
+        {
+            // No alternate role available for the cluster.
+            cluster.involved_artifacts = vec![ArtifactRole::Implementation];
+        }
+        job.apply_event(RepairJobEvent::TargetReassessmentRequired {
+            key: RepairAttemptKey::from_target(&targets[0], None),
+        });
+        job.apply_event(RepairJobEvent::TargetReassessmentRequired {
+            key: RepairAttemptKey::from_target(&targets[0], None),
+        });
+        assert_eq!(
+            job.no_progress_strategy(),
+            Some(RecoveryStrategy::OperatorMissing)
+        );
+        assert_eq!(
+            job.no_progress_exhaustion_reason(),
+            Some(NoProgressExhaustionReason::OperatorMissing)
+        );
+    }
+
+    #[test]
+    fn strategy_is_absent_without_no_progress_bans() {
+        // Issue #1006 (AC5): the legacy fail-fast path is unaffected — with no
+        // no-progress bans recorded there is no strategy and the diagnostic
+        // payload carries no `strategy` field.
+        let job = semantic_repair_job_for_test("A", ArtifactRole::Implementation);
+        assert_eq!(job.no_progress_strategy(), None);
+        let payload = job.no_progress_diagnostic_payload();
+        assert!(payload.get("strategy").is_none());
     }
 
     #[test]


### PR DESCRIPTION
Closes #1006

## Summary

- `NoProgressRecoveryPolicy` を fail-fast だけでなく pass-more に効かせるため、同じ failure key が残った場合に target role ban、operator escalation、contract arbitration、scaffold rebuild へ決定論的に切り替える strategy switch policy を実装する。

## Changed Files

- `src/agent/loop_run/no_progress_recovery.rs`
- `src/agent/loop_run/repair_attempt_outcome.rs`
- `src/agent/loop_run/contract_conflict_job.rs`
- `src/agent/loop_run/semantic_repair_planning.rs`
- `src/agent/loop_run/summary.rs`
- `workspace/v0.6.5/general-purpose-countermeasures-20260606.md`
- `src/session/sessions_cli.rs`
- `src/session/feedback.rs`

## Tests Run

- `cargo test`
- `cargo clippy`
- `cargo fmt`

## Known Risks

- None recorded by orchestration planner.

## Orchestration

- Run ID: `20260606-032310-orchestrate`
