### PR TITLE
Point offline file creation blocks to Write

### DIFF
--- a/src/tools/bash.rs
+++ b/src/tools/bash.rs
@@ -1069,7 +1069,7 @@ pub(crate) fn enforce_offline_policy(
             | BashCommandClass::Dangerous
     ) {
         return Err(format!(
-            "offline mode only allows read-only, build-test, or local script-run shell commands: {}",
+            "offline mode only allows read-only, build-test, or local script-run shell commands: {}. To create files, call Write directly; Write creates parent directories automatically.",
             command.trim()
         ));
     }
@@ -1789,6 +1789,20 @@ mod tests {
         );
         assert!(enforce_offline_policy("rm -rf /", BashCommandClass::Dangerous, true).is_err());
         assert!(enforce_offline_policy("ls", BashCommandClass::ReadOnly, true).is_ok());
+    }
+
+    #[test]
+    fn enforce_offline_policy_points_file_creation_to_write() {
+        let err = enforce_offline_policy("mkdir -p src", BashCommandClass::General, true)
+            .expect_err("offline must reject general mkdir");
+        assert!(
+            err.contains("call Write directly"),
+            "offline mkdir rejection should name the replacement tool: {err}"
+        );
+        assert!(
+            err.contains("Write creates parent directories automatically"),
+            "offline mkdir rejection should explain that separate mkdir is unnecessary: {err}"
+        );
     }
 
     // ---------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Task21-C from the blocked-mkdir trap triage. Offline Bash already blocks `mkdir -p` as a general/mutating command, and `Write` already creates parent directories automatically. This PR keeps the offline policy unchanged, but makes the block message actionable by pointing file creation to `Write` instead of leaving the model at a dead end.

This is intentionally not M002 and does not add a recovery loop. It removes an avoidable trap in the existing tool error path.

## Context

- Depends on #1042 for the cycle2 triage context.
- Companion split PR to #1045, which documents `Write` parent directory behavior in the tool catalog.
- Supersedes the Task21-C part of closed #1043.

## Changes

- Extend the offline policy rejection for general/mutating/dangerous Bash commands with: `To create files, call Write directly; Write creates parent directories automatically.`
- Add a unit test that the `mkdir -p` offline rejection names `Write` and its automatic parent directory creation behavior.

## Validation

- `cargo fmt -- --check`
- `cargo test enforce_offline_policy_points_file_creation_to_write`
- `git diff --check`

## Risk

The offline Bash allowlist is unchanged. The only behavior change is the ephemeral error text shown after a blocked command.