### PR TITLE
Add benchmark seed support and cycle 2 triage

### DIFF
--- a/docs/eval/INDEX.md
+++ b/docs/eval/INDEX.md
@@ -1,0 +1,7 @@
+# Evaluation Index
+
+## Minimal Loop
+
+- [Phase 3 cycle 1 evaluation](minimal-loop-phase3-cycle1-evaluation-20260612.md):
+  admission decision and current baseline for the first admitted minimal-loop
+  mechanism.

--- a/docs/eval/INDEX.md
+++ b/docs/eval/INDEX.md
@@ -5,3 +5,7 @@
 - [Phase 3 cycle 1 evaluation](minimal-loop-phase3-cycle1-evaluation-20260612.md):
   admission decision and current baseline for the first admitted minimal-loop
   mechanism.
+- [Mechanism ledger](mechanism-ledger.md): admitted minimal-loop mechanisms and
+  watchlist.
+- [Cycle 2 loss triage](triage/cycle2-loss-triage.md): residual losses after
+  M001 admission.

--- a/docs/eval/mechanism-ledger.md
+++ b/docs/eval/mechanism-ledger.md
@@ -1,0 +1,50 @@
+# Minimal Loop Mechanism Ledger
+
+This ledger records admitted minimal-loop mechanisms so Phase 3 additions stay
+small, measured, and reversible.
+
+## M001: completion-without-write feedback
+
+Status: admitted (2026-06-12)
+
+Introduced by: `#1036`
+
+Final audit date: 2026-06-12
+
+Admission report:
+[Minimal Loop Phase 3 Cycle 1 Evaluation](minimal-loop-phase3-cycle1-evaluation-20260612.md)
+
+Target scenarios:
+
+- `new-python-csv-small`
+- `fix-rust-parser-error`
+- `fix-readme-command`
+- `fix-python-slugify`
+
+Mechanism:
+
+- Trigger once per session when the model returns a no-tool completion before
+  any `Write` or `Edit` has executed.
+- Inject a neutral user-role ephemeral feedback asking the model to create or
+  modify files if the task requires it, or finish if no file change is needed.
+- Accept the next no-tool completion to prevent loops.
+
+Admission result:
+
+- Target set improved from 7/20 to 17/20 in the Task15 real rerun.
+- Final Task18 recheck baseline: minimal+M001 83/125 vs legacy-lite 71/125.
+- Elapsed mean remained faster: 38.5 sec vs 66.6 sec.
+
+Configuration:
+
+- Off flag: `ANVIL_NO_MINIMAL_COMPLETION_WITHOUT_WRITE_FEEDBACK=1`
+- Admission model: `qwen3.6:27b-coding-nvfp4`
+- Injected text: 210 characters, 38 whitespace-delimited words. The token count
+  is tokenizer-dependent; this is treated as a small one-message injection.
+
+Open watchlist:
+
+- `multi-file-rust-library`: one-run regression while feedback fired in all
+  runs; currently within n=5 noise.
+- `fix-js-date-helper`, `new-python-csv-small`, `non-coding-runbook`: remaining
+  losses require separate triage before any M002 admission.

--- a/docs/eval/minimal-loop-phase3-cycle1-evaluation-20260612.md
+++ b/docs/eval/minimal-loop-phase3-cycle1-evaluation-20260612.md
@@ -1,0 +1,150 @@
+# Minimal Loop Phase 3 Cycle 1 Evaluation
+
+- Date: 2026-06-12 JST
+- Branch recorded on: `develop`
+- Benchmark: `minimal-loop-expanded`
+- Model: `qwen3.6:27b-coding-nvfp4`
+- Mechanism under admission: completion-without-write feedback (#1036)
+
+## Executive Summary
+
+The first Phase 3 mechanism admission is accepted.
+
+After the Task18 check corrections, the current comparison is:
+
+| series | success | elapsed mean | note |
+|---|---:|---:|---|
+| legacy-lite | 71/125 | 66.6 sec | existing legacy-lite artifacts, rechecked |
+| minimal before mechanism | 68/125 | 28.9 sec | fixed-binary minimal artifacts, rechecked |
+| minimal with completion-without-write feedback | 83/125 | 38.5 sec | Task15 artifacts, rechecked |
+
+Minimal with the admitted mechanism is +12 runs over legacy-lite and remains
+1.7x faster on elapsed mean. The main admission target set improved from 7/20
+to 17/20 in the actual Task15 rerun.
+
+This does not prove that all +15 runs over the fixed-binary minimal baseline
+come from the mechanism. The non-fired-run variance analysis showed substantial
+run-to-run movement. It does show that the mechanism clears the admission bar
+under the current benchmark discipline and should remain enabled by default.
+
+## Source Runs
+
+Task15 was a real GPU/Ollama benchmark run:
+
+- Root: `.anvil/benchmarks/20260612T174200-32077`
+- Engine: `minimal`
+- Runs: 25 scenarios x 5 runs
+- Mechanism: `completion-without-write feedback` enabled
+- Off flag absent: `ANVIL_NO_MINIMAL_COMPLETION_WITHOUT_WRITE_FEEDBACK=1`
+
+Task18 was not a model rerun. It was a post-hoc recheck of saved artifacts:
+
+- legacy root: `.anvil/benchmarks/20260612T024532-70925`
+- Task14 fixed-binary minimal root: `.anvil/benchmarks/20260612T145227-40162`
+- Task15 feedback minimal root: `.anvil/benchmarks/20260612T174200-32077`
+
+This distinction matters: Task18 measures the effect of corrected
+`success_check` definitions, not new model behavior.
+
+## Admission Target
+
+The mechanism targeted four no-edit-loop scenarios identified during triage:
+
+| scenario | Task14 baseline | Task15 rerun | delta |
+|---|---:|---:|---:|
+| `new-python-csv-small` | 2/5 | 3/5 | +1 |
+| `fix-rust-parser-error` | 1/5 | 4/5 | +3 |
+| `fix-readme-command` | 2/5 | 5/5 | +3 |
+| `fix-python-slugify` | 2/5 | 5/5 | +3 |
+| total | 7/20 | 17/20 | +10 |
+
+This meets the primary admission criterion.
+
+## Final Scenario Table
+
+The following table uses the Task18 recheck as the current baseline.
+
+| scenario | legacy final | minimal before mechanism | minimal with mechanism | delta vs legacy |
+|---|---:|---:|---:|---:|
+| `fix-css-token-doc` | 5/5 | 3/5 | 4/5 | -1 |
+| `fix-js-date-helper` | 5/5 | 0/5 | 2/5 | -3 |
+| `fix-json-normalizer` | 5/5 | 5/5 | 5/5 | +0 |
+| `fix-python-retry-policy` | 5/5 | 5/5 | 4/5 | -1 |
+| `fix-python-slugify` | 4/5 | 2/5 | 5/5 | +1 |
+| `fix-readme-command` | 5/5 | 2/5 | 5/5 | +0 |
+| `fix-rust-parser-error` | 5/5 | 1/5 | 4/5 | -1 |
+| `fix-shell-safe-clean` | 2/5 | 5/5 | 5/5 | +3 |
+| `long-session-data-report` | 0/5 | 2/5 | 1/5 | +1 |
+| `long-session-large-component` | 0/5 | 1/5 | 5/5 | +5 |
+| `long-session-read-edit` | 0/5 | 1/5 | 1/5 | +1 |
+| `multi-file-docs-and-examples` | 0/5 | 2/5 | 4/5 | +4 |
+| `multi-file-node-package` | 0/5 | 5/5 | 5/5 | +5 |
+| `multi-file-python-package` | 0/5 | 2/5 | 1/5 | +1 |
+| `multi-file-rust-library` | 5/5 | 5/5 | 4/5 | -1 |
+| `new-large-react-kanban` | 0/5 | 2/5 | 1/5 | +1 |
+| `new-markdown-release-notes` | 5/5 | 5/5 | 5/5 | +0 |
+| `new-python-csv-small` | 5/5 | 2/5 | 3/5 | -2 |
+| `new-rust-cli-small` | 5/5 | 0/5 | 4/5 | -1 |
+| `new-typescript-formatter` | 5/5 | 4/5 | 5/5 | +0 |
+| `non-coding-research-brief` | 5/5 | 5/5 | 5/5 | +0 |
+| `non-coding-runbook` | 5/5 | 3/5 | 3/5 | -2 |
+| `scaffold-fastapi-service` | 0/5 | 5/5 | 1/5 | +1 |
+| `scaffold-next-dashboard` | 0/5 | 1/5 | 1/5 | +1 |
+| `scaffold-rust-cli` | 0/5 | 0/5 | 0/5 | +0 |
+
+## Confirmed Findings
+
+- The admitted mechanism directly addresses the observed no-edit-loop failure
+  class and moved the target set by +10 runs in the real Task15 rerun.
+- The current headline comparison is 83/125 minimal vs 71/125 legacy-lite.
+- The speed advantage remains material: 38.5 sec vs 66.6 sec elapsed mean.
+- The mechanism is small, deterministic, and has an explicit off flag:
+  `ANVIL_NO_MINIMAL_COMPLETION_WITHOUT_WRITE_FEEDBACK=1`.
+
+## Limits Of Interpretation
+
+- The full aggregate gain cannot be attributed only to the mechanism. In the
+  non-fired subset, Task15 runs where feedback did not fire still moved from
+  42/77 to 57/77.
+- Single-scenario n=5 swings are not reliable causal evidence. Treat +/-2 runs
+  as ordinary noise and +/-3 or larger as a triage trigger.
+- `scaffold-fastapi-service` is not evidence against the mechanism: it regressed
+  from 5/5 to 1/5, but feedback did not fire in any of those five runs.
+
+## Watchlist
+
+| item | status | next action |
+|---|---|---|
+| `multi-file-rust-library` | 5/5 to 4/5 while feedback fired in all five runs | Optional narrow on/off ablation, 10 runs each if GPU time is available |
+| `fix-js-date-helper` | still 2/5 vs legacy 5/5 after semantic check | Triage remaining behavior/missing-file failures before adding any mechanism |
+| `new-python-csv-small` | target improved but remains 3/5 vs legacy 5/5 | Inspect residual failures; do not assume parser or no-edit-loop cause |
+| scaffold scenarios | highly unstable, especially FastAPI | Treat n=5 scaffold swings as variance until reproduced |
+| `scaffold-rust-cli` | 0/5 for all current series | Still a true dead scenario; likely requires separate scaffold/loop triage |
+
+## Decision
+
+M001, completion-without-write feedback, is admitted and should remain enabled
+by default.
+
+The Phase 3 first-cycle baseline is:
+
+- legacy-lite: 71/125
+- minimal before mechanism: 68/125
+- minimal with M001: 83/125
+
+The next mechanism should not be added directly from the aggregate table.
+Continue the same discipline: failure triage first, single deterministic trigger,
+neutral feedback text, off flag, bounded line growth, and ledger update.
+
+## Recommended Next Step
+
+Start the next triage cycle from the remaining minimal losses:
+
+1. `fix-js-date-helper`
+2. `new-python-csv-small`
+3. `non-coding-runbook`
+4. scaffold instability, especially `scaffold-rust-cli`
+
+The strongest near-term candidate is not yet a mechanism; it is a focused triage
+of why `fix-js-date-helper` still fails after replacing line-count checks with
+semantic checks.

--- a/docs/eval/triage/cycle2-loss-triage.md
+++ b/docs/eval/triage/cycle2-loss-triage.md
@@ -1,0 +1,227 @@
+# Cycle 2 Loss Triage
+
+Date: 2026-06-12 JST
+
+Scope:
+
+- Legacy root: `.anvil/benchmarks/20260612T024532-70925`
+- Minimal+M001 root: `.anvil/benchmarks/20260612T174200-32077`
+- Model: `qwen3.6:27b-coding-nvfp4`
+
+This is investigation only. No minimal-loop, parser, prompt, or success-check
+code was changed for this triage.
+
+## Summary
+
+Targets:
+
+| scenario | legacy final | minimal+M001 final | residual gap |
+|---|---:|---:|---:|
+| `fix-js-date-helper` | 5/5 | 2/5 | -3 |
+| `new-python-csv-small` | 5/5 | 3/5 | -2 |
+| `non-coding-runbook` | 5/5 | 3/5 | -2 |
+
+Residual minimal failures:
+
+| class | count | runs |
+|---|---:|---|
+| `no_edit_loop_after_feedback` | 5 | `fix-js-date-helper` run-3/run-4, `new-python-csv-small` run-2/run-5, `non-coding-runbook` run-2 |
+| `artifact_quality_after_write` | 1 | `fix-js-date-helper` run-5 |
+| `max_iterations_without_session_log` | 1 | `non-coding-runbook` run-3 |
+| `check_failed` | 0 | none observed |
+| `anchor_mismatch` | 0 | none observed |
+
+Primary finding:
+
+- M001 improves the original no-edit-loop class but does not eliminate it. In
+  five residual failures, feedback fired and the model still either emitted no
+  tool call or tried blocked `Bash mkdir` instead of `Write`.
+- `fix-js-date-helper` also has one distinct failure where the file exists, but
+  the model stops after describing the required fix and leaves the buggy code in
+  place.
+- No remaining target failure is explained by a success-check false negative or
+  an Edit anchor mismatch.
+
+## `fix-js-date-helper`
+
+Result:
+
+- legacy: 5/5
+- minimal+M001: 2/5
+
+Minimal run outcomes:
+
+| run | success | M001 fired | reason | class |
+|---|---:|---:|---|---|
+| 1 | yes | no | ok after Task18 semantic recheck | n/a |
+| 2 | yes | yes | ok after feedback, `Write`, and repair | n/a |
+| 3 | no | yes | `missing_file:src/dateRange.js` | `no_edit_loop_after_feedback` |
+| 4 | no | yes | `missing_file:src/dateRange.js` | `no_edit_loop_after_feedback` |
+| 5 | no | no | semantic command failed | `artifact_quality_after_write` |
+
+Branch point:
+
+- Legacy reaches `Write:src/dateRange.js` immediately in successful runs.
+- Minimal run-3 and run-4 inspect an empty workdir, return prose saying they
+  will create `src/dateRange.js`, receive M001 feedback, then call blocked
+  `Bash mkdir -p src`. After the blocked command, both runs again say they will
+  use `Write` but emit no tool call. The target file is never created.
+- Minimal run-5 does create `src/dateRange.js`, but the final file still returns
+  `diffDays` without adding one or handling reversed ranges. The model describes
+  the fixes in prose and stops without `Edit` or `Write`.
+
+M001 and missing-file relation:
+
+- Missing-file failures: run-3 and run-4.
+- M001 fired in both missing-file failures.
+- Therefore the remaining missing-file failures are not caused by M001 being
+  absent. They are M001-ineffective cases where the follow-up action was either
+  blocked `Bash` or another no-tool completion.
+
+Classification:
+
+- `no_edit_loop_after_feedback`: 2
+- `artifact_quality_after_write`: 1
+
+Judgment:
+
+- Not a check problem after Task18 semantic recheck.
+- Not an anchor problem.
+- Mixed implementation/design gap: M001 is too weak for some runs after a
+  blocked general shell attempt, and there is no verifier-driven continuation
+  when a created file remains semantically wrong.
+
+Admission recommendation:
+
+- No immediate M002 from this scenario alone. The two patterns need separate
+  evidence after seeded reruns:
+  - blocked-shell-to-Write recovery
+  - semantic-failure continuation after a file was written
+
+## `new-python-csv-small`
+
+Result:
+
+- legacy: 5/5
+- minimal+M001: 3/5
+
+Minimal run outcomes:
+
+| run | success | M001 fired | reason | class |
+|---|---:|---:|---|---|
+| 1 | yes | no | ok | n/a |
+| 2 | no | yes | `missing_file:tools/csv_stats.py` | `no_edit_loop_after_feedback` |
+| 3 | yes | no | ok | n/a |
+| 4 | yes | yes | ok after feedback and `Write` | n/a |
+| 5 | no | yes | `missing_file:tools/csv_stats.py` | `no_edit_loop_after_feedback` |
+
+Branch point:
+
+- Legacy emits `Write:tools/csv_stats.py` directly in successful runs.
+- Minimal run-2 inspects the empty directory, says it will create the script,
+  receives M001, then again says it will create the file without a tool call.
+- Minimal run-5 first tries blocked `Bash mkdir -p tools`, then says it will use
+  `Write`, receives M001, and again says it will create the file without a tool
+  call.
+
+Classification:
+
+- `no_edit_loop_after_feedback`: 2
+
+Judgment:
+
+- The previous `min_lines:25` false negative is gone; this is not a check issue.
+- The residual failures are the same M001-ineffective no-edit class seen in
+  `fix-js-date-helper`, especially after directory creation gets routed through
+  blocked `Bash`.
+
+Admission recommendation:
+
+- Candidate only after Task19 seeded reruns confirm the pattern is stable.
+  If stable, the smallest candidate is not task-specific CSV logic; it is a
+  general blocked-shell-to-Write feedback or tool-selection repair.
+
+## `non-coding-runbook`
+
+Result:
+
+- legacy: 5/5
+- minimal+M001: 3/5
+
+Minimal run outcomes:
+
+| run | success | M001 fired | reason | class |
+|---|---:|---:|---|---|
+| 1 | yes | no | ok | n/a |
+| 2 | no | yes | `missing_file:runbooks/incident-triage.md` | `no_edit_loop_after_feedback` |
+| 3 | no | unknown | `rc=1`, max iterations, no copied session log | `max_iterations_without_session_log` |
+| 4 | yes | yes | ok after feedback and `Write` | n/a |
+| 5 | yes | no | ok after blocked `Bash` then `Write` | n/a |
+
+Branch point:
+
+- Legacy run-1 initially emits prose shaped like `Write(...)`, then reaches an
+  actual `Write:runbooks/incident-triage.md` call and succeeds.
+- Minimal run-2 checks for the directory, observes it is absent, says it will
+  create the runbook, receives M001, then again says it will create the runbook
+  without a tool call.
+- Minimal run-3 has no copied session log. `stdout.log` records:
+  `error: minimal loop reached max_iterations (12)`. The workdir is empty.
+
+Classification:
+
+- `no_edit_loop_after_feedback`: 1
+- `max_iterations_without_session_log`: 1
+
+Judgment:
+
+- run-2 matches the residual M001-ineffective pattern.
+- run-3 cannot be assigned a model-behavior branch point from llm-io because the
+  session was not copied; it should be treated as execution/observability debt
+  rather than a mechanism admission signal.
+
+Admission recommendation:
+
+- No standalone admission candidate. Keep this as supporting evidence for the
+  broader no-edit-after-feedback family, then re-evaluate after seed support and
+  better failed-session log preservation.
+
+## Cross-Scenario Pattern
+
+| pattern | affected runs | interpretation |
+|---|---:|---|
+| feedback fired, then blocked `Bash mkdir`, then no `Write` | 3 | model chooses the wrong tool after M001 and does not recover from offline policy feedback |
+| feedback fired, then no-tool prose again | 2 | M001 is acknowledged linguistically but not converted into a tool call |
+| file written but not semantically repaired | 1 | completion acceptance lacks semantic verification/continuation |
+| session log missing on rc=1 | 1 | observability gap |
+
+Legacy mechanism hints:
+
+- Legacy successful runs reach `Write` earlier and more consistently.
+- The observable advantage is artifact-directed persistence, not Edit anchor
+  precision.
+- This does not justify importing a broad legacy repair subsystem. The next
+  candidate, if any, should be a narrowly measured follow-up to a stable seeded
+  failure mode.
+
+## Decision
+
+No M002 should be admitted from this triage yet.
+
+Reasons:
+
+1. Task19 is explicitly addressing run-to-run variance; admission should wait
+   for seeded evidence.
+2. The residual failures combine at least two mechanisms: tool-selection repair
+   after blocked `Bash`, and semantic continuation after a file exists.
+3. The remaining `non-coding-runbook` rc=1 case lacks session logs, so it should
+   not drive mechanism design.
+
+Recommended next step after Task19:
+
+- Re-run the three target scenarios with deterministic bench seeds.
+- If the blocked-shell-to-Write pattern reproduces, consider a single
+  deterministic feedback triggered by a blocked general shell command before any
+  file change.
+- Keep semantic-verifier continuation separate; it is a larger behavior surface
+  and should not be bundled with blocked-shell recovery.

--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -9,12 +9,14 @@
 #   --dry-run         anvil 呼び出しを echo で代替
 #   --pam-ab          Same prompt suite with PAM enabled and disabled
 #   --bench-no-debug  anvil に --trace を付けない（BENCH_DEBUG=0 と同義）
+#   --no-bench-seed  ベンチ用の Ollama seed 注入を無効化
 #   --help            この用例を表示して終了
 #
 # Environment:
 #   BENCH_DEBUG=1 (default) anvil を --trace 付きで起動し、詳細ログを stderr に流す
 #                           （llm-io.jsonl は log level によらず常時保存される）
 #   BENCH_DEBUG=0           --trace を付けない。--bench-no-debug と等価。
+#   ANVIL_NO_BENCH_SEED=1   ベンチ用の Ollama seed 注入を無効化。
 #
 # Examples:
 #   scripts/bench.sh heavy --model qwen3.5:122b --runs 5
@@ -38,6 +40,7 @@ Usage: scripts/bench.sh <benchmark-name> [options]
   --pam-ab          Same prompt suite with PAM enabled and disabled
   --dry-run         anvil 呼び出しを echo で代替
   --bench-no-debug  anvil に --trace を付けない（BENCH_DEBUG=0 と同義）
+  --no-bench-seed   ベンチ用の Ollama seed 注入を無効化
   --help            この用例を表示して終了
 
 Examples:
@@ -57,12 +60,21 @@ no_precautions=0
 no_case_memory=0
 no_auto_test=0
 pam_ab=0
+bench_seed_enabled=1
 # BENCH_DEBUG toggles `--trace` on the anvil invocation. Allowed values: "0" or "1".
 BENCH_DEBUG="${BENCH_DEBUG:-1}"
 case "$BENCH_DEBUG" in
   0|1) ;;
   *)
     echo "Error: BENCH_DEBUG must be 0 or 1 (got: $BENCH_DEBUG)" >&2
+    exit 1
+    ;;
+esac
+case "${ANVIL_NO_BENCH_SEED:-0}" in
+  ""|0) ;;
+  1) bench_seed_enabled=0 ;;
+  *)
+    echo "Error: ANVIL_NO_BENCH_SEED must be 0 or 1 (got: $ANVIL_NO_BENCH_SEED)" >&2
     exit 1
     ;;
 esac
@@ -115,6 +127,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --bench-no-debug)
       BENCH_DEBUG=0
+      shift
+      ;;
+    --no-bench-seed)
+      bench_seed_enabled=0
       shift
       ;;
     --)
@@ -257,11 +273,17 @@ slugify() {
   printf '%s' "$1" | sed 's/[^A-Za-z0-9._-]/-/g'
 }
 
+# derive_bench_seed <benchmark> <case> <pam_variant> <run_index>
+derive_bench_seed() {
+  printf '%s|%s|%s|%s' "$1" "$2" "$3" "$4" | cksum | awk '{ print $1 }'
+}
+
 # -------- write_meta_json --------
 write_meta_json() {
-  # $1=rc, $2=elapsed_s, $3=model, $4=start_ts, $5=run_dir, $6=case, $7=task_kind, $8=pam_variant
+  # $1=rc, $2=elapsed_s, $3=model, $4=start_ts, $5=run_dir, $6=case, $7=task_kind, $8=pam_variant, $9=bench_seed
   local _rc="$1" _elapsed="$2" _model="$3" _start_ts="$4" _run_dir="$5"
   local _case="${6:-default}" _task_kind="${7:-coding}" _pam_variant="${8:-default}"
+  local _bench_seed="${9:-}"
   if [[ -z "$_run_dir" ]]; then
     return 0
   fi
@@ -274,6 +296,7 @@ write_meta_json() {
     --arg case "$_case" \
     --arg task_kind "$_task_kind" \
     --arg pam_variant "$_pam_variant" \
+    --arg bench_seed "$_bench_seed" \
     '{
       rc: $rc,
       elapsed_s: $elapsed_s,
@@ -281,7 +304,9 @@ write_meta_json() {
       start_ts: $start_ts,
       case: $case,
       task_kind: $task_kind,
-      pam_variant: $pam_variant
+      pam_variant: $pam_variant,
+      bench_seed: (if $bench_seed == "" then null else ($bench_seed | tonumber) end),
+      bench_seed_enabled: ($bench_seed != "")
     }' \
     > "$_run_dir/meta.json"
 }
@@ -447,6 +472,7 @@ CURRENT_TASK_KIND="coding"
 CURRENT_PAM_VARIANT="default"
 CURRENT_RUN_DIR=""
 CURRENT_START_TS=""
+CURRENT_BENCH_SEED=""
 RUN_LOGGED=0
 META_WRITTEN=0
 on_interrupt() {
@@ -459,6 +485,7 @@ on_interrupt() {
   if [[ "$META_WRITTEN" -eq 0 && -n "$CURRENT_RUN_DIR" ]]; then
     write_meta_json 130 0 "${CURRENT_MODEL:-unknown}" "${CURRENT_START_TS:-}" "$CURRENT_RUN_DIR" \
       "${CURRENT_CASE:-default}" "${CURRENT_TASK_KIND:-coding}" "${CURRENT_PAM_VARIANT:-default}" \
+      "${CURRENT_BENCH_SEED:-}" \
       || true
   fi
   if [[ -n "$models_arg" ]]; then
@@ -548,6 +575,11 @@ for model in "${cleaned_models[@]}"; do
         STATE_DIR="$RUN_DIR/state"
         CURRENT_RUN_DIR="$RUN_DIR"
         CURRENT_START_TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+        if [[ "$bench_seed_enabled" -eq 1 ]]; then
+          CURRENT_BENCH_SEED=$(derive_bench_seed "$benchmark_name" "$case_name" "$pam_variant" "$run")
+        else
+          CURRENT_BENCH_SEED=""
+        fi
 
         # STATE_DIR assert: absolute path & no ..
         if [[ "$STATE_DIR" != /* ]]; then
@@ -569,7 +601,7 @@ for model in "${cleaned_models[@]}"; do
         unset ANVIL_NO_REMINDER ANVIL_NO_CASE_RETRIEVAL ANVIL_NO_CASE_RECORD \
               ANVIL_NO_AUTO_TEST ANVIL_NO_TESTER ANVIL_NO_REPO_GRAPH \
               ANVIL_CASE_RECORD_DRY_RUN ANVIL_CASE_RETRIEVAL_DRY_RUN \
-              ANVIL_PAM_ADVISORY_ENABLED
+              ANVIL_PAM_ADVISORY_ENABLED ANVIL_BENCH_SEED
 
         # Build env_kv array from feature flags (bash array, no eval)
         declare -a env_kv=()
@@ -586,6 +618,9 @@ for model in "${cleaned_models[@]}"; do
           env_kv+=("ANVIL_PAM_ADVISORY_ENABLED=true")
         elif [[ "$pam_variant" == "pam_off" ]]; then
           env_kv+=("ANVIL_PAM_ADVISORY_ENABLED=false")
+        fi
+        if [[ -n "$CURRENT_BENCH_SEED" ]]; then
+          env_kv+=("ANVIL_BENCH_SEED=$CURRENT_BENCH_SEED")
         fi
 
         start=$SECONDS
@@ -663,7 +698,7 @@ for model in "${cleaned_models[@]}"; do
 
         # Write run-dir/meta.json so analyze_run.py can read rc/elapsed_s
         if write_meta_json "$rc" "$elapsed" "$model" "$CURRENT_START_TS" "$RUN_DIR" \
-          "$case_name" "$task_kind" "$pam_variant"; then
+          "$case_name" "$task_kind" "$pam_variant" "$CURRENT_BENCH_SEED"; then
           META_WRITTEN=1
         else
           echo "warning: meta.json write failed" >&2
@@ -702,6 +737,7 @@ for model in "${cleaned_models[@]}"; do
 
         CURRENT_RUN_DIR=""
         CURRENT_START_TS=""
+        CURRENT_BENCH_SEED=""
         cd "$REPO_ROOT" || { echo "Error: cd $REPO_ROOT failed" >&2; exit 1; }
       done
     done

--- a/src/ollama/transport.rs
+++ b/src/ollama/transport.rs
@@ -10,6 +10,8 @@ struct RequestOptions {
     temperature: f32,
     num_ctx: usize,
     num_predict: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    seed: Option<u64>,
 }
 
 #[derive(Serialize)]
@@ -104,6 +106,7 @@ impl<'a> GenerateTransport<'a> {
             temperature,
             num_ctx: self.context_window,
             num_predict: self.max_predict,
+            seed: bench_seed_from_env(),
         }
     }
 
@@ -131,6 +134,12 @@ impl<'a> GenerateTransport<'a> {
             .json(&request)
             .send()
     }
+}
+
+fn bench_seed_from_env() -> Option<u64> {
+    std::env::var("ANVIL_BENCH_SEED")
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
 }
 
 fn to_chat_messages(messages: &[ConversationMessage]) -> Vec<ChatMessage> {
@@ -177,12 +186,58 @@ pub fn should_use_native_tool_calls(model: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::should_use_native_tool_calls;
+    use super::{RequestOptions, bench_seed_from_env, should_use_native_tool_calls};
+
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
     #[test]
     fn native_tool_allowlist_is_narrow() {
         assert!(should_use_native_tool_calls("qwen3.6:27b-coding-nvfp4"));
         assert!(!should_use_native_tool_calls("qwen3.5:122b"));
         assert!(!should_use_native_tool_calls("qwen3.5:9b"));
+    }
+
+    #[test]
+    fn bench_seed_is_read_only_from_explicit_env() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        unsafe {
+            std::env::remove_var("ANVIL_BENCH_SEED");
+        }
+        assert_eq!(bench_seed_from_env(), None);
+
+        unsafe {
+            std::env::set_var("ANVIL_BENCH_SEED", "12345");
+        }
+        assert_eq!(bench_seed_from_env(), Some(12_345));
+
+        unsafe {
+            std::env::set_var("ANVIL_BENCH_SEED", "not-a-number");
+        }
+        assert_eq!(bench_seed_from_env(), None);
+
+        unsafe {
+            std::env::remove_var("ANVIL_BENCH_SEED");
+        }
+    }
+
+    #[test]
+    fn request_options_serialize_seed_only_when_present() {
+        let seeded = serde_json::to_value(RequestOptions {
+            temperature: 0.3,
+            num_ctx: 24_000,
+            num_predict: 2_048,
+            seed: Some(42),
+        })
+        .unwrap();
+        assert_eq!(seeded["seed"], 42);
+
+        let unseeded = serde_json::to_value(RequestOptions {
+            temperature: 0.3,
+            num_ctx: 24_000,
+            num_predict: 2_048,
+            seed: None,
+        })
+        .unwrap();
+        assert!(unseeded.get("seed").is_none());
     }
 }

--- a/tests/scripts/test_bench_smoke.sh
+++ b/tests/scripts/test_bench_smoke.sh
@@ -6,7 +6,7 @@
 #   * summary.tsv row count and column order match
 #   * --pam-ab expands the same prompt suite into pam_on/pam_off variants
 #   * run-dir contains session.json, meta.json, logs/llm-io.jsonl
-#   * meta.json "rc" and "elapsed_s" are numeric
+#   * meta.json "rc", "elapsed_s", and bench seed fields are valid
 
 set -euo pipefail
 
@@ -47,7 +47,7 @@ uuid="00000000-0000-4000-8000-000000000001"
 session_dir="$state_dir/sessions/$uuid"
 mkdir -p "$session_dir/logs"
 cat > "$session_dir/session.json" <<JSON
-{"id":"$uuid","pam":"${ANVIL_PAM_ADVISORY_ENABLED:-unset}","messages":[{"role":"assistant","content":"ok","tool_calls":[]}]}
+{"id":"$uuid","pam":"${ANVIL_PAM_ADVISORY_ENABLED:-unset}","seed":"${ANVIL_BENCH_SEED:-unset}","messages":[{"role":"assistant","content":"ok","tool_calls":[]}]}
 JSON
 echo '{"ts_ms":1,"event":"ollama.generate.start","payload":{}}' \
   > "$session_dir/logs/llm-io.jsonl"
@@ -131,6 +131,19 @@ for case_name in docs data; do
       cat "$run_dir/session.json" >&2
       exit 1
     }
+    seed_val=$(jq -r '.bench_seed' "$run_dir/meta.json")
+    seed_enabled=$(jq -r '.bench_seed_enabled' "$run_dir/meta.json")
+    if ! [[ "$seed_val" =~ ^[0-9]+$ && "$seed_enabled" == "true" ]]; then
+      echo "FAIL: meta.json bench_seed invalid in $run_dir/meta.json" >&2
+      cat "$run_dir/meta.json" >&2
+      exit 1
+    fi
+    jq -e --arg seed "$seed_val" '.seed == $seed' "$run_dir/session.json" >/dev/null || {
+      echo "FAIL: ANVIL_BENCH_SEED env mismatch in $run_dir/session.json" >&2
+      cat "$run_dir/session.json" >&2
+      cat "$run_dir/meta.json" >&2
+      exit 1
+    }
   done
 done
 
@@ -154,6 +167,28 @@ if ! [[ "$elapsed_val" =~ ^[0-9]+$ ]]; then
   echo "FAIL: meta.json elapsed_s is not numeric: $elapsed_val" >&2
   exit 1
 fi
+
+# Seed injection can be disabled for ablation.
+bash scripts/bench.sh bench-smoke-fixture --model "smoke-model" --runs 1 --no-bench-seed \
+  > "$tmp/bench-no-seed.stdout" 2> "$tmp/bench-no-seed.stderr" || {
+  echo "FAIL: bench.sh --no-bench-seed non-zero exit" >&2
+  cat "$tmp/bench-no-seed.stderr" >&2
+  exit 1
+}
+BENCH_ROOT_NO_SEED=$(awk '/^Done\. Results: / { sub(/^Done\. Results: /, ""); sub(/\/summary\.tsv$/, ""); print }' \
+  "$tmp/bench-no-seed.stdout")
+no_seed_run_dir="$BENCH_ROOT_NO_SEED/smoke-model/docs/default/run-1"
+jq -e '.bench_seed == null and .bench_seed_enabled == false' "$no_seed_run_dir/meta.json" >/dev/null || {
+  echo "FAIL: --no-bench-seed meta.json mismatch" >&2
+  cat "$no_seed_run_dir/meta.json" >&2
+  exit 1
+}
+jq -e '.seed == "unset"' "$no_seed_run_dir/session.json" >/dev/null || {
+  echo "FAIL: --no-bench-seed env leaked into fake anvil" >&2
+  cat "$no_seed_run_dir/session.json" >&2
+  exit 1
+}
+rm -rf "$BENCH_ROOT_NO_SEED"
 
 # Optional: analyze_run.py should succeed on the produced run-dir
 if command -v python3 >/dev/null 2>&1; then


### PR DESCRIPTION
## Linked Issue

None. User-directed minimal-loop Phase 3 follow-up tasks 19 and 20, plus the previously prepared Phase 3 cycle 1 evaluation report commit that had not yet reached remote `develop`.

## Summary

- Add benchmark-only deterministic Ollama seed injection derived from benchmark, scenario, PAM variant, and run index.
- Record `bench_seed` and `bench_seed_enabled` in each run `meta.json`, with `--no-bench-seed` and `ANVIL_NO_BENCH_SEED=1` as the off switch.
- Update the bench smoke test to verify seed propagation and off-flag behavior.
- Add the Phase 3 cycle 1 evaluation report, M001 mechanism ledger entry as `admitted (2026-06-12)`, and cycle 2 residual loss triage.

## Changed Files

- `src/ollama/transport.rs`
- `scripts/bench.sh`
- `tests/scripts/test_bench_smoke.sh`
- `docs/eval/minimal-loop-phase3-cycle1-evaluation-20260612.md`
- `docs/eval/mechanism-ledger.md`
- `docs/eval/triage/cycle2-loss-triage.md`
- `docs/eval/INDEX.md`

## Tests Run

- `cargo fmt -- --check`
- `bash -n scripts/bench.sh`
- `bash tests/scripts/test_bench_smoke.sh`
- `cargo test ollama::transport::tests`
- `git diff --check`

## Seed Smoke Procedure

For a real Ollama smoke after merge, use the same release binary and run one scenario twice with the same benchmark identity and run index:

1. `cargo build --release`
2. Run `scripts/bench.sh minimal-loop-expanded --model qwen3.6:27b-coding-nvfp4 --engine minimal --runs 1 --case new-python-csv-small` twice without `--no-bench-seed`.
3. Confirm both `meta.json` files contain the same numeric `bench_seed` and `bench_seed_enabled: true`.
4. Compare the two saved `logs/llm-io.jsonl` response streams and final artifacts.

Ollama backend behavior may still prevent byte-for-byte equality. If responses differ with the same seed, record the response/artifact diff; the acceptance goal is reduced variance, not a hard guarantee of perfect determinism.

## Known Risks

- `ANVIL_BENCH_SEED` is intentionally read by the Ollama transport when present, but `bench.sh` only injects it for benchmark runs. Normal interactive use is unchanged unless a caller explicitly sets that environment variable.
- The seed derivation uses `cksum`, so exact seed values are shell/platform dependent if the bench script is moved to a non-POSIX environment. Current Anvil bench usage is macOS/Linux shell based.
- Cycle 2 triage recommends no M002 yet; seeded reruns should come before another mechanism admission.

## Orchestration Run ID

N/A