### PR TITLE
Add llm-io prompt metrics schema

### DIFF
--- a/docs/eval/llm-io-schema.md
+++ b/docs/eval/llm-io-schema.md
@@ -1,0 +1,88 @@
+# llm-io.jsonl Schema
+
+`llm-io.jsonl` is an append-only JSON Lines stream stored under each session's
+`logs/` directory. Every line has this envelope:
+
+```json
+{
+  "ts_ms": 1700000000000,
+  "event": "ollama.chat.request",
+  "payload": {}
+}
+```
+
+All payloads are passed through the logging secret masker before they are
+written.
+
+## Ollama Request Events
+
+Events:
+
+- `ollama.generate.request`
+- `ollama.chat.request`
+
+Stable payload fields:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `base_url` | string | Ollama base URL. |
+| `model` | string | Requested model name. |
+| `stream` | boolean | Whether streaming was requested. |
+| `temperature` | number | Request temperature. |
+| `num_ctx` | number | Context window passed to Ollama. |
+| `num_predict` | number | Generation cap passed to Ollama. |
+| `tools` | array[string] | Tool names available to this request. |
+| `messages` | array[object] | Controller-side request messages before transport rendering. |
+| `prompt_metrics` | object | Prompt observability schema, versioned below. |
+
+`ollama.chat.request` also includes `format`, which is either a string or null.
+
+### `prompt_metrics` Version 1
+
+`prompt_metrics.schema_version` is `1`.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `schema_version` | number | Prompt metrics schema version. |
+| `final_prompt` | string | Controller-side final prompt rendering. For `/api/generate`, this is the exact prompt sent with `raw: true`. For `/api/chat`, this is Anvil's deterministic ChatML-style rendering of the same message list because Ollama's model template expansion is not observable client-side. |
+| `prompt_char_count` | number | Unicode scalar count of `final_prompt`. |
+| `approx_prompt_tokens` | number | Deterministic estimate using `chars / 4`, rounded up. |
+| `injection_blocks` | array[object] | Per-message breakdown used to attribute prompt growth. |
+
+Each `injection_blocks[]` item has this shape:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `index` | number | Zero-based message index in the request. |
+| `kind` | string | One of `system_prompt`, `system_injection`, `user_message`, `assistant_history`, `tool_result`, or `message`. |
+| `role` | string | Original `ConversationMessage.role`. |
+| `name` | string or null | Tool result name when present. |
+| `char_count` | number | Unicode scalar count of the message content. |
+| `approx_tokens` | number | Deterministic estimate for this block, including fixed per-message overhead. |
+| `tool_call_count` | number | Assistant tool-call count attached to this message. |
+
+## Ollama Reply Events
+
+Events:
+
+- `ollama.generate.reply_final`
+- `ollama.chat.reply_final`
+
+Stable payload fields:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `content` | string | Final assistant text after parser cleanup. |
+| `tool_calls` | array[object] | Parsed tool calls. |
+| `prompt_tokens` | number or null | Ollama `prompt_eval_count`, when provided. |
+| `completion_tokens` | number or null | Ollama `eval_count`, when provided. |
+
+## Raw Response Events
+
+Events:
+
+- `ollama.generate.response_raw`
+- `ollama.chat.response_raw`
+
+Non-streaming payloads include `model`, `stream`, and truncated raw `body`.
+Streaming payloads include `stream: true` and truncated line `chunks`.

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -9,9 +9,79 @@ use tracing_subscriber::EnvFilter;
 
 use crate::config::LogLevel;
 use crate::session::feedback::mask_secrets;
+use crate::session::store::ConversationMessage;
 
 static LLM_IO_LOGGER: OnceLock<Mutex<File>> = OnceLock::new();
 static LLM_IO_LOG_PATH: OnceLock<PathBuf> = OnceLock::new();
+
+pub const LLM_IO_PROMPT_SCHEMA_VERSION: u64 = 1;
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct PromptLogMetrics {
+    pub schema_version: u64,
+    pub final_prompt: String,
+    pub prompt_char_count: usize,
+    pub approx_prompt_tokens: usize,
+    pub injection_blocks: Vec<PromptInjectionBlock>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct PromptInjectionBlock {
+    pub index: usize,
+    pub kind: String,
+    pub role: String,
+    pub name: Option<String>,
+    pub char_count: usize,
+    pub approx_tokens: usize,
+    pub tool_call_count: usize,
+}
+
+pub fn build_prompt_log_metrics(
+    messages: &[ConversationMessage],
+    final_prompt: String,
+) -> PromptLogMetrics {
+    let prompt_char_count = final_prompt.chars().count();
+    let injection_blocks = messages
+        .iter()
+        .enumerate()
+        .map(|(index, message)| PromptInjectionBlock {
+            index,
+            kind: prompt_block_kind(index, message).to_string(),
+            role: message.role.clone(),
+            name: message.name.clone(),
+            char_count: message.content.chars().count(),
+            approx_tokens: approximate_message_tokens(message),
+            tool_call_count: message.tool_calls.len(),
+        })
+        .collect();
+
+    PromptLogMetrics {
+        schema_version: LLM_IO_PROMPT_SCHEMA_VERSION,
+        final_prompt,
+        prompt_char_count,
+        approx_prompt_tokens: approximate_text_tokens(prompt_char_count),
+        injection_blocks,
+    }
+}
+
+fn prompt_block_kind(index: usize, message: &ConversationMessage) -> &'static str {
+    match message.role.as_str() {
+        "system" if index == 0 => "system_prompt",
+        "system" => "system_injection",
+        "user" => "user_message",
+        "assistant" => "assistant_history",
+        "tool" => "tool_result",
+        _ => "message",
+    }
+}
+
+fn approximate_message_tokens(message: &ConversationMessage) -> usize {
+    approximate_text_tokens(message.content.chars().count()) + message.tool_calls.len() * 32 + 12
+}
+
+fn approximate_text_tokens(char_count: usize) -> usize {
+    char_count.div_ceil(4)
+}
 
 pub fn init_logging(log_level: LogLevel, log_path: &Path) -> Result<(), String> {
     let directive = log_level.env_filter();

--- a/src/ollama/client.rs
+++ b/src/ollama/client.rs
@@ -249,6 +249,7 @@ impl OllamaClient {
         let temperature = if tool_mode { 0.3 } else { 0.7 };
         let tool_names_vec = tool_names(tools.unwrap_or(&[]));
         let prompt = flatten_messages_to_chatml(messages);
+        let prompt_metrics = logging::build_prompt_log_metrics(messages, prompt.clone());
 
         logging::log_llm_event(
             "ollama.generate.request",
@@ -262,6 +263,7 @@ impl OllamaClient {
                 "num_predict": self.max_predict,
                 "tools": tool_names_vec,
                 "messages": messages,
+                "prompt_metrics": prompt_metrics,
             }),
         );
 
@@ -349,6 +351,8 @@ impl OllamaClient {
         F: FnMut(&str) -> Result<(), String>,
     {
         let tool_names_vec = tool_names(tools);
+        let final_prompt = flatten_messages_to_chatml(messages);
+        let prompt_metrics = logging::build_prompt_log_metrics(messages, final_prompt);
 
         logging::log_llm_event(
             "ollama.chat.request",
@@ -362,6 +366,7 @@ impl OllamaClient {
                 "format": response_format,
                 "tools": tool_names_vec,
                 "messages": messages,
+                "prompt_metrics": prompt_metrics,
             }),
         );
 

--- a/tests/llm_io_schema_tests.rs
+++ b/tests/llm_io_schema_tests.rs
@@ -1,0 +1,38 @@
+use anvil::logging::{LLM_IO_PROMPT_SCHEMA_VERSION, build_prompt_log_metrics};
+use anvil::session::store::ConversationMessage;
+
+#[test]
+fn prompt_metrics_schema_is_stable() {
+    let messages = vec![
+        ConversationMessage::system("You are Anvil.".to_string()),
+        ConversationMessage::user("Inspect src/lib.rs".to_string()),
+        ConversationMessage::tool("Read".to_string(), "pub fn run() {}".to_string()),
+    ];
+    let final_prompt = "<|im_start|>system\nYou are Anvil.<|im_end|>\n".to_string();
+
+    let metrics = build_prompt_log_metrics(&messages, final_prompt.clone());
+    let value = serde_json::to_value(&metrics).expect("metrics should serialize");
+
+    assert_eq!(value["schema_version"], LLM_IO_PROMPT_SCHEMA_VERSION);
+    assert_eq!(value["final_prompt"], final_prompt);
+    assert_eq!(value["prompt_char_count"], final_prompt.chars().count());
+    assert!(value["approx_prompt_tokens"].as_u64().unwrap() > 0);
+
+    let blocks = value["injection_blocks"].as_array().unwrap();
+    assert_eq!(blocks.len(), 3);
+
+    assert_eq!(blocks[0]["index"], 0);
+    assert_eq!(blocks[0]["kind"], "system_prompt");
+    assert_eq!(blocks[0]["role"], "system");
+    assert_eq!(blocks[0]["name"], serde_json::Value::Null);
+    assert_eq!(blocks[0]["tool_call_count"], 0);
+
+    assert_eq!(blocks[1]["kind"], "user_message");
+    assert_eq!(blocks[1]["role"], "user");
+
+    assert_eq!(blocks[2]["kind"], "tool_result");
+    assert_eq!(blocks[2]["role"], "tool");
+    assert_eq!(blocks[2]["name"], "Read");
+    assert_eq!(blocks[2]["char_count"], "pub fn run() {}".chars().count());
+    assert!(blocks[2]["approx_tokens"].as_u64().unwrap() > 0);
+}


### PR DESCRIPTION
## Linked Issue

- None. Minimal loop migration plan T0-1.

## Summary

- Add versioned `prompt_metrics` to `ollama.generate.request` and `ollama.chat.request` llm-io events.
- Record controller-side final prompt rendering, approximate prompt token count, and per-message injection block breakdown.
- Document the llm-io request/reply schema in `docs/eval/llm-io-schema.md`.
- Add a schema stability test for prompt metrics serialization.

## Changed Files

- `src/logging.rs`
- `src/ollama/client.rs`
- `docs/eval/llm-io-schema.md`
- `tests/llm_io_schema_tests.rs`

## Tests Run

- `cargo fmt --all -- --check`
- `cargo test prompt_metrics_schema_is_stable -q`
- `cargo test --test llm_io_schema_tests -q`
- `cargo test --test eval_harness_smoke -q`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test -q` (first sandboxed run hit local mockito server permission failures; rerun with elevated sandbox permissions passed)

## Known Risks

- `prompt_metrics.final_prompt` intentionally logs the full controller-side prompt after the existing secret masker. This increases llm-io log size, but T0-1 explicitly requires final prompt capture for evaluation.
- For `/api/chat`, `final_prompt` is a deterministic ChatML-style rendering of Anvil messages, not Ollama's internal model-template expansion, because that expansion is not observable from the client.

## Orchestration Run ID

- Not available.