### PR TITLE
Relax long-session-data-report success check

### DIFF
--- a/benchmarks/minimal-loop-expanded.yaml
+++ b/benchmarks/minimal-loop-expanded.yaml
@@ -307,7 +307,7 @@ cases:
         - path: reports/sales-analysis.md
           min_lines: 40
       commands:
-        - grep -R "top products" reports/sales-analysis.md
+        - grep -Ri "top products" reports/sales-analysis.md
 
   - name: non-coding-research-brief
     task_kind: research


### PR DESCRIPTION
## Summary

- Relax only the `long-session-data-report` success check in `benchmarks/minimal-loop-expanded.yaml`.
- Change the `top products` command from case-sensitive `grep -R` to case-insensitive `grep -Ri`.

## Triage Basis

From `docs/eval/triage/t2-4-dead-scenarios.md`:

> `long-session-data-report`: minimal run-2/run-3 create both CSV and report, but fail because the exact lowercase `top products` grep does not match headings such as `Top Products`; missing-output runs remain real failures.

This keeps missing-file and min-lines checks intact while removing a casing-only false negative.

## Verification

- `yq e '.cases | length' benchmarks/minimal-loop-expanded.yaml`
- `git diff --check`

## Known Risks

- This does not loosen the required files or report length. Runs that omit the CSV/report still fail.