### PR TITLE
Relax fix-json-normalizer success check

### DIFF
--- a/benchmarks/minimal-loop-expanded.yaml
+++ b/benchmarks/minimal-loop-expanded.yaml
@@ -120,7 +120,7 @@ cases:
     success_check:
       files:
         - path: src/normalizeJson.ts
-          min_lines: 30
+          min_lines: 15
       commands:
         - grep -R "normalizeJson" src/normalizeJson.ts
 


### PR DESCRIPTION
## Summary

- Relax only the `fix-json-normalizer` success check in `benchmarks/minimal-loop-expanded.yaml`.
- Change `src/normalizeJson.ts` from `min_lines: 30` to `min_lines: 15`.

## Triage Basis

From `docs/eval/triage/t2-4-dead-scenarios.md`:

> `fix-json-normalizer`: both engines create `src/normalizeJson.ts` and include `normalizeJson`, but fail because implementations are 15-25 lines and the check requires `min_lines:30`.

This is a check false negative, not an engine capability failure.

## Verification

- `yq e '.cases | length' benchmarks/minimal-loop-expanded.yaml`
- `git diff --check`

## Known Risks

- This only adjusts the line-count threshold. Semantic validation remains the existing `grep -R "normalizeJson" src/normalizeJson.ts` check.