### PR TITLE
Relax scaffold-next-dashboard success check

### DIFF
--- a/benchmarks/minimal-loop-expanded.yaml
+++ b/benchmarks/minimal-loop-expanded.yaml
@@ -227,9 +227,9 @@ cases:
     success_check:
       files:
         - path: src/app/page.tsx
-          min_lines: 50
-        - path: src/components/MetricCard.tsx
           min_lines: 30
+        - path: src/components/MetricCard.tsx
+          min_lines: 24
         - path: src/app/globals.css
           min_lines: 30
       commands:


### PR DESCRIPTION
## Summary

- Relax only the `scaffold-next-dashboard` success check in `benchmarks/minimal-loop-expanded.yaml`.
- Lower compact scaffold line thresholds:
  - `src/app/page.tsx`: `50` -> `30`
  - `src/components/MetricCard.tsx`: `30` -> `24`

## Triage Basis

From `docs/eval/triage/t2-4-dead-scenarios.md`:

> `scaffold-next-dashboard`: some runs create compact page/component files that miss overstrict line-count floors; other runs still have missing files and should remain failures.

This PR preserves the required file set, CSS floor, and `MetricCard` grep while accepting compact valid scaffolds.

## Verification

- `yq e '.cases | length' benchmarks/minimal-loop-expanded.yaml`
- `git diff --check`

## Known Risks

- Check relaxation alone is expected to have limited effect because several observed runs still miss required files.