### PR TITLE
Preserve failed bench run logs

### DIFF
--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -657,29 +657,41 @@ for model in "${cleaned_models[@]}"; do
         fi
         elapsed=$(( SECONDS - start ))
 
-        # session.json copy (nullglob → empty array if no match)
-        # bash 3.2 + set -u needs guard for empty array expansion
+        # session/log copy (nullglob → empty array if no match). Select the
+        # latest session directory rather than anchoring on session.json:
+        # failed runs can have llm-io/eval logs even when session.json was not
+        # flushed before process exit.
         session_copied=0
-        latest_session=""
-        session_json_list=("$STATE_DIR/sessions/"*/session.json)
-        if [[ ${#session_json_list[@]} -gt 0 ]]; then
-          for f in "${session_json_list[@]}"; do
-            latest_session="$f"
+        latest_session_dir=""
+        session_dir_list=("$STATE_DIR/sessions/"*)
+        if [[ ${#session_dir_list[@]} -gt 0 ]]; then
+          for d in "${session_dir_list[@]}"; do
+            if [[ -d "$d" && ! -L "$d" ]]; then
+              latest_session_dir="$d"
+            fi
           done
         fi
-        if [[ -n "$latest_session" && -f "$latest_session" && ! -L "$latest_session" ]]; then
-          # reject symlinks before copy to prevent information leakage
-          real_session=$(realpath "$latest_session" 2>/dev/null || true)
+        if [[ -n "$latest_session_dir" ]]; then
+          # reject symlinks / path escapes before copy to prevent information leakage
+          real_session_dir=$(realpath "$latest_session_dir" 2>/dev/null || true)
           real_state=$(realpath "$STATE_DIR" 2>/dev/null || true)
-          if [[ -n "$real_session" && -n "$real_state" && "$real_session" == "$real_state"/* ]]; then
-            if cp "$latest_session" ../session.json; then
-              session_copied=1
-            else
-              echo "warning: session.json copy failed" >&2
+          if [[ -n "$real_session_dir" && -n "$real_state" && "$real_session_dir" == "$real_state"/* ]]; then
+            latest_session="$latest_session_dir/session.json"
+            if [[ -f "$latest_session" && ! -L "$latest_session" ]]; then
+              real_session=$(realpath "$latest_session" 2>/dev/null || true)
+              if [[ -n "$real_session" && "$real_session" == "$real_state"/* ]]; then
+                if cp "$latest_session" ../session.json; then
+                  session_copied=1
+                else
+                  echo "warning: session.json copy failed" >&2
+                fi
+              else
+                echo "warning: session.json path outside STATE_DIR, skipping copy" >&2
+              fi
             fi
 
             # Copy structured logs from the state-dir session directory (if present).
-            session_id=$(basename "$(dirname "$latest_session")")
+            session_id=$(basename "$latest_session_dir")
             if [[ "$session_id" =~ ^[A-Za-z0-9._-]+$ ]]; then
               for log_name in llm-io.jsonl eval.jsonl; do
                 log_src="$STATE_DIR/sessions/$session_id/logs/$log_name"

--- a/tests/scripts/test_bench_smoke.sh
+++ b/tests/scripts/test_bench_smoke.sh
@@ -32,10 +32,13 @@ cat > "$fake_anvil" <<'EOF'
 # Parse --state-dir and write a session directory.
 set -euo pipefail
 state_dir=""
+prompt=""
 prev=""
 for arg in "$@"; do
   if [[ "$prev" == "--state-dir" ]]; then
     state_dir="$arg"
+  elif [[ "$prev" == "--prompt" ]]; then
+    prompt="$arg"
   fi
   prev="$arg"
 done
@@ -46,6 +49,14 @@ fi
 uuid="00000000-0000-4000-8000-000000000001"
 session_dir="$state_dir/sessions/$uuid"
 mkdir -p "$session_dir/logs"
+if [[ "$prompt" == "fail logs only" ]]; then
+  echo '{"ts_ms":1,"event":"ollama.generate.start","payload":{"failure_fixture":true}}' \
+    > "$session_dir/logs/llm-io.jsonl"
+  echo '{"schema_version":1,"session_id":"fake","final_outcome":"error"}' \
+    > "$session_dir/logs/eval.jsonl"
+  echo "fake anvil: failed before session flush" >&2
+  exit 1
+fi
 cat > "$session_dir/session.json" <<JSON
 {"id":"$uuid","pam":"${ANVIL_PAM_ADVISORY_ENABLED:-unset}","seed":"${ANVIL_BENCH_SEED:-unset}","messages":[{"role":"assistant","content":"ok","tool_calls":[]}]}
 JSON
@@ -60,6 +71,7 @@ chmod +x "$fake_anvil"
 # --- fake benchmark yaml ---
 bench_yaml_dir="$REPO_ROOT/benchmarks"
 bench_yaml="$bench_yaml_dir/bench-smoke-fixture.yaml"
+bench_fail_yaml="$bench_yaml_dir/bench-smoke-fail-fixture.yaml"
 mkdir -p "$bench_yaml_dir"
 cat > "$bench_yaml" <<'EOF'
 args:
@@ -70,7 +82,14 @@ cases:
   - name: data
     prompt: transform CSV rows
 EOF
-trap 'rm -rf "$tmp"; rm -f "$bench_yaml"' EXIT
+cat > "$bench_fail_yaml" <<'EOF'
+args:
+  max_iterations: 1
+cases:
+  - name: fail-logs-only
+    prompt: fail logs only
+EOF
+trap 'rm -rf "$tmp"; rm -f "$bench_yaml" "$bench_fail_yaml"' EXIT
 
 # --- invoke bench.sh ---
 export ANVIL_BIN="$fake_anvil"
@@ -189,6 +208,41 @@ jq -e '.seed == "unset"' "$no_seed_run_dir/session.json" >/dev/null || {
   exit 1
 }
 rm -rf "$BENCH_ROOT_NO_SEED"
+
+# Failed runs can have structured logs before session.json is flushed. Preserve
+# those logs for triage even when session.json cannot be copied.
+bash scripts/bench.sh bench-smoke-fail-fixture --model "smoke-model" --runs 1 \
+  > "$tmp/bench-fail.stdout" 2> "$tmp/bench-fail.stderr" || {
+  echo "FAIL: bench.sh fail-fixture wrapper should still complete" >&2
+  cat "$tmp/bench-fail.stderr" >&2
+  exit 1
+}
+BENCH_ROOT_FAIL=$(awk '/^Done\. Results: / { sub(/^Done\. Results: /, ""); sub(/\/summary\.tsv$/, ""); print }' \
+  "$tmp/bench-fail.stdout")
+fail_run_dir="$BENCH_ROOT_FAIL/smoke-model/fail-logs-only/default/run-1"
+if [[ ! -f "$fail_run_dir/logs/llm-io.jsonl" || ! -f "$fail_run_dir/logs/eval.jsonl" ]]; then
+  echo "FAIL: failed run logs were not copied" >&2
+  find "$fail_run_dir" -maxdepth 4 -type f >&2 || true
+  exit 1
+fi
+if [[ -e "$fail_run_dir/session.json" ]]; then
+  echo "FAIL: fail fixture should not create copied session.json" >&2
+  cat "$fail_run_dir/session.json" >&2
+  exit 1
+fi
+fail_rc=$(jq -r '.rc' "$fail_run_dir/meta.json")
+if [[ "$fail_rc" != "1" ]]; then
+  echo "FAIL: fail fixture meta rc mismatch: $fail_rc" >&2
+  cat "$fail_run_dir/meta.json" >&2
+  exit 1
+fi
+fail_session_copied=$(awk -F'\t' 'NR == 2 { print $8 }' "$BENCH_ROOT_FAIL/summary.tsv")
+if [[ "$fail_session_copied" != "0" ]]; then
+  echo "FAIL: fail fixture should report session_copied=0" >&2
+  cat "$BENCH_ROOT_FAIL/summary.tsv" >&2
+  exit 1
+fi
+rm -rf "$BENCH_ROOT_FAIL"
 
 # Optional: analyze_run.py should succeed on the produced run-dir
 if command -v python3 >/dev/null 2>&1; then


### PR DESCRIPTION
## Linked Issue

None. User-directed Task22, stacked on #1042 because it builds on the current bench smoke test changes.

## Summary

- Copy bench run logs from the latest session directory even when `session.json` was not flushed before a failing `anvil` exit.
- Keep `session_copied=0` when no `session.json` exists, but still preserve `logs/llm-io.jsonl` and `logs/eval.jsonl` for triage.
- Add a bench smoke fixture where fake anvil writes logs, exits rc=1, and never writes `session.json`.

## Changed Files

- `scripts/bench.sh`
- `tests/scripts/test_bench_smoke.sh`

## Tests Run

- `bash -n scripts/bench.sh tests/scripts/test_bench_smoke.sh`
- `bash tests/scripts/test_bench_smoke.sh`
- `git diff --check`

## Known Risks

- If the agent process exits before writing either `session.json` or logs, there is still nothing to copy. This PR fixes the observed case where logs exist but `session.json` does not.
- `summary.tsv` keeps the existing `session_copied` meaning: it reports whether `session.json` was copied, not whether logs were copied.

## Orchestration Run ID

N/A