### PR TITLE
Add minimal engine CLI stub

### DIFF
--- a/docs/cli-help.snapshot.txt
+++ b/docs/cli-help.snapshot.txt
@@ -41,6 +41,8 @@ Options:
           
       --deterministic-fallback <DETERMINISTIC_FALLBACK>
           Control deterministic recovery. `hint-only` only nudges the model, `minimal-patch` writes support files only, and `full-template` preserves legacy full template recovery. `support-only` and `full` remain aliases [possible values: off, hint-only, minimal-patch, full-template]
+      --engine <ENGINE>
+          [possible values: legacy, minimal]
       --experimental-specialized-fallback <EXPERIMENTAL_SPECIALIZED_FALLBACK>
           Issue #634: experimental opt-in for specialized fallback paths (FastAPI scaffold / Python CSV / FizzBuzz / fixed arithmetic patch / qwen3.5 固有 deterministic edit). Default off. Template 系は `--deterministic-fallback full-template` との AND 条件で発火。 [possible values: true, false]
       --no-footer

--- a/src/agent/loop_run/footer.rs
+++ b/src/agent/loop_run/footer.rs
@@ -1241,6 +1241,7 @@ mod tests {
             auto_plan: false,
             offline: false,
             deterministic_fallback: Default::default(),
+            engine: Default::default(),
             prompt: None,
             state_dir_override: None,
             resume: Default::default(),

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use clap::{Parser, Subcommand};
 
-use crate::config::DeterministicFallbackMode;
+use crate::config::{DeterministicFallbackMode, Engine};
 
 #[derive(Debug, Clone, Parser)]
 #[command(name = "anvil")]
@@ -48,6 +48,8 @@ pub struct CliArgs {
     /// legacy full template recovery. `support-only` and `full` remain aliases.
     #[arg(long = "deterministic-fallback", value_enum)]
     pub deterministic_fallback: Option<DeterministicFallbackMode>,
+    #[arg(long = "engine", value_enum)]
+    pub engine: Option<Engine>,
     /// Issue #634: experimental opt-in for specialized fallback paths
     /// (FastAPI scaffold / Python CSV / FizzBuzz / fixed arithmetic patch /
     /// qwen3.5 固有 deterministic edit). Default off. Template 系は
@@ -287,6 +289,7 @@ mod tests {
             auto_plan: false,
             offline: false,
             deterministic_fallback: None,
+            engine: None,
             experimental_specialized_fallback: None,
             no_footer: false,
             resume: None,
@@ -356,6 +359,15 @@ mod tests {
 
         let parsed = CliArgs::parse_from(["anvil", "--auto-plan"]);
         assert!(parsed.auto_plan);
+    }
+
+    #[test]
+    fn engine_flag_defaults_none_and_parses_minimal() {
+        let args = base_args();
+        assert_eq!(args.engine, None);
+
+        let parsed = CliArgs::parse_from(["anvil", "--engine", "minimal"]);
+        assert_eq!(parsed.engine, Some(Engine::Minimal));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -149,6 +149,37 @@ impl FromStr for DeterministicFallbackMode {
     }
 }
 
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Default, ValueEnum, serde::Serialize, serde::Deserialize,
+)]
+pub enum Engine {
+    #[default]
+    Legacy,
+    Minimal,
+}
+
+impl fmt::Display for Engine {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            Self::Legacy => "legacy",
+            Self::Minimal => "minimal",
+        };
+        write!(f, "{s}")
+    }
+}
+
+impl FromStr for Engine {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.trim().to_ascii_lowercase().replace('_', "-").as_str() {
+            "legacy" => Ok(Self::Legacy),
+            "minimal" => Ok(Self::Minimal),
+            other => Err(format!("unknown engine: {other}")),
+        }
+    }
+}
+
 /// Identifies where a `log_level` / legacy `debug` setting was read from, so
 /// `resolve_log_level` can emit source-appropriate warning messages.
 #[derive(Debug, Clone, Copy)]
@@ -232,6 +263,7 @@ pub struct Config {
     pub auto_plan: bool,
     pub offline: bool,
     pub deterministic_fallback: DeterministicFallbackMode,
+    pub engine: Engine,
     pub prompt: Option<String>,
     pub state_dir_override: Option<PathBuf>,
     pub resume: ResumeRequest,
@@ -330,6 +362,7 @@ pub struct PartialConfig {
     pub auto_plan: Option<bool>,
     pub offline: Option<bool>,
     pub deterministic_fallback: Option<DeterministicFallbackMode>,
+    pub engine: Option<Engine>,
     pub state_dir_override: Option<PathBuf>,
     /// `Some(false)` when an explicit disable signal is present
     /// (`--no-footer` / non-empty `ANVIL_NO_FOOTER` / `.anvil/config` `footer=false`).
@@ -415,6 +448,7 @@ impl Config {
             auto_plan: args.auto_plan.then_some(true),
             offline: args.offline.then_some(true),
             deterministic_fallback: args.deterministic_fallback,
+            engine: args.engine,
             state_dir_override: args.state_dir.clone(),
             // CLI footer flag is "disable-only": `--no-footer` emits Some(false),
             // omission emits None so file/env/default can still apply.
@@ -473,6 +507,7 @@ impl Config {
             auto_plan: merged.auto_plan.unwrap_or(false),
             offline,
             deterministic_fallback: merged.deterministic_fallback.unwrap_or_default(),
+            engine: merged.engine.unwrap_or_default(),
             prompt: args.prompt,
             state_dir_override: merged.state_dir_override,
             resume: ResumeRequest::from_flag(args.resume),
@@ -567,6 +602,9 @@ pub fn merge_partial_configs(configs: &[PartialConfig]) -> PartialConfig {
         }
         if config.deterministic_fallback.is_some() {
             merged.deterministic_fallback = config.deterministic_fallback;
+        }
+        if config.engine.is_some() {
+            merged.engine = config.engine;
         }
         if config.state_dir_override.is_some() {
             merged.state_dir_override = config.state_dir_override.clone();
@@ -664,6 +702,9 @@ pub fn load_config_file(path: &Path, warnings: &mut Vec<String>) -> Result<Parti
         deterministic_fallback: map
             .get("deterministic_fallback")
             .and_then(|value| value.parse::<DeterministicFallbackMode>().ok()),
+        engine: map
+            .get("engine")
+            .and_then(|value| value.parse::<Engine>().ok()),
         state_dir_override: map.get("state_dir").map(PathBuf::from),
         // Only emit Some(false) for explicit disable; any other value (true /
         // unrecognized / missing) leaves footer as None so default wins.
@@ -756,6 +797,9 @@ pub fn load_env_config(warnings: &mut Vec<String>) -> PartialConfig {
         deterministic_fallback: env::var("ANVIL_DETERMINISTIC_FALLBACK")
             .ok()
             .and_then(|value| value.parse::<DeterministicFallbackMode>().ok()),
+        engine: env::var("ANVIL_ENGINE")
+            .ok()
+            .and_then(|value| value.parse::<Engine>().ok()),
         state_dir_override: env::var("ANVIL_STATE_DIR").ok().map(PathBuf::from),
         // POSIX `NO_COLOR` convention: any non-empty value disables; matches
         // `ANVIL_NO_SPINNER` / `ANVIL_NO_INTERRUPT` precedent (see spinner.rs).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ use agent::loop_run::commands::{
     print_startup_banner, print_startup_banner_stderr_oneshot, short_id,
 };
 use cli::{CliArgs, Command};
-use config::Config;
+use config::{Config, Engine};
 use model_registry::{RuntimeModels, select_models};
 use ollama::client::OllamaClient;
 use session::compact::find_last_user_prompt;
@@ -71,6 +71,9 @@ pub fn run_cli(args: CliArgs) -> Result<(), String> {
     let (mut config, warnings) = Config::load(args)?;
     for warning in &warnings {
         eprintln!("warning: {warning}");
+    }
+    if config.engine == Engine::Minimal {
+        return Err("minimal engine is not implemented yet".to_string());
     }
     config.cwd = ensure_workspace_root(&config.cwd)?;
 

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -2,8 +2,8 @@ use std::path::PathBuf;
 
 use anvil::cli::CliArgs;
 use anvil::config::{
-    Config, DeterministicFallbackMode, LogLevel, PartialConfig, load_config_file, load_env_config,
-    merge_partial_configs, parse_key_value_config,
+    Config, DeterministicFallbackMode, Engine, LogLevel, PartialConfig, load_config_file,
+    load_env_config, merge_partial_configs, parse_key_value_config,
 };
 
 #[test]
@@ -78,6 +78,14 @@ fn merge_offline_prefers_later_sources() {
         },
     ]);
     assert_eq!(merged.offline, Some(true));
+}
+
+#[test]
+fn engine_parses_and_defaults_to_legacy() {
+    assert_eq!(Engine::default(), Engine::Legacy);
+    assert_eq!("legacy".parse::<Engine>().unwrap(), Engine::Legacy);
+    assert_eq!("minimal".parse::<Engine>().unwrap(), Engine::Minimal);
+    assert_eq!(Engine::Legacy.to_string(), "legacy");
 }
 
 #[test]
@@ -170,6 +178,21 @@ fn merge_experimental_specialized_fallback_prefers_later_sources() {
         PartialConfig::default(),
     ]);
     assert_eq!(merged.experimental_specialized_fallback, Some(true));
+}
+
+#[test]
+fn merge_engine_prefers_later_sources() {
+    let merged = merge_partial_configs(&[
+        PartialConfig {
+            engine: Some(Engine::Legacy),
+            ..PartialConfig::default()
+        },
+        PartialConfig {
+            engine: Some(Engine::Minimal),
+            ..PartialConfig::default()
+        },
+    ]);
+    assert_eq!(merged.engine, Some(Engine::Minimal));
 }
 
 /// Issue #634: `parse_key_value_config` accepts the new
@@ -548,12 +571,39 @@ fn minimal_args(cwd: &std::path::Path) -> CliArgs {
         auto_plan: false,
         offline: false,
         deterministic_fallback: None,
+        engine: None,
         experimental_specialized_fallback: None,
         no_footer: false,
         resume: None,
         state_dir: None,
         command: None,
     }
+}
+
+#[test]
+fn config_load_defaults_engine_to_legacy() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (cfg, _) = Config::load(minimal_args(tmp.path())).unwrap();
+    assert_eq!(cfg.engine, Engine::Legacy);
+}
+
+#[test]
+fn config_file_engine_minimal_is_loaded() {
+    let tmp = tempfile::tempdir().unwrap();
+    let config_path = tmp.path().join("config");
+    std::fs::write(&config_path, "engine = minimal\n").unwrap();
+    let mut warnings: Vec<String> = Vec::new();
+    let cfg = load_config_file(&config_path, &mut warnings).unwrap();
+    assert_eq!(cfg.engine, Some(Engine::Minimal));
+}
+
+#[test]
+fn env_config_reads_engine() {
+    with_env(&[("ANVIL_ENGINE", Some("minimal"))], || {
+        let mut warnings: Vec<String> = Vec::new();
+        let cfg = load_env_config(&mut warnings);
+        assert_eq!(cfg.engine, Some(Engine::Minimal));
+    });
 }
 
 const PHOTON_ENV_VARS: &[(&str, Option<&str>)] = &[

--- a/tests/engine_cli_tests.rs
+++ b/tests/engine_cli_tests.rs
@@ -1,0 +1,19 @@
+use anvil::cli::CliArgs;
+use clap::Parser;
+
+#[test]
+fn engine_minimal_returns_not_implemented_before_ollama_startup() {
+    let tmp = tempfile::tempdir().unwrap();
+    let args = CliArgs::parse_from([
+        "anvil",
+        "--engine",
+        "minimal",
+        "--prompt",
+        "hello",
+        "--cwd",
+        tmp.path().to_str().unwrap(),
+    ]);
+
+    let err = anvil::run_cli(args).expect_err("minimal engine should be a stub");
+    assert_eq!(err, "minimal engine is not implemented yet");
+}

--- a/tests/photon_warning_filter_smoke.rs
+++ b/tests/photon_warning_filter_smoke.rs
@@ -47,6 +47,7 @@ fn minimal_args(cwd: &std::path::Path) -> CliArgs {
         auto_plan: false,
         offline: false,
         deterministic_fallback: None,
+        engine: None,
         experimental_specialized_fallback: None,
         no_footer: false,
         resume: None,


### PR DESCRIPTION
## Linked Issue

- None. Minimal loop migration plan T1-1.

## Summary

- Add `--engine legacy|minimal` to the CLI with legacy as the default.
- Thread `Engine` through config, env (`ANVIL_ENGINE`), and `.anvil/config` (`engine = minimal`).
- Keep unspecified engine behavior on the legacy path unchanged.
- Return `minimal engine is not implemented yet` before Ollama startup when minimal is selected.
- Update CLI help snapshot and add regression tests.

## Changed Files

- `src/cli.rs`
- `src/config.rs`
- `src/lib.rs`
- `src/agent/loop_run/footer.rs`
- `docs/cli-help.snapshot.txt`
- `tests/config_tests.rs`
- `tests/engine_cli_tests.rs`
- `tests/photon_warning_filter_smoke.rs`

## Tests Run

- `cargo fmt --all -- --check`
- `cargo test engine -q`
- `cargo test --test config_tests engine -q`
- `scripts/check_cli_help_snapshot.sh`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test -q` (with elevated sandbox permissions for local mockito servers)

## Known Risks

- Minimal remains a deliberate stub in this PR. The full loop lands in later T1 tasks.
- `ANVIL_ENGINE` and config-file `engine` are additive conveniences matching the existing config merge pattern; the requested CLI flag remains the primary surface.

## Orchestration Run ID

- Not available.