### PR TITLE
#1008 feature: Expand non-coding evaluation set on the generic lifecycle

### DIFF
--- a/benchmarks/non-coding-lifecycle.yaml
+++ b/benchmarks/non-coding-lifecycle.yaml
@@ -1,0 +1,48 @@
+name: non-coding-lifecycle
+description: >-
+  Non-coding evaluation set (Issue #1008). One case per non-coding TaskKind
+  (docs / data / research / ops / authoring) exercised on the same
+  Objective / Evidence / Recovery lifecycle as coding. Fixtures are tiny,
+  reproducible, and network-free; evidence is judged by the deterministic
+  per-kind checkers (no LLM judge). Categories are pinned to the agent
+  classifier by the issue1008 divergence guard in task_contract.rs.
+args:
+  max_iterations: 30
+  chat_retries: 2
+  sidecar_model: qwen3.5:9b
+cases:
+  - name: docs-configuration-reference
+    category: docs
+    prompt: |
+      Update docs/configuration-reference.md with a configuration reference for the agent.
+      Document the configuration file location, the available settings with their default values, and a short troubleshooting section.
+      This is a documentation-only task: do not modify code.
+      Stop after confirming the documentation file is written.
+  - name: data-json-to-csv-summary
+    category: data
+    prompt: |
+      Create a small documented command that transforms input/events.json into output/event-summary.csv.
+      Required columns: id, name, event_count, last_seen.
+      Preserve the input row order, write a short note on how to run it, and include a tiny sample fixture if none exists.
+      Stop after confirming the transform artifact is present.
+  - name: research-logging-strategy-brief
+    category: research
+    prompt: |
+      Research and compare three local logging approaches (structured JSON logs, plain text logs, and rotating file logs) for a local CLI agent.
+      Capture the analysis in research/logging-strategy-brief.md with a recommendation, tradeoffs, failure modes, cited sources, and an explicit assumptions section.
+      Do not change code.
+      Stop after confirming the report file is written.
+  - name: ops-local-agent-triage-runbook
+    category: ops
+    prompt: |
+      Prepare an operations runbook at runbooks/local-agent-triage.md for a local Ollama-backed agent.
+      Include a symptom checklist, the exact shell commands to collect logs with their expected exit codes, the log files to gather and their locations, recovery steps, and escalation criteria.
+      Keep it operational and checklist-oriented.
+      Stop after confirming the runbook is written.
+  - name: authoring-onboarding-explainer
+    category: authoring
+    prompt: |
+      Rewrite the onboarding explanation of how the agent loop works into docs/agent-loop-onboarding.md for new contributors.
+      Use plain language for a beginner audience, a short analogy, and at least two concrete examples so a newcomer can follow it.
+      Do not modify code.
+      Stop after confirming the document is written.

--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -505,7 +505,7 @@ for model in "${cleaned_models[@]}"; do
       echo "Error: empty benchmark case name" >&2
       exit 1
     fi
-    if ! [[ "$task_kind" =~ ^(coding|docs|data|research|ops)$ ]]; then
+    if ! [[ "$task_kind" =~ ^(coding|docs|data|research|ops|authoring)$ ]]; then
       echo "Error: invalid task_kind/category for case $case_name: $task_kind" >&2
       exit 1
     fi

--- a/src/agent/loop_run/evidence_runner.rs
+++ b/src/agent/loop_run/evidence_runner.rs
@@ -384,6 +384,38 @@ mod tests {
     }
 
     #[test]
+    fn authoring_runner_emits_deterministic_content_evidence() {
+        // Issue #1008: authoring evidence is judged by the same deterministic
+        // content checker as docs (required-sections), with no LLM judge. A
+        // beginner-facing explainer with the requested sections passes.
+        let authoring =
+            evidence_runner_for_task_kind(TaskKind::Authoring).expect("authoring runner");
+        let output = authoring
+            .artifact_evidence(VerifierArtifact {
+                path: Some("docs/agent-loop-onboarding.md"),
+                excerpt: "## Setup\nFirst install the agent and open the config.\n## Example\nWalk through a beginner example of the loop.\n",
+                required_columns: &[],
+                required_sections: &[],
+            })
+            .expect("authoring evidence");
+        assert_eq!(
+            output,
+            EvidenceRunnerOutput::Completion(CompletionEvidence::RequiredSectionsPass {
+                path: Some("docs/agent-loop-onboarding.md".to_string()),
+            })
+        );
+
+        // Authoring is content-driven, not command/observation driven: the
+        // command and source-fetch surfaces stay inert (no coding-shaped
+        // verifier evidence is projected onto the prose terminal state).
+        assert_eq!(authoring.observe_command("printf ok", 0, true, None), None);
+        assert_eq!(
+            authoring.observe_source_fetch("https://example.test", true, None),
+            None
+        );
+    }
+
+    #[test]
     fn runner_failures_project_to_generic_terminal_states() {
         assert_eq!(
             EvidenceRunnerError::MissingRunner.generic_terminal_state(),

--- a/src/agent/loop_run/task_contract.rs
+++ b/src/agent/loop_run/task_contract.rs
@@ -5655,6 +5655,57 @@ mod tests {
         }
     }
 
+    // ---- Issue #1008: non-coding evaluation set divergence guard -----------
+    //
+    // The expanded non-coding evaluation set (`benchmarks/non-coding-lifecycle
+    // .yaml`) runs on the same lifecycle as coding. Each case must classify to
+    // its declared `category`, otherwise R5 (misroute fail-closed) would red a
+    // correct non-coding run. This pins prompt -> kind for every non-coding kind
+    // (docs / data / research / ops / authoring) against the real fixture file
+    // via `include_str!` (zero drift), and asserts every category is one of the
+    // five non-coding kinds (the suite is non-coding by construction).
+    #[test]
+    fn issue1008_non_coding_lifecycle_categories_match_agent_classifier() {
+        const YAML: &str = include_str!("../../../benchmarks/non-coding-lifecycle.yaml");
+        let cases = parse_benchmark_cases(YAML);
+        assert_eq!(
+            cases.len(),
+            5,
+            "expected the 5 non-coding-lifecycle cases (one per non-coding kind), \
+             parsed {}: {:?}",
+            cases.len(),
+            cases.iter().map(|(n, _, _)| n).collect::<Vec<_>>()
+        );
+        let mut seen_kinds = std::collections::BTreeSet::new();
+        for (name, category, prompt) in &cases {
+            assert!(
+                ["docs", "data", "research", "ops", "authoring"].contains(&category.as_str()),
+                "case `{name}` has category `{category}` — the non-coding evaluation \
+                 set must only contain non-coding kinds (no coding case)"
+            );
+            seen_kinds.insert(category.clone());
+            let classified = TaskContract::from_request(prompt).task_kind;
+            assert_eq!(
+                classified.as_str(),
+                category.as_str(),
+                "case `{name}`: agent classified `{}` but eval category is `{}` — \
+                 a misroute would make R5 fail a correct non-coding run. Adjust the \
+                 prompt wording or the category so they agree (no new YAML key).",
+                classified.as_str(),
+                category
+            );
+        }
+        // Every non-coding kind is exercised exactly once: the set is complete.
+        assert_eq!(
+            seen_kinds,
+            ["authoring", "data", "docs", "ops", "research"]
+                .iter()
+                .map(|s| s.to_string())
+                .collect::<std::collections::BTreeSet<_>>(),
+            "the non-coding evaluation set must cover every non-coding TaskKind once"
+        );
+    }
+
     // ---- Issue #917 Phase 1: classification confidence / needs_confirm -----
 
     #[test]

--- a/tests/test_eval_task_kind.py
+++ b/tests/test_eval_task_kind.py
@@ -503,6 +503,134 @@ class TestTaskKindEvalReporting(unittest.TestCase):
         self.assertEqual(completed["terminal_success"]["ok"], 6)
         self.assertEqual(data["by_recovery_job_kind"][0]["recovery_job_kind"], "none")
 
+    def test_report_aggregates_success_terminal_failure_class_for_non_coding_set(
+        self,
+    ) -> None:
+        # Issue #1008: the expanded non-coding evaluation set
+        # (benchmarks/non-coding-lifecycle.yaml) runs on the shared lifecycle.
+        # Its per-TaskKind success rate, terminal state, and failure class must
+        # aggregate for every non-coding kind -- including `authoring`, which the
+        # existing by_task_kind / by_failure_authority tests do not cover.
+        with tempfile.TemporaryDirectory() as raw:
+            bench_root = pathlib.Path(raw) / "bench-root"
+            passing = [
+                ("docs", "docs/configuration-reference.md"),
+                ("data", "output/event-summary.csv"),
+                ("research", "research/logging-strategy-brief.md"),
+                ("ops", "runbooks/local-agent-triage.md"),
+            ]
+            for task_kind, modified_path in passing:
+                _make_run(
+                    bench_root / "qwen3" / task_kind / "pam_off" / "run-1",
+                    task_kind=task_kind,
+                    pam_variant="pam_off",
+                    modified_path=modified_path,
+                    final_outcome="done",
+                )
+            # One failing authoring run populates the failure-class dimension with
+            # a neutral (non-coding) terminal state and authority.
+            _make_run(
+                bench_root / "qwen3" / "authoring" / "pam_off" / "run-1",
+                task_kind="authoring",
+                pam_variant="pam_off",
+                modified_path="docs/agent-loop-onboarding.md",
+                rc=1,
+                final_outcome="evidence_failed",
+                failure_authority="artifact_classification",
+            )
+
+            data = json.loads(
+                subprocess.run(
+                    [sys.executable, str(REPORT), "--format", "json", str(bench_root)],
+                    capture_output=True,
+                    text=True,
+                    cwd=str(REPO_ROOT),
+                    check=True,
+                ).stdout
+            )
+
+        def by_keys(items: list[dict[str, object]], **criteria: str) -> dict[str, object]:
+            for item in items:
+                if all(item.get(key) == value for key, value in criteria.items()):
+                    return item
+            raise AssertionError(f"missing {criteria}: {items}")
+
+        # Every non-coding kind is aggregated with a success-rate projection.
+        kinds = {item["task_kind"] for item in data["by_task_kind"]}
+        self.assertEqual(kinds, {"docs", "data", "research", "ops", "authoring"})
+        authoring = by_keys(data["by_task_kind"], task_kind="authoring")
+        self.assertEqual(authoring["runs"], 1)
+        self.assertEqual(authoring["terminal_success"]["ok"], 0)
+        self.assertEqual(authoring["terminal_success"]["total"], 1)
+
+        # Terminal-state aggregation separates the failing authoring run from the
+        # four completed runs (no coding vocabulary is projected onto it).
+        completed = by_keys(
+            data["by_generic_terminal_state"], generic_terminal_state="completed"
+        )
+        self.assertEqual(completed["runs"], 4)
+        failed = by_keys(
+            data["by_generic_terminal_state"], generic_terminal_state="evidence_failed"
+        )
+        self.assertEqual(failed["runs"], 1)
+
+        # Failure-class distribution carries the authoring failure.
+        artifact_cls = by_keys(
+            data["by_failure_authority"], failure_authority="artifact_classification"
+        )
+        self.assertEqual(artifact_cls["runs"], 1)
+
+    def test_analyze_deterministic_postcheck_for_non_coding_fixture_artifacts(
+        self,
+    ) -> None:
+        # Issue #1008 / AC3: the per-kind postcheck checker is deterministic and
+        # passes the fixture-shaped artifacts for docs/data/research/ops/authoring
+        # with no LLM judge. Each kind's artifact resolves to a stable reason.
+        cases = [
+            ("docs", "docs/configuration-reference.md", "docs_artifact"),
+            ("data", "output/event-summary.csv", "data_artifact"),
+            ("research", "research/logging-strategy-brief.md", "research_artifact"),
+            ("ops", "runbooks/local-agent-triage.md", "ops_artifact"),
+            ("authoring", "docs/agent-loop-onboarding.md", "authoring_artifact"),
+        ]
+        with tempfile.TemporaryDirectory() as raw:
+            root = pathlib.Path(raw)
+            for idx, (task_kind, artifact, reason) in enumerate(cases, start=1):
+                run_dir = root / f"pass-{idx}"
+                _make_run(
+                    run_dir,
+                    task_kind=task_kind,
+                    pam_variant="pam_off",
+                    modified_path=artifact,
+                    final_outcome="done",
+                )
+                first = self._analyze(run_dir)
+                self.assertTrue(
+                    first["postcheck_success"],
+                    f"{task_kind} artifact {artifact} should pass deterministically",
+                )
+                self.assertEqual(first["postcheck_reason"], reason)
+                # Determinism: a second analysis yields the identical verdict.
+                second = self._analyze(run_dir)
+                self.assertEqual(
+                    first["postcheck_success"], second["postcheck_success"]
+                )
+                self.assertEqual(first["postcheck_reason"], second["postcheck_reason"])
+
+            # Negative: a non-docs artifact fails the authoring checker (proving
+            # the checker discriminates rather than always passing).
+            neg_dir = root / "authoring-neg"
+            _make_run(
+                neg_dir,
+                task_kind="authoring",
+                pam_variant="pam_off",
+                modified_path="src/lib.rs",
+                final_outcome="done",
+            )
+            neg = self._analyze(neg_dir)
+            self.assertFalse(neg["postcheck_success"])
+            self.assertEqual(neg["postcheck_reason"], "missing_authoring_artifact")
+
     def test_analyze_emits_worker_lifecycle_metrics_from_eval_log(self) -> None:
         with tempfile.TemporaryDirectory() as raw:
             run_dir = pathlib.Path(raw) / "run-1"


### PR DESCRIPTION
Closes #1008

## Summary

- Anvil を coding 以外にも使える local-first agent にするため、docs / data transform / file organization / shell observation / research notes / media reading / learner explanation の評価セットを、Objective/Evidence/Recovery の同一 lifecycle 上に追加する。

## Changed Files

- `src/agent/loop_run/evidence_runner.rs`
- `src/agent/loop_run/task_contract.rs`
- `tests/test_eval_task_kind.py`
- `workspace/v0.6.5/general-purpose-countermeasures-20260606.md`
- `docs/data/research/ops/authoring`
- `src/session/sessions_cli.rs`
- `src/session/feedback.rs`
- `src/session/auto_promote_scrub.rs`

## Tests Run

- `cargo test`
- `cargo clippy`
- `cargo fmt`

## Known Risks

- None recorded by orchestration planner.

## Orchestration

- Run ID: `20260606-032310-orchestrate`
