### PR TITLE
Relax new-typescript-formatter success check

### DIFF
--- a/benchmarks/minimal-loop-expanded.yaml
+++ b/benchmarks/minimal-loop-expanded.yaml
@@ -36,7 +36,7 @@ cases:
     success_check:
       files:
         - path: src/formatTitle.ts
-          min_lines: 20
+          min_lines: 8
       commands:
         - grep -R "export function formatTitle" src/formatTitle.ts
 


### PR DESCRIPTION
## Summary

- Relax only the `new-typescript-formatter` success check in `benchmarks/minimal-loop-expanded.yaml`.
- Change `src/formatTitle.ts` from `min_lines: 20` to `min_lines: 8`.

## Triage Basis

From `docs/eval/triage/t2-4-dead-scenarios.md`:

> `new-typescript-formatter`: legacy creates an 8-line implementation in all runs; minimal creates an 8-line implementation in 4/5 runs and misses the file in 1/5. The main failure is `min_lines:20`.

This change preserves the real missing-file failure while removing the line-count false negative.

## Verification

- `yq e '.cases | length' benchmarks/minimal-loop-expanded.yaml`
- `git diff --check`

## Known Risks

- The check remains structural (`export function formatTitle`) rather than a full input/output formatter test.