### PR TITLE
Fix fix-python-retry-policy success check

### DIFF
--- a/benchmarks/minimal-loop-expanded.yaml
+++ b/benchmarks/minimal-loop-expanded.yaml
@@ -134,9 +134,11 @@ cases:
     success_check:
       files:
         - path: src/retry_policy.py
-          min_lines: 25
+          min_lines: 12
       commands:
         - grep -R "should_retry" src/retry_policy.py
+        - >
+          python3 -c "import importlib.util; spec = importlib.util.spec_from_file_location('retry_policy', 'src/retry_policy.py'); mod = importlib.util.module_from_spec(spec); spec.loader.exec_module(mod); fn = mod.should_retry; assert fn(429, 1); assert fn(500, 2); assert fn(599, 2); assert not fn(404, 1); assert not fn(200, 1); assert not fn(429, 3); assert not fn(500, 3)"
 
   - name: fix-css-token-doc
     task_kind: docs


### PR DESCRIPTION
## Linked Issue

- None. Task18 check false-negative cleanup.

## Summary

- Update only the `fix-python-retry-policy` success check.
- Lower `src/retry_policy.py` from `min_lines: 25` to `min_lines: 12` so concise valid implementations are not rejected.
- Add a semantic Python check for the prompt requirements:
  - retry `429`
  - retry `5xx`
  - do not retry `200`/`404`
  - do not retry after attempt `3`

## Triage Basis

Task15 report records one remaining false negative: `fix-python-retry-policy` run-1 failed with `src/retry_policy.py:24<25`. Direct root inspection also found legacy implementations at 13-16 lines that correctly implement the same retry policy. The previous line-count threshold was therefore overstrict.

## Changed Files

- `benchmarks/minimal-loop-expanded.yaml`

## Tests Run

- `git diff --check`
- `bash scripts/bench.sh minimal-loop-expanded --recheck-root /Users/maenokota/share/work/github_kewton/Anvil-develop/workspace/task15-rerun/.anvil/benchmarks/20260612T174200-32077`

Observed `fix-python-retry-policy` on Task15 root moves from `3/5` to `4/5`: the 24-line valid implementation passes, while the missing-file run stays failed.

## Known Risks

- The semantic check uses local `python3`, matching this Python scenario. If Python is unavailable in a future recheck environment, this scenario will fail as an environment issue.

## Orchestration Run ID

- N/A