### PR TITLE
Fix fix-js-date-helper success check

### DIFF
--- a/benchmarks/minimal-loop-expanded.yaml
+++ b/benchmarks/minimal-loop-expanded.yaml
@@ -72,9 +72,11 @@ cases:
     success_check:
       files:
         - path: src/dateRange.js
-          min_lines: 25
+          min_lines: 12
       commands:
         - grep -R "inclusiveDays" src/dateRange.js
+        - >
+          node -e "const fs = require('fs'); const vm = require('vm'); let src = fs.readFileSync('src/dateRange.js', 'utf8'); src = src.replace(/export\\s+function\\s+inclusiveDays/, 'function inclusiveDays'); const sandbox = { module: { exports: {} }, exports: {} }; vm.runInNewContext(src + '; module.exports.inclusiveDays = module.exports.inclusiveDays || (typeof inclusiveDays !== \"undefined\" ? inclusiveDays : undefined);', sandbox); const fn = sandbox.module.exports.inclusiveDays; if (typeof fn !== 'function') process.exit(1); if (fn('2024-01-01', '2024-01-01') !== 1) process.exit(1); if (fn('2024-01-02', '2024-01-01') !== 0) process.exit(1);"
 
   - name: fix-python-slugify
     task_kind: coding


### PR DESCRIPTION
## Linked Issue

- None. Task18 check false-negative cleanup.

## Summary

- Update only the `fix-js-date-helper` success check.
- Lower `src/dateRange.js` from `min_lines: 25` to `min_lines: 12` so concise valid implementations are not rejected.
- Add a semantic Node check for the two requirements from the prompt:
  - same-day ranges return `1`
  - reversed ranges return `0`

## Triage Basis

Task15 report records this remaining failure as: `fix-js-date-helper` remains `0/5`; failures are line-count false negatives or missing `src/dateRange.js`.

Direct root inspection confirmed Task15 run-1 and run-2 had valid 20-22 line implementations that failed only `min_lines:25`. The older Task14 15-18 line samples include implementations that still fail same-day/reversed behavior, so this PR uses a semantic check rather than a pure line-count relaxation.

## Changed Files

- `benchmarks/minimal-loop-expanded.yaml`

## Tests Run

- `git diff --check`
- `bash scripts/bench.sh minimal-loop-expanded --recheck-root /Users/maenokota/share/work/github_kewton/Anvil-develop/workspace/task15-rerun/.anvil/benchmarks/20260612T174200-32077`

Observed `fix-js-date-helper` on Task15 root moves from `0/5` to `2/5`: two valid concise implementations pass, two missing-file runs stay failed, and one behavioral failure stays failed.

## Known Risks

- The semantic check uses local `node`, matching this JavaScript scenario. If Node is unavailable in a future recheck environment, this scenario will fail as an environment issue.

## Orchestration Run ID

- N/A