### PR TITLE
Record benchmark build metadata

### DIFF
--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -216,6 +216,45 @@ fi
 # -------- repo root --------
 REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
 
+# -------- build metadata --------
+git_commit() {
+  git -C "$REPO_ROOT" rev-parse --verify HEAD 2>/dev/null || true
+}
+
+git_dirty_flag() {
+  if ! git -C "$REPO_ROOT" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    printf 'false'
+    return 0
+  fi
+  if [[ -n "$(git -C "$REPO_ROOT" status --porcelain 2>/dev/null || true)" ]]; then
+    printf 'true'
+  else
+    printf 'false'
+  fi
+}
+
+file_mtime_epoch() {
+  local path="$1"
+  stat -f '%m' "$path" 2>/dev/null || stat -c '%Y' "$path" 2>/dev/null || true
+}
+
+iso_from_epoch() {
+  local epoch="$1"
+  if [[ -z "$epoch" ]]; then
+    return 0
+  fi
+  date -u -r "$epoch" '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null \
+    || date -u -d "@$epoch" '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null \
+    || true
+}
+
+BENCH_GIT_COMMIT=$(git_commit)
+BENCH_GIT_DIRTY=$(git_dirty_flag)
+BENCH_GIT_REVISION="$BENCH_GIT_COMMIT"
+if [[ -n "$BENCH_GIT_REVISION" && "$BENCH_GIT_DIRTY" == "true" ]]; then
+  BENCH_GIT_REVISION="$BENCH_GIT_REVISION-dirty"
+fi
+
 # -------- benchmark-name validation --------
 if ! [[ "$benchmark_name" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; then
   echo "Error: invalid benchmark-name: $benchmark_name" >&2
@@ -246,6 +285,13 @@ if [[ "$DRY_RUN" -eq 0 ]]; then
     echo "  Run 'cargo build --release' or set ANVIL_BIN" >&2
     exit 1
   fi
+fi
+
+ANVIL_BIN_REAL=""
+ANVIL_BIN_MTIME=""
+if [[ -n "$ANVIL_BIN" ]]; then
+  ANVIL_BIN_REAL=$(realpath "$ANVIL_BIN" 2>/dev/null || printf '%s' "$ANVIL_BIN")
+  ANVIL_BIN_MTIME=$(iso_from_epoch "$(file_mtime_epoch "$ANVIL_BIN")")
 fi
 
 umask 077
@@ -295,10 +341,11 @@ slugify() {
 
 # -------- write_meta_json --------
 write_meta_json() {
-  # $1=rc, $2=elapsed_s, $3=model, $4=start_ts, $5=run_dir, $6=case, $7=task_kind, $8=pam_variant, $9=engine, $10=success_check_success, $11=success_check_reason
+  # $1=rc, $2=elapsed_s, $3=model, $4=start_ts, $5=run_dir, $6=case, $7=task_kind, $8=pam_variant, $9=engine, $10=success_check_success, $11=success_check_reason, $12=active_flags_json
   local _rc="$1" _elapsed="$2" _model="$3" _start_ts="$4" _run_dir="$5"
   local _case="${6:-default}" _task_kind="${7:-coding}" _pam_variant="${8:-default}"
   local _engine="${9:-legacy}" _success_check_success="${10:-null}" _success_check_reason="${11:-}"
+  local _active_flags_json="${12:-[]}"
   if [[ -z "$_run_dir" ]]; then
     return 0
   fi
@@ -314,6 +361,12 @@ write_meta_json() {
     --arg engine "$_engine" \
     --argjson success_check_success "$_success_check_success" \
     --arg success_check_reason "$_success_check_reason" \
+    --arg build_git_commit "$BENCH_GIT_COMMIT" \
+    --argjson build_git_dirty "$BENCH_GIT_DIRTY" \
+    --arg build_git_revision "$BENCH_GIT_REVISION" \
+    --arg build_binary_path "$ANVIL_BIN_REAL" \
+    --arg build_time "$ANVIL_BIN_MTIME" \
+    --argjson active_flags "$_active_flags_json" \
     '{
       rc: $rc,
       elapsed_s: $elapsed_s,
@@ -324,7 +377,15 @@ write_meta_json() {
       pam_variant: $pam_variant,
       engine: $engine,
       success_check_success: $success_check_success,
-      success_check_reason: (if $success_check_reason == "" then null else $success_check_reason end)
+      success_check_reason: (if $success_check_reason == "" then null else $success_check_reason end),
+      build: {
+        git_commit: (if $build_git_commit == "" then null else $build_git_commit end),
+        git_dirty: $build_git_dirty,
+        git_revision: (if $build_git_revision == "" then null else $build_git_revision end),
+        binary_path: (if $build_binary_path == "" then null else $build_binary_path end),
+        build_time: (if $build_time == "" then null else $build_time end)
+      },
+      active_flags: $active_flags
     }' \
     > "$_run_dir/meta.json"
 }
@@ -615,6 +676,7 @@ CURRENT_TASK_KIND="coding"
 CURRENT_PAM_VARIANT="default"
 CURRENT_RUN_DIR=""
 CURRENT_START_TS=""
+CURRENT_ACTIVE_FLAGS_JSON="[]"
 RUN_LOGGED=0
 META_WRITTEN=0
 on_interrupt() {
@@ -627,7 +689,7 @@ on_interrupt() {
   if [[ "$META_WRITTEN" -eq 0 && -n "$CURRENT_RUN_DIR" ]]; then
     write_meta_json 130 0 "${CURRENT_MODEL:-unknown}" "${CURRENT_START_TS:-}" "$CURRENT_RUN_DIR" \
       "${CURRENT_CASE:-default}" "${CURRENT_TASK_KIND:-coding}" "${CURRENT_PAM_VARIANT:-default}" \
-      "${CURRENT_ENGINE:-legacy}" "null" "interrupted" \
+      "${CURRENT_ENGINE:-legacy}" "null" "interrupted" "${CURRENT_ACTIVE_FLAGS_JSON:-[]}" \
       || true
   fi
   if [[ -n "$models_arg" ]]; then
@@ -767,6 +829,18 @@ for model in "${cleaned_models[@]}"; do
         elif [[ "$pam_variant" == "pam_off" ]]; then
           env_kv+=("ANVIL_PAM_ADVISORY_ENABLED=false")
         fi
+        active_flags_json=$(
+          {
+            printf 'BENCH_DEBUG=%s\n' "$BENCH_DEBUG"
+            printf 'ANVIL_BIN=%s\n' "$ANVIL_BIN_REAL"
+            printf 'ENGINE=%s\n' "$engine"
+            [[ -n "$max_iterations" ]] && printf 'MAX_ITERATIONS=%s\n' "$max_iterations"
+            [[ -n "$chat_retries" ]] && printf 'CHAT_RETRIES=%s\n' "$chat_retries"
+            [[ -n "$sidecar_model" ]] && printf 'SIDECAR_MODEL=%s\n' "$sidecar_model"
+            printf '%s\n' "${env_kv[@]+"${env_kv[@]}"}"
+          } | jq -R -s 'split("\n") | map(select(length > 0))'
+        )
+        CURRENT_ACTIVE_FLAGS_JSON="$active_flags_json"
 
         start=$SECONDS
         if [[ "$DRY_RUN" -eq 1 ]]; then
@@ -848,7 +922,7 @@ for model in "${cleaned_models[@]}"; do
         # Write run-dir/meta.json so analyze_run.py can read rc/elapsed_s
         if write_meta_json "$rc" "$elapsed" "$model" "$CURRENT_START_TS" "$RUN_DIR" \
           "$case_name" "$task_kind" "$pam_variant" "$engine" \
-          "$SUCCESS_CHECK_SUCCESS" "$SUCCESS_CHECK_REASON"; then
+          "$SUCCESS_CHECK_SUCCESS" "$SUCCESS_CHECK_REASON" "$active_flags_json"; then
           META_WRITTEN=1
         else
           echo "warning: meta.json write failed" >&2
@@ -890,6 +964,7 @@ for model in "${cleaned_models[@]}"; do
 
         CURRENT_RUN_DIR=""
         CURRENT_START_TS=""
+        CURRENT_ACTIVE_FLAGS_JSON="[]"
         cd "$REPO_ROOT" || { echo "Error: cd $REPO_ROOT failed" >&2; exit 1; }
       done
     done

--- a/scripts/report.py
+++ b/scripts/report.py
@@ -219,8 +219,11 @@ def _discover_runs(bench_root: Path) -> list[tuple[str, int, Path]]:
     Supports both legacy flat layout:
       <root>/<model>/run-N
 
-    and suite/PAM layout:
+    suite/PAM layout:
       <root>/<model>/<case>/<pam_variant>/run-N
+
+    and engine/case/PAM layout:
+      <root>/<model>/<engine>/<case>/<pam_variant>/run-N
     """
     runs: list[tuple[str, int, Path]] = []
     try:
@@ -239,42 +242,43 @@ def _discover_runs(bench_root: Path) -> list[tuple[str, int, Path]]:
         if _resolve_in(model_dir, bench_root) is None:
             _warn(f"skipping model dir outside BENCH_ROOT: {model_dir.name}")
             continue
-        try:
-            run_children = sorted(model_dir.iterdir(), key=_run_sort_key)
-        except OSError as e:
-            _warn(f"cannot list {model_dir.name}: {e}")
-            continue
-        for child in run_children:
-            if RUN_DIR_RE.match(child.name):
-                if _append_run(runs, bench_root, model_dir.name, child):
-                    _warn(f"reached MAX_RUNS={MAX_RUNS}, truncating discovery")
-                    return runs
-                continue
-            if not _valid_suite_dir(child, bench_root):
-                continue
-            try:
-                case_children = sorted(child.iterdir(), key=_run_sort_key)
-            except OSError as e:
-                _warn(f"cannot list {child}: {e}")
-                continue
-            for nested in case_children:
-                if RUN_DIR_RE.match(nested.name):
-                    if _append_run(runs, bench_root, model_dir.name, nested):
-                        _warn(f"reached MAX_RUNS={MAX_RUNS}, truncating discovery")
-                        return runs
-                    continue
-                if not _valid_suite_dir(nested, bench_root):
-                    continue
-                try:
-                    variant_children = sorted(nested.iterdir(), key=_run_sort_key)
-                except OSError as e:
-                    _warn(f"cannot list {nested}: {e}")
-                    continue
-                for run_dir in variant_children:
-                    if _append_run(runs, bench_root, model_dir.name, run_dir):
-                        _warn(f"reached MAX_RUNS={MAX_RUNS}, truncating discovery")
-                        return runs
+        if _discover_model_runs(runs, bench_root, model_dir.name, model_dir, 4):
+            _warn(f"reached MAX_RUNS={MAX_RUNS}, truncating discovery")
+            return runs
     return runs
+
+
+def _discover_model_runs(
+    runs: list[tuple[str, int, Path]],
+    bench_root: Path,
+    model_slug: str,
+    parent: Path,
+    depth_remaining: int,
+) -> bool:
+    """Recursively discover run dirs below one model dir with bounded depth."""
+    try:
+        children = sorted(parent.iterdir(), key=_run_sort_key)
+    except OSError as e:
+        _warn(f"cannot list {parent}: {e}")
+        return False
+    for child in children:
+        if RUN_DIR_RE.match(child.name):
+            if _append_run(runs, bench_root, model_slug, child):
+                return True
+            continue
+        if depth_remaining <= 0:
+            continue
+        if not _valid_suite_dir(child, bench_root):
+            continue
+        if _discover_model_runs(
+            runs,
+            bench_root,
+            model_slug,
+            child,
+            depth_remaining - 1,
+        ):
+            return True
+    return False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/scripts/test_bench_smoke.sh
+++ b/tests/scripts/test_bench_smoke.sh
@@ -7,6 +7,7 @@
 #   * --pam-ab expands the same prompt suite into pam_on/pam_off variants
 #   * run-dir contains session.json, meta.json, logs/llm-io.jsonl
 #   * meta.json "rc" and "elapsed_s" are numeric
+#   * meta.json records build provenance and active flags
 
 set -euo pipefail
 
@@ -61,6 +62,7 @@ echo '{"schema_version":1,"session_id":"fake","final_outcome":"done","pam_eval":
 exit 0
 EOF
 chmod +x "$fake_anvil"
+fake_anvil_real=$(realpath "$fake_anvil" 2>/dev/null || printf '%s' "$fake_anvil")
 
 # --- fake benchmark yaml ---
 bench_yaml_dir="$REPO_ROOT/benchmarks"
@@ -148,6 +150,19 @@ for engine in legacy minimal; do
         '.engine == $engine and .success_check_success == true and .success_check_reason == "ok"' \
         "$run_dir/meta.json" >/dev/null || {
         echo "FAIL: meta engine/success_check mismatch in $run_dir/meta.json" >&2
+        cat "$run_dir/meta.json" >&2
+        exit 1
+      }
+      jq -e --arg bin "$fake_anvil_real" --arg engine "$engine" --arg pam "ANVIL_PAM_ADVISORY_ENABLED=$expected_pam" \
+        '(.build.git_dirty | type == "boolean")
+         and (.build.git_revision == null or (.build.git_revision | type == "string"))
+         and .build.binary_path == $bin
+         and (.build.build_time == null or (.build.build_time | test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T")))
+         and (.active_flags | index("BENCH_DEBUG=1"))
+         and (.active_flags | index($pam))
+         and (.active_flags | index("ENGINE=" + $engine))' \
+        "$run_dir/meta.json" >/dev/null || {
+        echo "FAIL: meta build/active_flags mismatch in $run_dir/meta.json" >&2
         cat "$run_dir/meta.json" >&2
         exit 1
       }

--- a/tests/test_report_security.py
+++ b/tests/test_report_security.py
@@ -160,6 +160,19 @@ class TestReportSecurity(unittest.TestCase):
         # scratch should not appear as a row
         self.assertEqual(r.stdout.count("qwen3 |"), 1)
 
+    def test_engine_case_variant_layout_discovered(self) -> None:
+        bench_root = self.tmp / "bench-root"
+        bench_root.mkdir()
+        _make_run_dir(
+            bench_root / "qwen3" / "minimal" / "docs" / "default" / "run-1",
+            rid="engine-layout",
+        )
+
+        r = _run(str(bench_root))
+        self.assertEqual(r.returncode, 0, msg=r.stderr)
+        self.assertIn("| 1 | qwen3", r.stdout)
+        self.assertNotIn("(no runs discovered)", r.stdout)
+
     # ------------------------------------------------------------------
     # analyze_run.py failure: warn and continue
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds benchmark provenance to each run `meta.json`: git commit, dirty flag, revision, binary path, binary build time, and active flags.
- Fixes `scripts/report.py` discovery for engine/case/variant layouts such as `<root>/<model>/<engine>/<case>/<variant>/run-N`.
- Adds regression coverage for the new meta fields and rerun-root layout discovery.

## Verification

- `bash -n scripts/bench.sh`
- `PYTHONPYCACHEPREFIX=/tmp/anvil-pyc python3 -m py_compile scripts/report.py`
- `PYTHONPYCACHEPREFIX=/tmp/anvil-pyc python3 -m unittest tests.test_report_security -v`
- `PYTHONPYCACHEPREFIX=/tmp/anvil-pyc python3 -m unittest tests.test_report -v`
- `bash tests/scripts/test_bench_smoke.sh`
- `bash tests/scripts/test_report_compat.sh`
- `python3 scripts/report.py .anvil/benchmarks/20260612T105012-57478` no longer emits `(no runs discovered)`