### PR TITLE
Record minimal loop rerun after parser fixes

### DIFF
--- a/docs/eval/minimal-loop-t2-4-rerun-20260612.json
+++ b/docs/eval/minimal-loop-t2-4-rerun-20260612.json
@@ -1,0 +1,159 @@
+{
+  "date_jst": "2026-06-12",
+  "model": "qwen3.6:27b-coding-nvfp4",
+  "benchmark": "minimal-loop-expanded",
+  "conditions": [
+    "--max-iterations 12",
+    "--no-auto-test",
+    "--no-precautions",
+    "--no-case-memory",
+    "--bench-no-debug"
+  ],
+  "merged_fixes": [
+    {
+      "pr": 1021,
+      "title": "Restore minimal loop XML fallback downgrade",
+      "merge_commit": "e0813d824c8befb898ce528e20c08c10e477e40d"
+    },
+    {
+      "pr": 1022,
+      "title": "Salvage XML tool content in native replies",
+      "merge_commit": "767f7836470231362f134f13d21d91fd53b84a02"
+    }
+  ],
+  "roots": {
+    "legacy_source": ".anvil/benchmarks/20260612T024532-70925",
+    "minimal_source": ".anvil/benchmarks/20260612T105012-57478",
+    "combined": ".anvil/benchmarks/20260612T105012-combined-t2-4-rerun"
+  },
+  "row_summary": {
+    "legacy_initial": {
+      "rows": 125,
+      "rc0": 125,
+      "rc_nonzero": 0,
+      "success_check_ok": 46,
+      "success_check_ng": 79,
+      "success_check_null": 0,
+      "elapsed_total_sec": 8319
+    },
+    "minimal_initial": {
+      "rows": 125,
+      "rc0": 95,
+      "rc_nonzero": 30,
+      "success_check_ok": 35,
+      "success_check_ng": 60,
+      "success_check_null": 30,
+      "elapsed_total_sec": 6905
+    },
+    "minimal_rerun": {
+      "rows": 125,
+      "rc0": 96,
+      "rc_nonzero": 29,
+      "success_check_ok": 37,
+      "success_check_ng": 59,
+      "success_check_null": 29,
+      "elapsed_total_sec": 7779
+    }
+  },
+  "scenario_summary_minimal_rerun": [
+    {"scenario": "fix-css-token-doc", "rc0": 5, "rc_nonzero": 0, "success_ok": 4, "success_ng": 1, "success_null": 0},
+    {"scenario": "fix-js-date-helper", "rc0": 4, "rc_nonzero": 1, "success_ok": 0, "success_ng": 4, "success_null": 1},
+    {"scenario": "fix-json-normalizer", "rc0": 5, "rc_nonzero": 0, "success_ok": 0, "success_ng": 5, "success_null": 0},
+    {"scenario": "fix-python-retry-policy", "rc0": 2, "rc_nonzero": 3, "success_ok": 2, "success_ng": 0, "success_null": 3},
+    {"scenario": "fix-python-slugify", "rc0": 3, "rc_nonzero": 2, "success_ok": 3, "success_ng": 0, "success_null": 2},
+    {"scenario": "fix-readme-command", "rc0": 4, "rc_nonzero": 1, "success_ok": 3, "success_ng": 1, "success_null": 1},
+    {"scenario": "fix-rust-parser-error", "rc0": 3, "rc_nonzero": 2, "success_ok": 1, "success_ng": 2, "success_null": 2},
+    {"scenario": "fix-shell-safe-clean", "rc0": 3, "rc_nonzero": 2, "success_ok": 1, "success_ng": 2, "success_null": 2},
+    {"scenario": "long-session-data-report", "rc0": 5, "rc_nonzero": 0, "success_ok": 0, "success_ng": 5, "success_null": 0},
+    {"scenario": "long-session-large-component", "rc0": 5, "rc_nonzero": 0, "success_ok": 1, "success_ng": 4, "success_null": 0},
+    {"scenario": "long-session-read-edit", "rc0": 5, "rc_nonzero": 0, "success_ok": 1, "success_ng": 4, "success_null": 0},
+    {"scenario": "multi-file-docs-and-examples", "rc0": 5, "rc_nonzero": 0, "success_ok": 5, "success_ng": 0, "success_null": 0},
+    {"scenario": "multi-file-node-package", "rc0": 2, "rc_nonzero": 3, "success_ok": 1, "success_ng": 1, "success_null": 3},
+    {"scenario": "multi-file-python-package", "rc0": 4, "rc_nonzero": 1, "success_ok": 3, "success_ng": 1, "success_null": 1},
+    {"scenario": "multi-file-rust-library", "rc0": 5, "rc_nonzero": 0, "success_ok": 0, "success_ng": 5, "success_null": 0},
+    {"scenario": "new-large-react-kanban", "rc0": 5, "rc_nonzero": 0, "success_ok": 5, "success_ng": 0, "success_null": 0},
+    {"scenario": "new-markdown-release-notes", "rc0": 5, "rc_nonzero": 0, "success_ok": 5, "success_ng": 0, "success_null": 0},
+    {"scenario": "new-python-csv-small", "rc0": 0, "rc_nonzero": 5, "success_ok": 0, "success_ng": 0, "success_null": 5},
+    {"scenario": "new-rust-cli-small", "rc0": 5, "rc_nonzero": 0, "success_ok": 0, "success_ng": 5, "success_null": 0},
+    {"scenario": "new-typescript-formatter", "rc0": 2, "rc_nonzero": 3, "success_ok": 0, "success_ng": 2, "success_null": 3},
+    {"scenario": "non-coding-research-brief", "rc0": 0, "rc_nonzero": 5, "success_ok": 0, "success_ng": 0, "success_null": 5},
+    {"scenario": "non-coding-runbook", "rc0": 4, "rc_nonzero": 1, "success_ok": 2, "success_ng": 2, "success_null": 1},
+    {"scenario": "scaffold-fastapi-service", "rc0": 5, "rc_nonzero": 0, "success_ok": 0, "success_ng": 5, "success_null": 0},
+    {"scenario": "scaffold-next-dashboard", "rc0": 5, "rc_nonzero": 0, "success_ok": 0, "success_ng": 5, "success_null": 0},
+    {"scenario": "scaffold-rust-cli", "rc0": 5, "rc_nonzero": 0, "success_ok": 0, "success_ng": 5, "success_null": 0}
+  ],
+  "compare": {
+    "schema_version": 1,
+    "model_slug": "qwen3.6-27b-coding-nvfp4:legacy->minimal",
+    "generated_at": "2026-06-12T04:05:20Z",
+    "threshold": 0.05,
+    "metrics": {
+      "elapsed_s": {
+        "baseline": {"mean": 66.552, "ci_low": 50.69101025189079, "ci_high": 82.41298974810923, "n": 125},
+        "experiment": {"mean": 62.232, "ci_low": 45.984021597282506, "ci_high": 78.47997840271749, "n": 125},
+        "delta": -4.320000000000007,
+        "delta_pct": -0.06491164803461966,
+        "verdict": "improved"
+      },
+      "error_500_count": {
+        "baseline": {"mean": 0.0, "ci_low": 0.0, "ci_high": 0.0, "n": 125},
+        "experiment": {"mean": 0.0, "ci_low": 0.0, "ci_high": 0.0, "n": 125},
+        "delta": 0.0,
+        "delta_pct": null,
+        "verdict": "unchanged"
+      },
+      "iter_count": {
+        "baseline": {"mean": 2.712, "ci_low": 2.468296016260869, "ci_high": 2.9557039837391312, "n": 125},
+        "experiment": {"mean": 4.020833333333333, "ci_low": 3.6594981003642864, "ci_high": 4.38216856630238, "n": 96},
+        "delta": 1.3088333333333328,
+        "delta_pct": 0.4826081612586035,
+        "verdict": "regressed"
+      },
+      "page_tsx_has_game_keywords": {
+        "baseline": {"mean": 0.0, "ci_low": 0.0, "ci_high": 0.43449149475208104, "n": 5},
+        "experiment": {"mean": 0.0, "ci_low": 0.0, "ci_high": 0.48990002040399916, "n": 4},
+        "delta": 0.0,
+        "delta_pct": null,
+        "verdict": "unchanged"
+      },
+      "postcheck_success": {
+        "baseline": {"mean": 0.248, "ci_low": 0.18056639010525916, "ci_high": 0.3304611041202084, "n": 125},
+        "experiment": {"mean": 0.16, "ci_low": 0.10602751316968752, "ci_high": 0.23424767745197506, "n": 125},
+        "delta": -0.088,
+        "delta_pct": null,
+        "verdict": "regressed"
+      },
+      "rc": {
+        "baseline": {"mean": 1.0, "ci_low": 0.9701835432034374, "ci_high": 1.0, "n": 125},
+        "experiment": {"mean": 0.768, "ci_low": 0.6866850458237092, "ci_high": 0.8333333333333334, "n": 125},
+        "delta": -0.23199999999999998,
+        "delta_pct": null,
+        "verdict": "regressed"
+      },
+      "we_total": {
+        "baseline": {"mean": 1.752, "ci_low": 1.5423671751878785, "ci_high": 1.9616328248121215, "n": 125},
+        "experiment": {"mean": 1.008, "ci_low": 0.7615855488108729, "ci_high": 1.254414451189127, "n": 125},
+        "delta": -0.744,
+        "delta_pct": null,
+        "verdict": "informational"
+      }
+    },
+    "failure_categories": {
+      "baseline": {
+        "completed": 60,
+        "control_loop_exhausted": 6,
+        "missing_deliverable": 40,
+        "missing_evidence": 19
+      },
+      "experiment": {
+        "completed": 96,
+        "failed": 29
+      }
+    }
+  },
+  "log_observations": {
+    "parser_failure_text_occurrences": 352,
+    "native_xml_salvage_activations": 0
+  },
+  "assessment": "The parser fixes are merged, but the expected large recovery did not appear. Minimal remains worse than legacy on rc, postcheck_success, and iter_count, and the previously critical new-python-csv-small and non-coding-research-brief scenarios remain 0/5 on rc."
+}

--- a/docs/eval/minimal-loop-t2-4-rerun-20260612.md
+++ b/docs/eval/minimal-loop-t2-4-rerun-20260612.md
@@ -1,0 +1,115 @@
+# Minimal Loop T2-4 Rerun After Parser Fixes
+
+- Date: 2026-06-12 JST
+- Model: `qwen3.6:27b-coding-nvfp4`
+- Benchmark: `minimal-loop-expanded`
+- Matrix rerun: 25 cases x 5 runs x minimal engine = 125 runs
+- Compare baseline: legacy engine from the initial T2-4 run
+- Legacy source BENCH_ROOT: `.anvil/benchmarks/20260612T024532-70925`
+- Minimal source BENCH_ROOT: `.anvil/benchmarks/20260612T105012-57478`
+- Combined comparison BENCH_ROOT: `.anvil/benchmarks/20260612T105012-combined-t2-4-rerun`
+- Conditions: `--max-iterations 12 --no-auto-test --no-precautions --no-case-memory --bench-no-debug`
+
+## Merged Fixes
+
+| PR | merge commit | note |
+|---|---|---|
+| #1021 `Restore minimal loop XML fallback downgrade` | `e0813d824c8befb898ce528e20c08c10e477e40d` | Parser failure downgrades the session to XML fallback. |
+| #1022 `Salvage XML tool content in native replies` | `767f7836470231362f134f13d21d91fd53b84a02` | Well-formed XML in native content is delegated to XML fallback extraction before malformed rejection. |
+
+## Run Command
+
+```sh
+scripts/bench.sh minimal-loop-expanded \
+  --model qwen3.6:27b-coding-nvfp4 \
+  --runs 5 \
+  --engine minimal \
+  --max-iterations 12 \
+  --no-auto-test \
+  --no-precautions \
+  --no-case-memory \
+  --bench-no-debug
+```
+
+## Row Summary
+
+| engine / run | rows | rc=0 | rc!=0 | success_check ok | success_check ng | success_check null | elapsed total sec |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| legacy initial | 125 | 125 | 0 | 46 | 79 | 0 | 8319 |
+| minimal initial | 125 | 95 | 30 | 35 | 60 | 30 | 6905 |
+| minimal rerun | 125 | 96 | 29 | 37 | 59 | 29 | 7779 |
+
+## Scenario Summary For Minimal Rerun
+
+| scenario | rc=0 | rc!=0 | success ok | success ng | success null |
+|---|---:|---:|---:|---:|---:|
+| fix-css-token-doc | 5 | 0 | 4 | 1 | 0 |
+| fix-js-date-helper | 4 | 1 | 0 | 4 | 1 |
+| fix-json-normalizer | 5 | 0 | 0 | 5 | 0 |
+| fix-python-retry-policy | 2 | 3 | 2 | 0 | 3 |
+| fix-python-slugify | 3 | 2 | 3 | 0 | 2 |
+| fix-readme-command | 4 | 1 | 3 | 1 | 1 |
+| fix-rust-parser-error | 3 | 2 | 1 | 2 | 2 |
+| fix-shell-safe-clean | 3 | 2 | 1 | 2 | 2 |
+| long-session-data-report | 5 | 0 | 0 | 5 | 0 |
+| long-session-large-component | 5 | 0 | 1 | 4 | 0 |
+| long-session-read-edit | 5 | 0 | 1 | 4 | 0 |
+| multi-file-docs-and-examples | 5 | 0 | 5 | 0 | 0 |
+| multi-file-node-package | 2 | 3 | 1 | 1 | 3 |
+| multi-file-python-package | 4 | 1 | 3 | 1 | 1 |
+| multi-file-rust-library | 5 | 0 | 0 | 5 | 0 |
+| new-large-react-kanban | 5 | 0 | 5 | 0 | 0 |
+| new-markdown-release-notes | 5 | 0 | 5 | 0 | 0 |
+| new-python-csv-small | 0 | 5 | 0 | 0 | 5 |
+| new-rust-cli-small | 5 | 0 | 0 | 5 | 0 |
+| new-typescript-formatter | 2 | 3 | 0 | 2 | 3 |
+| non-coding-research-brief | 0 | 5 | 0 | 0 | 5 |
+| non-coding-runbook | 4 | 1 | 2 | 2 | 1 |
+| scaffold-fastapi-service | 5 | 0 | 0 | 5 | 0 |
+| scaffold-next-dashboard | 5 | 0 | 0 | 5 | 0 |
+| scaffold-rust-cli | 5 | 0 | 0 | 5 | 0 |
+
+## Compare.py Output
+
+```text
+# compare report
+
+- schema_version: 1
+- model_slug: qwen3.6-27b-coding-nvfp4:legacy->minimal
+- baseline_dir: .anvil/benchmarks/20260612T105012-combined-t2-4-rerun
+- experiment_dir: .anvil/benchmarks/20260612T105012-combined-t2-4-rerun
+- generated_at: 2026-06-12T04:05:38Z
+- threshold: 0.05
+
+| metric | baseline (mean [CI]) | experiment (mean [CI]) | delta | delta_pct | verdict |
+|---|---|---|---|---|---|
+| elapsed_s | 66.552 [50.691, 82.413] (n=125) | 62.232 [45.984, 78.480] (n=125) | -4.320 | -6.49% | improved |
+| error_500_count | 0.000 [0.000, 0.000] (n=125) | 0.000 [0.000, 0.000] (n=125) | 0.000 | null | unchanged |
+| iter_count | 2.712 [2.468, 2.956] (n=125) | 4.021 [3.659, 4.382] (n=96) | 1.309 | 48.26% | regressed |
+| page_tsx_has_game_keywords | 0.000 [0.000, 0.434] (n=5) | 0.000 [0.000, 0.490] (n=4) | 0.000 | null | unchanged |
+| postcheck_success | 0.248 [0.181, 0.330] (n=125) | 0.160 [0.106, 0.234] (n=125) | -0.088 | null | regressed |
+| rc | 1.000 [0.970, 1.000] (n=125) | 0.768 [0.687, 0.833] (n=125) | -0.232 | null | regressed |
+| we_total | 1.752 [1.542, 1.962] (n=125) | 1.008 [0.762, 1.254] (n=125) | -0.744 | null | informational |
+
+## failure categories
+
+| category | baseline | experiment |
+|---|---:|---:|
+| completed | 60 | 96 |
+| control_loop_exhausted | 6 | 0 |
+| failed | 0 | 29 |
+| missing_deliverable | 40 | 0 |
+| missing_evidence | 19 | 0 |
+```
+
+## Findings
+
+- The two parser fixes were merged before the rerun, but the expected large recovery did not appear. Minimal moved from 95/125 to 96/125 `rc=0`, and `success_check ok` moved from 35/125 to 37/125.
+- The two previously critical scenarios remain fully failing on return code: `new-python-csv-small` is 0/5 `rc=0`, and `non-coding-research-brief` is 0/5 `rc=0`.
+- Minimal is still faster than legacy on elapsed mean, but still worse on `rc`, `postcheck_success`, and `iter_count`.
+- The rerun logs contain 352 occurrences of parser failure text and no `ollama.chat.native_xml_salvage` activations. This suggests the task 7 native-content salvage path did not materially participate in this run.
+- `scripts/report.py` reported `no runs discovered` for this rerun root, while `scripts/compare.py` successfully analyzed the same combined root with meta fallback. The comparison above uses `compare.py` as the source of truth.
+
+## Assessment
+
+The parser downgrade restoration and native XML salvage are merged, but this rerun does not support moving to Phase 3 on the assumption that the parser issue was the dominant remaining blocker. The remaining failures should be triaged from the new run root, with priority on `new-python-csv-small`, `non-coding-research-brief`, and runs that still contain parser failure feedback after downgrade.


### PR DESCRIPTION
## Summary

- Records the post-merge T2-4 minimal rerun after #1021 and #1022.
- Adds the markdown report and structured JSON under `docs/eval/`.
- Documents that the expected parser-fix recovery did not appear: minimal rerun is 96/125 `rc=0` and 37/125 `success_check ok`.

## Verification

- `python3 -m json.tool docs/eval/minimal-loop-t2-4-rerun-20260612.json`
- `scripts/bench.sh minimal-loop-expanded --model qwen3.6:27b-coding-nvfp4 --runs 5 --engine minimal --max-iterations 12 --no-auto-test --no-precautions --no-case-memory --bench-no-debug`
- `python3 scripts/compare.py .anvil/benchmarks/20260612T105012-combined-t2-4-rerun --engines legacy,minimal`