### PR TITLE
Add minimal loop and engine benchmark matrix

### DIFF
--- a/benchmarks/heavy-space-invaders.yaml
+++ b/benchmarks/heavy-space-invaders.yaml
@@ -20,3 +20,11 @@ args:
   max_iterations: 40
   chat_retries: 2
   sidecar_model: qwen3.5:9b
+success_check:
+  files:
+    - path: src/components/SpaceInvaders.tsx
+      min_lines: 120
+    - path: src/app/page.tsx
+  commands:
+    - test -f src/components/SpaceInvaders.tsx
+    - grep -R "SpaceInvaders" src/app/page.tsx

--- a/benchmarks/minimal-loop-expanded.yaml
+++ b/benchmarks/minimal-loop-expanded.yaml
@@ -1,0 +1,334 @@
+name: minimal-loop-expanded
+description: Expanded engine-comparison suite for the minimal-loop migration.
+args:
+  max_iterations: 40
+  chat_retries: 2
+cases:
+  - name: new-rust-cli-small
+    task_kind: coding
+    scenario_category: new_file_small
+    prompt: |
+      Create src/bin/word_count.rs. Implement a small Rust CLI that reads stdin, counts words, and prints "words=<N>".
+    success_check:
+      files:
+        - path: src/bin/word_count.rs
+          min_lines: 20
+      commands:
+        - grep -R "words=" src/bin/word_count.rs
+
+  - name: new-python-csv-small
+    task_kind: coding
+    scenario_category: new_file_small
+    prompt: |
+      Create tools/csv_stats.py. It should read a CSV path from argv and print row_count and column_count.
+    success_check:
+      files:
+        - path: tools/csv_stats.py
+          min_lines: 25
+      commands:
+        - grep -R "row_count" tools/csv_stats.py
+
+  - name: new-typescript-formatter
+    task_kind: coding
+    scenario_category: new_file_small
+    prompt: |
+      Create src/formatTitle.ts exporting formatTitle(input: string): string. Trim, collapse spaces, and title-case words.
+    success_check:
+      files:
+        - path: src/formatTitle.ts
+          min_lines: 20
+      commands:
+        - grep -R "export function formatTitle" src/formatTitle.ts
+
+  - name: new-markdown-release-notes
+    task_kind: docs
+    scenario_category: new_file_small
+    prompt: |
+      Create docs/release-notes-template.md with sections Summary, Changes, Verification, Rollback.
+    success_check:
+      files:
+        - path: docs/release-notes-template.md
+          min_lines: 12
+      commands:
+        - grep -R "Rollback" docs/release-notes-template.md
+
+  - name: new-large-react-kanban
+    task_kind: coding
+    scenario_category: new_file_large
+    prompt: |
+      Create src/components/KanbanBoard.tsx. Implement a self-contained React Kanban board with three columns, cards, add-card form, move buttons, and local component state.
+    success_check:
+      files:
+        - path: src/components/KanbanBoard.tsx
+          min_lines: 140
+      commands:
+        - grep -R "KanbanBoard" src/components/KanbanBoard.tsx
+
+  - name: fix-js-date-helper
+    task_kind: coding
+    scenario_category: existing_code_fix
+    prompt: |
+      Create src/dateRange.js with a buggy inclusiveDays(start, end), then fix it so same-day ranges return 1 and reversed ranges return 0.
+    success_check:
+      files:
+        - path: src/dateRange.js
+          min_lines: 25
+      commands:
+        - grep -R "inclusiveDays" src/dateRange.js
+
+  - name: fix-python-slugify
+    task_kind: coding
+    scenario_category: existing_code_fix
+    prompt: |
+      Create src/slugify.py with a slugify(text) helper, then fix it to lowercase, remove punctuation, collapse whitespace, and trim hyphens.
+    success_check:
+      files:
+        - path: src/slugify.py
+          min_lines: 25
+      commands:
+        - grep -R "def slugify" src/slugify.py
+
+  - name: fix-rust-parser-error
+    task_kind: coding
+    scenario_category: existing_code_fix
+    prompt: |
+      Create src/config_parser.rs with parse_bool_flag(input: &str) -> Result<bool, String>. Handle true/false/yes/no/on/off case-insensitively and return a useful error.
+    success_check:
+      files:
+        - path: src/config_parser.rs
+          min_lines: 35
+      commands:
+        - grep -R "parse_bool_flag" src/config_parser.rs
+
+  - name: fix-readme-command
+    task_kind: docs
+    scenario_category: existing_code_fix
+    prompt: |
+      Create README.md with install and usage sections for a CLI named mini-agent. Include a corrected command example using mini-agent run --prompt.
+    success_check:
+      files:
+        - path: README.md
+          min_lines: 20
+      commands:
+        - grep -R "mini-agent run --prompt" README.md
+
+  - name: fix-json-normalizer
+    task_kind: coding
+    scenario_category: existing_code_fix
+    prompt: |
+      Create src/normalizeJson.ts. Export normalizeJson(value) that returns stable sorted-object JSON with two-space indentation.
+    success_check:
+      files:
+        - path: src/normalizeJson.ts
+          min_lines: 30
+      commands:
+        - grep -R "normalizeJson" src/normalizeJson.ts
+
+  - name: fix-python-retry-policy
+    task_kind: coding
+    scenario_category: existing_code_fix
+    prompt: |
+      Create src/retry_policy.py. Implement should_retry(status_code, attempt) for 429 and 5xx only, with max 3 attempts.
+    success_check:
+      files:
+        - path: src/retry_policy.py
+          min_lines: 25
+      commands:
+        - grep -R "should_retry" src/retry_policy.py
+
+  - name: fix-css-token-doc
+    task_kind: docs
+    scenario_category: existing_code_fix
+    prompt: |
+      Create docs/design-tokens.md documenting spacing, color, typography, and border-radius tokens for a dashboard UI.
+    success_check:
+      files:
+        - path: docs/design-tokens.md
+          min_lines: 24
+      commands:
+        - grep -R "border-radius" docs/design-tokens.md
+
+  - name: fix-shell-safe-clean
+    task_kind: coding
+    scenario_category: existing_code_fix
+    prompt: |
+      Create scripts/safe_clean.sh. It should remove only build/, dist/, and coverage/ under the current directory after printing what it will remove.
+    success_check:
+      files:
+        - path: scripts/safe_clean.sh
+          min_lines: 25
+      commands:
+        - grep -R "coverage" scripts/safe_clean.sh
+
+  - name: multi-file-node-package
+    task_kind: coding
+    scenario_category: multi_file
+    prompt: |
+      Create package.json, src/index.js, and test/index.test.js for a small Node package exporting add(a,b) and clamp(value,min,max).
+    success_check:
+      files:
+        - path: package.json
+        - path: src/index.js
+          min_lines: 20
+        - path: test/index.test.js
+          min_lines: 20
+      commands:
+        - grep -R "clamp" src/index.js
+
+  - name: multi-file-rust-library
+    task_kind: coding
+    scenario_category: multi_file
+    prompt: |
+      Create Cargo.toml, src/lib.rs, and tests/math_tests.rs for a Rust library with mean and median functions.
+    success_check:
+      files:
+        - path: Cargo.toml
+        - path: src/lib.rs
+          min_lines: 30
+        - path: tests/math_tests.rs
+          min_lines: 20
+      commands:
+        - grep -R "median" src/lib.rs
+
+  - name: multi-file-docs-and-examples
+    task_kind: docs
+    scenario_category: multi_file
+    prompt: |
+      Create docs/getting-started.md and examples/basic-config.toml for a local-first agent configuration guide.
+    success_check:
+      files:
+        - path: docs/getting-started.md
+          min_lines: 24
+        - path: examples/basic-config.toml
+          min_lines: 8
+      commands:
+        - grep -R "ollama" docs/getting-started.md
+
+  - name: multi-file-python-package
+    task_kind: coding
+    scenario_category: multi_file
+    prompt: |
+      Create pyproject.toml, src/miniloop/__init__.py, src/miniloop/tokens.py, and tests/test_tokens.py. Implement approximate_token_count.
+    success_check:
+      files:
+        - path: pyproject.toml
+        - path: src/miniloop/tokens.py
+          min_lines: 25
+        - path: tests/test_tokens.py
+          min_lines: 20
+      commands:
+        - grep -R "approximate_token_count" src/miniloop/tokens.py
+
+  - name: scaffold-next-dashboard
+    task_kind: coding
+    scenario_category: scaffold
+    prompt: |
+      Scaffold a small Next-style app structure with src/app/page.tsx, src/components/MetricCard.tsx, and src/app/globals.css for an operations dashboard.
+    success_check:
+      files:
+        - path: src/app/page.tsx
+          min_lines: 50
+        - path: src/components/MetricCard.tsx
+          min_lines: 30
+        - path: src/app/globals.css
+          min_lines: 30
+      commands:
+        - grep -R "MetricCard" src/app/page.tsx
+
+  - name: scaffold-fastapi-service
+    task_kind: coding
+    scenario_category: scaffold
+    prompt: |
+      Scaffold a FastAPI-style service with pyproject.toml, app/main.py, app/routes/health.py, and tests/test_health.py.
+    success_check:
+      files:
+        - path: pyproject.toml
+        - path: app/main.py
+          min_lines: 25
+        - path: app/routes/health.py
+          min_lines: 20
+        - path: tests/test_health.py
+          min_lines: 20
+      commands:
+        - grep -R "FastAPI" app/main.py
+
+  - name: scaffold-rust-cli
+    task_kind: coding
+    scenario_category: scaffold
+    prompt: |
+      Scaffold a Rust CLI with Cargo.toml, src/main.rs, src/args.rs, and tests/cli_smoke.rs. The CLI should support --name and print a greeting.
+    success_check:
+      files:
+        - path: Cargo.toml
+        - path: src/main.rs
+          min_lines: 30
+        - path: src/args.rs
+          min_lines: 25
+        - path: tests/cli_smoke.rs
+          min_lines: 15
+      commands:
+        - grep -R -- "--name" src/args.rs
+
+  - name: long-session-read-edit
+    task_kind: coding
+    scenario_category: long_session
+    prompt: |
+      Create docs/notes/architecture.md with at least 80 lines of notes, then create src/summary.ts exporting summarizeArchitectureNotes with a concise summary of those notes.
+    success_check:
+      files:
+        - path: docs/notes/architecture.md
+          min_lines: 80
+        - path: src/summary.ts
+          min_lines: 30
+      commands:
+        - grep -R "summarizeArchitectureNotes" src/summary.ts
+
+  - name: long-session-large-component
+    task_kind: coding
+    scenario_category: long_session
+    prompt: |
+      Create src/components/InvoiceEditor.tsx with a rich invoice editor: line items, subtotal, tax, discount, notes, and validation messages.
+    success_check:
+      files:
+        - path: src/components/InvoiceEditor.tsx
+          min_lines: 180
+      commands:
+        - grep -R "InvoiceEditor" src/components/InvoiceEditor.tsx
+
+  - name: long-session-data-report
+    task_kind: data
+    scenario_category: long_session
+    prompt: |
+      Create data/sample-sales.csv with sample rows and reports/sales-analysis.md summarizing totals, top products, anomalies, and next actions.
+    success_check:
+      files:
+        - path: data/sample-sales.csv
+          min_lines: 12
+        - path: reports/sales-analysis.md
+          min_lines: 40
+      commands:
+        - grep -R "top products" reports/sales-analysis.md
+
+  - name: non-coding-research-brief
+    task_kind: research
+    scenario_category: non_coding
+    prompt: |
+      Create reports/local-llm-brief.md. Write a concise research brief comparing local LLM tradeoffs: latency, privacy, model size, and evaluation.
+    success_check:
+      files:
+        - path: reports/local-llm-brief.md
+          min_lines: 35
+      commands:
+        - grep -R "privacy" reports/local-llm-brief.md
+
+  - name: non-coding-runbook
+    task_kind: ops
+    scenario_category: non_coding
+    prompt: |
+      Create runbooks/incident-triage.md. Include severity levels, first-response checklist, communication cadence, and rollback criteria.
+    success_check:
+      files:
+        - path: runbooks/incident-triage.md
+          min_lines: 35
+      commands:
+        - grep -R "rollback" runbooks/incident-triage.md

--- a/docs/cli-help.snapshot.txt
+++ b/docs/cli-help.snapshot.txt
@@ -17,6 +17,8 @@ Options:
           
       --context-budget <CONTEXT_BUDGET>
           
+      --num-predict <NUM_PREDICT>
+          Override Ollama num_predict. Defaults to 2048 for legacy and 8192 for minimal
       --max-iterations <MAX_ITERATIONS>
           
       --chat-timeout-secs <CHAT_TIMEOUT_SECS>

--- a/docs/compare.md
+++ b/docs/compare.md
@@ -153,7 +153,7 @@ suite/PAM run の場合は以下の入れ子 layout もサポートする。
 - 入力パスは `Path.resolve(strict=True)` 後に top-level symlink を拒否
 - `scripts/analyze_run.py` は compare.py と同一 repo の regular file のみ許可
 - `subprocess.run` 呼び出しは `shell=False`、`PYTHONPATH` 等を遮断した env、`-I` で isolated mode
-- `run-*` は `MAX_RUNS = 100` で上限、超過は exit 1
+- `run-*` は `MAX_RUNS = 500` で上限、超過は exit 1
 - `os.umask(0o077)` を `main` の先頭で設定
 
 ## 8. バージョン管理

--- a/docs/eval/minimal-loop-t2-4-20260612.json
+++ b/docs/eval/minimal-loop-t2-4-20260612.json
@@ -1,0 +1,141 @@
+{
+  "baseline_dir": ".anvil/benchmarks/20260612T051125-combined-t2-4",
+  "experiment_dir": ".anvil/benchmarks/20260612T051125-combined-t2-4",
+  "failure_categories": {
+    "baseline": {
+      "completed": 60,
+      "control_loop_exhausted": 6,
+      "missing_deliverable": 40,
+      "missing_evidence": 19
+    },
+    "experiment": {
+      "completed": 95,
+      "failed": 30
+    }
+  },
+  "generated_at": "2026-06-11T22:13:58Z",
+  "metrics": {
+    "elapsed_s": {
+      "baseline": {
+        "ci_high": 82.41298974810923,
+        "ci_low": 50.69101025189079,
+        "mean": 66.552,
+        "n": 125
+      },
+      "delta": -11.312000000000005,
+      "delta_pct": -0.16997235244620754,
+      "experiment": {
+        "ci_high": 70.40950958460488,
+        "ci_low": 40.07049041539512,
+        "mean": 55.24,
+        "n": 125
+      },
+      "verdict": "improved"
+    },
+    "error_500_count": {
+      "baseline": {
+        "ci_high": 0.0,
+        "ci_low": 0.0,
+        "mean": 0.0,
+        "n": 125
+      },
+      "delta": 0.0,
+      "delta_pct": null,
+      "experiment": {
+        "ci_high": 0.0,
+        "ci_low": 0.0,
+        "mean": 0.0,
+        "n": 125
+      },
+      "verdict": "unchanged"
+    },
+    "iter_count": {
+      "baseline": {
+        "ci_high": 2.9557039837391312,
+        "ci_low": 2.468296016260869,
+        "mean": 2.712,
+        "n": 125
+      },
+      "delta": 1.1722105263157894,
+      "delta_pct": 0.4322310200279459,
+      "experiment": {
+        "ci_high": 4.291562642219357,
+        "ci_low": 3.4768584104122224,
+        "mean": 3.8842105263157896,
+        "n": 95
+      },
+      "verdict": "regressed"
+    },
+    "page_tsx_has_game_keywords": {
+      "baseline": {
+        "ci_high": 0.43449149475208104,
+        "ci_low": 0.0,
+        "mean": 0.0,
+        "n": 5
+      },
+      "delta": 0.0,
+      "delta_pct": null,
+      "experiment": {
+        "ci_high": 0.5615060804490177,
+        "ci_low": 0.0,
+        "mean": 0.0,
+        "n": 3
+      },
+      "verdict": "unchanged"
+    },
+    "postcheck_success": {
+      "baseline": {
+        "ci_high": 0.3304611041202084,
+        "ci_low": 0.18056639010525916,
+        "mean": 0.248,
+        "n": 125
+      },
+      "delta": -0.07999999999999999,
+      "delta_pct": null,
+      "experiment": {
+        "ci_high": 0.24321075117462784,
+        "ci_low": 0.11258737613828976,
+        "mean": 0.168,
+        "n": 125
+      },
+      "verdict": "regressed"
+    },
+    "rc": {
+      "baseline": {
+        "ci_high": 1.0,
+        "ci_low": 0.9701835432034374,
+        "mean": 1.0,
+        "n": 125
+      },
+      "delta": -0.24,
+      "delta_pct": null,
+      "experiment": {
+        "ci_high": 0.826400398499301,
+        "ci_low": 0.6780950439664865,
+        "mean": 0.76,
+        "n": 125
+      },
+      "verdict": "regressed"
+    },
+    "we_total": {
+      "baseline": {
+        "ci_high": 1.9616328248121215,
+        "ci_low": 1.5423671751878785,
+        "mean": 1.752,
+        "n": 125
+      },
+      "delta": -0.928,
+      "delta_pct": null,
+      "experiment": {
+        "ci_high": 1.0329317414079102,
+        "ci_low": 0.6150682585920896,
+        "mean": 0.824,
+        "n": 125
+      },
+      "verdict": "informational"
+    }
+  },
+  "model_slug": "qwen3.6-27b-coding-nvfp4:legacy->minimal",
+  "schema_version": 1,
+  "threshold": 0.05
+}

--- a/docs/eval/minimal-loop-t2-4-20260612.md
+++ b/docs/eval/minimal-loop-t2-4-20260612.md
@@ -1,0 +1,64 @@
+# Minimal Loop T2-4 Initial Full Comparison
+
+- Date: 2026-06-12 JST
+- Model: `qwen3.6:27b-coding-nvfp4`
+- Benchmark: `minimal-loop-expanded`
+- Matrix: 25 cases x 5 runs x 2 engines = 250 runs
+- Combined BENCH_ROOT: `.anvil/benchmarks/20260612T051125-combined-t2-4`
+- Legacy source BENCH_ROOT: `.anvil/benchmarks/20260612T024532-70925`
+- Minimal source BENCH_ROOT: `.anvil/benchmarks/20260612T051125-8470`
+- Conditions: `--max-iterations 12 --no-auto-test --no-precautions --no-case-memory --bench-no-debug`
+
+## T1-8 Smoke
+
+`heavy-space-invaders` was run with `qwen3:8b` and `--engine minimal` after the parser-feedback fix.
+
+- BENCH_ROOT: `.anvil/benchmarks/20260612T051004-7069`
+- Result: `rc=0`, `success_check_success=true`, `elapsed_sec=46`
+- Generated files: `src/components/SpaceInvaders.tsx` (229 lines), `src/app/page.tsx` (10 lines)
+
+## T2-4 Row Summary
+
+| engine | rows | rc=0 | success_check ok | success_check ng | elapsed total sec |
+|---|---:|---:|---:|---:|---:|
+| legacy | 125 | 125 | 46 | 79 | 8319 |
+| minimal | 125 | 95 | 35 | 90 | 6905 |
+
+## Compare.py Output
+
+# compare report
+
+- schema_version: 1
+- model_slug: qwen3.6-27b-coding-nvfp4:legacy->minimal
+- baseline_dir: .anvil/benchmarks/20260612T051125-combined-t2-4
+- experiment_dir: .anvil/benchmarks/20260612T051125-combined-t2-4
+- generated_at: 2026-06-11T22:13:40Z
+- threshold: 0.05
+
+| metric | baseline (mean [CI]) | experiment (mean [CI]) | delta | delta_pct | verdict |
+|---|---|---|---|---|---|
+| elapsed_s | 66.552 [50.691, 82.413] (n=125) | 55.240 [40.070, 70.410] (n=125) | -11.312 | -17.00% | ✅ improved |
+| error_500_count | 0.000 [0.000, 0.000] (n=125) | 0.000 [0.000, 0.000] (n=125) | 0.000 | null | ➖ unchanged |
+| iter_count | 2.712 [2.468, 2.956] (n=125) | 3.884 [3.477, 4.292] (n=95) | 1.172 | 43.22% | ❌ regressed |
+| page_tsx_has_game_keywords | 0.000 [0.000, 0.434] (n=5) | 0.000 [0.000, 0.562] (n=3) | 0.000 | null | ➖ unchanged |
+| postcheck_success | 0.248 [0.181, 0.330] (n=125) | 0.168 [0.113, 0.243] (n=125) | -0.080 | null | ❌ regressed |
+| rc | 1.000 [0.970, 1.000] (n=125) | 0.760 [0.678, 0.826] (n=125) | -0.240 | null | ❌ regressed |
+| we_total | 1.752 [1.542, 1.962] (n=125) | 0.824 [0.615, 1.033] (n=125) | -0.928 | null | ℹ️ informational |
+
+## failure categories
+
+| category | baseline | experiment |
+|---|---:|---:|
+| completed | 60 | 95 |
+| control_loop_exhausted | 6 | 0 |
+| failed | 0 | 30 |
+| missing_deliverable | 40 | 0 |
+| missing_evidence | 19 | 0 |
+
+
+## Notes
+
+- A default full comparison was attempted first, but legacy entered long control/verification loops. On `qwen3:8b`, `new-large-react-kanban` legacy run 1 took 1,071 sec and ended as `no_repo_progress`; on `qwen3.6:27b-coding-nvfp4`, default legacy entered verifier repair loops. The committed full comparison therefore uses the explicit ablation flags above to isolate the loop behavior and make the 250-run matrix tractable.
+- During the first minimal run, real Ollama output exposed an unterminated `<anvil_tool_call>` parser failure. Minimal loop now treats `tool call parser failed` as recoverable ephemeral feedback instead of exiting immediately.
+- `compare.py` now includes `meta.json` fallback for failed runs that exit before `session.json` is copied, so rc/postcheck failures are counted instead of silently skipped.
+- Interpretation: minimal improves elapsed time, but regresses rc and success_check rates under this benchmark. Phase 3 should not adopt minimal broadly yet; it should target the failing categories and scenarios first.

--- a/scripts/analyze_run.py
+++ b/scripts/analyze_run.py
@@ -570,11 +570,14 @@ def _read_meta(run_dir: Path) -> dict[str, Any]:
     fallback = {
         "case": "default",
         "elapsed_s": None,
+        "engine": "legacy",
         "failure_authority": None,
         "pam_variant": "default",
         "postcheck_reason": None,
         "postcheck_success": None,
         "rc": None,
+        "success_check_reason": None,
+        "success_check_success": None,
         "task_kind": DEFAULT_TASK_KIND,
         "_task_kind_source": "default",
     }
@@ -627,6 +630,7 @@ def _read_meta(run_dir: Path) -> dict[str, Any]:
     return {
         "case": _safe_meta_string(data, "case") or "default",
         "elapsed_s": elapsed_s,
+        "engine": _safe_meta_string(data, "engine") or "legacy",
         "failure_authority": _normalize_failure_authority(
             _safe_meta_string(data, "failure_authority")
         ),
@@ -634,6 +638,8 @@ def _read_meta(run_dir: Path) -> dict[str, Any]:
         "postcheck_reason": _safe_meta_string(data, "postcheck_reason"),
         "postcheck_success": _safe_bool(data, "postcheck_success"),
         "rc": rc,
+        "success_check_reason": _safe_meta_string(data, "success_check_reason"),
+        "success_check_success": _safe_bool(data, "success_check_success"),
         "task_kind": task_kind,
         "_task_kind_source": task_kind_source,
     }
@@ -2072,7 +2078,10 @@ def main(argv: list[str]) -> int:
     if not isinstance(recovery_strategies, list):
         recovery_strategies = []
 
-    if isinstance(meta.get("postcheck_success"), bool):
+    if isinstance(meta.get("success_check_success"), bool):
+        postcheck_success = meta["success_check_success"]
+        postcheck_reason = meta["success_check_reason"] or "success_check"
+    elif isinstance(meta.get("postcheck_success"), bool):
         postcheck_success = meta["postcheck_success"]
         postcheck_reason = meta["postcheck_reason"] or "meta_postcheck"
     else:
@@ -2178,6 +2187,7 @@ def main(argv: list[str]) -> int:
         **({"task_kind_misroute": True} if task_kind_misroute else {}),
         "deliverable_kind": deliverable_kind,
         "elapsed_s": meta["elapsed_s"],
+        "engine": meta["engine"],
         "evidence_kind": evidence_kind,
         "error_500_count": error_500_count,
         "evaluation_taxonomy": {
@@ -2207,6 +2217,8 @@ def main(argv: list[str]) -> int:
         "recovery_strategy_count": recovery_strategy_count,
         "run_id": session_metrics["run_id"],
         "schema_version": SCHEMA_VERSION,
+        "success_check_reason": meta["success_check_reason"],
+        "success_check_success": meta["success_check_success"],
         "task_kind": task_kind,
         "token_completion": token_completion,
         "token_prompt": token_prompt,

--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -5,6 +5,8 @@
 #   benchmark-name    benchmarks/ 配下の yaml ファイル名（拡張子なし）
 #   --model <name>    使用モデル
 #   --models <list>   カンマ区切りで複数モデル（matrix 実行、逐次）
+#   --engine <name>   legacy|minimal（デフォルト: legacy）
+#   --engines <list>  カンマ区切りで複数 engine（例: legacy,minimal）
 #   --runs <n>        実行回数（デフォルト: 5）
 #   --dry-run         anvil 呼び出しを echo で代替
 #   --pam-ab          Same prompt suite with PAM enabled and disabled
@@ -31,6 +33,8 @@ Usage: scripts/bench.sh <benchmark-name> [options]
                     ※ first-write: planned for future, not yet supported
   --model <name>    使用モデル
   --models <list>   カンマ区切りで複数モデル（matrix 実行、逐次）
+  --engine <name>   legacy|minimal（デフォルト: legacy）
+  --engines <list>  カンマ区切りで複数 engine（例: legacy,minimal）
   --runs <n>        実行回数（デフォルト: 5）
   --no-precautions  Reminder Sidecar を無効化（ANVIL_NO_REMINDER=1）
   --no-case-memory  Case memory を無効化（ANVIL_NO_CASE_RETRIEVAL=1 ANVIL_NO_CASE_RECORD=1）
@@ -51,6 +55,8 @@ EOF
 benchmark_name=""
 model_arg=""
 models_arg=""
+engine_arg=""
+engines_arg=""
 runs=5
 DRY_RUN=0
 no_precautions=0
@@ -86,6 +92,16 @@ while [[ $# -gt 0 ]]; do
     --models)
       [[ $# -ge 2 ]] || { echo "Error: --models requires a value" >&2; exit 1; }
       models_arg="$2"
+      shift 2
+      ;;
+    --engine)
+      [[ $# -ge 2 ]] || { echo "Error: --engine requires a value" >&2; exit 1; }
+      engine_arg="$2"
+      shift 2
+      ;;
+    --engines)
+      [[ $# -ge 2 ]] || { echo "Error: --engines requires a value" >&2; exit 1; }
+      engines_arg="$2"
       shift 2
       ;;
     --runs)
@@ -153,6 +169,11 @@ fi
 
 if [[ -n "$model_arg" && -n "$models_arg" ]]; then
   echo "Error: --model and --models are mutually exclusive" >&2
+  exit 1
+fi
+
+if [[ -n "$engine_arg" && -n "$engines_arg" ]]; then
+  echo "Error: --engine and --engines are mutually exclusive" >&2
   exit 1
 fi
 
@@ -259,9 +280,10 @@ slugify() {
 
 # -------- write_meta_json --------
 write_meta_json() {
-  # $1=rc, $2=elapsed_s, $3=model, $4=start_ts, $5=run_dir, $6=case, $7=task_kind, $8=pam_variant
+  # $1=rc, $2=elapsed_s, $3=model, $4=start_ts, $5=run_dir, $6=case, $7=task_kind, $8=pam_variant, $9=engine, $10=success_check_success, $11=success_check_reason
   local _rc="$1" _elapsed="$2" _model="$3" _start_ts="$4" _run_dir="$5"
   local _case="${6:-default}" _task_kind="${7:-coding}" _pam_variant="${8:-default}"
+  local _engine="${9:-legacy}" _success_check_success="${10:-null}" _success_check_reason="${11:-}"
   if [[ -z "$_run_dir" ]]; then
     return 0
   fi
@@ -274,6 +296,9 @@ write_meta_json() {
     --arg case "$_case" \
     --arg task_kind "$_task_kind" \
     --arg pam_variant "$_pam_variant" \
+    --arg engine "$_engine" \
+    --argjson success_check_success "$_success_check_success" \
+    --arg success_check_reason "$_success_check_reason" \
     '{
       rc: $rc,
       elapsed_s: $elapsed_s,
@@ -281,9 +306,103 @@ write_meta_json() {
       start_ts: $start_ts,
       case: $case,
       task_kind: $task_kind,
-      pam_variant: $pam_variant
+      pam_variant: $pam_variant,
+      engine: $engine,
+      success_check_success: $success_check_success,
+      success_check_reason: (if $success_check_reason == "" then null else $success_check_reason end)
     }' \
     > "$_run_dir/meta.json"
+}
+
+validate_engine() {
+  local e="$1"
+  case "$e" in
+    legacy|minimal) ;;
+    *)
+      echo "Error: engine must be legacy or minimal, got: $e" >&2
+      exit 1
+      ;;
+  esac
+}
+
+SUCCESS_CHECK_SUCCESS="null"
+SUCCESS_CHECK_REASON="no_success_check"
+evaluate_success_check() {
+  # $1=case_idx
+  local case_idx="$1"
+  local selector
+  if [[ "$case_count" -eq 0 ]]; then
+    selector='(.success_check // {})'
+  else
+    selector="(.cases[$case_idx].success_check // .success_check // {})"
+  fi
+
+  local has_check
+  has_check=$(yq -r "$selector | has(\"files\") or has(\"commands\")" "$BENCH_YAML")
+  if [[ "$has_check" != "true" ]]; then
+    SUCCESS_CHECK_SUCCESS="null"
+    SUCCESS_CHECK_REASON="no_success_check"
+    return 0
+  fi
+
+  local ok=1
+  local reasons=()
+  local file_count command_count
+  file_count=$(yq -r "$selector | (.files // []) | length" "$BENCH_YAML")
+  command_count=$(yq -r "$selector | (.commands // []) | length" "$BENCH_YAML")
+
+  for (( check_idx=0; check_idx<file_count; check_idx++ )); do
+    local rel min_lines path line_count
+    rel=$(yq -r "$selector | .files[$check_idx].path // .files[$check_idx] // \"\"" "$BENCH_YAML")
+    min_lines=$(yq -r "$selector | .files[$check_idx].min_lines // \"\"" "$BENCH_YAML")
+    if [[ -z "$rel" || "$rel" == "null" || "$rel" == /* || "$rel" == *..* ]]; then
+      ok=0
+      reasons+=("invalid_file_check")
+      continue
+    fi
+    path="$WORKDIR/$rel"
+    if [[ ! -f "$path" ]]; then
+      ok=0
+      reasons+=("missing_file:$rel")
+      continue
+    fi
+    if [[ -n "$min_lines" && "$min_lines" != "null" ]]; then
+      if ! [[ "$min_lines" =~ ^[0-9]+$ ]]; then
+        ok=0
+        reasons+=("invalid_min_lines:$rel")
+        continue
+      fi
+      line_count=$(wc -l < "$path" | tr -d '[:space:]')
+      if [[ "$line_count" -lt "$min_lines" ]]; then
+        ok=0
+        reasons+=("min_lines:$rel:$line_count<$min_lines")
+      fi
+    fi
+  done
+
+  for (( check_idx=0; check_idx<command_count; check_idx++ )); do
+    local command
+    command=$(yq -r "$selector | .commands[$check_idx].command // .commands[$check_idx] // \"\"" "$BENCH_YAML")
+    if [[ -z "$command" || "$command" == "null" ]]; then
+      ok=0
+      reasons+=("invalid_command_check")
+      continue
+    fi
+    if ! (cd "$WORKDIR" && bash -lc "$command" >/dev/null 2>&1); then
+      ok=0
+      reasons+=("command_failed:$check_idx")
+    fi
+  done
+
+  if [[ "$ok" -eq 1 ]]; then
+    SUCCESS_CHECK_SUCCESS="true"
+    SUCCESS_CHECK_REASON="ok"
+  else
+    SUCCESS_CHECK_SUCCESS="false"
+    local joined
+    joined=$(IFS=','; echo "${reasons[*]}")
+    SUCCESS_CHECK_REASON="$joined"
+  fi
 }
 
 # -------- validate_models_array --------
@@ -420,6 +539,22 @@ else
   models_array=("$model_arg")
 fi
 
+# -------- engine list parse --------
+engines_array=()
+engine_path_segment=0
+engine_cli_explicit=0
+if [[ -n "$engines_arg" ]]; then
+  IFS=',' read -ra engines_array <<< "$engines_arg"
+  engine_path_segment=1
+  engine_cli_explicit=1
+elif [[ -n "$engine_arg" ]]; then
+  engines_array=("$engine_arg")
+  engine_path_segment=1
+  engine_cli_explicit=1
+else
+  engines_array=("legacy")
+fi
+
 # trim whitespace & drop empties
 cleaned_models=()
 for m in "${models_array[@]}"; do
@@ -436,12 +571,30 @@ if [[ ${#cleaned_models[@]} -eq 0 ]]; then
   exit 1
 fi
 
+cleaned_engines=()
+for e in "${engines_array[@]}"; do
+  e_trim="${e#"${e%%[![:space:]]*}"}"
+  e_trim="${e_trim%"${e_trim##*[![:space:]]}"}"
+  if [[ -n "$e_trim" ]]; then
+    validate_engine "$e_trim"
+    for seen in "${cleaned_engines[@]+"${cleaned_engines[@]}"}"; do
+      [[ "$seen" == "$e_trim" ]] && { echo "Error: duplicate engine: $e_trim" >&2; exit 1; }
+    done
+    cleaned_engines+=("$e_trim")
+  fi
+done
+if [[ ${#cleaned_engines[@]} -eq 0 ]]; then
+  echo "Error: no valid engines specified" >&2
+  exit 1
+fi
+
 # validate models (character set, duplicate, slug collision)
 validate_models_array
 
 # -------- trap (registered after cleaned_models is populated) --------
 CURRENT_RUN=""
 CURRENT_MODEL=""
+CURRENT_ENGINE="legacy"
 CURRENT_CASE="default"
 CURRENT_TASK_KIND="coding"
 CURRENT_PAM_VARIANT="default"
@@ -459,6 +612,7 @@ on_interrupt() {
   if [[ "$META_WRITTEN" -eq 0 && -n "$CURRENT_RUN_DIR" ]]; then
     write_meta_json 130 0 "${CURRENT_MODEL:-unknown}" "${CURRENT_START_TS:-}" "$CURRENT_RUN_DIR" \
       "${CURRENT_CASE:-default}" "${CURRENT_TASK_KIND:-coding}" "${CURRENT_PAM_VARIANT:-default}" \
+      "${CURRENT_ENGINE:-legacy}" "null" "interrupted" \
       || true
   fi
   if [[ -n "$models_arg" ]]; then
@@ -484,7 +638,11 @@ for model in "${cleaned_models[@]}"; do
   model_idx=$((model_idx + 1))
   model_slug=$(slugify "$model")
 
-  for (( case_idx=0; case_idx<case_loop_count; case_idx++ )); do
+  engine_idx=0
+  for engine in "${cleaned_engines[@]}"; do
+    engine_idx=$((engine_idx + 1))
+
+    for (( case_idx=0; case_idx<case_loop_count; case_idx++ )); do
     if [[ "$case_count" -eq 0 ]]; then
       case_name="default"
       task_kind="coding"
@@ -525,19 +683,23 @@ for model in "${cleaned_models[@]}"; do
 
     for pam_variant in "${pam_variants[@]}"; do
       for (( run=1; run<=runs; run++ )); do
-        printf '[model %d/%d | case %d/%d | %s | run %d/%d] %s\n' \
-          "$model_idx" "${#cleaned_models[@]}" "$((case_idx + 1))" "$case_loop_count" \
-          "$pam_variant" "$run" "$runs" "$model" >&2
+        printf '[model %d/%d | engine %d/%d | case %d/%d | %s | run %d/%d] %s / %s\n' \
+          "$model_idx" "${#cleaned_models[@]}" "$engine_idx" "${#cleaned_engines[@]}" \
+          "$((case_idx + 1))" "$case_loop_count" "$pam_variant" "$run" "$runs" "$model" "$engine" >&2
 
         CURRENT_RUN="$run"
         CURRENT_MODEL="$model"
+        CURRENT_ENGINE="$engine"
         CURRENT_CASE="$case_name"
         CURRENT_TASK_KIND="$task_kind"
         CURRENT_PAM_VARIANT="$pam_variant"
         RUN_LOGGED=0
         META_WRITTEN=0
 
-        if [[ "$case_slug" == "default" && "$pam_variant" == "default" ]]; then
+        if [[ "$engine_path_segment" -eq 1 ]]; then
+          RUN_DIR="$BENCH_ROOT/$model_slug/$engine/$case_slug/$pam_variant/run-$run"
+          workdir_rel="$model_slug/$engine/$case_slug/$pam_variant/run-$run/workdir"
+        elif [[ "$case_slug" == "default" && "$pam_variant" == "default" ]]; then
           RUN_DIR="$BENCH_ROOT/$model_slug/run-$run"
           workdir_rel="$model_slug/run-$run/workdir"
         else
@@ -590,11 +752,14 @@ for model in "${cleaned_models[@]}"; do
 
         start=$SECONDS
         if [[ "$DRY_RUN" -eq 1 ]]; then
-          echo "(dry-run) anvil --oneshot --prompt ... --state-dir $STATE_DIR --model $model --case $case_name --pam-variant $pam_variant" \
+          echo "(dry-run) anvil --oneshot --prompt ... --state-dir $STATE_DIR --model $model --engine $engine --case $case_name --pam-variant $pam_variant" \
             > ../stdout.log
           rc=0
         else
           anvil_args=(--oneshot --offline --prompt "$prompt" --state-dir "$STATE_DIR" --model "$model")
+          if [[ "$engine_cli_explicit" -eq 1 ]]; then
+            anvil_args+=(--engine "$engine")
+          fi
           if [[ -n "$max_iterations" ]]; then
             anvil_args+=(--max-iterations "$max_iterations")
           fi
@@ -621,6 +786,7 @@ for model in "${cleaned_models[@]}"; do
           rc=$?
         fi
         elapsed=$(( SECONDS - start ))
+        evaluate_success_check "$case_idx"
 
         # session.json copy (nullglob → empty array if no match)
         # bash 3.2 + set -u needs guard for empty array expansion
@@ -663,7 +829,8 @@ for model in "${cleaned_models[@]}"; do
 
         # Write run-dir/meta.json so analyze_run.py can read rc/elapsed_s
         if write_meta_json "$rc" "$elapsed" "$model" "$CURRENT_START_TS" "$RUN_DIR" \
-          "$case_name" "$task_kind" "$pam_variant"; then
+          "$case_name" "$task_kind" "$pam_variant" "$engine" \
+          "$SUCCESS_CHECK_SUCCESS" "$SUCCESS_CHECK_REASON"; then
           META_WRITTEN=1
         else
           echo "warning: meta.json write failed" >&2
@@ -684,6 +851,9 @@ for model in "${cleaned_models[@]}"; do
               pam_variant: .pam_variant,
               postcheck_success: .postcheck_success,
               postcheck_reason: .postcheck_reason,
+              success_check_success: .success_check_success,
+              success_check_reason: .success_check_reason,
+              engine: .engine,
               tool_call_count: .tool_call_total,
               failure_kind: .failure_kind,
               token_prompt: .token_prompt,
@@ -705,6 +875,7 @@ for model in "${cleaned_models[@]}"; do
         cd "$REPO_ROOT" || { echo "Error: cd $REPO_ROOT failed" >&2; exit 1; }
       done
     done
+  done
   done
 
   if [[ -n "$models_arg" ]]; then

--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -8,6 +8,8 @@
 #   --engine <name>   legacy|minimal（デフォルト: legacy）
 #   --engines <list>  カンマ区切りで複数 engine（例: legacy,minimal）
 #   --runs <n>        実行回数（デフォルト: 5）
+#   --max-iterations <n>
+#                     YAML の args.max_iterations を全 case で上書き
 #   --dry-run         anvil 呼び出しを echo で代替
 #   --pam-ab          Same prompt suite with PAM enabled and disabled
 #   --bench-no-debug  anvil に --trace を付けない（BENCH_DEBUG=0 と同義）
@@ -36,6 +38,8 @@ Usage: scripts/bench.sh <benchmark-name> [options]
   --engine <name>   legacy|minimal（デフォルト: legacy）
   --engines <list>  カンマ区切りで複数 engine（例: legacy,minimal）
   --runs <n>        実行回数（デフォルト: 5）
+  --max-iterations <n>
+                    YAML の args.max_iterations を全 case で上書き
   --no-precautions  Reminder Sidecar を無効化（ANVIL_NO_REMINDER=1）
   --no-case-memory  Case memory を無効化（ANVIL_NO_CASE_RETRIEVAL=1 ANVIL_NO_CASE_RECORD=1）
   --no-auto-test    Auto test を無効化（ANVIL_NO_AUTO_TEST=1）
@@ -58,6 +62,7 @@ models_arg=""
 engine_arg=""
 engines_arg=""
 runs=5
+max_iterations_override=""
 DRY_RUN=0
 no_precautions=0
 no_case_memory=0
@@ -107,6 +112,11 @@ while [[ $# -gt 0 ]]; do
     --runs)
       [[ $# -ge 2 ]] || { echo "Error: --runs requires a value" >&2; exit 1; }
       runs="$2"
+      shift 2
+      ;;
+    --max-iterations)
+      [[ $# -ge 2 ]] || { echo "Error: --max-iterations requires a value" >&2; exit 1; }
+      max_iterations_override="$2"
       shift 2
       ;;
     --no-precautions)
@@ -179,6 +189,11 @@ fi
 
 if ! [[ "$runs" =~ ^[1-9][0-9]*$ ]]; then
   echo "Error: --runs must be a positive integer, got: $runs" >&2
+  exit 1
+fi
+
+if ! { [[ -z "$max_iterations_override" ]] || [[ "$max_iterations_override" =~ ^[1-9][0-9]*$ ]]; }; then
+  echo "Error: --max-iterations must be a positive integer, got: $max_iterations_override" >&2
   exit 1
 fi
 
@@ -658,6 +673,9 @@ for model in "${cleaned_models[@]}"; do
       chat_retries=$(yq -r ".cases[$case_idx].args.chat_retries // .args.chat_retries // \"\"" "$BENCH_YAML")
       sidecar_model=$(yq -r ".cases[$case_idx].args.sidecar_model // .args.sidecar_model // \"\"" "$BENCH_YAML")
     fi
+    if [[ -n "$max_iterations_override" ]]; then
+      max_iterations="$max_iterations_override"
+    fi
 
     if [[ -z "$case_name" || "$case_name" == "null" ]]; then
       echo "Error: empty benchmark case name" >&2
@@ -752,11 +770,11 @@ for model in "${cleaned_models[@]}"; do
 
         start=$SECONDS
         if [[ "$DRY_RUN" -eq 1 ]]; then
-          echo "(dry-run) anvil --oneshot --prompt ... --state-dir $STATE_DIR --model $model --engine $engine --case $case_name --pam-variant $pam_variant" \
+          echo "(dry-run) anvil --oneshot --offline --yes --prompt ... --state-dir $STATE_DIR --model $model --engine $engine --case $case_name --pam-variant $pam_variant" \
             > ../stdout.log
           rc=0
         else
-          anvil_args=(--oneshot --offline --prompt "$prompt" --state-dir "$STATE_DIR" --model "$model")
+          anvil_args=(--oneshot --offline --yes --prompt "$prompt" --state-dir "$STATE_DIR" --model "$model")
           if [[ "$engine_cli_explicit" -eq 1 ]]; then
             anvil_args+=(--engine "$engine")
           fi

--- a/scripts/compare.py
+++ b/scripts/compare.py
@@ -39,7 +39,7 @@ from typing import Any, Callable, Literal
 SCHEMA_VERSION = 1
 DEFAULT_THRESHOLD_PCT = 0.05  # continuous metrics: relative-delta threshold (5%)
 DEFAULT_THRESHOLD_ABS = 0.05  # bool_rate metrics: absolute-delta threshold (5pt)
-MAX_RUNS = 100  # DoS guard
+MAX_RUNS = 500  # DoS guard; supports 20-30 scenarios x 5 runs x engine matrices.
 MIN_VALID_RUNS = 3  # below this -> exit 3
 ALPHA = 0.05  # 95% CI
 UMASK = 0o077
@@ -475,6 +475,13 @@ def _analyze_one(
         _warn(f"analyze_run.py spawn failed for {run_dir}: {e}")
         return None
     if result.returncode != 0:
+        fallback = _analyze_meta_only(run_dir)
+        if fallback is not None:
+            _warn(
+                f"analyze_run.py rc={result.returncode} for {run_dir}; "
+                "using meta.json fallback"
+            )
+            return fallback
         _warn(
             f"analyze_run.py rc={result.returncode} for {run_dir}: "
             f"{(result.stderr or '').strip()}"
@@ -493,6 +500,56 @@ def _analyze_one(
         _warn(f"analyze_run.py schema_version={sv} for {run_dir}, skipping")
         return None
     return data
+
+
+def _analyze_meta_only(run_dir: Path) -> dict[str, Any] | None:
+    """Build minimal comparable metrics from run-dir/meta.json.
+
+    Some failed Anvil runs exit before a session.json is copied. Those runs are
+    still valid benchmark failures and must count toward rc / elapsed /
+    postcheck rates.
+    """
+    meta_path = run_dir / "meta.json"
+    if not _is_regular_file(meta_path):
+        return None
+    try:
+        meta = json.loads(meta_path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(meta, dict):
+        return None
+
+    rc = meta.get("rc")
+    elapsed_s = meta.get("elapsed_s")
+    success = meta.get("success_check_success")
+    failure_kind = meta.get("failure_kind")
+    failure_class = failure_kind if isinstance(failure_kind, str) and failure_kind else "run_error"
+    terminal_state = "completed" if rc == 0 else "failed"
+
+    return {
+        "schema_version": 1,
+        "run_id": run_dir.name,
+        "rc": rc,
+        "elapsed_s": elapsed_s,
+        "iter_count": None,
+        "error_500_count": 0,
+        "we_total": 0,
+        "postcheck_success": success,
+        "postcheck_reason": meta.get("success_check_reason"),
+        "success_check_success": success,
+        "success_check_reason": meta.get("success_check_reason"),
+        "engine": meta.get("engine"),
+        "task_kind": meta.get("task_kind"),
+        "pam_variant": meta.get("pam_variant"),
+        "failure_kind": failure_kind,
+        "generic_terminal_state": terminal_state,
+        "failure_observation": {
+            "failure_class": failure_class,
+            "terminal_state": terminal_state,
+            "postcheck_success": success,
+        },
+        "page_tsx_has_game_keywords": None,
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/compare.py
+++ b/scripts/compare.py
@@ -106,6 +106,7 @@ class CompareResult:
     generated_at: str
     threshold: float
     metrics: dict[str, MetricResult] = field(default_factory=dict)
+    failure_categories: dict[str, dict[str, int]] = field(default_factory=dict)
 
 
 # ---------------------------------------------------------------------------
@@ -216,6 +217,24 @@ def _find_model_slug(baseline: Path, experiment: Path) -> str:
     return b_slug
 
 
+def _find_single_model_slug(root: Path) -> str:
+    try:
+        entries = [p for p in sorted(root.iterdir()) if p.is_dir() and not p.is_symlink()]
+    except OSError as e:
+        _die(f"bench root listing failed: {e}", 1)
+        raise
+    slugs = [p.name for p in entries]
+    if len(slugs) == 0:
+        _die(f"BENCH_ROOT contains no model_slug directory: {root}", 1)
+    if len(slugs) > 1:
+        _die(
+            f"BENCH_ROOT contains multiple model_slug directories "
+            f"({', '.join(slugs)}); engine comparison supports a single slug only",
+            1,
+        )
+    return slugs[0]
+
+
 def _collect_run_dirs(root: Path, slug: str) -> list[Path]:
     """Collect run-* directories under root/<slug>/.
 
@@ -240,41 +259,45 @@ def _collect_run_dirs(root: Path, slug: str) -> list[Path]:
             return
         runs.append(p)
 
-    try:
-        entries = sorted(slug_dir.iterdir())
-    except OSError as e:
-        _die(f"cannot list {slug_dir}: {e}", 2)
-        raise  # unreachable
-    for p in entries:
-        if p.name.startswith("run-"):
-            _append_if_run(p)
-            continue
-        if p.is_symlink() or not p.is_dir():
-            continue
+    def _walk(p: Path, depth: int) -> None:
+        if depth > 5:
+            return
         try:
-            nested_entries = sorted(p.iterdir())
+            entries = sorted(p.iterdir())
         except OSError as e:
             _warn(f"cannot list {p}: {e}")
-            continue
-        for nested in nested_entries:
-            if nested.name.startswith("run-"):
-                _append_if_run(nested)
+            return
+        for child in entries:
+            if child.name.startswith("run-"):
+                _append_if_run(child)
                 continue
-            if nested.is_symlink() or not nested.is_dir():
+            if child.is_symlink() or not child.is_dir():
                 continue
-            try:
-                variant_entries = sorted(nested.iterdir())
-            except OSError as e:
-                _warn(f"cannot list {nested}: {e}")
-                continue
-            for run_dir in variant_entries:
-                _append_if_run(run_dir)
+            _walk(child, depth + 1)
+
+    _walk(slug_dir, 0)
     if len(runs) > MAX_RUNS:
         _die(
             f"run-dir count {len(runs)} exceeds MAX_RUNS={MAX_RUNS} for {slug_dir}",
             1,
         )
     return runs
+
+
+def _failure_category_counts(runs: list[dict[str, Any]]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for run in runs:
+        category = run.get("generic_terminal_state")
+        if not isinstance(category, str) or not category:
+            observation = run.get("failure_observation")
+            if isinstance(observation, dict):
+                raw = observation.get("failure_class")
+                if isinstance(raw, str) and raw:
+                    category = raw
+        if not isinstance(category, str) or not category:
+            category = "unknown"
+        counts[category] = counts.get(category, 0) + 1
+    return dict(sorted(counts.items()))
 
 
 def _now() -> str:
@@ -729,6 +752,18 @@ def _render_markdown(result: CompareResult) -> str:
         lines.append(
             f"| {key} | {b_cell} | {e_cell} | {delta_s} | {dp_s} | {verdict_s} |"
         )
+    if result.failure_categories:
+        lines.append("")
+        lines.append("## failure categories")
+        lines.append("")
+        lines.append("| category | baseline | experiment |")
+        lines.append("|---|---:|---:|")
+        baseline_counts = result.failure_categories.get("baseline", {})
+        experiment_counts = result.failure_categories.get("experiment", {})
+        for category in sorted(set(baseline_counts) | set(experiment_counts)):
+            lines.append(
+                f"| {category} | {baseline_counts.get(category, 0)} | {experiment_counts.get(category, 0)} |"
+            )
     lines.append("")
     return "\n".join(lines)
 
@@ -761,6 +796,7 @@ def _render_json(result: CompareResult) -> str:
         "generated_at": result.generated_at,
         "threshold": result.threshold,
         "metrics": {k: _mr_to_json(v) for k, v in sorted(result.metrics.items())},
+        "failure_categories": result.failure_categories,
     }
     return json.dumps(out, sort_keys=True, ensure_ascii=False, indent=2) + "\n"
 
@@ -775,8 +811,8 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
         prog="compare.py",
         description="A/B comparison of two bench BENCH_ROOTs.",
     )
-    parser.add_argument("baseline_dir", help="baseline BENCH_ROOT")
-    parser.add_argument("experiment_dir", help="experiment BENCH_ROOT")
+    parser.add_argument("baseline_dir", help="baseline BENCH_ROOT, or BENCH_ROOT with --engines")
+    parser.add_argument("experiment_dir", nargs="?", help="experiment BENCH_ROOT")
     parser.add_argument(
         "--metric",
         default=None,
@@ -794,6 +830,11 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
         default=DEFAULT_THRESHOLD_PCT,
         help="delta threshold (default: 0.05)",
     )
+    parser.add_argument(
+        "--engines",
+        default=None,
+        help="compare two engines within one BENCH_ROOT, e.g. legacy,minimal",
+    )
     return parser.parse_args(argv)
 
 
@@ -807,6 +848,67 @@ def main(argv: list[str]) -> int:
     analyze_path = _resolve_analyze_run_path()
 
     baseline_dir = _validate_input(Path(ns.baseline_dir))
+
+    if ns.engines:
+        if ns.experiment_dir is not None:
+            _die("--engines mode accepts exactly one BENCH_ROOT positional argument", 1)
+        raw_engines = [e.strip() for e in ns.engines.split(",") if e.strip()]
+        if len(raw_engines) != 2:
+            _die("--engines must contain exactly two engine names", 1)
+        baseline_engine, experiment_engine = raw_engines
+        slug = _find_single_model_slug(baseline_dir)
+        run_dirs = _collect_run_dirs(baseline_dir, slug)
+        if len(run_dirs) == 0:
+            _die(f"zero run-dirs for slug={slug!r}", 2)
+
+        grouped: dict[str, list[dict[str, Any]]] = {
+            baseline_engine: [],
+            experiment_engine: [],
+        }
+        for rd in run_dirs:
+            analyzed = _analyze_one(rd, analyze_path)
+            if analyzed is None:
+                continue
+            engine = analyzed.get("engine")
+            if engine in grouped:
+                grouped[engine].append(analyzed)
+
+        b_filtered = _filter_runs(grouped[baseline_engine])
+        e_filtered = _filter_runs(grouped[experiment_engine])
+        if len(b_filtered) < MIN_VALID_RUNS or len(e_filtered) < MIN_VALID_RUNS:
+            _die(
+                f"insufficient valid runs "
+                f"({baseline_engine}={len(b_filtered)}, {experiment_engine}={len(e_filtered)}; "
+                f"MIN_VALID_RUNS={MIN_VALID_RUNS})",
+                3,
+            )
+
+        metric_list = _resolve_metric_keys(
+            [s for s in (ns.metric or "").split(",") if s.strip()] if ns.metric else None
+        )
+        metrics = _compare(b_filtered, e_filtered, metric_list, ns.threshold)
+        result = CompareResult(
+            schema_version=SCHEMA_VERSION,
+            baseline_dir=baseline_dir,
+            experiment_dir=baseline_dir,
+            model_slug=f"{slug}:{baseline_engine}->{experiment_engine}",
+            generated_at=_now(),
+            threshold=ns.threshold,
+            metrics=metrics,
+            failure_categories={
+                "baseline": _failure_category_counts(b_filtered),
+                "experiment": _failure_category_counts(e_filtered),
+            },
+        )
+        if ns.format == "json":
+            sys.stdout.write(_render_json(result))
+        else:
+            sys.stdout.write(_render_markdown(result))
+        return 0
+
+    if ns.experiment_dir is None:
+        _die("experiment_dir is required unless --engines is used", 1)
+
     experiment_dir = _validate_input(Path(ns.experiment_dir))
 
     slug = _find_model_slug(baseline_dir, experiment_dir)
@@ -857,6 +959,10 @@ def main(argv: list[str]) -> int:
         generated_at=_now(),
         threshold=ns.threshold,
         metrics=metrics,
+        failure_categories={
+            "baseline": _failure_category_counts(b_filtered),
+            "experiment": _failure_category_counts(e_filtered),
+        },
     )
 
     if ns.format == "json":

--- a/src/agent/loop_run/footer.rs
+++ b/src/agent/loop_run/footer.rs
@@ -1230,6 +1230,7 @@ mod tests {
             requested_sidecar_model: None,
             ollama_host: "http://127.0.0.1:11434".to_string(),
             context_budget: 24_000,
+            num_predict: 2_048,
             max_iterations: 12,
             chat_timeout_secs: 300,
             chat_retries: 2,

--- a/src/agent/minimal_loop/compact.rs
+++ b/src/agent/minimal_loop/compact.rs
@@ -1,0 +1,215 @@
+use std::collections::BTreeSet;
+
+use crate::session::store::ConversationMessage;
+
+pub const MINIMAL_COMPACT_SUMMARY_PREFIX: &str = "[minimal-compact-summary]";
+
+const SUMMARY_MAX_CHARS: usize = 1_800;
+
+pub fn compact_if_needed(messages: &mut Vec<ConversationMessage>, context_budget: usize) -> bool {
+    let threshold = compaction_threshold(context_budget);
+    if approximate_token_count(messages) <= threshold {
+        return false;
+    }
+
+    let protected = protected_message_indices(messages, threshold / 2);
+    let mut summary_input = Vec::new();
+    let mut kept = Vec::new();
+
+    for (idx, message) in messages.iter().enumerate() {
+        if message.role == "system" || is_minimal_compact_summary(message) {
+            continue;
+        }
+        if protected.contains(&idx) {
+            kept.push(message.clone());
+        } else {
+            summary_input.push(message.clone());
+        }
+    }
+
+    let mut compacted = Vec::new();
+    if let Some(summary) = deterministic_summary(&summary_input) {
+        compacted.push(ConversationMessage::assistant(summary, Vec::new()));
+    }
+    compacted.extend(kept);
+    *messages = compacted;
+    true
+}
+
+pub fn approximate_token_count(messages: &[ConversationMessage]) -> usize {
+    messages
+        .iter()
+        .map(|message| {
+            let content_tokens = message.content.chars().count() / 4;
+            let tool_call_tokens = message.tool_calls.len() * 32;
+            content_tokens + tool_call_tokens + 12
+        })
+        .sum()
+}
+
+pub fn is_minimal_compact_summary(message: &ConversationMessage) -> bool {
+    message.role == "assistant" && message.content.starts_with(MINIMAL_COMPACT_SUMMARY_PREFIX)
+}
+
+fn compaction_threshold(context_budget: usize) -> usize {
+    context_budget.saturating_mul(7).saturating_div(10).max(1)
+}
+
+fn protected_message_indices(
+    messages: &[ConversationMessage],
+    recent_budget_tokens: usize,
+) -> BTreeSet<usize> {
+    let mut protected = BTreeSet::new();
+
+    if let Some((idx, _)) = messages
+        .iter()
+        .enumerate()
+        .rev()
+        .find(|(_, message)| message.role == "user")
+    {
+        protected.insert(idx);
+    }
+
+    for tool_name in ["Read", "Edit"] {
+        for (idx, _) in messages
+            .iter()
+            .enumerate()
+            .rev()
+            .filter(|(_, message)| {
+                message.role == "tool" && message.name.as_deref() == Some(tool_name)
+            })
+            .take(2)
+        {
+            protected.insert(idx);
+        }
+    }
+
+    let mut recent_tokens = 0usize;
+    for (idx, message) in messages.iter().enumerate().rev() {
+        if message.role == "system" || is_minimal_compact_summary(message) {
+            continue;
+        }
+        let next = approximate_token_count(std::slice::from_ref(message));
+        if recent_tokens + next > recent_budget_tokens && protected.len() >= 4 {
+            break;
+        }
+        protected.insert(idx);
+        recent_tokens += next;
+    }
+
+    protected
+}
+
+fn deterministic_summary(messages: &[ConversationMessage]) -> Option<String> {
+    let mut lines = Vec::new();
+    for message in messages
+        .iter()
+        .filter(|m| m.role != "system")
+        .rev()
+        .take(12)
+    {
+        let label = match message.role.as_str() {
+            "tool" => message.name.as_deref().unwrap_or("tool"),
+            other => other,
+        };
+        let preview = message.content.replace('\n', " ");
+        let preview = preview.chars().take(140).collect::<String>();
+        if !preview.trim().is_empty() || !message.tool_calls.is_empty() {
+            lines.push(format!("{label}: {preview}"));
+        }
+    }
+    if lines.is_empty() {
+        return None;
+    }
+    lines.reverse();
+    let body = lines.join("\n");
+    Some(format!(
+        "{MINIMAL_COMPACT_SUMMARY_PREFIX}\n{}",
+        body.chars().take(SUMMARY_MAX_CHARS).collect::<String>()
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn message_count_alone_does_not_trigger_compaction() {
+        let mut messages = (0..80)
+            .map(|i| ConversationMessage::user(format!("ok {i}")))
+            .collect::<Vec<_>>();
+
+        let compacted = compact_if_needed(&mut messages, 100_000);
+
+        assert!(!compacted);
+        assert_eq!(messages.len(), 80);
+    }
+
+    #[test]
+    fn token_compaction_keeps_recent_read_and_edit_outputs() {
+        let mut messages = vec![ConversationMessage::system(
+            "legacy recovery note that must not survive".to_string(),
+        )];
+        for i in 0..24 {
+            messages.push(ConversationMessage::assistant(
+                format!("old context {i} {}", "x".repeat(160)),
+                Vec::new(),
+            ));
+        }
+        messages.push(ConversationMessage::user(
+            "Please edit src/lib.rs using the visible anchor".to_string(),
+        ));
+        messages.push(ConversationMessage::tool(
+            "Read".to_string(),
+            "src/lib.rs excerpt: KEEP_THIS_ANCHOR".to_string(),
+        ));
+        messages.push(ConversationMessage::tool(
+            "Edit".to_string(),
+            "ERROR: target text not found in src/lib.rs".to_string(),
+        ));
+
+        let compacted = compact_if_needed(&mut messages, 800);
+
+        assert!(compacted);
+        assert!(messages.iter().all(|message| message.role != "system"));
+        assert!(
+            messages
+                .iter()
+                .any(|message| message.content.starts_with(MINIMAL_COMPACT_SUMMARY_PREFIX))
+        );
+        assert!(
+            messages
+                .iter()
+                .any(|message| message.content.contains("KEEP_THIS_ANCHOR"))
+        );
+        assert!(
+            messages
+                .iter()
+                .any(|message| message.content.contains("target text not found"))
+        );
+    }
+
+    #[test]
+    fn old_minimal_summaries_are_replaced_not_nested() {
+        let mut messages = vec![ConversationMessage::assistant(
+            format!("{MINIMAL_COMPACT_SUMMARY_PREFIX}\nold summary"),
+            Vec::new(),
+        )];
+        for i in 0..20 {
+            messages.push(ConversationMessage::assistant(
+                format!("old context {i} {}", "x".repeat(200)),
+                Vec::new(),
+            ));
+        }
+        messages.push(ConversationMessage::user("latest request".to_string()));
+
+        assert!(compact_if_needed(&mut messages, 600));
+
+        let summary_count = messages
+            .iter()
+            .filter(|message| message.content.starts_with(MINIMAL_COMPACT_SUMMARY_PREFIX))
+            .count();
+        assert_eq!(summary_count, 1);
+        assert!(messages.iter().any(|m| m.content == "latest request"));
+    }
+}

--- a/src/agent/minimal_loop/feedback.rs
+++ b/src/agent/minimal_loop/feedback.rs
@@ -37,6 +37,12 @@ impl FeedbackState {
             "{MINIMAL_FEEDBACK_PREFIX}\nYour Edit anchor did not match the file. Read the target file again, then issue a smaller exact Edit using text that is currently present."
         ))
     }
+
+    pub fn malformed_tool_call(&self, error: &str) -> String {
+        format!(
+            "{MINIMAL_FEEDBACK_PREFIX}\nYour previous tool call was malformed and was not executed ({error}). Reply with exactly one complete <anvil_tool_call>{{\"name\":\"ToolName\",\"arguments\":{{...}}}}</anvil_tool_call> block, or plain text if the task is already complete."
+        )
+    }
 }
 
 fn is_edit_anchor_mismatch(error: &str) -> bool {
@@ -91,6 +97,11 @@ mod tests {
             state
                 .edit_anchor_mismatch("target text not found in src/lib.rs")
                 .is_none()
+        );
+        assert!(
+            state
+                .malformed_tool_call("tool call parser failed")
+                .starts_with(MINIMAL_FEEDBACK_PREFIX)
         );
     }
 

--- a/src/agent/minimal_loop/feedback.rs
+++ b/src/agent/minimal_loop/feedback.rs
@@ -1,0 +1,108 @@
+pub const MINIMAL_FEEDBACK_PREFIX: &str = "[minimal-feedback]";
+
+#[derive(Debug, Default, Clone)]
+pub struct FeedbackState {
+    empty_response_sent: bool,
+    missing_tool_sent: bool,
+    edit_anchor_sent: bool,
+}
+
+impl FeedbackState {
+    pub fn empty_response(&mut self) -> Option<String> {
+        if self.empty_response_sent {
+            return None;
+        }
+        self.empty_response_sent = true;
+        Some(format!(
+            "{MINIMAL_FEEDBACK_PREFIX}\nYour previous response was empty. Continue the task now. Use a tool if repository facts or files are needed."
+        ))
+    }
+
+    pub fn missing_tool_call(&mut self, user_prompt: &str) -> Option<String> {
+        if self.missing_tool_sent || !looks_like_repo_action(user_prompt) {
+            return None;
+        }
+        self.missing_tool_sent = true;
+        Some(format!(
+            "{MINIMAL_FEEDBACK_PREFIX}\nThe user asked for a repository change. Use exactly one relevant tool call next instead of only describing the work."
+        ))
+    }
+
+    pub fn edit_anchor_mismatch(&mut self, error: &str) -> Option<String> {
+        if self.edit_anchor_sent || !is_edit_anchor_mismatch(error) {
+            return None;
+        }
+        self.edit_anchor_sent = true;
+        Some(format!(
+            "{MINIMAL_FEEDBACK_PREFIX}\nYour Edit anchor did not match the file. Read the target file again, then issue a smaller exact Edit using text that is currently present."
+        ))
+    }
+}
+
+fn is_edit_anchor_mismatch(error: &str) -> bool {
+    let lower = error.to_ascii_lowercase();
+    lower.contains("target text not found") || lower.contains("old_string was not found")
+}
+
+fn looks_like_repo_action(prompt: &str) -> bool {
+    let lower = prompt.to_ascii_lowercase();
+    [
+        "edit",
+        "write",
+        "create",
+        "modify",
+        "fix",
+        "implement",
+        "add",
+        "delete",
+        "update",
+        "refactor",
+        "test",
+        "修正",
+        "実装",
+        "作成",
+        "追加",
+        "変更",
+        "削除",
+        "更新",
+    ]
+    .iter()
+    .any(|needle| lower.contains(needle))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn feedback_is_single_use_per_kind() {
+        let mut state = FeedbackState::default();
+
+        assert!(state.empty_response().is_some());
+        assert!(state.empty_response().is_none());
+        assert!(state.missing_tool_call("fix src/lib.rs").is_some());
+        assert!(state.missing_tool_call("fix src/lib.rs").is_none());
+        assert!(
+            state
+                .edit_anchor_mismatch("target text not found in src/lib.rs")
+                .is_some()
+        );
+        assert!(
+            state
+                .edit_anchor_mismatch("target text not found in src/lib.rs")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn missing_tool_feedback_only_for_action_prompts() {
+        let mut state = FeedbackState::default();
+
+        assert!(
+            state
+                .missing_tool_call("explain this architecture")
+                .is_none()
+        );
+        assert!(state.missing_tool_call("README を修正して").is_some());
+    }
+}

--- a/src/agent/minimal_loop/loop_run.rs
+++ b/src/agent/minimal_loop/loop_run.rs
@@ -85,6 +85,10 @@ pub fn run_session<C: MinimalChatClient>(
                 session.native_tools_disabled = true;
                 continue;
             }
+            Err(err) if is_tool_call_parser_failure(&err) => {
+                pending_feedback = Some(feedback_state.malformed_tool_call(&err));
+                continue;
+            }
             Err(err) => return Err(err),
         };
 
@@ -190,6 +194,12 @@ fn is_native_tool_parser_failure(error: &str) -> bool {
     lower.contains("native tool parser failed")
         || lower.contains("unexpected end element")
         || lower.contains("unexpected eof")
+}
+
+fn is_tool_call_parser_failure(error: &str) -> bool {
+    error
+        .to_ascii_lowercase()
+        .contains("tool call parser failed")
 }
 
 #[cfg(test)]
@@ -321,6 +331,45 @@ mod tests {
         assert_eq!(reply, "done after downgrade");
         assert_eq!(client.native_modes, vec![true, false]);
         assert!(session.native_tools_disabled);
+    }
+
+    #[test]
+    fn xml_parser_failure_uses_ephemeral_feedback_and_retries() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut client = MockClient::default();
+        client.push_err("tool call parser failed: unterminated <anvil_tool_call> block");
+        client.push_reply(
+            "",
+            vec![tool_call(
+                "Write",
+                json!({"path": "fixed.txt", "content": "ok"}),
+            )],
+        );
+        client.push_reply("done", Vec::new());
+        let mut session = SessionSnapshot::default();
+
+        let reply = run_session(
+            &mut client,
+            "qwen3:8b",
+            &mut session,
+            "create fixed.txt",
+            &config(temp.path().to_path_buf(), 4),
+        )
+        .unwrap();
+
+        assert_eq!(reply, "done");
+        assert_eq!(
+            std::fs::read_to_string(temp.path().join("fixed.txt")).unwrap(),
+            "ok"
+        );
+        assert!(client.feedback_seen);
+        assert!(
+            !session
+                .messages
+                .iter()
+                .any(|m| m.content.starts_with(MINIMAL_FEEDBACK_PREFIX)),
+            "ephemeral feedback must not be persisted to the session"
+        );
     }
 
     #[test]

--- a/src/agent/minimal_loop/loop_run.rs
+++ b/src/agent/minimal_loop/loop_run.rs
@@ -1,0 +1,385 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
+
+use crate::modes::plan_act::ExecutionMode;
+use crate::ollama::client::{AssistantReply, OllamaClient, should_use_native_tool_calls};
+use crate::session::store::{ConversationMessage, SessionSnapshot};
+use crate::tools::registry::{ToolContext, ToolRegistry, ToolSpec};
+use crate::util::workspace_paths::WorkspacePolicy;
+
+use super::compact::compact_if_needed;
+use super::feedback::FeedbackState;
+use super::prompt::build_system_prompt;
+
+pub trait MinimalChatClient {
+    fn chat(
+        &mut self,
+        model: &str,
+        messages: &[ConversationMessage],
+        tools: &[ToolSpec],
+        native_tools_enabled: bool,
+    ) -> Result<AssistantReply, String>;
+}
+
+impl MinimalChatClient for OllamaClient {
+    fn chat(
+        &mut self,
+        model: &str,
+        messages: &[ConversationMessage],
+        tools: &[ToolSpec],
+        native_tools_enabled: bool,
+    ) -> Result<AssistantReply, String> {
+        self.chat_with_mode(model, messages, tools, native_tools_enabled)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct MinimalLoopConfig {
+    pub work_root: PathBuf,
+    pub mode: ExecutionMode,
+    pub context_budget: usize,
+    pub max_iterations: usize,
+    pub auto_approve: bool,
+    pub offline: bool,
+    pub cancel_flag: Option<Arc<AtomicBool>>,
+}
+
+pub fn run_session<C: MinimalChatClient>(
+    client: &mut C,
+    model: &str,
+    session: &mut SessionSnapshot,
+    user_prompt: &str,
+    config: &MinimalLoopConfig,
+) -> Result<String, String> {
+    let registry = ToolRegistry::default();
+    let mut native_tools_enabled =
+        should_use_native_tool_calls(model) && !session.native_tools_disabled;
+    let workspace_policy = WorkspacePolicy::for_task_request(user_prompt);
+    let mut feedback_state = FeedbackState::default();
+    let mut pending_feedback: Option<String> = None;
+    let mut tool_calls_seen = false;
+
+    session
+        .messages
+        .push(ConversationMessage::user(user_prompt.to_string()));
+
+    let mut iterations = 0usize;
+    while iterations < config.max_iterations {
+        iterations += 1;
+        let tools = tool_specs_for_mode(&registry, config.mode);
+        compact_if_needed(&mut session.messages, config.context_budget);
+        let request_messages = build_request_messages(
+            session,
+            &registry,
+            &config.work_root,
+            pending_feedback.as_deref(),
+        );
+        let reply = match client.chat(model, &request_messages, &tools, native_tools_enabled) {
+            Ok(reply) => {
+                pending_feedback = None;
+                reply
+            }
+            Err(err) if native_tools_enabled && is_native_tool_parser_failure(&err) => {
+                native_tools_enabled = false;
+                session.native_tools_disabled = true;
+                continue;
+            }
+            Err(err) => return Err(err),
+        };
+
+        let tool_calls = reply.tool_calls.clone();
+        session.messages.push(ConversationMessage::assistant(
+            reply.content.clone(),
+            tool_calls.clone(),
+        ));
+
+        if tool_calls.is_empty() {
+            if reply.content.trim().is_empty()
+                && let Some(feedback) = feedback_state.empty_response()
+            {
+                pending_feedback = Some(feedback);
+                continue;
+            }
+            if !tool_calls_seen
+                && let Some(feedback) = feedback_state.missing_tool_call(user_prompt)
+            {
+                pending_feedback = Some(feedback);
+                continue;
+            }
+            return Ok(reply.content);
+        }
+        tool_calls_seen = true;
+
+        let tool_context = ToolContext {
+            root: config.work_root.clone(),
+            mode: config.mode,
+            plan_path: None,
+            plan_stage: session.mode_state.plan_stage,
+            auto_approve: config.auto_approve,
+            interactive_approval: false,
+            offline: config.offline,
+            cancel_flag: config.cancel_flag.clone(),
+            tmp_tests_root: None,
+            tester_active: false,
+            workspace_policy,
+        };
+
+        for call in tool_calls {
+            let result = match registry.execute(&call.name, &call.arguments, &tool_context) {
+                Ok(result) => result,
+                Err(err) => {
+                    if call.name == "Edit"
+                        && let Some(feedback) = feedback_state.edit_anchor_mismatch(&err)
+                    {
+                        pending_feedback.get_or_insert(feedback);
+                    }
+                    format!("ERROR: {err}")
+                }
+            };
+            session
+                .messages
+                .push(ConversationMessage::tool(call.name, result));
+        }
+    }
+
+    Err(format!(
+        "minimal loop reached max_iterations ({})",
+        config.max_iterations
+    ))
+}
+
+fn build_request_messages(
+    session: &SessionSnapshot,
+    registry: &ToolRegistry,
+    work_root: &std::path::Path,
+    ephemeral_feedback: Option<&str>,
+) -> Vec<ConversationMessage> {
+    let mut messages = Vec::with_capacity(session.messages.len() + 2);
+    messages.push(ConversationMessage::system(build_system_prompt(
+        work_root,
+        registry.specs(),
+    )));
+    messages.extend(
+        session
+            .messages
+            .iter()
+            .filter(|message| message.role != "system")
+            .cloned(),
+    );
+    if let Some(feedback) = ephemeral_feedback {
+        messages.push(ConversationMessage::user(feedback.to_string()));
+    }
+    messages
+}
+
+fn tool_specs_for_mode(registry: &ToolRegistry, mode: ExecutionMode) -> Vec<ToolSpec> {
+    registry
+        .specs()
+        .iter()
+        .filter(|spec| {
+            mode == ExecutionMode::Act
+                || matches!(spec.function.name.as_str(), "Read" | "Glob" | "Grep")
+        })
+        .cloned()
+        .collect()
+}
+
+fn is_native_tool_parser_failure(error: &str) -> bool {
+    let lower = error.to_ascii_lowercase();
+    lower.contains("native tool parser failed")
+        || lower.contains("unexpected end element")
+        || lower.contains("unexpected eof")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::feedback::MINIMAL_FEEDBACK_PREFIX;
+    use super::*;
+    use crate::ollama::xml_fallback::ToolCall;
+    use serde_json::json;
+    use std::collections::VecDeque;
+
+    enum MockResponse {
+        Reply(AssistantReply),
+        Err(String),
+    }
+
+    #[derive(Default)]
+    struct MockClient {
+        responses: VecDeque<MockResponse>,
+        native_modes: Vec<bool>,
+        feedback_seen: bool,
+    }
+
+    impl MockClient {
+        fn push_reply(&mut self, content: &str, tool_calls: Vec<ToolCall>) {
+            self.responses
+                .push_back(MockResponse::Reply(AssistantReply {
+                    content: content.to_string(),
+                    tool_calls,
+                    prompt_tokens: None,
+                    completion_tokens: None,
+                }));
+        }
+
+        fn push_err(&mut self, err: &str) {
+            self.responses.push_back(MockResponse::Err(err.to_string()));
+        }
+    }
+
+    impl MinimalChatClient for MockClient {
+        fn chat(
+            &mut self,
+            _model: &str,
+            messages: &[ConversationMessage],
+            tools: &[ToolSpec],
+            native_tools_enabled: bool,
+        ) -> Result<AssistantReply, String> {
+            assert_eq!(messages[0].role, "system");
+            assert_eq!(messages.iter().filter(|m| m.role == "system").count(), 1);
+            assert!(!tools.is_empty());
+            self.native_modes.push(native_tools_enabled);
+            self.feedback_seen |= messages
+                .iter()
+                .any(|m| m.content.starts_with(MINIMAL_FEEDBACK_PREFIX));
+            match self.responses.pop_front().expect("mock response") {
+                MockResponse::Reply(reply) => Ok(reply),
+                MockResponse::Err(err) => Err(err),
+            }
+        }
+    }
+
+    fn tool_call(name: &str, arguments: serde_json::Value) -> ToolCall {
+        ToolCall {
+            id: format!("call-{name}"),
+            name: name.to_string(),
+            arguments,
+        }
+    }
+
+    fn config(root: PathBuf, max_iterations: usize) -> MinimalLoopConfig {
+        MinimalLoopConfig {
+            work_root: root,
+            mode: ExecutionMode::Act,
+            context_budget: 24_000,
+            max_iterations,
+            auto_approve: true,
+            offline: false,
+            cancel_flag: None,
+        }
+    }
+
+    #[test]
+    fn normal_loop_executes_tool_then_returns_final_response() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut client = MockClient::default();
+        client.push_reply(
+            "",
+            vec![tool_call(
+                "Write",
+                json!({"path": "hello.txt", "content": "hello"}),
+            )],
+        );
+        client.push_reply("done", Vec::new());
+        let mut session = SessionSnapshot::default();
+
+        let reply = run_session(
+            &mut client,
+            "qwen3:8b",
+            &mut session,
+            "write hello",
+            &config(temp.path().to_path_buf(), 4),
+        )
+        .unwrap();
+
+        assert_eq!(reply, "done");
+        assert_eq!(
+            std::fs::read_to_string(temp.path().join("hello.txt")).unwrap(),
+            "hello"
+        );
+        assert!(session.messages.iter().any(|m| m.role == "tool"));
+    }
+
+    #[test]
+    fn native_parser_failure_downgrades_to_xml_for_session() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut client = MockClient::default();
+        client.push_err("native tool parser failed: unexpected eof");
+        client.push_reply("done after downgrade", Vec::new());
+        let mut session = SessionSnapshot::default();
+
+        let reply = run_session(
+            &mut client,
+            "qwen3.6:27b-coding-nvfp4",
+            &mut session,
+            "answer",
+            &config(temp.path().to_path_buf(), 4),
+        )
+        .unwrap();
+
+        assert_eq!(reply, "done after downgrade");
+        assert_eq!(client.native_modes, vec![true, false]);
+        assert!(session.native_tools_disabled);
+    }
+
+    #[test]
+    fn max_iterations_returns_error_when_tools_never_finish() {
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::write(temp.path().join("loop.txt"), "loop").unwrap();
+        let mut client = MockClient::default();
+        client.push_reply("", vec![tool_call("Read", json!({"path": "loop.txt"}))]);
+        client.push_reply("", vec![tool_call("Read", json!({"path": "loop.txt"}))]);
+        let mut session = SessionSnapshot::default();
+
+        let err = run_session(
+            &mut client,
+            "qwen3:8b",
+            &mut session,
+            "keep reading",
+            &config(temp.path().to_path_buf(), 2),
+        )
+        .unwrap_err();
+
+        assert_eq!(err, "minimal loop reached max_iterations (2)");
+    }
+
+    #[test]
+    fn edit_anchor_feedback_is_ephemeral_and_not_persisted() {
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::write(temp.path().join("main.rs"), "fn main() {}\n").unwrap();
+        let mut client = MockClient::default();
+        client.push_reply(
+            "",
+            vec![tool_call(
+                "Edit",
+                json!({
+                    "path": "main.rs",
+                    "old_string": "missing anchor",
+                    "new_string": "replacement",
+                }),
+            )],
+        );
+        client.push_reply("done", Vec::new());
+        let mut session = SessionSnapshot::default();
+
+        let reply = run_session(
+            &mut client,
+            "qwen3:8b",
+            &mut session,
+            "fix main.rs",
+            &config(temp.path().to_path_buf(), 4),
+        )
+        .unwrap();
+
+        assert_eq!(reply, "done");
+        assert!(client.feedback_seen);
+        assert!(
+            !session
+                .messages
+                .iter()
+                .any(|m| m.content.starts_with(MINIMAL_FEEDBACK_PREFIX)),
+            "ephemeral feedback must not be persisted to the session"
+        );
+    }
+}

--- a/src/agent/minimal_loop/mod.rs
+++ b/src/agent/minimal_loop/mod.rs
@@ -1,0 +1,6 @@
+mod compact;
+mod feedback;
+mod loop_run;
+pub mod prompt;
+
+pub use loop_run::{MinimalChatClient, MinimalLoopConfig, run_session};

--- a/src/agent/minimal_loop/prompt.rs
+++ b/src/agent/minimal_loop/prompt.rs
@@ -1,0 +1,84 @@
+use std::path::Path;
+
+use crate::tools::registry::ToolSpec;
+
+pub fn build_system_prompt(work_root: &Path, tools: &[ToolSpec]) -> String {
+    let tool_catalog = render_tool_catalog(tools);
+    format!(
+        "You are Anvil, a local-first coding agent running against a local Ollama model.\n\
+\n\
+Rules:\n\
+1. Prefer tools when repository facts or file contents are needed.\n\
+2. Reply in the user's language.\n\
+3. Never use sudo or destructive shell commands.\n\
+4. Make small coherent changes and verify when practical.\n\
+5. Use repository-relative paths under the project root.\n\
+6. If a tool fails, try a different local approach or explain the blocker.\n\
+7. Do not invent files, outputs, tests, or command results you have not observed.\n\
+8. In Plan mode, only inspect files and produce a plan; do not edit.\n\
+\n\
+Project root: {}\n\
+\n\
+Tools:\n\
+{}\n\
+\n\
+When native tool calls are unavailable, emit exactly one XML tool call like:\n\
+<anvil_tool_call>{{\"name\":\"Read\",\"arguments\":{{\"path\":\"README.md\"}}}}</anvil_tool_call>",
+        work_root.display(),
+        tool_catalog,
+    )
+}
+
+fn render_tool_catalog(tools: &[ToolSpec]) -> String {
+    tools
+        .iter()
+        .map(|tool| format!("- {}: {}", tool.function.name, tool.function.description))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tools::registry::ToolRegistry;
+
+    #[test]
+    fn fixed_prompt_snapshot_has_at_most_ten_rules() {
+        let registry = ToolRegistry::default();
+        let prompt = build_system_prompt(Path::new("/workspace/project"), registry.specs());
+
+        let expected = "You are Anvil, a local-first coding agent running against a local Ollama model.\n\
+\n\
+Rules:\n\
+1. Prefer tools when repository facts or file contents are needed.\n\
+2. Reply in the user's language.\n\
+3. Never use sudo or destructive shell commands.\n\
+4. Make small coherent changes and verify when practical.\n\
+5. Use repository-relative paths under the project root.\n\
+6. If a tool fails, try a different local approach or explain the blocker.\n\
+7. Do not invent files, outputs, tests, or command results you have not observed.\n\
+8. In Plan mode, only inspect files and produce a plan; do not edit.\n\
+\n\
+Project root: /workspace/project\n\
+\n\
+Tools:\n\
+- Bash: Run a shell command in the project directory. Runtime classifies commands as read-only, build-test, or general, and offline mode blocks networked or general shell commands.\n\
+- Read: Read a text file or list a directory. Use repository-relative paths.\n\
+- Write: Create or overwrite a file. Use repository-relative paths.\n\
+- Edit: Replace exact text in an existing file. Use repository-relative paths.\n\
+- Glob: Find files by glob pattern.\n\
+- Grep: Search repository text.\n\
+\n\
+When native tool calls are unavailable, emit exactly one XML tool call like:\n\
+<anvil_tool_call>{\"name\":\"Read\",\"arguments\":{\"path\":\"README.md\"}}</anvil_tool_call>";
+
+        assert_eq!(prompt, expected);
+        assert_eq!(
+            prompt
+                .lines()
+                .filter(|line| { line.chars().next().is_some_and(|ch| ch.is_ascii_digit()) })
+                .count(),
+            8
+        );
+    }
+}

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -1,4 +1,5 @@
 pub mod loop_run;
+pub mod minimal_loop;
 pub mod orchestration;
 pub mod permissions;
 pub mod prompting;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -18,6 +18,9 @@ pub struct CliArgs {
     pub ollama_host: Option<String>,
     #[arg(long = "context-budget")]
     pub context_budget: Option<usize>,
+    /// Override Ollama num_predict. Defaults to 2048 for legacy and 8192 for minimal.
+    #[arg(long = "num-predict")]
+    pub num_predict: Option<usize>,
     #[arg(long = "max-iterations")]
     pub max_iterations: Option<usize>,
     #[arg(long = "chat-timeout-secs")]
@@ -276,6 +279,7 @@ mod tests {
             sidecar_model: None,
             ollama_host: None,
             context_budget: None,
+            num_predict: None,
             max_iterations: None,
             chat_timeout_secs: None,
             chat_retries: None,
@@ -368,6 +372,15 @@ mod tests {
 
         let parsed = CliArgs::parse_from(["anvil", "--engine", "minimal"]);
         assert_eq!(parsed.engine, Some(Engine::Minimal));
+    }
+
+    #[test]
+    fn num_predict_flag_defaults_none_and_parses_value() {
+        let args = base_args();
+        assert_eq!(args.num_predict, None);
+
+        let parsed = CliArgs::parse_from(["anvil", "--num-predict", "8192"]);
+        assert_eq!(parsed.num_predict, Some(8192));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -252,6 +252,7 @@ pub struct Config {
     pub requested_sidecar_model: Option<String>,
     pub ollama_host: String,
     pub context_budget: usize,
+    pub num_predict: usize,
     pub max_iterations: usize,
     pub chat_timeout_secs: u64,
     pub chat_retries: usize,
@@ -352,6 +353,7 @@ pub struct PartialConfig {
     pub sidecar_model: Option<String>,
     pub ollama_host: Option<String>,
     pub context_budget: Option<usize>,
+    pub num_predict: Option<usize>,
     pub max_iterations: Option<usize>,
     pub chat_timeout_secs: Option<u64>,
     pub chat_retries: Option<usize>,
@@ -438,6 +440,7 @@ impl Config {
             sidecar_model: args.sidecar_model.clone(),
             ollama_host: args.ollama_host.clone(),
             context_budget: args.context_budget,
+            num_predict: args.num_predict,
             max_iterations: args.max_iterations,
             chat_timeout_secs: args.chat_timeout_secs,
             chat_retries: args.chat_retries,
@@ -490,12 +493,19 @@ impl Config {
         }
         let photon_enabled = !offline && merged.photon_enabled.unwrap_or(false);
 
+        let engine = merged.engine.unwrap_or_default();
+        let default_num_predict = match engine {
+            Engine::Legacy => 2_048,
+            Engine::Minimal => 8_192,
+        };
+
         let config = Self {
             cwd,
             requested_model: merged.model,
             requested_sidecar_model: merged.sidecar_model,
             ollama_host,
             context_budget: merged.context_budget.unwrap_or(24_000),
+            num_predict: merged.num_predict.unwrap_or(default_num_predict),
             max_iterations: merged.max_iterations.unwrap_or(50),
             chat_timeout_secs: merged.chat_timeout_secs.unwrap_or(300),
             chat_retries: merged.chat_retries.unwrap_or(2),
@@ -507,7 +517,7 @@ impl Config {
             auto_plan: merged.auto_plan.unwrap_or(false),
             offline,
             deterministic_fallback: merged.deterministic_fallback.unwrap_or_default(),
-            engine: merged.engine.unwrap_or_default(),
+            engine,
             prompt: args.prompt,
             state_dir_override: merged.state_dir_override,
             resume: ResumeRequest::from_flag(args.resume),
@@ -572,6 +582,9 @@ pub fn merge_partial_configs(configs: &[PartialConfig]) -> PartialConfig {
         }
         if config.context_budget.is_some() {
             merged.context_budget = config.context_budget;
+        }
+        if config.num_predict.is_some() {
+            merged.num_predict = config.num_predict;
         }
         if config.max_iterations.is_some() {
             merged.max_iterations = config.max_iterations;
@@ -686,6 +699,7 @@ pub fn load_config_file(path: &Path, warnings: &mut Vec<String>) -> Result<Parti
         context_budget: map
             .get("context_budget")
             .and_then(|value| value.parse().ok()),
+        num_predict: map.get("num_predict").and_then(|value| value.parse().ok()),
         max_iterations: map
             .get("max_iterations")
             .and_then(|value| value.parse().ok()),
@@ -767,6 +781,9 @@ pub fn load_env_config(warnings: &mut Vec<String>) -> PartialConfig {
             .ok()
             .or_else(|| env::var("ANVIL_PROVIDER_URL").ok()),
         context_budget: env::var("ANVIL_CONTEXT_BUDGET")
+            .ok()
+            .and_then(|value| value.parse().ok()),
+        num_predict: env::var("ANVIL_NUM_PREDICT")
             .ok()
             .and_then(|value| value.parse().ok()),
         max_iterations: env::var("ANVIL_MAX_ITERATIONS")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,9 +72,6 @@ pub fn run_cli(args: CliArgs) -> Result<(), String> {
     for warning in &warnings {
         eprintln!("warning: {warning}");
     }
-    if config.engine == Engine::Minimal {
-        return Err("minimal engine is not implemented yet".to_string());
-    }
     config.cwd = ensure_workspace_root(&config.cwd)?;
 
     let state_root = resolve_state_root(&config)?;
@@ -115,7 +112,7 @@ pub fn run_cli(args: CliArgs) -> Result<(), String> {
         config.ollama_host.clone(),
         config.chat_timeout_secs,
         config.context_budget,
-        2_048,
+        config.num_predict,
     )?;
     let available_models = client.list_models()?;
     let models = select_models(
@@ -177,27 +174,6 @@ pub fn run_cli(args: CliArgs) -> Result<(), String> {
         None
     };
 
-    // Acquire the fixed-footer lease before constructing `Agent` so the
-    // handle can be plumbed into the agent. Phase A: `acquire` always
-    // returns a disabled handle (cargo non-TTY harness short-circuits and
-    // the install path is itself still skeleton-only), so the lease is
-    // safe to take on every non-sessions path. AC9's strict zero-acquire
-    // for the oneshot path lands in Phase C alongside the real worker
-    // install (issue #430). The lease drops at the end of `run_cli`.
-    // `_footer_lease` (underscore-prefixed but NOT bare `_`) keeps the lease
-    // alive for the full `run_cli` scope; bare `_` would drop immediately.
-    let _footer_lease = FooterLease::acquire(&config);
-    let footer_handle = _footer_lease.handle_clone();
-
-    let mut agent = Agent::new(
-        config,
-        models,
-        client,
-        session_store,
-        session,
-        footer_handle,
-    );
-
     // Banner: REPL / resume get stdout; oneshot gets stderr so stdout stays
     // clean for script consumers.
     if is_oneshot {
@@ -216,6 +192,38 @@ pub fn run_cli(args: CliArgs) -> Result<(), String> {
         );
     }
 
+    if config.engine == Engine::Minimal {
+        return run_minimal_engine(
+            config,
+            models,
+            client,
+            session_store,
+            session,
+            resume_prompt,
+        );
+    }
+
+    // Acquire the fixed-footer lease before constructing `Agent` so the
+    // handle can be plumbed into the legacy agent. Phase A: `acquire` always
+    // returns a disabled handle (cargo non-TTY harness short-circuits and
+    // the install path is itself still skeleton-only), so the lease is
+    // safe to take on every legacy non-sessions path. AC9's strict zero-acquire
+    // for the oneshot path lands in Phase C alongside the real worker
+    // install (issue #430). The lease drops at the end of `run_cli`.
+    // `_footer_lease` (underscore-prefixed but NOT bare `_`) keeps the lease
+    // alive for the full `run_cli` scope; bare `_` would drop immediately.
+    let _footer_lease = FooterLease::acquire(&config);
+    let footer_handle = _footer_lease.handle_clone();
+
+    let mut agent = Agent::new(
+        config,
+        models,
+        client,
+        session_store,
+        session,
+        footer_handle,
+    );
+
     if let Some(prompt) = resume_prompt {
         // Resume: replay the last user turn, then fall into the REPL loop
         // (banner has already been printed above).
@@ -231,6 +239,52 @@ pub fn run_cli(args: CliArgs) -> Result<(), String> {
     }
 
     agent.run_repl_loop()
+}
+
+fn run_minimal_engine(
+    config: Config,
+    models: RuntimeModels,
+    mut client: OllamaClient,
+    session_store: SessionStore,
+    mut session: session::store::SessionSnapshot,
+    resume_prompt: Option<String>,
+) -> Result<(), String> {
+    let prompt = match resume_prompt {
+        Some(prompt) => prompt,
+        None => match &config.prompt {
+            Some(prompt) => prompt.clone(),
+            None => stdin_prompt()?.ok_or_else(|| {
+                "minimal engine currently requires --prompt, stdin, or --resume".to_string()
+            })?,
+        },
+    };
+
+    let work_root = session
+        .active_root
+        .clone()
+        .unwrap_or_else(|| config.cwd.clone());
+    let loop_config = agent::minimal_loop::MinimalLoopConfig {
+        work_root: work_root.clone(),
+        mode: session.mode_state.mode,
+        context_budget: config.context_budget,
+        max_iterations: config.max_iterations,
+        auto_approve: config.yes_mode,
+        offline: config.offline,
+        cancel_flag: None,
+    };
+    let reply = agent::minimal_loop::run_session(
+        &mut client,
+        &models.main,
+        &mut session,
+        &prompt,
+        &loop_config,
+    )?;
+    session.active_root = (work_root != config.cwd).then_some(work_root);
+    session_store.save(&session)?;
+    if !reply.is_empty() {
+        println!("{reply}");
+    }
+    Ok(())
 }
 
 /// Lightweight state-root resolver for the `sessions` subcommand path, where

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -558,6 +558,7 @@ fn minimal_args(cwd: &std::path::Path) -> CliArgs {
         sidecar_model: None,
         ollama_host: None,
         context_budget: None,
+        num_predict: None,
         max_iterations: None,
         chat_timeout_secs: None,
         chat_retries: None,
@@ -585,6 +586,27 @@ fn config_load_defaults_engine_to_legacy() {
     let tmp = tempfile::tempdir().unwrap();
     let (cfg, _) = Config::load(minimal_args(tmp.path())).unwrap();
     assert_eq!(cfg.engine, Engine::Legacy);
+    assert_eq!(cfg.num_predict, 2_048);
+}
+
+#[test]
+fn config_load_defaults_minimal_num_predict_to_8192() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut args = minimal_args(tmp.path());
+    args.engine = Some(Engine::Minimal);
+    let (cfg, _) = Config::load(args).unwrap();
+    assert_eq!(cfg.engine, Engine::Minimal);
+    assert_eq!(cfg.num_predict, 8_192);
+}
+
+#[test]
+fn config_load_num_predict_override_wins() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut args = minimal_args(tmp.path());
+    args.engine = Some(Engine::Minimal);
+    args.num_predict = Some(4_096);
+    let (cfg, _) = Config::load(args).unwrap();
+    assert_eq!(cfg.num_predict, 4_096);
 }
 
 #[test]
@@ -598,11 +620,30 @@ fn config_file_engine_minimal_is_loaded() {
 }
 
 #[test]
+fn config_file_num_predict_is_loaded() {
+    let tmp = tempfile::tempdir().unwrap();
+    let config_path = tmp.path().join("config");
+    std::fs::write(&config_path, "num_predict = 4096\n").unwrap();
+    let mut warnings: Vec<String> = Vec::new();
+    let cfg = load_config_file(&config_path, &mut warnings).unwrap();
+    assert_eq!(cfg.num_predict, Some(4_096));
+}
+
+#[test]
 fn env_config_reads_engine() {
     with_env(&[("ANVIL_ENGINE", Some("minimal"))], || {
         let mut warnings: Vec<String> = Vec::new();
         let cfg = load_env_config(&mut warnings);
         assert_eq!(cfg.engine, Some(Engine::Minimal));
+    });
+}
+
+#[test]
+fn env_config_reads_num_predict() {
+    with_env(&[("ANVIL_NUM_PREDICT", Some("4096"))], || {
+        let mut warnings: Vec<String> = Vec::new();
+        let cfg = load_env_config(&mut warnings);
+        assert_eq!(cfg.num_predict, Some(4_096));
     });
 }
 

--- a/tests/engine_cli_tests.rs
+++ b/tests/engine_cli_tests.rs
@@ -1,9 +1,28 @@
 use anvil::cli::CliArgs;
+use anvil::session::sessions_cli::{ShowView, scan_session_meta};
+use anvil::session::store::SessionSnapshot;
 use clap::Parser;
 
 #[test]
-fn engine_minimal_returns_not_implemented_before_ollama_startup() {
+fn engine_minimal_runs_one_ollama_turn() {
+    let mut server = mockito::Server::new();
+    let tags = server
+        .mock("GET", "/api/tags")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"models":[{"name":"qwen3:8b","details":{}}]}"#)
+        .expect(1)
+        .create();
+    let generate = server
+        .mock("POST", "/api/generate")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"response":"minimal ok","done":true}"#)
+        .expect(1)
+        .create();
+
     let tmp = tempfile::tempdir().unwrap();
+    let state = tempfile::tempdir().unwrap();
     let args = CliArgs::parse_from([
         "anvil",
         "--engine",
@@ -12,8 +31,33 @@ fn engine_minimal_returns_not_implemented_before_ollama_startup() {
         "hello",
         "--cwd",
         tmp.path().to_str().unwrap(),
+        "--state-dir",
+        state.path().to_str().unwrap(),
+        "--ollama-host",
+        &server.url(),
     ]);
 
-    let err = anvil::run_cli(args).expect_err("minimal engine should be a stub");
-    assert_eq!(err, "minimal engine is not implemented yet");
+    anvil::run_cli(args).unwrap();
+
+    tags.assert();
+    generate.assert();
+
+    let metas = scan_session_meta(state.path());
+    assert_eq!(metas.len(), 1);
+    assert_eq!(metas[0].message_count, 2);
+
+    let session_dir = std::fs::read_dir(state.path().join("sessions"))
+        .unwrap()
+        .next()
+        .unwrap()
+        .unwrap()
+        .path();
+    let data = std::fs::read_to_string(session_dir.join("session.json")).unwrap();
+    let snapshot: SessionSnapshot = serde_json::from_str(&data).unwrap();
+    let show = ShowView::from_snapshot(&snapshot);
+    assert_eq!(show.first_user_preview.as_deref(), Some("hello"));
+    assert_eq!(
+        show.last_assistant_or_tool_preview.as_deref(),
+        Some("minimal ok")
+    );
 }

--- a/tests/photon_warning_filter_smoke.rs
+++ b/tests/photon_warning_filter_smoke.rs
@@ -34,6 +34,7 @@ fn minimal_args(cwd: &std::path::Path) -> CliArgs {
         sidecar_model: None,
         ollama_host: None,
         context_budget: None,
+        num_predict: None,
         max_iterations: None,
         chat_timeout_secs: None,
         chat_retries: None,

--- a/tests/scripts/test_bench_smoke.sh
+++ b/tests/scripts/test_bench_smoke.sh
@@ -32,10 +32,14 @@ cat > "$fake_anvil" <<'EOF'
 # Parse --state-dir and write a session directory.
 set -euo pipefail
 state_dir=""
+engine="legacy"
 prev=""
 for arg in "$@"; do
   if [[ "$prev" == "--state-dir" ]]; then
     state_dir="$arg"
+  fi
+  if [[ "$prev" == "--engine" ]]; then
+    engine="$arg"
   fi
   prev="$arg"
 done
@@ -47,8 +51,9 @@ uuid="00000000-0000-4000-8000-000000000001"
 session_dir="$state_dir/sessions/$uuid"
 mkdir -p "$session_dir/logs"
 cat > "$session_dir/session.json" <<JSON
-{"id":"$uuid","pam":"${ANVIL_PAM_ADVISORY_ENABLED:-unset}","messages":[{"role":"assistant","content":"ok","tool_calls":[]}]}
+{"id":"$uuid","pam":"${ANVIL_PAM_ADVISORY_ENABLED:-unset}","engine":"$engine","messages":[{"role":"assistant","content":"ok","tool_calls":[]}]}
 JSON
+printf 'ok\n' > result.txt
 echo '{"ts_ms":1,"event":"ollama.generate.start","payload":{}}' \
   > "$session_dir/logs/llm-io.jsonl"
 echo '{"schema_version":1,"session_id":"fake","final_outcome":"done","pam_eval":{"advisory_only":true}}' \
@@ -64,6 +69,12 @@ mkdir -p "$bench_yaml_dir"
 cat > "$bench_yaml" <<'EOF'
 args:
   max_iterations: 1
+success_check:
+  files:
+    - path: result.txt
+      min_lines: 1
+  commands:
+    - test -f result.txt
 cases:
   - name: docs
     prompt: update README copy
@@ -76,7 +87,7 @@ trap 'rm -rf "$tmp"; rm -f "$bench_yaml"' EXIT
 export ANVIL_BIN="$fake_anvil"
 export BENCH_DEBUG=1
 cd "$REPO_ROOT"
-bash scripts/bench.sh bench-smoke-fixture --model "smoke-model" --runs 1 --pam-ab \
+bash scripts/bench.sh bench-smoke-fixture --model "smoke-model" --runs 1 --pam-ab --engines legacy,minimal \
   > "$tmp/bench.stdout" 2> "$tmp/bench.stderr" || {
   echo "FAIL: bench.sh non-zero exit" >&2
   cat "$tmp/bench.stderr" >&2
@@ -108,38 +119,48 @@ if [[ "$header" != "$expected_header" ]]; then
 fi
 
 rows=$(($(wc -l < "$summary") - 1))
-if [[ "$rows" -ne 4 ]]; then
-  echo "FAIL: expected 4 data rows, got $rows" >&2
+if [[ "$rows" -ne 8 ]]; then
+  echo "FAIL: expected 8 data rows, got $rows" >&2
   exit 1
 fi
 
-for case_name in docs data; do
-  for pam_variant in pam_on pam_off; do
-    run_dir="$BENCH_ROOT/smoke-model/$case_name/$pam_variant/run-1"
-    for f in session.json meta.json logs/llm-io.jsonl logs/eval.jsonl workdir; do
-      if [[ ! -e "$run_dir/$f" ]]; then
-        echo "FAIL: missing $run_dir/$f" >&2
-        exit 1
+for engine in legacy minimal; do
+  for case_name in docs data; do
+    for pam_variant in pam_on pam_off; do
+      run_dir="$BENCH_ROOT/smoke-model/$engine/$case_name/$pam_variant/run-1"
+      for f in session.json meta.json logs/llm-io.jsonl logs/eval.jsonl workdir workdir/result.txt; do
+        if [[ ! -e "$run_dir/$f" ]]; then
+          echo "FAIL: missing $run_dir/$f" >&2
+          exit 1
+        fi
+      done
+      expected_pam="true"
+      if [[ "$pam_variant" == "pam_off" ]]; then
+        expected_pam="false"
       fi
+      jq -e --arg expected "$expected_pam" --arg engine "$engine" \
+        '.pam == $expected and .engine == $engine' "$run_dir/session.json" >/dev/null || {
+        echo "FAIL: PAM/env mismatch in $run_dir/session.json" >&2
+        cat "$run_dir/session.json" >&2
+        exit 1
+      }
+      jq -e --arg engine "$engine" \
+        '.engine == $engine and .success_check_success == true and .success_check_reason == "ok"' \
+        "$run_dir/meta.json" >/dev/null || {
+        echo "FAIL: meta engine/success_check mismatch in $run_dir/meta.json" >&2
+        cat "$run_dir/meta.json" >&2
+        exit 1
+      }
     done
-    expected_pam="true"
-    if [[ "$pam_variant" == "pam_off" ]]; then
-      expected_pam="false"
-    fi
-    jq -e --arg expected "$expected_pam" '.pam == $expected' "$run_dir/session.json" >/dev/null || {
-      echo "FAIL: PAM env mismatch in $run_dir/session.json" >&2
-      cat "$run_dir/session.json" >&2
-      exit 1
-    }
   done
 done
 
-run_dir="$BENCH_ROOT/smoke-model/docs/pam_on/run-1"
+run_dir="$BENCH_ROOT/smoke-model/legacy/docs/pam_on/run-1"
 
 pam_on_count=$(awk -F'\t' 'NR > 1 && $4 == "pam_on" { n++ } END { print n + 0 }' "$summary")
 pam_off_count=$(awk -F'\t' 'NR > 1 && $4 == "pam_off" { n++ } END { print n + 0 }' "$summary")
-if [[ "$pam_on_count" -ne 2 || "$pam_off_count" -ne 2 ]]; then
-  echo "FAIL: expected 2 pam_on and 2 pam_off rows" >&2
+if [[ "$pam_on_count" -ne 4 || "$pam_off_count" -ne 4 ]]; then
+  echo "FAIL: expected 4 pam_on and 4 pam_off rows" >&2
   cat "$summary" >&2
   exit 1
 fi

--- a/tests/scripts/test_compare_smoke.sh
+++ b/tests/scripts/test_compare_smoke.sh
@@ -22,11 +22,12 @@ trap 'rm -rf "$tmp"' EXIT
 SLUG="smoke-model"
 
 build_run() {
-  # $1=run-dir, $2=rc, $3=elapsed_s, $4=run_id, $5=iter_count
+  # $1=run-dir, $2=rc, $3=elapsed_s, $4=run_id, $5=iter_count, $6=engine
   local dir="$1" rc="$2" elapsed="$3" rid="$4" iters="$5"
+  local engine="${6:-legacy}"
   mkdir -p "$dir"
   cat > "$dir/meta.json" <<EOF
-{"rc": $rc, "elapsed_s": $elapsed, "model": "$SLUG", "start_ts": "2026-01-01T00:00:00Z"}
+{"rc": $rc, "elapsed_s": $elapsed, "model": "$SLUG", "engine": "$engine", "start_ts": "2026-01-01T00:00:00Z"}
 EOF
   python3 - "$dir/session.json" "$rid" "$iters" <<'PY'
 import json, sys
@@ -90,7 +91,34 @@ assert data["schema_version"] == 1, data
 assert data["model_slug"] == slug, data
 assert "metrics" in data and isinstance(data["metrics"], dict), data
 assert "rc" in data["metrics"], data
+assert "failure_categories" in data, data
 print("json validated")
+PY
+
+# --- engine mode ---
+engine_root="$tmp/engine-root"
+build_run "$engine_root/$SLUG/legacy/docs/default/run-1" 0 120 "el1" 10 legacy
+build_run "$engine_root/$SLUG/legacy/docs/default/run-2" 0 130 "el2" 11 legacy
+build_run "$engine_root/$SLUG/legacy/docs/default/run-3" 1 125 "el3" 9 legacy
+build_run "$engine_root/$SLUG/minimal/docs/default/run-1" 0 100 "em1" 8 minimal
+build_run "$engine_root/$SLUG/minimal/docs/default/run-2" 0 110 "em2" 9 minimal
+build_run "$engine_root/$SLUG/minimal/docs/default/run-3" 0 105 "em3" 7 minimal
+
+engine_json="$tmp/engine.json"
+if ! COMPARE_NOW=2026-01-01T00:00:00Z \
+  python3 "$SCRIPT" --format json --engines legacy,minimal "$engine_root" > "$engine_json" 2> "$tmp/engine.err"; then
+  echo "FAIL: compare.py engine mode exit non-zero" >&2
+  cat "$tmp/engine.err" >&2
+  exit 1
+fi
+python3 - "$engine_json" <<'PY'
+import json, sys
+with open(sys.argv[1]) as f:
+    data = json.load(f)
+assert data["model_slug"].endswith(":legacy->minimal"), data
+assert "rc" in data["metrics"], data
+assert "failure_categories" in data, data
+print("engine json validated")
 PY
 
 echo "PASS: compare.py smoke test"


### PR DESCRIPTION
## Summary
- Implement `--engine minimal` with a new `src/agent/minimal_loop` prompt, loop, token-based compaction, and ephemeral feedback path.
- Add `--num-predict` config/env/CLI support with legacy default 2048 and minimal default 8192.
- Extend benchmark tooling with YAML `success_check`, `--engines legacy,minimal`, engine-aware analyze/compare output, and a 25-case `minimal-loop-expanded` suite.

## Notes
- This is stacked on #1017 (`minimal-loop-t1-1`).
- Phase 2 full comparison execution remains a human/GPU task per the plan gate.

## Verification
- `cargo test minimal_loop -q`
- `cargo test --test config_tests -q`
- `cargo test --test engine_cli_tests -q`
- `bash scripts/check_cli_help_snapshot.sh`
- `bash tests/scripts/test_bench_smoke.sh`
- `bash tests/scripts/test_compare_smoke.sh`
- `python3 tests/test_compare_security.py`
- `python3 tests/test_eval_task_kind.py`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test -q`