### PR TITLE
Relax multi-file-rust-library success check

### DIFF
--- a/benchmarks/minimal-loop-expanded.yaml
+++ b/benchmarks/minimal-loop-expanded.yaml
@@ -184,7 +184,7 @@ cases:
       files:
         - path: Cargo.toml
         - path: src/lib.rs
-          min_lines: 30
+          min_lines: 20
         - path: tests/math_tests.rs
           min_lines: 20
       commands:


### PR DESCRIPTION
## Summary

- Relax only the `multi-file-rust-library` success check in `benchmarks/minimal-loop-expanded.yaml`.
- Change `src/lib.rs` from `min_lines: 30` to `min_lines: 20`.

## Triage Basis

From `docs/eval/triage/t2-4-dead-scenarios.md`:

> `multi-file-rust-library`: required files exist and `median` is present for both engines, but `src/lib.rs` is 20-28 lines and the check requires `min_lines:30`.

This line-count threshold removes the scenario's discriminating value.

## Verification

- `yq e '.cases | length' benchmarks/minimal-loop-expanded.yaml`
- `git diff --check`

## Known Risks

- This keeps the existing file-presence and `grep -R "median" src/lib.rs` checks; it only adjusts the line-count floor.