### PR TITLE
Add minimal completion-without-write feedback

### DIFF
--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -46,6 +46,9 @@ Usage: scripts/bench.sh <benchmark-name> [options]
   --no-precautions  Reminder Sidecar を無効化（ANVIL_NO_REMINDER=1）
   --no-case-memory  Case memory を無効化（ANVIL_NO_CASE_RETRIEVAL=1 ANVIL_NO_CASE_RECORD=1）
   --no-auto-test    Auto test を無効化（ANVIL_NO_AUTO_TEST=1）
+  --no-minimal-completion-without-write-feedback
+                    Minimal の no-write completion feedback を無効化
+                    （ANVIL_NO_MINIMAL_COMPLETION_WITHOUT_WRITE_FEEDBACK=1）
   --pam-ab          Same prompt suite with PAM enabled and disabled
   --dry-run         anvil 呼び出しを echo で代替
   --recheck-root <path>
@@ -73,6 +76,7 @@ DRY_RUN=0
 no_precautions=0
 no_case_memory=0
 no_auto_test=0
+no_minimal_completion_without_write_feedback=0
 pam_ab=0
 recheck_root=""
 # BENCH_DEBUG toggles `--trace` on the anvil invocation. Allowed values: "0" or "1".
@@ -136,6 +140,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --no-auto-test)
       no_auto_test=1
+      shift
+      ;;
+    --no-minimal-completion-without-write-feedback)
+      no_minimal_completion_without_write_feedback=1
       shift
       ;;
     --pam-ab)
@@ -949,6 +957,7 @@ for model in "${cleaned_models[@]}"; do
         # Unset ANVIL_NO_* from caller env to prevent baseline cell contamination.
         unset ANVIL_NO_REMINDER ANVIL_NO_CASE_RETRIEVAL ANVIL_NO_CASE_RECORD \
               ANVIL_NO_AUTO_TEST ANVIL_NO_TESTER ANVIL_NO_REPO_GRAPH \
+              ANVIL_NO_MINIMAL_COMPLETION_WITHOUT_WRITE_FEEDBACK \
               ANVIL_CASE_RECORD_DRY_RUN ANVIL_CASE_RETRIEVAL_DRY_RUN \
               ANVIL_PAM_ADVISORY_ENABLED
 
@@ -962,6 +971,9 @@ for model in "${cleaned_models[@]}"; do
         fi
         if [[ "$no_auto_test" -eq 1 ]]; then
           env_kv+=("ANVIL_NO_AUTO_TEST=1")
+        fi
+        if [[ "$no_minimal_completion_without_write_feedback" -eq 1 ]]; then
+          env_kv+=("ANVIL_NO_MINIMAL_COMPLETION_WITHOUT_WRITE_FEEDBACK=1")
         fi
         if [[ "$pam_variant" == "pam_on" ]]; then
           env_kv+=("ANVIL_PAM_ADVISORY_ENABLED=true")

--- a/src/agent/minimal_loop/feedback.rs
+++ b/src/agent/minimal_loop/feedback.rs
@@ -3,6 +3,7 @@ pub const MINIMAL_FEEDBACK_PREFIX: &str = "[minimal-feedback]";
 #[derive(Debug, Default, Clone)]
 pub struct FeedbackState {
     empty_response_sent: bool,
+    completion_without_write_sent: bool,
     missing_tool_sent: bool,
     edit_anchor_sent: bool,
 }
@@ -25,6 +26,16 @@ impl FeedbackState {
         self.missing_tool_sent = true;
         Some(format!(
             "{MINIMAL_FEEDBACK_PREFIX}\nThe user asked for a repository change. Use exactly one relevant tool call next instead of only describing the work."
+        ))
+    }
+
+    pub fn completion_without_write(&mut self) -> Option<String> {
+        if self.completion_without_write_sent {
+            return None;
+        }
+        self.completion_without_write_sent = true;
+        Some(format!(
+            "{MINIMAL_FEEDBACK_PREFIX}\nNo file changes have been made in this session. If the task requires creating or modifying files, do that now with Write or Edit. If no file change is needed, say so and finish."
         ))
     }
 
@@ -86,6 +97,8 @@ mod tests {
 
         assert!(state.empty_response().is_some());
         assert!(state.empty_response().is_none());
+        assert!(state.completion_without_write().is_some());
+        assert!(state.completion_without_write().is_none());
         assert!(state.missing_tool_call("fix src/lib.rs").is_some());
         assert!(state.missing_tool_call("fix src/lib.rs").is_none());
         assert!(

--- a/src/agent/minimal_loop/loop_run.rs
+++ b/src/agent/minimal_loop/loop_run.rs
@@ -12,6 +12,9 @@ use super::compact::compact_if_needed;
 use super::feedback::FeedbackState;
 use super::prompt::{PromptToolMode, build_system_prompt};
 
+pub const NO_COMPLETION_WITHOUT_WRITE_FEEDBACK_FLAG: &str =
+    "ANVIL_NO_MINIMAL_COMPLETION_WITHOUT_WRITE_FEEDBACK";
+
 pub trait MinimalChatClient {
     fn chat(
         &mut self,
@@ -43,6 +46,7 @@ pub struct MinimalLoopConfig {
     pub auto_approve: bool,
     pub offline: bool,
     pub cancel_flag: Option<Arc<AtomicBool>>,
+    pub completion_without_write_feedback: bool,
 }
 
 pub fn run_session<C: MinimalChatClient>(
@@ -59,6 +63,8 @@ pub fn run_session<C: MinimalChatClient>(
     let mut feedback_state = FeedbackState::default();
     let mut pending_feedback: Option<String> = None;
     let mut tool_calls_seen = false;
+    let mut write_or_edit_calls_seen = false;
+    let mut completion_without_write_feedback_sent = false;
 
     session
         .messages
@@ -117,7 +123,19 @@ pub fn run_session<C: MinimalChatClient>(
                 pending_feedback = Some(feedback);
                 continue;
             }
-            if !tool_calls_seen
+            if should_send_completion_without_write_feedback(
+                config,
+                write_or_edit_calls_seen,
+                completion_without_write_feedback_sent,
+            ) && let Some(feedback) = feedback_state.completion_without_write()
+            {
+                completion_without_write_feedback_sent = true;
+                pending_feedback = Some(feedback);
+                continue;
+            }
+            if config.mode == ExecutionMode::Act
+                && !tool_calls_seen
+                && !completion_without_write_feedback_sent
                 && let Some(feedback) = feedback_state.missing_tool_call(user_prompt)
             {
                 pending_feedback = Some(feedback);
@@ -142,6 +160,9 @@ pub fn run_session<C: MinimalChatClient>(
         };
 
         for call in tool_calls {
+            if is_write_or_edit_tool(&call.name) {
+                write_or_edit_calls_seen = true;
+            }
             let result = match registry.execute(&call.name, &call.arguments, &tool_context) {
                 Ok(result) => result,
                 Err(err) => {
@@ -163,6 +184,26 @@ pub fn run_session<C: MinimalChatClient>(
         "minimal loop reached max_iterations ({})",
         config.max_iterations
     ))
+}
+
+pub fn completion_without_write_feedback_disabled_from_env() -> bool {
+    std::env::var_os(NO_COMPLETION_WITHOUT_WRITE_FEEDBACK_FLAG)
+        .is_some_and(|value| !value.is_empty())
+}
+
+fn should_send_completion_without_write_feedback(
+    config: &MinimalLoopConfig,
+    write_or_edit_calls_seen: bool,
+    completion_without_write_feedback_sent: bool,
+) -> bool {
+    config.mode == ExecutionMode::Act
+        && config.completion_without_write_feedback
+        && !write_or_edit_calls_seen
+        && !completion_without_write_feedback_sent
+}
+
+fn is_write_or_edit_tool(name: &str) -> bool {
+    matches!(name, "Write" | "Edit")
 }
 
 fn build_request_messages(
@@ -326,6 +367,7 @@ mod tests {
             auto_approve: true,
             offline: false,
             cancel_flag: None,
+            completion_without_write_feedback: true,
         }
     }
 
@@ -366,6 +408,7 @@ mod tests {
         let mut client = MockClient::default();
         client.push_err("native tool parser failed: unexpected eof");
         client.push_reply("done after downgrade", Vec::new());
+        client.push_reply("done after downgrade", Vec::new());
         let mut session = SessionSnapshot::default();
 
         let reply = run_session(
@@ -378,12 +421,13 @@ mod tests {
         .unwrap();
 
         assert_eq!(reply, "done after downgrade");
-        assert_eq!(client.native_modes, vec![true, false]);
+        assert_eq!(client.native_modes, vec![true, false, false]);
         assert_eq!(client.tool_counts[1], 0);
         assert!(!client.system_prompts[0].contains("<anvil_tool_call>"));
         assert!(client.system_prompts[1].contains("<anvil_tool_call>"));
-        assert_eq!(client.feedback_messages.len(), 1);
+        assert_eq!(client.feedback_messages.len(), 2);
         assert!(client.feedback_messages[0].contains("<anvil_tool_call>"));
+        assert!(client.feedback_messages[1].contains("No file changes"));
         assert!(session.native_tools_disabled);
     }
 
@@ -442,6 +486,7 @@ mod tests {
             let err = parser_failure_for_type_a_payload(payload);
             client.push_err(&err);
             client.push_reply("done after downgrade", Vec::new());
+            client.push_reply("done after downgrade", Vec::new());
             let mut session = SessionSnapshot::default();
 
             let reply = run_session(
@@ -454,10 +499,11 @@ mod tests {
             .unwrap();
 
             assert_eq!(reply, "done after downgrade");
-            assert_eq!(client.native_modes, vec![true, false]);
+            assert_eq!(client.native_modes, vec![true, false, false]);
             assert_eq!(client.tool_counts[0], 6);
             assert_eq!(client.tool_counts[1], 0);
             assert!(client.feedback_messages[0].contains("<anvil_tool_call>"));
+            assert!(client.feedback_messages[1].contains("No file changes"));
             assert!(session.native_tools_disabled);
         }
     }
@@ -520,5 +566,118 @@ mod tests {
                 .any(|m| m.content.starts_with(MINIMAL_FEEDBACK_PREFIX)),
             "ephemeral feedback must not be persisted to the session"
         );
+    }
+
+    #[test]
+    fn completion_without_write_feedback_then_write_then_complete() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut client = MockClient::default();
+        client.push_reply("I will create README.md.", Vec::new());
+        client.push_reply(
+            "",
+            vec![tool_call(
+                "Write",
+                json!({"path": "README.md", "content": "# Demo\n"}),
+            )],
+        );
+        client.push_reply("done", Vec::new());
+        let mut session = SessionSnapshot::default();
+
+        let reply = run_session(
+            &mut client,
+            "qwen3:8b",
+            &mut session,
+            "create README.md",
+            &config(temp.path().to_path_buf(), 4),
+        )
+        .unwrap();
+
+        assert_eq!(reply, "done");
+        assert_eq!(
+            std::fs::read_to_string(temp.path().join("README.md")).unwrap(),
+            "# Demo\n"
+        );
+        assert_eq!(client.feedback_messages.len(), 1);
+        assert!(client.feedback_messages[0].contains("No file changes"));
+        assert!(
+            !session
+                .messages
+                .iter()
+                .any(|m| m.content.starts_with(MINIMAL_FEEDBACK_PREFIX)),
+            "ephemeral feedback must not be persisted to the session"
+        );
+    }
+
+    #[test]
+    fn completion_without_write_feedback_accepts_second_no_tool_response() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut client = MockClient::default();
+        client.push_reply("I will create README.md.", Vec::new());
+        client.push_reply("No file change is needed.", Vec::new());
+        let mut session = SessionSnapshot::default();
+
+        let reply = run_session(
+            &mut client,
+            "qwen3:8b",
+            &mut session,
+            "create README.md",
+            &config(temp.path().to_path_buf(), 4),
+        )
+        .unwrap();
+
+        assert_eq!(reply, "No file change is needed.");
+        assert_eq!(client.feedback_messages.len(), 1);
+        assert!(client.feedback_messages[0].contains("No file changes"));
+        assert!(
+            !session
+                .messages
+                .iter()
+                .any(|m| m.content.starts_with(MINIMAL_FEEDBACK_PREFIX)),
+            "ephemeral feedback must not be persisted to the session"
+        );
+    }
+
+    #[test]
+    fn completion_without_write_feedback_can_be_disabled() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut client = MockClient::default();
+        client.push_reply("Here is the explanation.", Vec::new());
+        let mut session = SessionSnapshot::default();
+        let mut cfg = config(temp.path().to_path_buf(), 4);
+        cfg.completion_without_write_feedback = false;
+
+        let reply = run_session(
+            &mut client,
+            "qwen3:8b",
+            &mut session,
+            "explain this repository",
+            &cfg,
+        )
+        .unwrap();
+
+        assert_eq!(reply, "Here is the explanation.");
+        assert!(client.feedback_messages.is_empty());
+    }
+
+    #[test]
+    fn completion_without_write_feedback_does_not_fire_in_plan_mode() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut client = MockClient::default();
+        client.push_reply("Plan: create README.md after review.", Vec::new());
+        let mut session = SessionSnapshot::default();
+        let mut cfg = config(temp.path().to_path_buf(), 4);
+        cfg.mode = ExecutionMode::Plan;
+
+        let reply = run_session(
+            &mut client,
+            "qwen3:8b",
+            &mut session,
+            "create README.md",
+            &cfg,
+        )
+        .unwrap();
+
+        assert_eq!(reply, "Plan: create README.md after review.");
+        assert!(client.feedback_messages.is_empty());
     }
 }

--- a/src/agent/minimal_loop/mod.rs
+++ b/src/agent/minimal_loop/mod.rs
@@ -3,4 +3,7 @@ mod feedback;
 mod loop_run;
 pub mod prompt;
 
-pub use loop_run::{MinimalChatClient, MinimalLoopConfig, run_session};
+pub use loop_run::{
+    MinimalChatClient, MinimalLoopConfig, NO_COMPLETION_WITHOUT_WRITE_FEEDBACK_FLAG,
+    completion_without_write_feedback_disabled_from_env, run_session,
+};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -271,6 +271,8 @@ fn run_minimal_engine(
         auto_approve: config.yes_mode,
         offline: config.offline,
         cancel_flag: None,
+        completion_without_write_feedback:
+            !agent::minimal_loop::completion_without_write_feedback_disabled_from_env(),
     };
     let reply = agent::minimal_loop::run_session(
         &mut client,


### PR DESCRIPTION
## Linked Issue

N/A - Phase 3 mechanism admission for minimal loop.

## Summary

- Adds a one-shot minimal-loop feedback when an Act-mode session is about to complete with no tool calls and no Write/Edit calls have happened in the session.
- The feedback is user-role ephemeral and is not persisted to session history.
- The second no-tool response is accepted normally, so file-change-free tasks can still finish after one clarification turn.
- Adds an individual ablation flag and bench option for measuring the mechanism independently.

## Admission Evidence

- Target scenario IDs from local triage `docs/eval/triage/t2-4-minimal-loss-clusters.md`: `new-python-csv-small`, `fix-rust-parser-error`, `fix-readme-command`, `fix-python-slugify`.
- Baseline after Task14 recheck: `docs/eval/minimal-loop-t2-4-recheck-20260612.md`, legacy-lite 66/125 vs minimal 69/125.
- Failure mode addressed: `no_edit_loop`, where minimal explores the empty workdir and then completes in natural language without writing files.
- Feedback payload size: 196 chars, 35 whitespace words, 61 tokens by the current minimal-loop approximation (`chars / 4 + message overhead 12`).
- Off flag: `ANVIL_NO_MINIMAL_COMPLETION_WITHOUT_WRITE_FEEDBACK=1`.
- Bench ablation option: `--no-minimal-completion-without-write-feedback`; when used, meta active_flags records `ANVIL_NO_MINIMAL_COMPLETION_WITHOUT_WRITE_FEEDBACK=1`.
- Minimal-loop core line count excluding `#[cfg(test)]`: 504 before, 559 after, still under P7's 1,000-line cap.

## Changed Files

- `src/agent/minimal_loop/loop_run.rs`
- `src/agent/minimal_loop/feedback.rs`
- `src/agent/minimal_loop/mod.rs`
- `src/lib.rs`
- `scripts/bench.sh`

## Tests Run

- `cargo test minimal_loop --lib`
- `bash tests/scripts/test_bench_smoke.sh`
- `bash -n scripts/bench.sh`
- `git diff --check`
- `cargo check --bin anvil`

## State Transition Tests

- `completion_without_write_feedback_then_write_then_complete`
- `completion_without_write_feedback_accepts_second_no_tool_response`
- `completion_without_write_feedback_can_be_disabled`
- `completion_without_write_feedback_does_not_fire_in_plan_mode`

## Known Risks

- The trigger is intentionally deterministic and does not classify task intent. In Act mode, a no-write/no-tool completion for a non-file task can receive one extra feedback turn. The second no-tool response is accepted to cap this cost.
- Plan mode is excluded because editing is forbidden there.

## Human Task After Merge

Run a fresh minimal-only 125-run benchmark with this mechanism enabled. Reuse the Task14 recheck legacy baseline. Check target recovery for `new-python-csv-small`, `fix-rust-parser-error`, `fix-readme-command`, and `fix-python-slugify`; also check non-regression for multi-file/generation wins such as `multi-file-node-package`, `multi-file-rust-library`, `scaffold-fastapi-service`, `new-typescript-formatter`, `new-markdown-release-notes`, and `non-coding-research-brief`.

For ablation, rerun minimal with `--no-minimal-completion-without-write-feedback`.

## Orchestration Run ID

N/A