### PR TITLE
Record Task15 admission and variance analysis

### DIFF
--- a/docs/eval/INDEX.md
+++ b/docs/eval/INDEX.md
@@ -4,6 +4,8 @@
 
 - [Task15 feedback rerun](minimal-loop-t2-4-task15-feedback-rerun-20260612.md):
   first admitted Phase 3 mechanism, minimal 80/125.
+- [Task15 non-fired run variance](t2-4-run-variance.md):
+  GPU-free estimate of scenario-level run-to-run variance.
 - [Task14 recheck baseline](minimal-loop-t2-4-recheck-20260612.md):
   check-only baseline before Task15, minimal 69/125 and legacy-lite 66/125.
 - [Mechanism ledger](mechanism-ledger.md):
@@ -15,6 +17,7 @@
 - [Parser-fix rerun](minimal-loop-t2-4-rerun-20260612.md)
 - [Task14 recheck baseline](minimal-loop-t2-4-recheck-20260612.md)
 - [Task15 feedback rerun](minimal-loop-t2-4-task15-feedback-rerun-20260612.md)
+- [Task15 non-fired run variance](t2-4-run-variance.md)
 
 ## Triage
 

--- a/docs/eval/INDEX.md
+++ b/docs/eval/INDEX.md
@@ -1,0 +1,22 @@
+# Evaluation Index
+
+## Current Baselines
+
+- [Task15 feedback rerun](minimal-loop-t2-4-task15-feedback-rerun-20260612.md):
+  first admitted Phase 3 mechanism, minimal 80/125.
+- [Task14 recheck baseline](minimal-loop-t2-4-recheck-20260612.md):
+  check-only baseline before Task15, minimal 69/125 and legacy-lite 66/125.
+- [Mechanism ledger](mechanism-ledger.md):
+  admitted minimal-loop mechanisms and audit status.
+
+## T2-4 Reports
+
+- [Initial T2-4 comparison](minimal-loop-t2-4-20260612.md)
+- [Parser-fix rerun](minimal-loop-t2-4-rerun-20260612.md)
+- [Task14 recheck baseline](minimal-loop-t2-4-recheck-20260612.md)
+- [Task15 feedback rerun](minimal-loop-t2-4-task15-feedback-rerun-20260612.md)
+
+## Triage
+
+- [Parser contamination triage](triage/t2-4-parser-contamination.md)
+- [Parser feedback loop deepdive](triage/t2-4-parser-feedback-loop-deepdive-20260612.md)

--- a/docs/eval/mechanism-ledger.md
+++ b/docs/eval/mechanism-ledger.md
@@ -1,0 +1,52 @@
+# Mechanism Ledger
+
+This ledger records every mechanism admitted into `minimal_loop`. It is intended
+to make growth visible: each new feedback, guard, recovery path, or prompt
+addition must have a measured reason, an off flag, and a current audit status.
+
+## Entries
+
+| id | mechanism | status | admitted by | final audit date |
+|---|---|---|---|---|
+| M001 | completion-without-write feedback | admitted | #1036 | 2026-06-12 |
+
+## M001: Completion-Without-Write Feedback
+
+| field | value |
+|---|---|
+| mechanism | completion-without-write feedback |
+| PR | #1036 |
+| status | admitted |
+| trigger | Act-mode no-tool completion while session has observed zero `Write`/`Edit` calls |
+| action | Inject one user-role ephemeral feedback message; accept the second no-tool response |
+| target scenarios | `new-python-csv-small`, `fix-rust-parser-error`, `fix-readme-command`, `fix-python-slugify` |
+| injection size | 196 chars, 35 whitespace words, approximately 61 minimal-loop tokens |
+| off flag | `ANVIL_NO_MINIMAL_COMPLETION_WITHOUT_WRITE_FEEDBACK=1` |
+| bench option | `--no-minimal-completion-without-write-feedback` |
+| admission model | `qwen3.6:27b-coding-nvfp4` |
+| admission benchmark | `minimal-loop-expanded`, 25 scenarios x 5 runs |
+| admission report | [minimal-loop-t2-4-task15-feedback-rerun-20260612.md](minimal-loop-t2-4-task15-feedback-rerun-20260612.md) |
+| baseline report | [minimal-loop-t2-4-recheck-20260612.md](minimal-loop-t2-4-recheck-20260612.md) |
+| final audit date | 2026-06-12 |
+
+Admission result:
+
+| metric | before | after | delta |
+|---|---:|---:|---:|
+| overall minimal success | 69/125 | 80/125 | +11 |
+| target scenarios total | 7/20 | 17/20 | +10 |
+| legacy-lite reference | 66/125 | 66/125 | n/a |
+| minimal elapsed mean | 28.9 sec | 38.5 sec | +9.6 sec |
+
+Audit notes:
+
+- The mechanism passed the primary admission criterion: all four target
+  no-edit-loop scenarios improved.
+- `scaffold-fastapi-service` regressed from 5/5 to 1/5, but the mechanism did
+  not fire in that scenario's runs, so current evidence does not support a
+  direct causal link.
+- `multi-file-rust-library` regressed from 5/5 to 4/5 and feedback fired in all
+  five runs; this remains the only watchlist item with plausible mechanism
+  involvement, but the observed delta is one run at n=5.
+- Future reviews should compare against this ledger before admitting another
+  feedback or recovery mechanism.

--- a/docs/eval/minimal-loop-t2-4-task15-feedback-rerun-20260612.md
+++ b/docs/eval/minimal-loop-t2-4-task15-feedback-rerun-20260612.md
@@ -1,0 +1,186 @@
+# Minimal Loop T2-4 Task15 Feedback Rerun
+
+- Date: 2026-06-12 JST
+- Benchmark: `minimal-loop-expanded`
+- Model: `qwen3.6:27b-coding-nvfp4`
+- Engine: `minimal`
+- Mechanism: completion-without-write feedback from #1036
+- Source root: `.anvil/benchmarks/20260612T174200-32077`
+- Baseline report: `docs/eval/minimal-loop-t2-4-recheck-20260612.md`
+
+## Build And Flag Verification
+
+| item | value |
+|---|---|
+| source commit | `b12f33b2578d6a81e0fd4c8a7d4e12a272d3fe00` |
+| git dirty | `false` |
+| binary path | `/Users/maenokota/share/work/github_kewton/Anvil-develop/workspace/task15-rerun/target/release/anvil` |
+| binary build time | `2026-06-12T08:40:27Z` |
+| off flag | `ANVIL_NO_MINIMAL_COMPLETION_WITHOUT_WRITE_FEEDBACK=1` absent from `active_flags` |
+
+Representative `meta.json` active flags:
+
+```text
+BENCH_DEBUG=0
+ANVIL_BIN=/Users/maenokota/share/work/github_kewton/Anvil-develop/workspace/task15-rerun/target/release/anvil
+ENGINE=minimal
+MAX_ITERATIONS=12
+CHAT_RETRIES=2
+ANVIL_NO_REMINDER=1
+ANVIL_NO_CASE_RETRIEVAL=1
+ANVIL_NO_CASE_RECORD=1
+ANVIL_NO_AUTO_TEST=1
+```
+
+## Run Command
+
+```sh
+bash scripts/bench.sh minimal-loop-expanded \
+  --model qwen3.6:27b-coding-nvfp4 \
+  --runs 5 \
+  --engine minimal \
+  --max-iterations 12 \
+  --no-auto-test \
+  --no-precautions \
+  --no-case-memory \
+  --bench-no-debug
+```
+
+## Aggregate Result
+
+| row | value |
+|---|---:|
+| runs | 125 |
+| `meta.json` files | 125 |
+| `rc=0` | 122/125 |
+| success_check | 80/125 |
+| elapsed total | 4812 sec |
+| elapsed mean | 38.5 sec |
+
+Compared with the Task14 recheck baseline:
+
+| engine / run | success | delta vs previous minimal | elapsed mean sec |
+|---|---:|---:|---:|
+| legacy-lite recheck reference | 66/125 | n/a | 66.6 |
+| minimal Task14 recheck baseline | 69/125 | n/a | 28.9 |
+| minimal Task15 feedback rerun | 80/125 | +11 | 38.5 |
+
+Task15 improves minimal from 69/125 to 80/125 and puts it +14 runs above the
+legacy-lite reference. Runtime regresses from 28.9s to 38.5s mean, but remains
+faster than legacy-lite.
+
+## Admission Target Scenarios
+
+| scenario | Task14 baseline | Task15 rerun | delta |
+|---|---:|---:|---:|
+| `new-python-csv-small` | 2/5 | 3/5 | +1 |
+| `fix-rust-parser-error` | 1/5 | 4/5 | +3 |
+| `fix-readme-command` | 2/5 | 5/5 | +3 |
+| `fix-python-slugify` | 2/5 | 5/5 | +3 |
+| total | 7/20 | 17/20 | +10 |
+
+The mechanism meets the primary admission target: all four targeted
+no-edit-loop scenarios improved, with +10 runs across the target set.
+
+## Non-Regression Watchlist
+
+| scenario | Task14 baseline | Task15 rerun | delta | note |
+|---|---:|---:|---:|---|
+| `multi-file-node-package` | 5/5 | 5/5 | +0 | stable |
+| `multi-file-rust-library` | 5/5 | 4/5 | -1 | one missing `tests/math_tests.rs` |
+| `scaffold-fastapi-service` | 5/5 | 1/5 | -4 | missing FastAPI files in 4 runs |
+| `new-typescript-formatter` | 4/5 | 5/5 | +1 | improved |
+| `new-markdown-release-notes` | 5/5 | 5/5 | +0 | stable |
+| `non-coding-research-brief` | 5/5 | 5/5 | +0 | stable |
+
+The watchlist is mixed. The serious regression is `scaffold-fastapi-service`,
+but the feedback did not fire in that scenario's five runs, so this is not
+direct evidence that the new feedback caused the regression. Treat it as
+run-to-run variance or a separate scaffold instability until ablation says
+otherwise. `multi-file-rust-library` did fire feedback in all five runs and
+lost one run, so it should be included in ablation review.
+
+## Scenario Summary
+
+| scenario | legacy recheck | minimal Task14 | minimal Task15 | delta vs Task14 | delta vs legacy |
+|---|---:|---:|---:|---:|---:|
+| fix-css-token-doc | 5/5 | 3/5 | 4/5 | +1 | -1 |
+| fix-js-date-helper | 5/5 | 1/5 | 0/5 | -1 | -5 |
+| fix-json-normalizer | 5/5 | 5/5 | 5/5 | +0 | +0 |
+| fix-python-retry-policy | 0/5 | 5/5 | 3/5 | -2 | +3 |
+| fix-python-slugify | 4/5 | 2/5 | 5/5 | +3 | +1 |
+| fix-readme-command | 5/5 | 2/5 | 5/5 | +3 | +0 |
+| fix-rust-parser-error | 5/5 | 1/5 | 4/5 | +3 | -1 |
+| fix-shell-safe-clean | 2/5 | 5/5 | 5/5 | +0 | +3 |
+| long-session-data-report | 0/5 | 2/5 | 1/5 | -1 | +1 |
+| long-session-large-component | 0/5 | 1/5 | 5/5 | +4 | +5 |
+| long-session-read-edit | 0/5 | 1/5 | 1/5 | +0 | +1 |
+| multi-file-docs-and-examples | 0/5 | 2/5 | 4/5 | +2 | +4 |
+| multi-file-node-package | 0/5 | 5/5 | 5/5 | +0 | +5 |
+| multi-file-python-package | 0/5 | 2/5 | 1/5 | -1 | +1 |
+| multi-file-rust-library | 5/5 | 5/5 | 4/5 | -1 | -1 |
+| new-large-react-kanban | 0/5 | 2/5 | 1/5 | -1 | +1 |
+| new-markdown-release-notes | 5/5 | 5/5 | 5/5 | +0 | +0 |
+| new-python-csv-small | 5/5 | 2/5 | 3/5 | +1 | -2 |
+| new-rust-cli-small | 5/5 | 0/5 | 4/5 | +4 | -1 |
+| new-typescript-formatter | 5/5 | 4/5 | 5/5 | +1 | +0 |
+| non-coding-research-brief | 5/5 | 5/5 | 5/5 | +0 | +0 |
+| non-coding-runbook | 5/5 | 3/5 | 3/5 | +0 | -2 |
+| scaffold-fastapi-service | 0/5 | 5/5 | 1/5 | -4 | +1 |
+| scaffold-next-dashboard | 0/5 | 1/5 | 1/5 | +0 | +1 |
+| scaffold-rust-cli | 0/5 | 0/5 | 0/5 | +0 | +0 |
+
+## Feedback Firing
+
+- Unique runs with completion-without-write feedback: 48/125
+- Success among feedback-fired runs: 23/48
+- Success among non-feedback runs: 57/77
+
+This does not imply the feedback is harmful. The trigger selects sessions that
+were already about to finish without any file changes, so feedback-fired runs
+are a harder subset.
+
+Selected scenario-level firing outcomes:
+
+| scenario | feedback-fired success | non-feedback success |
+|---|---:|---:|
+| `new-python-csv-small` | 1/3 | 2/2 |
+| `fix-rust-parser-error` | 1/2 | 3/3 |
+| `fix-readme-command` | 2/2 | 3/3 |
+| `fix-python-slugify` | 1/1 | 4/4 |
+| `multi-file-rust-library` | 4/5 | n/a |
+| `scaffold-fastapi-service` | n/a | 1/5 |
+
+## Direct Failure Notes
+
+- `scaffold-fastapi-service` failed 4/5 with missing `app/main.py`,
+  `app/routes/health.py`, and/or `tests/test_health.py`. Feedback did not fire
+  in any of those five runs.
+- `multi-file-rust-library` failed 1/5 with missing `tests/math_tests.rs`.
+- `fix-python-retry-policy` regressed to 3/5. Failures were one line-count false
+  negative (`src/retry_policy.py:24<25`) and one missing target file.
+- `fix-js-date-helper` remains 0/5; failures are line-count false negatives or
+  missing `src/dateRange.js`.
+- `scaffold-rust-cli` remains a true dead scenario at 0/5.
+
+## Assessment
+
+Task15 is a net positive and satisfies the primary admission target:
+
+- Overall success improved by +11 runs.
+- Target no-edit-loop scenarios improved by +10 runs.
+- Minimal now beats the legacy-lite recheck reference by +14 runs.
+
+However, non-regression is not fully clean. `scaffold-fastapi-service` regressed
+sharply, even though the new feedback did not fire there; `multi-file-rust-library`
+lost one run where feedback did fire. The right next step is an ablation run with
+`--no-minimal-completion-without-write-feedback` or a narrower targeted rerun of
+the watchlist scenarios before treating the regressions as causal.
+
+Recommended follow-up:
+
+1. Record this report in a docs PR.
+2. Run ablation with `--no-minimal-completion-without-write-feedback` if GPU time
+   allows, at least for the watchlist scenarios.
+3. Triage remaining failures in `fix-js-date-helper`, `scaffold-rust-cli`, and
+   scaffold instability separately from the no-edit-loop mechanism.

--- a/docs/eval/t2-4-run-variance.md
+++ b/docs/eval/t2-4-run-variance.md
@@ -1,0 +1,124 @@
+# T2-4 Run Variance From Non-Fired Task15 Runs
+
+- Date: 2026-06-12 JST
+- Fixed-binary baseline root: `.anvil/benchmarks/20260612T145227-40162`
+- Task15 root: `.anvil/benchmarks/20260612T174200-32077`
+- Model: `qwen3.6:27b-coding-nvfp4`
+- Engine: `minimal`
+
+## Method
+
+This analysis uses Task15 runs where the completion-without-write feedback did
+not fire. The firing detector reads only each canonical
+`run-*/logs/llm-io.jsonl` file and checks for the `[minimal-feedback]` marker.
+Duplicated logs under `state/sessions/` are ignored.
+
+For each Task15 non-fired scenario/run pair, the same scenario/run pair is read
+from the fixed-binary baseline root. The fixed-binary side uses
+`summary.recheck.tsv`; the Task15 side uses the original `summary.tsv` because
+Task15 was already run after the Task14 check fixes.
+
+Run numbers are replicate identifiers, not deterministic seeds. The comparison
+therefore estimates run-to-run variance, not a strict paired sample.
+
+## Aggregate
+
+| metric | value |
+|---|---:|
+| Task15 feedback-fired runs | 48/125 |
+| Task15 feedback-non-fired runs | 77/125 |
+| fixed-binary success in non-fired subset | 42/77 |
+| Task15 success in non-fired subset | 57/77 |
+| changed outcome pairs | 33/77 |
+| fixed failed / Task15 passed | 24 |
+| fixed passed / Task15 failed | 9 |
+
+The non-fired subset moved by +15 successes even though the feedback did not
+fire. This means a material part of the Task15 aggregate movement is ordinary
+run-to-run variance, not mechanism effect.
+
+## Scenario Table
+
+| scenario | non-fired n | fixed-binary success | Task15 success | delta | pair flips |
+|---|---:|---:|---:|---:|---|
+| `fix-css-token-doc` | 3 | 2/3 | 3/3 | +1 | +1 |
+| `fix-js-date-helper` | 2 | 1/2 | 0/2 | -1 | -1 |
+| `fix-json-normalizer` | 5 | 5/5 | 5/5 | +0 | 0 |
+| `fix-python-retry-policy` | 1 | 1/1 | 1/1 | +0 | 0 |
+| `fix-python-slugify` | 4 | 1/4 | 4/4 | +3 | +3 |
+| `fix-readme-command` | 3 | 0/3 | 3/3 | +3 | +3 |
+| `fix-rust-parser-error` | 3 | 0/3 | 3/3 | +3 | +3 |
+| `fix-shell-safe-clean` | 5 | 5/5 | 5/5 | +0 | 0 |
+| `long-session-data-report` | 3 | 0/3 | 1/3 | +1 | +1 |
+| `long-session-large-component` | 4 | 0/4 | 4/4 | +4 | +4 |
+| `long-session-read-edit` | 4 | 0/4 | 1/4 | +1 | +1 |
+| `multi-file-docs-and-examples` | 2 | 0/2 | 2/2 | +2 | +2 |
+| `multi-file-node-package` | 3 | 3/3 | 3/3 | +0 | 0 |
+| `multi-file-python-package` | 4 | 2/4 | 0/4 | -2 | -2 |
+| `new-markdown-release-notes` | 5 | 5/5 | 5/5 | +0 | 0 |
+| `new-python-csv-small` | 2 | 0/2 | 2/2 | +2 | +2 |
+| `new-rust-cli-small` | 1 | 0/1 | 1/1 | +1 | +1 |
+| `new-typescript-formatter` | 5 | 4/5 | 5/5 | +1 | +1 |
+| `non-coding-research-brief` | 5 | 5/5 | 5/5 | +0 | 0 |
+| `non-coding-runbook` | 3 | 2/3 | 2/3 | +0 | +1 / -1 |
+| `scaffold-fastapi-service` | 5 | 5/5 | 1/5 | -4 | -4 |
+| `scaffold-next-dashboard` | 4 | 1/4 | 1/4 | +0 | +1 / -1 |
+| `scaffold-rust-cli` | 1 | 0/1 | 0/1 | +0 | 0 |
+
+Signed scenario deltas in this non-fired subset:
+
+| delta | scenario count |
+|---:|---:|
+| -4 | 1 |
+| -2 | 1 |
+| -1 | 1 |
+| 0 | 9 |
+| +1 | 5 |
+| +2 | 2 |
+| +3 | 3 |
+| +4 | 1 |
+
+Absolute deltas:
+
+| abs(delta) | scenario count |
+|---:|---:|
+| 0 | 9 |
+| 1 | 6 |
+| 2 | 3 |
+| 3 | 3 |
+| 4 | 2 |
+
+## Scaffold FastAPI
+
+`scaffold-fastapi-service` is the key watchlist case because it moved from 5/5
+in the fixed-binary baseline to 1/5 in Task15. Feedback did not fire in any of
+its five Task15 runs.
+
+| run | fixed-binary | Task15 | Task15 reason |
+|---|---|---|---|
+| run-1 | pass | fail | `missing_file:app/main.py,command_failed:0` |
+| run-2 | pass | fail | `missing_file:app/main.py,missing_file:app/routes/health.py,missing_file:tests/test_health.py,command_failed:0` |
+| run-3 | pass | fail | `missing_file:app/main.py,missing_file:app/routes/health.py,missing_file:tests/test_health.py,command_failed:0` |
+| run-4 | pass | fail | `missing_file:app/main.py,missing_file:app/routes/health.py,missing_file:tests/test_health.py,command_failed:0` |
+| run-5 | pass | pass | `ok` |
+
+Because the feedback never fired, this regression is explainable as
+run-to-run variance or scaffold-specific instability. It is not evidence that
+the completion-without-write feedback caused the regression.
+
+## Variance Rule
+
+For n=5 scenario-level comparisons, treat +/-2 runs as normal noise unless the
+same direction repeats across related scenarios or an llm-io trace shows a
+deterministic mechanism path. Treat +/-3 or larger as an investigation trigger,
+not as causal proof.
+
+This run provides one extreme calibration point: `scaffold-fastapi-service`
+moved by -4 with zero feedback firings. Therefore even a 5/5 to 1/5 movement can
+be explained by variance for an unstable scaffold scenario, but it should still
+be triaged before admission decisions rely on it.
+
+The Task15 admission result remains useful as an aggregate signal, but this
+analysis weakens any claim that the full +11 overall movement is solely caused
+by the new mechanism. A narrow on/off ablation is still the cleanest way to
+separate mechanism effect from sampling variance for watchlist scenarios.


### PR DESCRIPTION
## Linked Issue

- None. Follow-up from minimal-loop Phase 3 admission work.

## Summary

- Add `docs/eval/mechanism-ledger.md` and record mechanism M001: completion-without-write feedback (#1036).
- Add the formal Task15 feedback rerun report under `docs/eval/`.
- Add `docs/eval/t2-4-run-variance.md`, using Task15 non-fired runs to estimate run-to-run scenario variance without GPU reruns.
- Add `docs/eval/INDEX.md` to make current T2-4 reports and triage docs discoverable.

## Changed Files

- `docs/eval/mechanism-ledger.md`
- `docs/eval/minimal-loop-t2-4-task15-feedback-rerun-20260612.md`
- `docs/eval/t2-4-run-variance.md`
- `docs/eval/INDEX.md`

## Tests Run

- `git diff --cached --check`
- GPU-free log/summary analysis over:
  - fixed-binary root `20260612T145227-40162`
  - Task15 root `20260612T174200-32077`

## Known Risks

- Docs-only change. No runtime behavior changes.
- The variance analysis compares replicate IDs, not deterministic seeds, so it is an estimate rather than a strict paired sample.

## Orchestration Run ID

- N/A