### PR TITLE
Relax new-rust-cli-small success check

### DIFF
--- a/benchmarks/minimal-loop-expanded.yaml
+++ b/benchmarks/minimal-loop-expanded.yaml
@@ -12,7 +12,7 @@ cases:
     success_check:
       files:
         - path: src/bin/word_count.rs
-          min_lines: 20
+          min_lines: 8
       commands:
         - grep -R "words=" src/bin/word_count.rs
 


### PR DESCRIPTION
## Summary

- Relax only the `new-rust-cli-small` success check in `benchmarks/minimal-loop-expanded.yaml`.
- Change `src/bin/word_count.rs` from `min_lines: 20` to `min_lines: 8`.

## Triage Basis

From `docs/eval/triage/t2-4-dead-scenarios.md`:

> `new-rust-cli-small`: legacy creates a correct 8-line stdin word-count implementation with `words=`, but fails only because `min_lines:20`; minimal still has real no-write failures.

This change lets the scenario distinguish legacy success from minimal no-write failure instead of marking both as dead.

## Verification

- `yq e '.cases | length' benchmarks/minimal-loop-expanded.yaml`
- `git diff --check`

## Known Risks

- The check remains lightweight and still relies on `grep -R "words=" src/bin/word_count.rs` rather than executing the Rust CLI.