### PR TITLE
Relax scaffold-fastapi-service success check

### DIFF
--- a/benchmarks/minimal-loop-expanded.yaml
+++ b/benchmarks/minimal-loop-expanded.yaml
@@ -244,11 +244,11 @@ cases:
       files:
         - path: pyproject.toml
         - path: app/main.py
-          min_lines: 25
+          min_lines: 6
         - path: app/routes/health.py
-          min_lines: 20
+          min_lines: 8
         - path: tests/test_health.py
-          min_lines: 20
+          min_lines: 10
       commands:
         - grep -R "FastAPI" app/main.py
 


### PR DESCRIPTION
## Summary

- Relax only the `scaffold-fastapi-service` success check in `benchmarks/minimal-loop-expanded.yaml`.
- Lower compact scaffold line thresholds:
  - `app/main.py`: `25` -> `6`
  - `app/routes/health.py`: `20` -> `8`
  - `tests/test_health.py`: `20` -> `10`

## Triage Basis

From `docs/eval/triage/t2-4-dead-scenarios.md`:

> `scaffold-fastapi-service`: minimal creates the required files but compact implementations miss the line-count floors; legacy remains incomplete because pyproject/routes/tests are missing.

This preserves required-file checks and the `FastAPI` grep while accepting compact valid scaffolds.

## Verification

- `yq e '.cases | length' benchmarks/minimal-loop-expanded.yaml`
- `git diff --check`

## Known Risks

- The lower line counts intentionally allow minimal scaffolds. This PR does not change the required-file set.